### PR TITLE
Update test_against_taxsim.py to include Windows and Mac OS

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: minor
+  changes:
+    changed:
+      - Added pip dependency to environment.yml.
+      - Made test_against_taxsim.py compatible with Windows and Mac operating systems.

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: policyengine-us
 dependencies:
-  - python=3.9
+  - python>=3.8
   - pip
   - pip:
     - policyengine-us

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: policyengine-us
 dependencies:
-  - python=3.8
+  - python>=3.8
   - pip
   - pip:
     - policyengine-us

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: policyengine-us
 dependencies:
   - python=3.9
+  - pip
   - pip:
     - policyengine-us

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: policyengine-us
 dependencies:
-  - python>=3.8
+  - python=3.8
   - pip
   - pip:
     - policyengine-us

--- a/policyengine_us/tests/microsimulation/test_against_taxsim.py
+++ b/policyengine_us/tests/microsimulation/test_against_taxsim.py
@@ -7,7 +7,6 @@ from policyengine_us.tools.taxsim.generate_taxsim_tests import (
 import numpy as np
 import pytest
 import pandas as pd
-import platform
 
 # Disable warnings
 import warnings
@@ -19,22 +18,20 @@ STATES = ["MD", "MA", "NY", "WA"]
 DISTANCE = 100
 MINIMUM_PERCENT_CLOSE = 0
 
-if os.name != "nt":
 
-    @pytest.fixture(scope="module")
-    def taxsim():
-        taxsim = TaxSim35()
+@pytest.fixture(scope="module")
+def taxsim():
+    taxsim = TaxSim35()
 
-        yield taxsim.generate_from_microsimulation(
-            CPS, 2022, None, True, False
-        ).set_index("taxsim_taxsimid")
+    yield taxsim.generate_from_microsimulation(
+        CPS, 2022, None, True, False
+    ).set_index("taxsim_taxsimid")
 
-    @pytest.fixture(scope="module")
-    def sim():
-        yield Microsimulation()
+@pytest.fixture(scope="module")
+def sim():
+    yield Microsimulation()
 
 
-@pytest.mark.skipif(True, reason="This test temporarily suspended.")
 def test_federal_tax_against_taxsim(sim, taxsim):
     tax = sim.calc("income_tax")
     tax.index = sim.calc("tax_unit_id").values
@@ -48,7 +45,6 @@ def test_federal_tax_against_taxsim(sim, taxsim):
     assert percent_close > MINIMUM_PERCENT_CLOSE
 
 
-@pytest.mark.skipif(True, reason="This test temporarily suspended.")
 @pytest.mark.parametrize("state", STATES)
 def test_state_income_tax_against_taxsim(state: str, sim, taxsim):
     in_state = sim.calc("tax_unit_state").values == state

--- a/policyengine_us/tests/microsimulation/test_against_taxsim.py
+++ b/policyengine_us/tests/microsimulation/test_against_taxsim.py
@@ -27,6 +27,7 @@ def taxsim():
         CPS, 2022, None, True, False
     ).set_index("taxsim_taxsimid")
 
+
 @pytest.fixture(scope="module")
 def sim():
     yield Microsimulation()

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "pyyaml",
         "requests",
         "synthimpute",
-        "tables",
+        "tables==3.6.1",
         "tqdm",
         "click>=8.0.0",
         "tabulate",


### PR DESCRIPTION
@nikhilwoodruff @MaxGhenis. This PR makes two changes. 

1) Updates the `environment.yml` file to include `pip` as a dependency. When this is not the case, my machine gives me an admonition when I create the `policyengine-us` conda environment.

2) Updates the `test_against_taxsim.py` file to function on machines that use Linux, Windows, and Mac operating systems. It currently skips these tests for Windows and Mac operating systems and only works for Linux operating system as in the CI tests. See Issue #1415. The output on my Mac for the `pytest policyengine_us/tests/ --maxfail=0` was previously the following, in which all five `test_against_taxsim.py` tests are skipped.
```
platform darwin -- Python 3.9.15, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /Users/richardevans/Docs/Economics/OSE/policyengine-us
plugins: dependency-0.5.1
collected 1072 items                                                           

policyengine_us/tests/test_variables.py ................................ [  2%]
........................................................................ [  9%]
........................................................................ [ 16%]
........................................................................ [ 23%]
........................................................................ [ 29%]
........................................................................ [ 36%]
........................................................................ [ 43%]
........................................................................ [ 50%]
........................................................................ [ 56%]
........................................................................ [ 63%]
........................................................................ [ 70%]
........................................................................ [ 76%]
........................................................................ [ 83%]
........................................................................ [ 90%]
........................................................................ [ 97%]
....................                                                     [ 98%]
policyengine_us/tests/microsimulation/test_against_taxsim.py sssss       [ 99%]
policyengine_us/tests/microsimulation/test_microsim.py .                 [ 99%]
policyengine_us/tests/microsimulation/data/test_imports.py ..            [ 99%]
policyengine_us/tests/microsimulation/data/acs/test_acs.py ss            [ 99%]
policyengine_us/tests/microsimulation/data/cps/test_cps.py ..            [100%]
...
=== 1065 passed, 7 skipped, 19 warnings in 52.19s ===
```
With the changes in this PR, the `test_against_taxsim.py` tests are all run and they all pass. The output is below.
```
platform darwin -- Python 3.9.15, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /Users/richardevans/Docs/Economics/OSE/policyengine-us
plugins: dependency-0.5.1
collected 1072 items                                                           

policyengine_us/tests/test_variables.py ................................ [  2%]
........................................................................ [  9%]
........................................................................ [ 16%]
........................................................................ [ 23%]
........................................................................ [ 29%]
........................................................................ [ 36%]
........................................................................ [ 43%]
........................................................................ [ 50%]
........................................................................ [ 56%]
........................................................................ [ 63%]
........................................................................ [ 70%]
........................................................................ [ 76%]
........................................................................ [ 83%]
........................................................................ [ 90%]
........................................................................ [ 97%]
....................                                                     [ 98%]
policyengine_us/tests/microsimulation/test_against_taxsim.py .....       [ 99%]
policyengine_us/tests/microsimulation/test_microsim.py .                 [ 99%]
policyengine_us/tests/microsimulation/data/test_imports.py ..            [ 99%]
policyengine_us/tests/microsimulation/data/acs/test_acs.py ss            [ 99%]
policyengine_us/tests/microsimulation/data/cps/test_cps.py ..            [100%]
...
=== 1070 passed, 2 skipped, 25 warnings in 35.73s ===
``` 