### PR TITLE
Fix NYC CDCC age restriction unit

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Change NYC CDCC age restriction unit from currency to year.

--- a/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/cdcc/child_age_restriction.yaml
+++ b/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/cdcc/child_age_restriction.yaml
@@ -1,6 +1,6 @@
 description: Expenses on children under this age qualify for CDCC.
 metadata:
-  unit: currency-USD
+  unit: year
   label: NYC CDCC Child Age Limit
   reference:
     - title: Instructions for Form IT-216

--- a/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/cdcc/child_age_restriction.yaml
+++ b/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/cdcc/child_age_restriction.yaml
@@ -1,7 +1,7 @@
 description: Expenses on children under this age qualify for the NYC CDCC.
 metadata:
   unit: year
-  label: NYC CDCC Child Age Limit
+  label: NYC CDCC child age limit
   reference:
     - title: Instructions for Form IT-216
       href: https://www.tax.ny.gov/pdf/current_forms/it/it216i.pdf

--- a/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/cdcc/child_age_restriction.yaml
+++ b/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/cdcc/child_age_restriction.yaml
@@ -1,4 +1,4 @@
-description: Expenses on children under this age qualify for CDCC.
+description: Expenses on children under this age qualify for the NYC CDCC.
 metadata:
   unit: year
   label: NYC CDCC Child Age Limit


### PR DESCRIPTION
Fixes #2182

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d7bf57c</samp>

### Summary
🐛📝🧹

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the parameter unit.
2.  📝 - This emoji represents a documentation update, which is the purpose of the change to the changelog entry.
3.  🧹 - This emoji represents a code cleanup or improvement, which is the effect of the change to the parameter metadata.
-->
This pull request fixes a bug and improves clarity in the `NYC CDCC child age restriction` parameter. It changes the unit of the parameter from `currency-USD` to `year` in the file `child_age_restriction.yaml` and adds a changelog entry in `changelog_entry.yaml`.

> _`NYC CDCC` bug_
> _Fixed by changing parameter_
> _Winter of errors_

### Walkthrough
* Fix bug and improve clarity of NYC CDCC child age restriction parameter ([link](https://github.com/PolicyEngine/policyengine-us/pull/2183/files?diff=unified&w=0#diff-d28c7e9bef40ff690e7bd9821a0b34dd5222e3640defd4a68564a139b9d173b1L3-R3), [link](https://github.com/PolicyEngine/policyengine-us/pull/2183/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


