### PR TITLE
Add .coveragerc file to suppress couldnt-parse coverage warnings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+disable_warnings = couldnt-parse

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Printing of annoying coverage warning messages.


### PR DESCRIPTION
Fixes #1621.