### PR TITLE
Allow data tests to work without a policyengine_us package being installed

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Inability of data tests to work without a policyengine_us package.

--- a/docs/gov/states/md/tax/income/deductions/standard-deduction.ipynb
+++ b/docs/gov/states/md/tax/income/deductions/standard-deduction.ipynb
@@ -3381,7 +3381,7 @@
     "\n",
     "df = pd.concat(l)\n",
     "\n",
-    "df[\"Filing Status\"] = np.where(df.adults==1, \"Single\", \"Other\")\n",
+    "df[\"Filing Status\"] = np.where(df.adults == 1, \"Single\", \"Other\")\n",
     "\n",
     "LABELS = dict(\n",
     "    employment_income=\"Employment income\",\n",

--- a/policyengine_us/conftest.py
+++ b/policyengine_us/conftest.py
@@ -1,0 +1,1 @@
+# This empty conftest.py file enables pytest to locate the policyengine_us code


### PR DESCRIPTION
This pull request allows developers to run the data tests without having to install a `policyengine_us` package.  This is a non-substantive change that allows the project to support a wider range of working styles among volunteer contributors.