### PR TITLE
Removed "uncapped" from OR refundable credits

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - removed "uncapped" from OR refundable credits description

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
     fixed:
     - removed "uncapped" from OR refundable credits description

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - removed "uncapped" from OR refundable credits description
+    - Removed "uncapped" from OR refundable credits description.

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/or_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/or_refundable_credits.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class or_refundable_credits(Variable):
     value_type = float
     entity = TaxUnit
-    label = "OR uncapped refundable tax credits"
+    label = "OR refundable tax credits"
     unit = USD
     definition_period = YEAR
 

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/or_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/or_refundable_credits.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class or_refundable_credits(Variable):
     value_type = float
     entity = TaxUnit
-    label = "OR refundable tax credits"
+    label = "Oregon refundable tax credits"
     unit = USD
     definition_period = YEAR
 


### PR DESCRIPTION
OR refundable credits description
Fixes #1782

Thanks for contributing! Please remove any top-level sections that do not apply to your changes.

- [ ] `make format && make documentation` has been run.

# New variable

- [ ] Label field added
- [ ] Documentation field added
- [ ] Unit field added
- [ ] Default value field added if relevant
- [ ] Variable name follows conventions
- [ ] Unit test(s) added
- [ ] Integration test(s) added if relevant
- [ ] Issues this PR fixes linked

## What's changed

Description of the changes here.

# Bug fix

- [ ] Regression test added
- [ ] Regression test passing

## What this fixes and how it's fixed

Description of how this fix works goes here. Link any issues this PR fixes.
