### PR TITLE
Add state supplement to household benefits

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Add state supplement to household benefits.

--- a/policyengine_us/variables/household/income/household/household_benefits.py
+++ b/policyengine_us/variables/household/income/household/household_benefits.py
@@ -10,6 +10,7 @@ class household_benefits(Variable):
     adds = [
         "social_security",
         "ssi",
+        "state_supplement",
         "ca_cvrp",  # California Clean Vehicle Rebate Project.
         "snap",
         "wic",


### PR DESCRIPTION
#1723 only added it to SPM unit benefits, so it didn't flow through to net income