### PR TITLE
Add legal code reference for Nebraska Social Security subtraction

### DIFF
--- a/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/social_security/fraction.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/social_security/fraction.yaml
@@ -8,7 +8,7 @@ metadata:
   unit: /1
   period: year
   reference:
-  - title: 2021 NE income tax form and instruction booklet
+  - title: 316 Nebraska Administrative Code | Chapter 22 | §002
     href: https://revenue.nebraska.gov/files/doc/tax-forms/2021/f_1040n_booklet.pdf
-  - title: 2022 NE income tax form and instruction booklet
+  - title: 316 Nebraska Administrative Code | Chapter 22 | §002
     href: https://revenue.nebraska.gov/files/doc/2022_Ne_Individual_Income_Tax_Booklet_8-307-2022_final_5.pdf


### PR DESCRIPTION
Reference Update

## What's changed

The reference has been changed

## What this fixes and how it's fixed

The reference has been updated to show more details about where the legal codes belong. 
