### PR TITLE
Fix CalEITC branching bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Bug causing incorrect CalEITC amounts when not computed first.

--- a/policyengine_us/variables/gov/states/ca/tax/income/credits/earned_income/ca_eitc.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/credits/earned_income/ca_eitc.py
@@ -13,10 +13,12 @@ def get_ca_eitc_branch(tax_unit, period, parameters):
         VARIABLES_TO_CLEAR = [
             "eitc_eligible",
             "eitc_phase_in_rate",
+            "eitc_phase_out_start",
             "eitc_phase_out_rate",
             "eitc_maximum",
             "eitc_phased_in",
             "eitc_reduction",
+            "earned_income_tax_credit",
         ]
 
         for variable in VARIABLES_TO_CLEAR:


### PR DESCRIPTION
Caused by not clearing *all* the EITC variables in the branch.