### PR TITLE
Update default year to 2023

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Update default year to 2023.

--- a/policyengine_us/data/datasets/cps/income_parameters.yaml
+++ b/policyengine_us/data/datasets/cps/income_parameters.yaml
@@ -5,18 +5,22 @@ taxable_interest_fraction:
   2020: 0.680  # SOI 2020 data
   2021: 0.680  # SOI 2020 data
   2022: 0.680  # SOI 2020 data
+  2023: 0.680  # SOI 2020 data
 
 qualified_dividend_fraction:
   2020: 0.448  # SOI 2018 data
   2021: 0.448  # SOI 2018 data
   2022: 0.448  # SOI 2018 data
+  2023: 0.448  # SOI 2018 data
 
 taxable_pension_fraction:
   2020: 1.000  # no SOI data, so arbitrary assumption
   2021: 1.000  # no SOI data, so arbitrary assumption
   2022: 1.000  # no SOI data, so arbitrary assumption
+  2023: 1.000  # no SOI data, so arbitrary assumption
 
 long_term_capgain_fraction:
   2020: 0.880  # SOI 2012 data
   2021: 0.880  # SOI 2012 data
   2022: 0.880  # SOI 2012 data
+  2023: 0.880  # SOI 2012 data

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -58,10 +58,10 @@ class Microsimulation(CoreMicrosimulation):
     default_tax_benefit_system = CountryTaxBenefitSystem
     default_tax_benefit_system_instance = system
     default_dataset = CPS
-    default_dataset_year = 2022
+    default_dataset_year = 2023
     default_role = "member"
-    default_calculation_period = 2022
-    default_input_period = 2022
+    default_calculation_period = 2023
+    default_input_period = 2023
 
 
 class IndividualSim(CoreIndividualSim):  # Deprecated
@@ -82,6 +82,9 @@ class IndividualSim(CoreIndividualSim):  # Deprecated
         "family",
     ]
 
+
+if 2023 not in CPS.years:
+    CPS.download(2023)
 
 if 2022 not in CPS.years:
     CPS.download(2022)


### PR DESCRIPTION
Fixes #1629

This doesn't update the documentation to 2023 (https://github.com/PolicyEngine/policyengine-us/issues/1634).