### PR TITLE
Revise starting point of pa_total_taxable_income calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Base of PA taxable income from adjusted_gross_income to irs_gross_income.

--- a/policyengine_us/variables/gov/states/pa/tax/income/taxable_income/pa_total_taxable_income.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/taxable_income/pa_total_taxable_income.py
@@ -11,8 +11,8 @@ class pa_total_taxable_income(Variable):
     defined_for = StateCode.PA
 
     def formula(tax_unit, period, parameters):
-        us_agi = add(tax_unit, period, ["adjusted_gross_income"])
+        us_gross_income = add(tax_unit, period, ["irs_gross_income"])
         p = parameters(period).gov.states.pa.tax.income
         sources = p.nontaxable_income_sources
         pa_nontaxable_income = add(tax_unit, period, sources)
-        return us_agi - pa_nontaxable_income
+        return max_(0, us_gross_income - pa_nontaxable_income)


### PR DESCRIPTION
Fixes #1740.   Making these changes eliminates all the PA `x21` sample tax differences reported in issue #993.