### PR TITLE
Add items to MA disallowed US above-the-line deduction (ALD) list

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - alimony_income and self_employment_tax_ald to list of MA disallowed ALDs.

--- a/policyengine_us/parameters/gov/states/ma/tax/income/ald/disallowed.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/ald/disallowed.yaml
@@ -5,6 +5,20 @@ values:
     - ira_contributions # (f)
     - sep_simple_qualified_plan_contributions # (f)
     - early_withdrawal_penalty # (h)
+    - self_employment_tax_ald
+  2018-01-01:
+    - loss_ald # (c)
+    - ira_contributions # (f)
+    - sep_simple_qualified_plan_contributions # (f)
+    - early_withdrawal_penalty # (h)
+    - self_employment_tax_ald
+    - alimony_income  # is a US ALD only in 2018 through 2025
+  2026-01-01:
+    - loss_ald # (c)
+    - ira_contributions # (f)
+    - sep_simple_qualified_plan_contributions # (f)
+    - early_withdrawal_penalty # (h)
+    - self_employment_tax_ald  
 metadata:
   unit: variable
   name: ma_ald_disallowed


### PR DESCRIPTION
Fixes #1739.   There may be a need for more fixes.
These fixes eliminate all (more than 99,000) of the MA `x21` sample tax differences encountered in the TAXSIM35 validation testing described in issue #993.