### PR TITLE
Suppress MO income tax debugging print statement

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - MO income tax debugging print is converted to a comment.

--- a/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_c.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_c.py
@@ -30,7 +30,7 @@ class mo_pension_and_ss_or_ssd_deduction_section_c(Variable):
         taxable_social_security_benefits = person(
             "taxable_social_security", period
         )
-        print(taxable_social_security_benefits, agi_over_ss_or_ssd_allowance)
+        # print(taxable_social_security_benefits, agi_over_ss_or_ssd_allowance)
         return max_(
             taxable_social_security_benefits - agi_over_ss_or_ssd_allowance, 0
         )


### PR DESCRIPTION
Converts what appears to be a stray debugging print statement into a comment.

This change eliminates extraneous output written to the screen whenever the MO income tax calculations are being done.