### PR TITLE
New Jersey TANF Maximum Allowable Income

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - New Jersey TANF maximum allowable income.

--- a/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
@@ -5,8 +5,10 @@ metadata:
   period: month
   label: New Jersey TANF monthly income limit per additional person
   reference:
-    - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits
-      href: https://casetext.com/regulation/new-jersey-administrative-code/title-10-human-services/chapter-90-work-first-new-jersey-program/subchapter-3-financial-eligibility-income-resources-benefits/section-1090-33-wfnjtanf-initial-allowable-maximum-income-and-maximum-benefit-payment-levels-schedules-i-and-ii
+    - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits | § 10:90-3.3 WFNJ/TANF-initial allowable maximum income and maximum benefit payment levels (Schedules I and II)
+      href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=977adb3e-e3a6-4eba-8d54-e69ee35f7dcd&nodeid=AAOAERAAEAAD&nodepath=%2FROOT%2FAAO%2FAAOAER%2FAAOAERAAE%2FAAOAERAAEAAD&level=4&haschildren=&populated=false&title=%C2%A7+10%3A90-3.3+WFNJ%2FTANF-initial+allowable+maximum+income+and+maximum+benefit+payment+levels+(Schedules+I+and+II)&config=00JAA1YTg5OGJlYi04MTI4LTRlNjQtYTc4Yi03NTQxN2E5NmE0ZjQKAFBvZENhdGFsb2ftaXPxZTR7bRPtX1Jok9kz&pddocfullpath=%2Fshared%2Fdocument%2Fadministrative-codes%2Furn%3AcontentItem%3A5XKV-PWD1-JTGH-B3FM-00008-00&ecomp=8gf5kkk&prid=039b2ed1-6268-497c-a43f-3e4c508cdc00
+    - title: New Jersey State Plan for TANF(2021-2023)
+      href: https://www.nj.gov/humanservices/dfd/programs/workfirstnj/tanf_2021_23_st_plan.pdf#page=63
 
 values:
-  2023-01-01: 75
+  2023-01-01: 99

--- a/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/additional.yaml
@@ -5,6 +5,7 @@ metadata:
   period: month
   label: New Jersey TANF monthly income limit per additional person
   reference:
+    # Legal code provides 2003 law; state plan provides updated values.
     - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits | § 10:90-3.3 WFNJ/TANF-initial allowable maximum income and maximum benefit payment levels (Schedules I and II)
       href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=977adb3e-e3a6-4eba-8d54-e69ee35f7dcd&nodeid=AAOAERAAEAAD&nodepath=%2FROOT%2FAAO%2FAAOAER%2FAAOAERAAE%2FAAOAERAAEAAD&level=4&haschildren=&populated=false&title=%C2%A7+10%3A90-3.3+WFNJ%2FTANF-initial+allowable+maximum+income+and+maximum+benefit+payment+levels+(Schedules+I+and+II)&config=00JAA1YTg5OGJlYi04MTI4LTRlNjQtYTc4Yi03NTQxN2E5NmE0ZjQKAFBvZENhdGFsb2ftaXPxZTR7bRPtX1Jok9kz&pddocfullpath=%2Fshared%2Fdocument%2Fadministrative-codes%2Furn%3AcontentItem%3A5XKV-PWD1-JTGH-B3FM-00008-00&ecomp=8gf5kkk&prid=039b2ed1-6268-497c-a43f-3e4c508cdc00
     - title: New Jersey State Plan for TANF(2021-2023)

--- a/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/main.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/main.yaml
@@ -7,22 +7,24 @@ metadata:
     - range(1, 9)
   label: New Jersey TANF monthly maximum allowable income
   reference:
-    - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits
-      href: https://casetext.com/regulation/new-jersey-administrative-code/title-10-human-services/chapter-90-work-first-new-jersey-program/subchapter-3-financial-eligibility-income-resources-benefits/section-1090-33-wfnjtanf-initial-allowable-maximum-income-and-maximum-benefit-payment-levels-schedules-i-and-ii
+    - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits | § 10:90-3.3 WFNJ/TANF-initial allowable maximum income and maximum benefit payment levels (Schedules I and II)
+      href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=977adb3e-e3a6-4eba-8d54-e69ee35f7dcd&nodeid=AAOAERAAEAAD&nodepath=%2FROOT%2FAAO%2FAAOAER%2FAAOAERAAE%2FAAOAERAAEAAD&level=4&haschildren=&populated=false&title=%C2%A7+10%3A90-3.3+WFNJ%2FTANF-initial+allowable+maximum+income+and+maximum+benefit+payment+levels+(Schedules+I+and+II)&config=00JAA1YTg5OGJlYi04MTI4LTRlNjQtYTc4Yi03NTQxN2E5NmE0ZjQKAFBvZENhdGFsb2ftaXPxZTR7bRPtX1Jok9kz&pddocfullpath=%2Fshared%2Fdocument%2Fadministrative-codes%2Furn%3AcontentItem%3A5XKV-PWD1-JTGH-B3FM-00008-00&ecomp=8gf5kkk&prid=039b2ed1-6268-497c-a43f-3e4c508cdc00
+    - title: New Jersey State Plan for TANF(2021-2023)
+      href: https://www.nj.gov/humanservices/dfd/programs/workfirstnj/tanf_2021_23_st_plan.pdf#page=63
 
 1: 
-  2023-01-01: 243
+  2023-01-01: 321
 2: 
-  2023-01-01: 483
+  2023-01-01: 638
 3: 
-  2023-01-01: 636
+  2023-01-01: 839
 4: 
-  2023-01-01: 732
+  2023-01-01: 966
 5: 
-  2023-01-01: 828
-6: 
-  2023-01-01: 924
-7:
-  2023-01-01: 1_015
-8:
   2023-01-01: 1_092
+6: 
+  2023-01-01: 1_221
+7:
+  2023-01-01: 1_341
+8:
+  2023-01-01: 1_442

--- a/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/main.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/tanf/maximum_allowable_income/main.yaml
@@ -7,6 +7,7 @@ metadata:
     - range(1, 9)
   label: New Jersey TANF monthly maximum allowable income
   reference:
+    # Legal code provides 2003 law; state plan provides updated values.
     - title: New Jersey Administration State Code | Work First New Jersey Program | Financial Eligibility, Income, Resources, Benefits | § 10:90-3.3 WFNJ/TANF-initial allowable maximum income and maximum benefit payment levels (Schedules I and II)
       href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=977adb3e-e3a6-4eba-8d54-e69ee35f7dcd&nodeid=AAOAERAAEAAD&nodepath=%2FROOT%2FAAO%2FAAOAER%2FAAOAERAAE%2FAAOAERAAEAAD&level=4&haschildren=&populated=false&title=%C2%A7+10%3A90-3.3+WFNJ%2FTANF-initial+allowable+maximum+income+and+maximum+benefit+payment+levels+(Schedules+I+and+II)&config=00JAA1YTg5OGJlYi04MTI4LTRlNjQtYTc4Yi03NTQxN2E5NmE0ZjQKAFBvZENhdGFsb2ftaXPxZTR7bRPtX1Jok9kz&pddocfullpath=%2Fshared%2Fdocument%2Fadministrative-codes%2Furn%3AcontentItem%3A5XKV-PWD1-JTGH-B3FM-00008-00&ecomp=8gf5kkk&prid=039b2ed1-6268-497c-a43f-3e4c508cdc00
     - title: New Jersey State Plan for TANF(2021-2023)

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/tanf/nj_tanf_maximum_allowable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/tanf/nj_tanf_maximum_allowable_income.yaml
@@ -1,10 +1,10 @@
-- name: If no children and one adult, New Jersey TANF maximum allowable income is $243/mo.
+- name: If no children and one adult, New Jersey TANF maximum allowable income is $321/mo.
   period: 2023
   input:
     state_code: NJ
     spm_unit_size: 1
   output:
-    nj_tanf_maximum_allowable_income: 243 * 12
+    nj_tanf_maximum_allowable_income: 321 * 12
 
 - name: If not eligible, we don't calculate it.
   period: 2023
@@ -14,10 +14,10 @@
   output:
     nj_tanf_maximum_allowable_income: 0
 
-- name: If 10 people, maximum allowable income is $1092 + 2 * $75 = $1242 per month.
+- name: If 10 people, maximum allowable income is $1442 + 2 * $99 = $1640 per month.
   period: 2023
   input:
     state_code: NJ
     spm_unit_size: 10
   output:
-    nj_tanf_maximum_allowable_income: 1242 * 12
+    nj_tanf_maximum_allowable_income: 1_640 * 12


### PR DESCRIPTION
Fixes #2202

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8b32256</samp>

### Summary
📝📈📈

<!--
1.  📝 - This emoji represents the change to the changelog entry, which is a documentation update.
2. 📈 - This emoji represents the change to the monthly income limit per additional person parameter, which is an increase in a numeric value.
3. 📈 - This emoji also represents the change to the monthly maximum allowable income parameter, which is another increase in a numeric value.
-->
This pull request fixes the New Jersey TANF income parameters in `policyengine_us`, based on the latest state sources. It updates the values and references for the `maximum_allowable_income` parameter and its subparameters in `main.yaml` and `additional.yaml`, and adds a changelog entry for the minor version bump.

> _`TANF` income grows_
> _New Jersey updates values_
> _Winter of relief_

### Walkthrough
*  Increase the New Jersey TANF monthly income limits and update the references for the parameters ([link](https://github.com/PolicyEngine/policyengine-us/pull/2203/files?diff=unified&w=0#diff-832e77ca7e39f09ef2681b40aec0a5bf746d59cb9a1d52b146be756cb2ccb0c5L8-R14), [link](https://github.com/PolicyEngine/policyengine-us/pull/2203/files?diff=unified&w=0#diff-6146995ea7521e9270eb9e39c1e6d663e07119ac0f4e77dcf96097af558a1582L10-R30))
*  Update the changelog entry to reflect the minor version bump and the bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/2203/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


