### PR TITLE
Bug fixes

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: minor
+  changes:
+    added:
+    - Self-employment tax abolition switch.
+    fixed:
+    - Some OK households had NaN net income.

--- a/policyengine_us/parameters/gov/contrib/ubi_center/flat_tax/abolish_self_emp_tax.yaml
+++ b/policyengine_us/parameters/gov/contrib/ubi_center/flat_tax/abolish_self_emp_tax.yaml
@@ -1,0 +1,6 @@
+description: Abolish self-employment tax liabilities.
+values:
+  2000-01-01: false
+metadata:
+  unit: bool
+  label: Abolish self-employment tax

--- a/policyengine_us/tests/microsimulation/test_microsim.py
+++ b/policyengine_us/tests/microsimulation/test_microsim.py
@@ -2,4 +2,5 @@ def test_microsim_runs_cps():
     from policyengine_us import Microsimulation
 
     sim = Microsimulation()
-    sim.calc("spm_unit_net_income")
+    hnet = sim.calc("household_net_income")
+    assert not hnet.isna().any(), "Some households have NaN net income."

--- a/policyengine_us/variables/gov/irs/tax/self_employment/self_employment_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/self_employment/self_employment_tax.py
@@ -7,7 +7,12 @@ class self_employment_tax(Variable):
     label = "self-employment tax"
     definition_period = YEAR
     unit = USD
-    adds = [
-        "self_employment_social_security_tax",
-        "self_employment_medicare_tax",
-    ]
+
+    def formula(person, period, parameters):
+        if parameters(
+            period
+        ).gov.contrib.ubi_center.flat_tax.abolish_self_emp_tax:
+            return 0
+        return person("self_employment_social_security_tax", period) + person(
+            "self_employment_medicare_tax", period
+        )

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
@@ -26,6 +26,6 @@ class ok_child_care_child_tax_credit(Variable):
         ok_ctc = us_ctc * p.child.ctc_fraction
         # determine prorated fraction
         ok_agi = tax_unit("ok_agi", period)
-        prorate = min_(1, max_(0, ok_agi / us_agi))
+        prorate = min_(1, max_(0, where(us_agi != 0, ok_agi / us_agi, 0)))
         # receive greater of OK cdcc or OK ctc amounts prorated if AGI eligible
         return agi_eligible * prorate * max_(ok_cdcc, ok_ctc)

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_eitc.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_eitc.py
@@ -16,7 +16,7 @@ class ok_eitc(Variable):
     def formula(tax_unit, period, parameters):
         us_agi = tax_unit("adjusted_gross_income", period)
         ok_agi = tax_unit("ok_agi", period)
-        prorate = min_(1, max_(0, ok_agi / us_agi))
+        prorate = min_(1, max_(0, where(us_agi != 0, ok_agi / us_agi, 0)))
         us_eitc = tax_unit("earned_income_tax_credit", period)
         p = parameters(period).gov.states.ok.tax.income.credits.earned_income
         return prorate * p.eitc_fraction * us_eitc


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 086ebea</samp>

### Summary
🆕🐛🧮

<!--
1.  🆕 for adding a new parameter
2.  🐛 for fixing a bug
3.  🧮 for modifying a formula
-->
This pull request adds a new parameter to enable abolishing self-employment tax and fixes two bugs that caused errors in Oklahoma tax credits. The parameter is defined in `abolish_self_emp_tax.yaml` and used in `self_employment_tax.py`. The bugs are fixed in `ok_child_care_child_tax_credit.py` and `ok_eitc.py`.

> _`Abolish_se_tax`_
> _A new switch for the model_
> _Fall brings fewer bugs_

### Walkthrough
*  Add a new parameter to allow abolishing self-employment tax ([link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-c17213e718162a345664c7232f6a5b059ed6cb8841b3419d0d9c26b1d3e7dc8aR1-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-25e59e9432b4388fecf6bff758a4592a5e0a03b4cf421a6ff3da3d112ddfb86dL10-R18))
   - Create a new parameter file `abolish_self_emp_tax.yaml` with a description and a default value of false ([link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-c17213e718162a345664c7232f6a5b059ed6cb8841b3419d0d9c26b1d3e7dc8aR1-R6))
   - Modify the formula for `self_employment_tax` to return zero if the parameter is true, and otherwise add the self-employment social security tax and the self-employment medicare tax ([link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-25e59e9432b4388fecf6bff758a4592a5e0a03b4cf421a6ff3da3d112ddfb86dL10-R18))
* Fix a bug that caused some Oklahoma households to have NaN net income ([link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-e43600e4138d3eca0afa5a0a6ee2a198c2a21b86336ff1d2874904e8f3aa1ccaL29-R29), [link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-6cee2b365a2ab5c4f5216f4ecef3af4ffce949c3eefebadd0d066b64d0fa5b24L19-R19))
   - Add a where clause to handle the case of zero US adjusted gross income in the formulas for `ok_child_care_child_tax_credit` and `ok_eitc`, and set the prorate fraction to zero in that case ([link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-e43600e4138d3eca0afa5a0a6ee2a198c2a21b86336ff1d2874904e8f3aa1ccaL29-R29), [link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-6cee2b365a2ab5c4f5216f4ecef3af4ffce949c3eefebadd0d066b64d0fa5b24L19-R19))
* Update the changelog entry for the pull request ([link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R6))
   - Indicate the new parameter and the bug fix in the changelog entry file `changelog_entry.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2185/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R6))


