### PR TITLE
Fix README.md display on PyPI

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,5 +1,5 @@
 - bump: patch
   changes:
     changed:
-    - DOC,BLD: setup.py: set `long_description_content_type='text/markdown'` for pypi
+    - Fixed README.md display on PyPI.
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - DOC,BLD: setup.py: set `long_description_content_type='text/markdown'` for pypi
+

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author="PolicyEngine",
     author_email="hello@policyengine.org",
     long_description=readme,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author="PolicyEngine",
     author_email="hello@policyengine.org",
     long_description=readme,
+    long_description_content_type='text/markdown',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",


### PR DESCRIPTION
## What this fixes and how it's fixed

- The README.md render on PyPI: https://pypi.org/project/policyengine-us/
- https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata
- https://github.com/pypa/readme_renderer/blob/main/readme_renderer/__main__.py