### PR TITLE
Correct the qualified_business_income variable formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+      - Qualified business income to be a personal variable.
+      - Qualified business income to be net of several personal deductions.

--- a/policyengine_us/parameters/gov/irs/ald/deductions.yaml
+++ b/policyengine_us/parameters/gov/irs/ald/deductions.yaml
@@ -11,6 +11,7 @@ values:
     - domestic_production_ald
     - health_savings_account_ald
     - self_employed_health_insurance_ald
+    - self_employed_pension_contribution_ald
     - ira_contributions
     - sep_simple_qualified_plan_contributions
     - qualified_adoption_assistance_expense
@@ -27,6 +28,7 @@ values:
     - qualified_tuition_expenses
     - health_savings_account_ald
     - self_employed_health_insurance_ald
+    - self_employed_pension_contribution_ald
     - ira_contributions
     - sep_simple_qualified_plan_contributions
     - qualified_adoption_assistance_expense
@@ -42,6 +44,7 @@ values:
     - educator_expense
     - health_savings_account_ald
     - self_employed_health_insurance_ald
+    - self_employed_pension_contribution_ald
     - ira_contributions
     - sep_simple_qualified_plan_contributions
     - qualified_adoption_assistance_expense
@@ -57,6 +60,7 @@ values:
     - educator_expense
     - health_savings_account_ald
     - self_employed_health_insurance_ald
+    - self_employed_pension_contribution_ald
     - ira_contributions
     - sep_simple_qualified_plan_contributions
     - qualified_adoption_assistance_expense

--- a/policyengine_us/parameters/gov/irs/deductions/qbi/deduction_definition.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/qbi/deduction_definition.yaml
@@ -1,8 +1,8 @@
 description: Sources of qualified business income deductions.
 values:
   2018-01-01:
-    - self_employment_tax_ald
-    - self_employed_health_insurance_ald
+    - self_employment_tax_ald_person
+    - self_employed_health_insurance_ald_person
 metadata:
   unit: variable
   name: qbi_deduction_definition

--- a/policyengine_us/parameters/gov/irs/deductions/qbi/deduction_definition.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/qbi/deduction_definition.yaml
@@ -1,0 +1,9 @@
+description: Sources of qualified business income deductions.
+values:
+  2018-01-01:
+    - self_employment_tax_ald
+    - self_employed_health_insurance_ald
+metadata:
+  unit: variable
+  name: qbi_deduction_definition
+  label: Qualified business income deductions

--- a/policyengine_us/parameters/gov/irs/deductions/qbi/deduction_definition.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/qbi/deduction_definition.yaml
@@ -3,6 +3,7 @@ values:
   2018-01-01:
     - self_employment_tax_ald_person
     - self_employed_health_insurance_ald_person
+    - self_employed_pension_contribution_ald_person
 metadata:
   unit: variable
   name: qbi_deduction_definition

--- a/policyengine_us/parameters/gov/irs/deductions/qbi/income_definition.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/qbi/income_definition.yaml
@@ -1,4 +1,4 @@
-description: Income sources which count as qualified business income.
+description: Income sources that count as qualified business income.
 values:
   2018-01-01:
     - self_employment_income
@@ -8,4 +8,4 @@ values:
 metadata:
   unit: variable
   name: qbi_income_definition
-  label: Qualified business income definition
+  label: Qualified business income sources

--- a/policyengine_us/tests/policy/baseline/gov/irs/integration/qbid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/integration/qbid.yaml
@@ -1,0 +1,21 @@
+- name: Tax unit illustrating problem highlighted in GitHub issue 903
+  absolute_error_margin: 0.01
+  period: 2019
+  input:
+    people:
+      person1:
+        is_tax_unit_head: 1
+        age: 60
+        self_employment_income: 200_000
+        business_is_qualified: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:  # expected results from TAXSIM35
+    adjusted_gross_income: 189_082.05
+    qualified_business_income: 189_082.05

--- a/policyengine_us/tests/policy/contrib/taxsim/taxsim_v10.yaml
+++ b/policyengine_us/tests/policy/contrib/taxsim/taxsim_v10.yaml
@@ -1307,7 +1307,7 @@
         taxsim_childcare: 0
         taxsim_scorp: 0
   output:
-    taxsim_v10: 252_502
+    taxsim_v10: 252_466.67
 
 
 - name: Tax unit 17 (CPS ID 1325801) matches TAXSIM35 outputs

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_health_insurance_ald.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_health_insurance_ald.py
@@ -12,6 +12,5 @@ class self_employed_health_insurance_ald(Variable):
 
     def formula(tax_unit, period, parameters):
         person = tax_unit.members
-        earnings = max_(0, person("self_employment_income", period))
-        premiums = person("self_employed_health_insurance_premiums", period)
-        return tax_unit.sum(min_(earnings, premiums))
+        ald = person("self_employed_health_insurance_ald_person", period)
+        return tax_unit.sum(ald)

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_health_insurance_ald_person.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_health_insurance_ald_person.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class self_employed_health_insurance_ald_person(Variable):
+    value_type = float
+    entity = Person
+    label = "Self-employed health insurance ALD for each person"
+    unit = USD
+    documentation = "Personal above-the-line deduction for self-employed health insurance contributions."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/162#l"
+
+    def formula(person, period, parameters):
+        earnings = max_(0, person("self_employment_income", period))
+        premiums = person("self_employed_health_insurance_premiums", period)
+        return min_(earnings, premiums)

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_pension_contribution_ald.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_pension_contribution_ald.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class self_employed_pension_contribution_ald(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Self-employed pension contribution ALD"
+    unit = USD
+    documentation = "Above-the-line deduction for self-employed pension plan contributions."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/162#l"
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        ald = person("self_employed_pension_contribution_ald_person", period)
+        return tax_unit.sum(ald)

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_pension_contribution_ald_person.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_pension_contribution_ald_person.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class self_employed_pension_contribution_ald_person(Variable):
+    value_type = float
+    entity = Person
+    label = "Self-employed pension contribution ALD for each person"
+    unit = USD
+    documentation = "Personal above-the-line deduction for self-employed pension plan contributions."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/162#l"
+
+    def formula(person, period, parameters):
+        earnings = max_(0, person("self_employment_income", period))
+        contributions = person("self_employed_pension_contributions", period)
+        return min_(earnings, contributions)

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employment_tax_ald.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employment_tax_ald.py
@@ -12,10 +12,5 @@ class self_employment_tax_ald(Variable):
 
     def formula(tax_unit, period, parameters):
         person = tax_unit.members
-        self_employment_tax = person("self_employment_tax", period)
-        is_dependent = person("is_tax_unit_dependent", period)
-        total_tax = tax_unit.sum(self_employment_tax * ~is_dependent)
-        percent_deductible = parameters(
-            period
-        ).gov.irs.ald.self_employment_tax.percent_deductible
-        return total_tax * percent_deductible
+        ald = person("self_employment_tax_ald_person", period)
+        return tax_unit.sum(ald)

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employment_tax_ald_person.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employment_tax_ald_person.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class self_employment_tax_ald_person(Variable):
+    value_type = float
+    entity = Person
+    label = "Self-employment tax ALD deduction for each person"
+    unit = USD
+    documentation = "Personal above-the-line deduction for self-employment tax"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/164#f"
+
+    def formula(person, period, parameters):
+        self_employment_tax = person("self_employment_tax", period)
+        is_dependent = person("is_tax_unit_dependent", period)
+        total_tax = self_employment_tax * ~is_dependent
+        percent_deductible = parameters(
+            period
+        ).gov.irs.ald.self_employment_tax.percent_deductible
+        return total_tax * percent_deductible

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employment_tax_ald_person.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employment_tax_ald_person.py
@@ -12,9 +12,7 @@ class self_employment_tax_ald_person(Variable):
 
     def formula(person, period, parameters):
         self_employment_tax = person("self_employment_tax", period)
-        is_dependent = person("is_tax_unit_dependent", period)
-        total_tax = self_employment_tax * ~is_dependent
         percent_deductible = parameters(
             period
         ).gov.irs.ald.self_employment_tax.percent_deductible
-        return total_tax * percent_deductible
+        return self_employment_tax * percent_deductible

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
@@ -16,6 +16,6 @@ class qualified_business_income(Variable):
         gross_qbi = add(person, period, income_components)
         deduction_components = p.deduction_definition
         qbi_deductions = add(person, period, deduction_components)
-        adjusted_income = max_(0, gross_qbi - qbi_deductions)
+        adjusted_qbi = max_(0, gross_qbi - qbi_deductions)
         qualified = person("business_is_qualified", period)
-        return adjusted_income * qualified
+        return adjusted_qbi * qualified

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
@@ -5,18 +5,17 @@ class qualified_business_income(Variable):
     value_type = float
     entity = Person
     label = "Qualified business income"
-    documentation = "Income connected with the trade or conduct of a qualified trade or business. A qualified trade or business is any trade or business other than a specified service trade or business, or employment. The list of specified service trades can be found at https://www.law.cornell.edu/uscode/text/26/1202#e_3_A."
+    documentation = "Business income that qualifies for the qualified business income deduction."
     unit = USD
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/uscode/text/26/199A#c"
 
-    def formula(tax_unit, period, parameters):
-        components = parameters(
-            period
-        ).gov.irs.deductions.qbi.max.income_definition
-        total_income = add(tax_unit, period, components)
-        qualified = tax_unit("business_is_qualified", period)
-        return total_income * qualified
-
-    # Note. does not implement https://www.law.cornell.edu/uscode/text/26/199A#d_3, which provides exceptions for where some specified service business income may be
-    # treated as qualified business income depending on taxable income.
+    def formula(person, period, parameters):
+        p = parameters(period).gov.irs.deductions.qbi
+        income_components = p.income_definition
+        gross_qbi = add(person, period, income_components)
+        deduction_components = p.deduction_definition
+        qbi_deductions = add(person, period, deduction_components)
+        adjusted_income = max_(0, gross_qbi - qbi_deductions)
+        qualified = person("business_is_qualified", period)
+        return adjusted_income * qualified

--- a/policyengine_us/variables/household/expense/pensions/self_employed_pension_contributions.py
+++ b/policyengine_us/variables/household/expense/pensions/self_employed_pension_contributions.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class self_employed_pension_contributions(Variable):
+    value_type = float
+    entity = Person
+    label = "Self-employed pension contributions"
+    unit = USD
+    documentation = "Pension plan contributions associated with plans for the self employed."
+    definition_period = YEAR


### PR DESCRIPTION
Fixes #903.

The first commit in this pull request adds a new test that fails.

The subsequent commits revise the `qualified_business_income` variable to be calculated at the person (instead of the tax unit) level, and to reflect several deductions, as discussed in issue #903.  A number of other changes needed to be made in order to accomplish this primary change.  

After these changes the new test passes.

