### PR TITLE
Update Maryland EITC refundable match

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Removed Maryland refundable EITC match drop from 45% to 28%, reflecting recent legislation.

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/childless/max_amount.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/childless/max_amount.yaml
@@ -4,8 +4,7 @@ values:
 metadata:
   unit: currency-USD
   period: year
-  name: md_eitc_childless_max
-  label: MD childless EITC maximum
+  label: Maryland childless EITC maximum
   reference:
     - title: Md. Code, Tax-Gen. § 10-704(c)(3)(iii)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/childless/percent_match.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/childless/percent_match.yaml
@@ -4,8 +4,7 @@ values:
 metadata:
   unit: /1
   period: year
-  name: md_eitc_childless_match
-  label: MD childless EITC match
+  label: Maryland childless EITC match
   reference:
     - title: Md. Code, Tax-Gen. § 10-704(c)(3)(ii)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/match/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/match/non_refundable.yaml
@@ -3,8 +3,7 @@ values:
   2019-01-01: 0.5
 metadata:
   unit: /1
-  name: md_non_single_childless_non_refundable_eitc_match
-  label: MD non-refundable EITC match
+  label: Maryland non-refundable EITC match
   reference:
     - title: Md. Code, Tax-Gen. § 10-704(c)(1)(i)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/match/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/match/refundable.yaml
@@ -6,11 +6,9 @@ values:
   2017-01-01: 0.27
   2018-01-01: 0.28
   2020-01-01: 0.45
-  2023-01-01: 0.28
 metadata:
   unit: /1
-  name: md_eitc_refundable_match
-  label: MD refundable EITC match
+  label: Maryland refundable EITC match
   reference:
     - title: Md. Code, Tax-Gen. § 10-704(c)(2)(ii)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/poverty_line/earned_income_share.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/poverty_line/earned_income_share.yaml
@@ -3,7 +3,6 @@ values:
   2018-01-01: 0.05
 metadata:
   unit: /1
-  name: md_poverty_line_credit_rate
   label: Maryland Poverty Line Credit rate
   reference:
     - title: MD. Tax - General Code Ann. § 10-709 (2021)

--- a/policyengine_us/parameters/gov/states/md/tax/income/deductions/standard/rate.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/deductions/standard/rate.yaml
@@ -2,7 +2,6 @@ description: Maryland provides a standard deduction of this share of a filer's a
 metadata:
   period: year
   unit: /1
-  name: md_standard_deduction_rate
   label: MD standard deduction as a percent of AGI
   reference:
     - title: "MD Code, Tax - General, § 10-217 (b)"

--- a/policyengine_us/parameters/gov/states/md/tax/income/exemptions/blind.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/exemptions/blind.yaml
@@ -7,5 +7,4 @@ metadata:
       href: "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1"
   unit: currency-USD
   period: year
-  name: md_income_tax_blind_exemption
-  label: MD income tax blind exemption
+  label: Maryland income tax blind exemption

--- a/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/head.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/head.yaml
@@ -34,8 +34,7 @@ metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
-  name: md_personal_exemption_head
-  label: MD personal exemption for head of household filers, based on AGI
+  label: Maryland personal exemption for head of household filers, based on AGI
   reference:
     - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(2)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1

--- a/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/joint.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/joint.yaml
@@ -34,8 +34,7 @@ metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
-  name: md_personal_exemption_joint
-  label: MD personal exemption for joint filers, based on AGI
+  label: Maryland personal exemption for joint filers, based on AGI
   reference:
     - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(2)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1

--- a/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/separate.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/separate.yaml
@@ -33,8 +33,7 @@ metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
-  name: md_personal_exemption_separate
-  label: MD personal exemption for married filing separate filers, based on AGI
+  label: Maryland personal exemption for married filing separate filers, based on AGI
   reference:
     - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(1)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1

--- a/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/single.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/single.yaml
@@ -33,8 +33,7 @@ metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
-  name: md_personal_exemption_single
-  label: MD personal exemption for single filers, based on AGI
+  label: Maryland personal exemption for single filers, based on AGI
   reference:
     - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(1)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1

--- a/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/widow.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/exemptions/personal/widow.yaml
@@ -34,8 +34,7 @@ metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
-  name: md_personal_exemption_widow
-  label: MD personal exemption for widow(er) filers, based on AGI
+  label: Maryland personal exemption for widow(er) filers, based on AGI
   reference:
     - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(2)
       href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1

--- a/policyengine_us/parameters/gov/states/md/tax/income/rates/head.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/rates/head.yaml
@@ -3,8 +3,7 @@ metadata:
   type: marginal_rate
   threshold_unit: currency-USD
   rate_unit: /1
-  name: md_income_tax_rate_head
-  label: MD State income tax rate for head of household filers
+  label: Maryland income tax rate for head of household filers
   reference:
     - title: Tax Foundation State Individual Income Tax Rates and Brackets
       href: https://taxfoundation.org/publications/state-individual-income-tax-rates-and-brackets/#Structures

--- a/policyengine_us/parameters/gov/states/md/tax/income/rates/joint.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/rates/joint.yaml
@@ -3,8 +3,7 @@ metadata:
   type: marginal_rate
   threshold_unit: currency-USD
   rate_unit: /1
-  name: md_income_tax_rate_joint
-  label: MD State income tax rate for joint filers
+  label: Maryland income tax rate for joint filers
   reference:
     - title: Tax Foundation State Individual Income Tax Rates and Brackets
       href: https://taxfoundation.org/publications/state-individual-income-tax-rates-and-brackets/#Structures

--- a/policyengine_us/parameters/gov/states/md/tax/income/rates/separate.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/rates/separate.yaml
@@ -3,8 +3,7 @@ metadata:
   type: marginal_rate
   threshold_unit: currency-USD
   rate_unit: /1
-  name: md_income_tax_rate_separate
-  label: MD State income tax rate for married filing separately filers.
+  label: Maryland income tax rate for married filing separately filers.
   reference:
     - title: Tax Foundation State Individual Income Tax Rates and Brackets
       href: https://taxfoundation.org/publications/state-individual-income-tax-rates-and-brackets/#Structures

--- a/policyengine_us/parameters/gov/states/md/tax/income/rates/single.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/rates/single.yaml
@@ -3,8 +3,7 @@ metadata:
   type: marginal_rate
   threshold_unit: currency-USD
   rate_unit: /1
-  name: md_income_tax_rate_single
-  label: MD State income tax rate for single filers.
+  label: Maryland income tax rate for single filers.
   reference:
     - title: Tax Foundation State Individual Income Tax Rates and Brackets
       href: https://taxfoundation.org/publications/state-individual-income-tax-rates-and-brackets/#Structures

--- a/policyengine_us/parameters/gov/states/md/tax/income/rates/widow.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/rates/widow.yaml
@@ -3,8 +3,7 @@ metadata:
   type: marginal_rate
   threshold_unit: currency-USD
   rate_unit: /1
-  name: md_income_tax_rate_widow
-  label: MD State income tax rate for widow(er) filers
+  label: Maryland income tax rate for widow(er) filers
   reference:
     - title: Tax Foundation State Individual Income Tax Rates and Brackets
       href: https://taxfoundation.org/publications/state-individual-income-tax-rates-and-brackets/#Structures

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_refundable_eitc.yaml
@@ -1,0 +1,29 @@
+- name: 100% match for childless filers.
+  period: 2023
+  input:
+    md_non_refundable_eitc: 100
+    md_income_tax_before_credits: 0
+    eitc_child_count: 0
+    state_code: MD
+  output:
+    md_refundable_eitc: 100
+
+- name: 45% match for filers with children.
+  period: 2023
+  input:
+    md_non_refundable_eitc: 200
+    md_income_tax_before_credits: 100
+    eitc_child_count: 2
+    state_code: MD
+  output:
+    md_refundable_eitc: 45
+
+- name: Nothing if income tax before credits exceeds non-refundable EITC.
+  period: 2023
+  input:
+    md_non_refundable_eitc: 200
+    md_income_tax_before_credits: 300
+    eitc_child_count: 2
+    state_code: MD
+  output:
+    md_refundable_eitc: 0

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_non_refundable_eitc.py
@@ -13,10 +13,10 @@ class md_non_refundable_eitc(Variable):
 
     def formula(tax_unit, period, parameters):
         federal_eitc = tax_unit("eitc", period)
-        md_eitc = parameters(period).gov.states.md.tax.income.credits.eitc
+        p = parameters(period).gov.states.md.tax.income.credits.eitc
         childless = tax_unit("eitc_child_count", period) == 0
         return where(
             childless,
-            min_(md_eitc.childless.max_amount, federal_eitc),
-            md_eitc.non_refundable_match * federal_eitc,
+            min_(p.childless.max_amount, federal_eitc),
+            p.match.non_refundable * federal_eitc,
         )

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_non_single_childless_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_non_single_childless_non_refundable_eitc.py
@@ -21,7 +21,7 @@ class md_non_single_childless_non_refundable_eitc(Variable):
             "md_qualifies_for_single_childless_eitc", period
         )
         eligible = ~single_childless
-        uncapped = p.non_refundable_match * federal_eitc
+        uncapped = p.match.non_refundable * federal_eitc
         amount = eligible * min_(tax_before_credits, uncapped)
         has_children = add(tax_unit, period, ["is_child"]) > 0
         mca = parameters(period).gov.contrib.maryland_child_alliance

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_non_single_childless_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_non_single_childless_refundable_eitc.py
@@ -31,7 +31,7 @@ class md_non_single_childless_refundable_eitc(Variable):
         )
         params = parameters(period)
         p = params.gov.states.md.tax.income.credits.eitc
-        matched_eitc = p.refundable_match * federal_eitc_without_age_minimum
+        matched_eitc = p.match.refundable * federal_eitc_without_age_minimum
         amount = eligible * max_(0, matched_eitc - md_tax_before_credits)
         has_children = add(tax_unit, period, ["is_child"]) > 0
         mca = params.gov.contrib.maryland_child_alliance

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_refundable_eitc.py
@@ -13,8 +13,8 @@ class md_refundable_eitc(Variable):
 
     def formula(tax_unit, period, parameters):
         non_refundable_eitc = tax_unit("md_non_refundable_eitc", period)
-        md_eitc = parameters(period).gov.states.md.tax.income.credits.eitc
+        p = parameters(period).gov.states.md.tax.income.credits.eitc
         income_tax = tax_unit("md_income_tax_before_credits", period)
         excess = max_(0, non_refundable_eitc - income_tax)
         childless = tax_unit("eitc_child_count", period) == 0
-        return where(childless, excess, md_eitc.refundable_match * excess)
+        return where(childless, excess, p.match.refundable * excess)

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_refundable_eitc.py
@@ -17,4 +17,5 @@ class md_refundable_eitc(Variable):
         income_tax = tax_unit("md_income_tax_before_credits", period)
         excess = max_(0, non_refundable_eitc - income_tax)
         childless = tax_unit("eitc_child_count", period) == 0
-        return where(childless, excess, p.match.refundable * excess)
+        multiplier = where(childless, 1, p.match.refundable)
+        return excess * multiplier


### PR DESCRIPTION
Fixes #2215

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 19c6917</samp>

### Summary
🐛🧹♻️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the first change, to correct the Maryland refundable EITC match parameter according to the latest legislation.
2.  🧹 - This emoji represents a cleanup or refactoring, which is the common theme of the changes that remove the unnecessary `name` attributes from the parameter metadata and reorganize the parameter files into subfolders.
3.  ♻️ - This emoji represents a recycling or updating, which is the effect of the changes that rename the parameter files and update the formulas that use them, to reflect the new parameter names and locations.
-->
This pull request fixes a parameter value for the Maryland refundable EITC match rate, based on recent legislation. It also removes unnecessary `name` attributes from the metadata of various Maryland income tax parameters, and reorganizes the parameter files related to the EITC match rates into a subfolder. It also updates the formulas of two Maryland EITC variables to use the new parameter names.

> _`md_eitc` changes_
> _Parameters simplified_
> _Autumn leaves fall fast_

### Walkthrough
*  Update Maryland refundable EITC match parameter to reflect recent legislation ([link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-75fa6187f7eddc7806924a486a068e8b97613982b6311e9a0b4fa4942c45daaeL9-R11))
*  Remove redundant `name` attributes from parameter metadata and use file names instead ([link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-1f8484d2d4fe54afbcc9867c58752d5fb4449f57f7352c06b296f501dda45144L7-R7), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-7ad6001332775ff3df1df6c31a993b2d11076c6c73210e682b2a87c3a1c3f5f3L7-R7), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-b69159dfe6267c253379f547320fb3e9234b457abf7becffb8be91240c8a7daeL6-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-7f35c1afb417ad3ded93ea24dd4be6873d3b0f127b5fd2f1c9caacc14345572aL6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-2fd0af8ae5b7ab250a8f7b2530f118100fb6c84aa8b1658b50bc1eb8ee5313bdL5), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-bb82446e92cb4fcb1c3c8818761a2efebcde9298df416dd690a6bc0f38aacbd8L10-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-52e082125fe127b0848cd8d7e5ed2c1117af9d6b98629773fde6fd2e0ef0c352L37-R37), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-5f0465aa1646ef8bd7e2080d3f63c89601e2c1250d182b2ac7e9470bb3fe9f35L37-R37), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-f891aac8a27f8cb39509cc1752446cfb1eeb5a39b820554515a22df31c554dd1L36-R36), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-df5b76739ee9e2ef422759e1ab8923774ae9fcb5d7cc19bcb04cb44f03c6558bL36-R36), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-e76101033052ef9bd21d573dc256472abfb5dba1e7e6fef3817b612eb64052eaL37-R37), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-56ac410685279e44b00911a50d2138e0e0fded38a542161f24997084e229e118L6-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-92b68364ebf20ba7bca3c1182e2128261f4b5d7f73eb7cde1ebe84b0ee3fd357L6-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-5956169e59eb65f904c28ad456d40ae158447f2075591510e7badea7934df6aaL6-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-a929b9be228b7a46216f985bbe7d04d82565132c5854ac2713d35632c32a3bc4L6-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-27030cab2cde6b7fde4c41e2a6e94256e3331482a4ff223bb2702dacf5984989L6-R6))
*  Reorganize EITC match parameters into a subfolder and rename files to `refundable.yaml` and `non_refundable.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-b69159dfe6267c253379f547320fb3e9234b457abf7becffb8be91240c8a7daeL6-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-75fa6187f7eddc7806924a486a068e8b97613982b6311e9a0b4fa4942c45daaeL9-R11))
*  Update formulas for `md_non_refundable_eitc` and `md_non_single_childless_non_refundable_eitc` variables to use new parameter names ([link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-658bb432c15729c136baa898c656abea576fbda6e7edeb202e19ba9dfb6b9750L16-R21), [link](https://github.com/PolicyEngine/policyengine-us/pull/2216/files?diff=unified&w=0#diff-2691de12341609de85a595c0853fa86ddc783b68b5a526b7e75650cb92b164d5L24-R24))


