### PR TITLE
Update PA SNAP net income limit to 200%

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Model PA's increased SNAP gross income limit.

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/gross.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/gross.yaml
@@ -84,6 +84,8 @@ OR:
   2020-07-01: 1.85
 PA:
   2020-07-01: 1.6
+  # https://www.snapscreener.com/blog/pennsylvania-snap-increase
+  2022-10-01: 2
 RI:
   2020-07-01: 1.85
 SC:

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
@@ -60,14 +60,3 @@
         state_code: NY
   output:
     ny_ctc: 100
-
-- name: Simpler calculation if not set to pre-TCJA.
-  period: 2022
-  input:
-    gov.states.ny.tax.income.credits.ctc.pre_tcja: false
-    ctc: 1_000
-    ctc_qualifying_child: true
-    state_code: NY
-    age: 5 # Must be 4+ to be eligible.
-  output:
-    ny_ctc: 330

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
@@ -60,3 +60,14 @@
         state_code: NY
   output:
     ny_ctc: 100
+
+- name: Simpler calculation if not set to pre-TCJA.
+  period: 2022
+  input:
+    gov.states.ny.tax.income.credits.ctc.pre_tcja: false
+    ctc: 1_000
+    ctc_qualifying_child: true
+    state_code: NY
+    age: 5 # Must be 4+ to be eligible.
+  output:
+    ny_ctc: 330


### PR DESCRIPTION
Fixes #1545
