### PR TITLE
Correct MA bank interest deduction logic

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - MA bank interest deduction logic.

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/general.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/general.yaml
@@ -161,3 +161,35 @@
     # That an unused (or excess) PartB exemption can be used to reduce BOTH
     # PartA and PartC income is described in the document at this URL:
     # https://www.mass.gov/service-details/view-massachusetts-personal-income-tax-exemption
+
+- name: Tax unit that illustrates problem described in GitHub issue 1354
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: 1
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 0
+        age: 60
+        employment_income: 40_000
+        qualified_dividend_income: 20_000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+  output:  # expected results from online TAXSIM35 11/01/22 version
+    ma_income_tax: 2_680.00

--- a/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.py
@@ -32,14 +32,12 @@ class ma_part_b_taxable_income_deductions(Variable):
             fica_person * person("is_tax_unit_spouse", period),
         )
         fica = tax_unit.sum(fica_head) + tax_unit.sum(fica_spouse)
-        # (B)(a)(6): Interest and dividends deduction.
-        interest_and_dividends = add(
-            tax_unit, period, ["interest_income", "dividend_income"]
-        )
+        # Bank interest deduction.
+        bank_interest = add(tax_unit, period, ["taxable_interest_income"])
         filing_status = tax_unit("filing_status", period)
-        interest_and_dividends = min_(
+        bank_interest_deduction = min_(
             tax.exemptions.interest[filing_status],
-            interest_and_dividends,
+            bank_interest,
         )
         # (B)(a)(9): Rent deduction.
         rent = add(tax_unit, period, ["rent"])
@@ -52,7 +50,7 @@ class ma_part_b_taxable_income_deductions(Variable):
         charitable_deduction = tax_unit("charitable_deduction", period)
         return (
             fica
-            + interest_and_dividends
+            + bank_interest_deduction
             + rent_deduction
             + charitable_deduction
         )


### PR DESCRIPTION
Fixes #1354.
The first commit adds a test that fails because of the problem highlighted in #1354.
The second commit fixes that problem.