### PR TITLE
Provide missing 2021 NY supplemental income tax parameters

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Missing 2021 NY supplemental income tax parameters.

--- a/policyengine_us/parameters/gov/states/ny/tax/income/supplemental/min_agi.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/supplemental/min_agi.yaml
@@ -1,11 +1,11 @@
 description: Filers with AGI over this amount pay the NY supplemental tax.
 values:
-  2022-01-01: 107_650
+  2021-01-01: 107_650
 metadata:
   unit: currency-USD
   period: year
   name: ny_sup_min_agi
   label: NY State supplemental tax minimum AGI
   reference:
-    - title: Section 601 Imposition of tax (d-4)
-      href: https://www.nysenate.gov/legislation/laws/TAX/606
+    - title: Section 601 Imposition of tax, (d-2) for 2021 and (d-3) for 2022
+      href: https://www.nysenate.gov/legislation/laws/TAX/601

--- a/policyengine_us/parameters/gov/states/ny/tax/income/supplemental/phase_in_length.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/supplemental/phase_in_length.yaml
@@ -1,11 +1,11 @@
 description: Each bracket of the NY supplemental tax phases in over this length.
 values:
-  2022-01-01: 50_000
+  2021-01-01: 50_000
 metadata:
   unit: currency-USD
   period: year
   name: ny_sup_phase_in_length
   label: NY State supplemental tax phase-in length
   reference:
-    - title: Section 601 Imposition of tax (d-4)
-      href: https://www.nysenate.gov/legislation/laws/TAX/606
+    - title: Section 601 Imposition of tax, (d-2) for 2021 and (d-3) for 2022
+      href: https://www.nysenate.gov/legislation/laws/TAX/601

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/ny_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/ny_income_tax.yaml
@@ -7,3 +7,55 @@
     ny_income_tax_before_credits: 1
   output:
     ny_income_tax: -1
+
+- name: Tax unit with taxsimid 99902 in p21.its.csv and p21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: 1
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 0
+        age: 38
+        employment_income: 117000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 1
+        is_tax_unit_dependent: 0
+        age: 44
+        employment_income: 139000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person3:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 1
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        premium_tax_credit: 0  # not in TAXSIM35
+        ny_supplemental_eitc: 0  # not in TAXSIM35
+        pa_use_tax: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: NY
+  output:  # expected from TAXSIM35
+    ny_income_tax: 15125.54

--- a/policyengine_us/variables/gov/states/ny/tax/income/ny_supplemental_tax.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/ny_supplemental_tax.py
@@ -10,7 +10,7 @@ class ny_supplemental_tax(Variable):
     definition_period = YEAR
     defined_for = StateCode.NY
 
-    def formula_2022(tax_unit, period, parameters):
+    def formula(tax_unit, period, parameters):
         ny_taxable_income = tax_unit("ny_taxable_income", period)
         ny_agi = tax_unit("ny_agi", period)
         tax = parameters(period).gov.states.ny.tax.income


### PR DESCRIPTION
Fix #1483.

