### PR TITLE
Add a TAXSIM35 emulation parameter to facilitate validation testing

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: minor
+  changes:
+    added:
+      - TAXSIM35 emulation parameter.
+      - TAXSIM35 emulation logic to PA income tax forgiveness calculations.
+      - Test of PA income tax calculations using TAXSIM35 emulation.

--- a/policyengine_us/parameters/contrib/nber/taxsim35_emulation.yaml
+++ b/policyengine_us/parameters/contrib/nber/taxsim35_emulation.yaml
@@ -1,0 +1,7 @@
+description: Whether emulating TAXSIM35 income tax calculations.
+values:
+  0000-01-01: false
+metadata:
+  type: bool
+  label: TAXSIM35 emulation
+  name: taxsim35_emulation

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax.yaml
@@ -150,3 +150,81 @@
         state_code: PA
   output:  # expected results from TAXSIM35
     pa_income_tax: 1719.20
+
+- name: Tax unit with taxsimid 13632 in r21.its.csv and r21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    contrib.nber.taxsim35_emulation: true
+    people:
+      person1:
+        is_tax_unit_head: 1
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 0
+        age: 74
+        employment_income: 26000
+        taxable_interest_income: 5010
+        social_security: 24000
+        real_estate_taxes: 23000
+        interest_expense: 17000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 1
+        is_tax_unit_dependent: 0
+        age: 74
+        employment_income: 22000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person3:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 1
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person4:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 1
+        age: 16
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person5:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 1
+        age: 16
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person6:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 1
+        age: 16
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        tax_unit_childcare_expenses: 1000
+        premium_tax_credit: 0  # not in TAXSIM35
+        pa_use_tax: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5, person6]
+        state_code: PA
+  output:  # expected results from TAXSIM35
+    pa_income_tax: 1308.44

--- a/policyengine_us/variables/gov/states/pa/tax/income/pa_tax_forgiveness.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/pa_tax_forgiveness.py
@@ -25,20 +25,17 @@ class pa_tax_forgiveness_rate(Variable):
             filing_status == filing_statuses.SEPARATE
         )
         base_multiplier = where(joint_separate, 2, 1)
-        base = (
-            parameters(period).gov.states.pa.tax.forgiveness.base
-            * base_multiplier
-        )
-        rate_per_dependent = parameters(
-            period
-        ).gov.states.pa.tax.forgiveness.dependent_rate
+        p = parameters(period)
+        base = p.gov.states.pa.tax.forgiveness.base * base_multiplier
+        rate_per_dependent = p.gov.states.pa.tax.forgiveness.dependent_rate
         eligibility_income_increment = base + (
             rate_per_dependent * child_dependents
         )
         excess = eligibility_income - eligibility_income_increment
-        forgiveness_increment = parameters(
-            period
-        ).gov.states.pa.tax.forgiveness.rate_increment
-        increments = np.ceil(excess / forgiveness_increment)
-        percent = parameters(period).gov.states.pa.tax.forgiveness.tax_back
+        forgiveness_increment = p.gov.states.pa.tax.forgiveness.rate_increment
+        if p.contrib.nber.taxsim35_emulation:
+            increments = excess / forgiveness_increment
+        else:
+            increments = np.ceil(excess / forgiveness_increment)
+        percent = p.gov.states.pa.tax.forgiveness.tax_back
         return min_(max_(1 - percent * increments, 0), 1)


### PR DESCRIPTION
Fixes #1518, which eliminates all the remaining PA income tax differences in #993.