### PR TITLE
Eliminate double counting in IL income additions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+      - Misnamed variable il_final_taxation_amount renamed il_income_tax.
+      - Boolean logic errors in il_personal_exemption_eligibility_statusil_personal_exemption_eligibility_status formula.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,5 +1,5 @@
 - bump: patch
   changes:
     fixed:
-      - Misnamed variable il_final_taxation_amount renamed il_income_tax.
-      - Boolean logic errors in il_personal_exemption_eligibility_statusil_personal_exemption_eligibility_status formula.
+      - Incorrect IL income additions.
+

--- a/policyengine_us/parameters/gov/states/il/tax/income/base/additions.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/base/additions.yaml
@@ -1,8 +1,6 @@
 description: Illinois Base Income Addition Sources
 values:
   2021-01-01:
-    - tax_exempt_interest_income
-    - dividend_income
     - il_schedule_m_additions
 metadata:
   unit: variable

--- a/policyengine_us/tests/policy/baseline/gov/states/il/income_tax/income/il_base_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/income_tax/income/il_base_income.yaml
@@ -5,7 +5,8 @@
     dividend_income: 2_500
     il_schedule_m_subtractions: 100
   output:
-    il_base_income: 12_400
+    il_base_income: 9_900
+
 - name: $25,000 in AGI, $4,500 in federal tax exempt interest, $1,300 in Schedule M additions, $50 in Schedule M subtractions.
   period: 2021
   input:
@@ -14,7 +15,8 @@
     il_schedule_m_additions: 1_300
     il_schedule_m_subtractions: 50
   output:
-    il_base_income: 30_750
+    il_base_income: 26_250
+
 - name: $5,000 in AGI, $1,300 in social secuirty benefits.
   period: 2021
   input:

--- a/policyengine_us/tests/policy/baseline/gov/states/il/income_tax/taxes/il_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/income_tax/taxes/il_income_tax.yaml
@@ -5,7 +5,7 @@
     il_total_payments_and_refundable_credits: 7123
     state_code: IL
   output:
-    il_final_taxation_amount: 1023498 - 7123
+    il_income_tax: 1023498 - 7123
 - name: "Test #2"
   period: 2021
   input:
@@ -13,4 +13,4 @@
     il_total_payments_and_refundable_credits: 35839
     state_code: IL
   output:
-    il_final_taxation_amount: 2312934 - 35839
+    il_income_tax: 2312934 - 35839

--- a/policyengine_us/variables/gov/states/il/tax/income/exemptions/il_personal_exemption_eligibility_status.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/exemptions/il_personal_exemption_eligibility_status.py
@@ -37,7 +37,7 @@ class il_personal_exemption_eligibility_status(Variable):
         # Criteria for complete ineligibility.
         ineligible = (
             (
-                (not joint)
+                ~joint
                 & (claimable_count > 0)
                 & (il_base_income > tax_unit_personal_eligibility_amount)
             )
@@ -60,9 +60,9 @@ class il_personal_exemption_eligibility_status(Variable):
                 & (claimable_count == 1)
                 & (il_base_income > tax_unit_personal_eligibility_amount)
             )
-            | ((not joint) & (claimable_count == 0))
+            | (~joint & (claimable_count == 0))
             | (
-                (not joint)
+                ~joint
                 & (claimable_count == 1)
                 & (il_base_income < tax_unit_personal_eligibility_amount)
             )

--- a/policyengine_us/variables/gov/states/il/tax/income/il_income_tax.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/il_income_tax.py
@@ -1,10 +1,10 @@
 from policyengine_us.model_api import *
 
 
-class il_final_taxation_amount(Variable):
+class il_income_tax(Variable):
     value_type = float
     entity = TaxUnit
-    label = "Il Final Taxation Amount"
+    label = "Illinois income tax"
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.IL

--- a/policyengine_us/variables/gov/states/il/tax/income/il_total_payments_and_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/il_total_payments_and_refundable_credits.py
@@ -7,7 +7,6 @@ class il_total_payments_and_refundable_credits(Variable):
     label = "Il Total Payments And Refundable Credit"
     unit = USD
     definition_period = YEAR
-
     defined_for = StateCode.IL
 
     adds = [


### PR DESCRIPTION
Fixes #1683.   After making the changes in this PR, many thousands of differences between PolicyEngineUS and TAXSIM35 go away.