### PR TITLE
Add md_cdcc unit tests and simplify md_cdcc formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - More md_cdcc unit tests.

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_cdcc.yaml
@@ -4,7 +4,7 @@
     cdcc: 100
     filing_status: SINGLE
     adjusted_gross_income: 95_901  # $95,900 is the limit.
-    state_code_str: MD
+    state_code: MD
   output:
     md_cdcc: 0
 
@@ -14,7 +14,7 @@
     cdcc: 100
     filing_status: JOINT
     adjusted_gross_income: 149_051  # $149,050 is the limit.
-    state_code_str: MD
+    state_code: MD
   output:
     md_cdcc: 0
   
@@ -24,7 +24,7 @@
     cdcc: 100
     filing_status: SINGLE
     adjusted_gross_income: 0
-    state_code_str: MD
+    state_code: MD
   output:
     md_cdcc: 32
 
@@ -34,7 +34,7 @@
     cdcc: 100
     filing_status: JOINT
     adjusted_gross_income: 0
-    state_code_str: MD
+    state_code: MD
   output:
     md_cdcc: 32
 
@@ -43,8 +43,27 @@
   input:
     cdcc: 100
     filing_status: JOINT
-    adjusted_gross_income: 0
-    state_code_str: MD
+    adjusted_gross_income: 50_000
+    state_code: MD
   output:
     md_cdcc: 32
 
+- name: Single parent with $80,000 income will get 24% of the CDCC
+  period: 2021
+  input:
+    cdcc: 100
+    filing_status: SINGLE
+    adjusted_gross_income: 80_000
+    state_code: MD
+  output:
+    md_cdcc: 24
+
+- name: Joint filer with $125,000 income will get 24% of the CDCC
+  period: 2021
+  input:
+    cdcc: 100
+    filing_status: JOINT
+    adjusted_gross_income: 125_000
+    state_code: MD
+  output:
+    md_cdcc: 24

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
@@ -17,8 +17,7 @@ class md_cdcc(Variable):
         agi = tax_unit("adjusted_gross_income", period)
         p = parameters(period).gov.states.md.tax.income.credits.cdcc
         # Eligibility is based on AGI.
-        in_md = tax_unit.household("state_code_str", period) == "MD"
-        eligible = (agi <= p.eligibility.agi_cap[filing_status]) & in_md
+        eligible = agi <= p.eligibility.agi_cap[filing_status]
         # Maximum is a percent of federal.
         max_cdcc = p.percent * tax_unit("cdcc", period)
         # Phases out based on filing status.


### PR DESCRIPTION
As I was investigating MD income tax differences between PolicyEngineUS and TAXSIM35, I noticed that the unit tests for the `md_cdcc` variable formula could be expanded to include cases in which there was a partial phase-out of the percent applied to the federal CDCC amount.  Also, there was an opportunity for a minor simplification of the `md_cdcc` formula.  So, there are no substantive changes in this pull request, but it does strengthen the test suite.