### PR TITLE
Add several pension income variables

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Incomplete specification of pension income variables.

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/integration_tests/mo_pension_and_ss_or_ssd.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/integration_tests/mo_pension_and_ss_or_ssd.yaml
@@ -12,8 +12,7 @@
         age: 72
         employment_income: 25_000
         is_tax_unit_spouse: true
-        public_pension_income: 10_000
-        taxable_pension_income: 10_000
+        taxable_public_pension_income: 10_000
     tax_units:
       tax_unit:
         premium_tax_credit: 0
@@ -103,7 +102,7 @@
         age: 72
         employment_income: 25_000
         is_tax_unit_spouse: true
-        taxable_pension_income: 10_000
+        taxable_private_pension_income: 10_000
     tax_units:
       tax_unit:
         premium_tax_credit: 0
@@ -128,15 +127,15 @@
         age: 78
         employment_income: 25_000
         is_tax_unit_head: true
-        public_pension_income: 5_000
-        taxable_pension_income: 10_000
+        taxable_public_pension_income: 5_000
+        taxable_private_pension_income: 5_000
         taxable_social_security: 10_000
       person2:
         age: 72
         employment_income: 25_000
         is_tax_unit_spouse: true
-        public_pension_income: 5_000
-        taxable_pension_income: 10_000
+        taxable_public_pension_income: 5_000
+        taxable_private_pension_income: 5_000
         taxable_social_security: 10_000
     tax_units:
       tax_unit:
@@ -161,15 +160,15 @@
         age: 78
         employment_income: 25_000
         is_tax_unit_head: true
-        public_pension_income: 5_000
-        taxable_pension_income: 5_000
+        taxable_public_pension_income: 2_500
+        taxable_private_pension_income: 2_500
         taxable_social_security: 10_000
       person2:
         age: 72
         employment_income: 25_000
         is_tax_unit_spouse: true
-        public_pension_income: 5_000
-        taxable_pension_income: 5_000
+        taxable_public_pension_income: 2_500
+        taxable_private_pension_income: 2_500
         taxable_social_security: 10_000
     tax_units:
       tax_unit:
@@ -195,15 +194,15 @@
         age: 78
         employment_income: 25_000
         is_tax_unit_head: true
-        public_pension_income: 5_000
-        taxable_pension_income: 10_000
+        taxable_public_pension_income: 5_000
+        taxable_private_pension_income: 5_000
         taxable_social_security: 11_000
       person2:
         age: 72
         employment_income: 25_000
         is_tax_unit_spouse: true
-        public_pension_income: 5_000
-        taxable_pension_income: 10_000
+        taxable_public_pension_income: 5_000
+        taxable_private_pension_income: 5_000
         taxable_social_security: 10_000
     tax_units:
       tax_unit:
@@ -229,14 +228,12 @@
         age: 78
         employment_income: 25_000
         is_tax_unit_head: true
-        public_pension_income: 10_000
-        taxable_pension_income: 10_000
+        taxable_public_pension_income: 10_000
       person2:
         age: 72
         employment_income: 25_000
         is_tax_unit_spouse: true
-        public_pension_income: 10_000
-        taxable_pension_income: 10_000
+        taxable_public_pension_income: 10_000
     tax_units:
       tax_unit:
         premium_tax_credit: 0
@@ -261,12 +258,12 @@
         age: 78
         employment_income: 25_000
         is_tax_unit_head: true
-        taxable_pension_income: 10_000        
+        taxable_private_pension_income: 10_000        
       person2:
         age: 72
         employment_income: 25_000
         is_tax_unit_spouse: true
-        taxable_pension_income: 10_000
+        taxable_private_pension_income: 10_000
     tax_units:
       tax_unit:
         premium_tax_credit: 0
@@ -291,14 +288,14 @@
         age: 78
         employment_income: 5_000
         is_tax_unit_head: true
-        taxable_pension_income: 10_000
-        public_pension_income: 5_000
+        taxable_private_pension_income: 5_000
+        taxable_public_pension_income: 5_000
       person2:
         age: 72
         employment_income: 5_000
         is_tax_unit_spouse: true
-        taxable_pension_income: 10_000
-        public_pension_income: 5_000
+        taxable_private_pension_income: 5_000
+        taxable_public_pension_income: 5_000
     tax_units:
       tax_unit:
         premium_tax_credit: 0

--- a/policyengine_us/variables/household/income/person/pensions/private_pension_income.py
+++ b/policyengine_us/variables/household/income/person/pensions/private_pension_income.py
@@ -1,14 +1,15 @@
 from policyengine_us.model_api import *
 
 
-class tax_exempt_pension_income(Variable):
+class private_pension_income(Variable):
     value_type = float
     entity = Person
-    label = "tax-exempt pension income"
+    label = "private pension income"
     unit = USD
+    documentation = "Income from non-government employee pensions."
     definition_period = YEAR
 
     adds = [
-        "tax_exempt_public_pension_income",
         "tax_exempt_private_pension_income",
+        "taxable_private_pension_income",
     ]

--- a/policyengine_us/variables/household/income/person/pensions/public_pension_income.py
+++ b/policyengine_us/variables/household/income/person/pensions/public_pension_income.py
@@ -4,7 +4,12 @@ from policyengine_us.model_api import *
 class public_pension_income(Variable):
     value_type = float
     entity = Person
-    label = "Public pension income"
+    label = "public pension income"
     unit = USD
     documentation = "Income from government employee pensions."
     definition_period = YEAR
+
+    adds = [
+        "tax_exempt_public_pension_income",
+        "taxable_public_pension_income",
+    ]

--- a/policyengine_us/variables/household/income/person/pensions/tax_exempt_private_pension_income.py
+++ b/policyengine_us/variables/household/income/person/pensions/tax_exempt_private_pension_income.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class tax_exempt_private_pension_income(Variable):
+    value_type = float
+    entity = Person
+    label = "tax-exempt private pension income"
+    unit = USD
+    documentation = "Tax-exempt income from non-government employee pensions."
+    definition_period = YEAR

--- a/policyengine_us/variables/household/income/person/pensions/tax_exempt_public_pension_income.py
+++ b/policyengine_us/variables/household/income/person/pensions/tax_exempt_public_pension_income.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class tax_exempt_public_pension_income(Variable):
     value_type = float
     entity = Person
-    label = "Pension income"
+    label = "tax-exempt public pension income"
     unit = USD
     documentation = "Tax-exempt income from government employee pensions."
     definition_period = YEAR

--- a/policyengine_us/variables/household/income/person/pensions/taxable_pension_income.py
+++ b/policyengine_us/variables/household/income/person/pensions/taxable_pension_income.py
@@ -4,6 +4,8 @@ from policyengine_us.model_api import *
 class taxable_pension_income(Variable):
     value_type = float
     entity = Person
-    label = "Taxable pension income"
+    label = "taxable pension income"
     unit = USD
     definition_period = YEAR
+
+    adds = ["taxable_public_pension_income", "taxable_private_pension_income"]

--- a/policyengine_us/variables/household/income/person/pensions/taxable_private_pension_income.py
+++ b/policyengine_us/variables/household/income/person/pensions/taxable_private_pension_income.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class taxable_private_pension_income(Variable):
+    value_type = float
+    entity = Person
+    label = "taxable private pension income"
+    unit = USD
+    documentation = "Taxable income from non-government employee pensions."
+    definition_period = YEAR

--- a/policyengine_us/variables/household/income/person/pensions/taxable_public_pension_income.py
+++ b/policyengine_us/variables/household/income/person/pensions/taxable_public_pension_income.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class taxable_public_pension_income(Variable):
+    value_type = float
+    entity = Person
+    label = "taxable public pension income"
+    unit = USD
+    documentation = "Taxable income from government employee pensions."
+    definition_period = YEAR


### PR DESCRIPTION
Fixes #1676.
Also, uses newly added pension variables to clarify the input in several MO tests.