### PR TITLE
Reorganise local area variables

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Reorganised local level area variables.

--- a/policyengine_us/variables/input/county_fips.py
+++ b/policyengine_us/variables/input/county_fips.py
@@ -1,8 +1,0 @@
-from policyengine_us.model_api import *
-
-
-class county_fips(Variable):
-    value_type = int
-    entity = Household
-    definition_period = YEAR
-    documentation = "County FIPS code"

--- a/policyengine_us/variables/input/geography.py
+++ b/policyengine_us/variables/input/geography.py
@@ -142,3 +142,18 @@ class reported_slspc(Variable):
     unit = USD
     definition_period = YEAR
     hidden_input = True
+
+
+class county_fips(Variable):
+    value_type = int
+    entity = Household
+    definition_period = YEAR
+    documentation = "County FIPS code"
+
+
+class state_fips(Variable):
+    value_type = int
+    entity = Household
+    definition_period = YEAR
+    documentation = "State FIPS code"
+    default_value = 6

--- a/policyengine_us/variables/input/state_fips.py
+++ b/policyengine_us/variables/input/state_fips.py
@@ -1,9 +1,0 @@
-from policyengine_us.model_api import *
-
-
-class state_fips(Variable):
-    value_type = int
-    entity = Household
-    definition_period = YEAR
-    documentation = "State FIPS code"
-    default_value = 6


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9a8b8eb</samp>

### Summary
📝🆕🗺️

<!--
1.  📝 - This emoji can be used to represent the change to the changelog entry, as it suggests writing or documentation.
2.  🆕 - This emoji can be used to represent the addition of new input variables to the model, as it suggests something new or novel.
3.  🗺️ - This emoji can be used to represent the use of FIPS codes for geographic areas, as it suggests maps or location.
-->
This pull request adds `county_fips` and `state_fips` input variables to the policy engine US model, which allow linking households to local policies and data based on geographic codes. It also removes redundant files and updates the changelog entry.

> _`FIPS` codes added_
> _Linking households to data_
> _Winter census near_

### Walkthrough
*  Add input variables for county and state FIPS codes ([link](https://github.com/PolicyEngine/policyengine-us/pull/2201/files?diff=unified&w=0#diff-44e6d0bd87f375a8cb975d1d1da15f08f70aff92767e089bc90cd05e1aff6e1bR145-R159))
* Delete redundant input files for county and state FIPS codes ([link](https://github.com/PolicyEngine/policyengine-us/pull/2201/files?diff=unified&w=0#diff-591074603c95786d6300db0227178df9d860ccb2aa7029ddacdbf9244d1b4db9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2201/files?diff=unified&w=0#diff-0a5dfb6b03db8f5d76f55530adf71fdcff4f2f3ac288963c1eca93895f258c16))
* Update changelog entry for the pull request ([link](https://github.com/PolicyEngine/policyengine-us/pull/2201/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


