### PR TITLE
Lower SSI asset limit pass rate to 8.8%

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes: 
+    fixed:
+      - Lowered SSI asset limit pass rate to 8.8%.

--- a/policyengine_us/parameters/gov/ssa/ssi/eligibility/resources/README.md
+++ b/policyengine_us/parameters/gov/ssa/ssi/eligibility/resources/README.md
@@ -1,0 +1,10 @@
+# Resources
+
+[SSA reported $5.293 billion in SSI expenditures in February 2023](https://www.ssa.gov/policy/docs/quickfacts/stat_snapshot/#table3).
+Adjust `pass_rate.yaml` to match this for SSI in 2023 ($5.293 billion * 12 = $63.5 billion).
+
+Check with this code:
+```python
+from policyengine_us import Microsimulation
+Microsimulation().calc("ssi", map_to="person", period=2023).sum() / 1e9
+```

--- a/policyengine_us/parameters/gov/ssa/ssi/eligibility/resources/pass_rate.yaml
+++ b/policyengine_us/parameters/gov/ssa/ssi/eligibility/resources/pass_rate.yaml
@@ -1,3 +1,3 @@
 description: Proportion of SSI-aged-blind-disabled recipients who meet the asset test.
 values:
-  0000-01-01: 0.45
+  0000-01-01: 0.088


### PR DESCRIPTION
Fixes #2036 - there was far too much SSI before