### PR TITLE
NJ TANF Initial Maximum Allowable Income Levels

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-    - Add New Jersey TANF maximum allowable income
+    - New Jersey TANF maximum allowable income.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Add New Jersey TANF maximum allowable income

--- a/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
@@ -1,0 +1,12 @@
+description: New Jersey limits its TANF program to households with up to this income level for people beyond size.
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: New Nersey TANF monthly income limit per additional person
+  reference:
+    - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits
+      href: https://casetext.com/regulation/new-jersey-administrative-code/title-10-human-services/chapter-90-work-first-new-jersey-program/subchapter-3-financial-eligibility-income-resources-benefits/section-1090-33-wfnjtanf-initial-allowable-maximum-income-and-maximum-benefit-payment-levels-schedules-i-and-ii
+
+values:
+  2023-01-01: 75

--- a/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
@@ -3,7 +3,7 @@ description: New Jersey limits its TANF program to households with up to this in
 metadata:
   unit: currency-USD
   period: month
-  label: New Nersey TANF monthly income limit per additional person
+  label: New Jersey TANF monthly income limit per additional person
   reference:
     - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits
       href: https://casetext.com/regulation/new-jersey-administrative-code/title-10-human-services/chapter-90-work-first-new-jersey-program/subchapter-3-financial-eligibility-income-resources-benefits/section-1090-33-wfnjtanf-initial-allowable-maximum-income-and-maximum-benefit-payment-levels-schedules-i-and-ii

--- a/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/main.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/main.yaml
@@ -1,0 +1,28 @@
+description: New Jersey limits its TANF program to households with up to this income level, by household size.
+
+metadata:
+  unit: currency-USD
+  period: month
+  breakdown:
+    - range(1, 9)
+  label: New Jersey TANF monthly maximum allowable income
+  reference:
+    - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits
+      href: https://casetext.com/regulation/new-jersey-administrative-code/title-10-human-services/chapter-90-work-first-new-jersey-program/subchapter-3-financial-eligibility-income-resources-benefits/section-1090-33-wfnjtanf-initial-allowable-maximum-income-and-maximum-benefit-payment-levels-schedules-i-and-ii
+
+1: 
+  2023-01-01: 243
+2: 
+  2023-01-01: 483
+3: 
+  2023-01-01: 636
+4: 
+  2023-01-01: 732
+5: 
+  2023-01-01: 828
+6: 
+  2023-01-01: 924
+7:
+  2023-01-01: 1_015
+8:
+  2023-01-01: 1_092

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/tanf/nj_tanf_maximum_allowable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/tanf/nj_tanf_maximum_allowable_income.yaml
@@ -1,0 +1,23 @@
+- name: If no children and one adult, New Jersey TANF maximum allowable income is $243/mo.
+  period: 2023
+  input:
+    state_code: NJ
+    spm_unit_size: 1
+  output:
+    nj_tanf_maximum_allowable_income: 243 * 12
+
+- name: If not eligible, we don't calculate it.
+  period: 2023
+  input:
+    state_code: CO
+    spm_unit_size: 1
+  output:
+    nj_tanf_maximum_allowable_income: 0
+
+- name: If 10 people, maximum allowable income is $1092 + 2 * $75 = $1242 per month.
+  period: 2023
+  input:
+    state_code: NJ
+    spm_unit_size: 10
+  output:
+    nj_tanf_maximum_allowable_income: 1242 * 12

--- a/policyengine_us/variables/gov/states/nj/njdhs/tanf/nj_tanf_maximum_allowable_income.py
+++ b/policyengine_us/variables/gov/states/nj/njdhs/tanf/nj_tanf_maximum_allowable_income.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class nj_tanf_maximum_allowable_income(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "New Jersey TANF maximum allowable income"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.NJ
+
+    def formula(spm_unit, period, parameters):
+        # Get number of people in SPM unit.
+        people = spm_unit("spm_unit_size", period)
+        # Cap them at the maximum specified in the tables.
+        capped_people = min_(people, 8).astype(int)
+        # Calculate additional people beyond the maximum in tables.
+        additional_people = people - capped_people
+        # Get the relevant part of the parameter tree.
+        p = parameters(
+            period
+        ).gov.states.nj.njdhs.tanf.maximum_allowable_income
+        # Look up the main maximum allowable income for the number of (capped) people.
+        base = p.main[capped_people]
+        # Add the additional maximum allowable income for the additional people.
+        additional_maximum_allowable_income = p.additional * additional_people
+        monthly = base + additional_maximum_allowable_income
+        # Return annual value.
+        return monthly * MONTHS_IN_YEAR


### PR DESCRIPTION
Fixes #2143

Co-authored-by: VioletChen0916 <VioletChen0916@users.noreply.github.com>

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 15008b6</samp>

### Summary
📝📄🆕

<!--
1.  📝 - This emoji represents the change to the changelog entry, which is a documentation update.
2. 📄 - This emoji represents the addition of the two YAML files, which are new data sources for the parameters.
3. 🆕 - This emoji represents the addition of the new Python file, which is a new feature for the New Jersey TANF maximum allowable income variable.
-->
This pull request adds a new variable and parameters for the New Jersey TANF maximum allowable income, which determines the eligibility for cash assistance. It creates two YAML files for the parameter values and metadata, and one Python file for the variable formula and metadata. It also updates the changelog entry to reflect the new feature.

> _`nj_tanf_income`_
> _New parameter and variable_
> _Autumn of welfare_

### Walkthrough
*  Add a new variable for the New Jersey TANF maximum allowable income ([link](https://github.com/PolicyEngine/policyengine-us/pull/2160/files?diff=unified&w=0#diff-dd754a7f2b8f6d47b64c618ac0948f829ff1aed2145a848d262e40266eb62e7fR1-R29))
* Add two new parameters for the New Jersey TANF maximum allowable income ([link](https://github.com/PolicyEngine/policyengine-us/pull/2160/files?diff=unified&w=0#diff-832e77ca7e39f09ef2681b40aec0a5bf746d59cb9a1d52b146be756cb2ccb0c5R1-R12), [link](https://github.com/PolicyEngine/policyengine-us/pull/2160/files?diff=unified&w=0#diff-6146995ea7521e9270eb9e39c1e6d663e07119ac0f4e77dcf96097af558a1582R1-R28))
* Update the changelog entry to reflect the new feature ([link](https://github.com/PolicyEngine/policyengine-us/pull/2160/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


