### PR TITLE
Add IL to the state income tax list

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+      - Incomplete list of state income tax variables by adding IL.
+

--- a/policyengine_us/modelled_policies.yaml
+++ b/policyengine_us/modelled_policies.yaml
@@ -25,6 +25,11 @@ filtered:
       - Maryland State income tax
       not_modelled:
       - Maryland TANF
+    MO:
+      modelled:
+      - Missouri State income tax
+      not_modelled:
+      - Missouri TANF
     NY:
       modelled:
       - New York State income tax

--- a/policyengine_us/modelled_policies.yaml
+++ b/policyengine_us/modelled_policies.yaml
@@ -11,6 +11,10 @@ core:
     - WIC
 filtered:
   state_name:
+    IL:
+      modelled:
+      - Illinois State income tax
+      - Illinois TANF
     MA:
       modelled:
       - Massachusetts State income tax

--- a/policyengine_us/variables/gov/states/tax/income/state_income_tax.py
+++ b/policyengine_us/variables/gov/states/tax/income/state_income_tax.py
@@ -8,12 +8,15 @@ class state_income_tax(Variable):
     unit = USD
     definition_period = YEAR
     adds = [
+        # state income tax variables listed in alphabetical order:
+        "il_income_tax",
         "ma_income_tax",
-        "wa_income_tax",
         "md_income_tax",
+        # "mo_income_tax",  --- activating will cause circular logic errors
         "ny_income_tax",
-        "pa_income_tax",
         "or_income_tax",
+        "pa_income_tax",
+        "wa_income_tax",
     ]
 
     def formula(tax_unit, period, parameters):


### PR DESCRIPTION
Thanks to the development effort of @yvvijay121, the Illinois income tax has been working for some time.  But the `il_income_tax` variable has never been added to the list of working state income taxes in the `state_income_tax` variable formula.  This pull request adds the `il_income_tax` variable to that list and alphabetizes the list.  This addition causes no test changes.
