### PR TITLE
Add switch to use branching to determine itemization

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Switch to branch to determine itemization.

--- a/policyengine_us/parameters/simulation/branch_to_determine_itemization.yaml
+++ b/policyengine_us/parameters/simulation/branch_to_determine_itemization.yaml
@@ -1,0 +1,6 @@
+description: PolicyEngine branches to determine itemization if this is true; otherwise it compares the standard against itemized deductions.
+values:
+  0000-01-01: false
+metadata:
+  unit: bool
+  label: Branch to determine itemization

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
@@ -30,15 +30,15 @@ class tax_unit_itemizes(Variable):
         itemized_deductions = (
             add(tax_unit, period, deductions_if_itemizing) + salt_cap
         )
-        deductions_if_not_itemizing = tax_unit(
-            "standard_deduction", period
-        )  # Ignore QBID here, it requires SALT.
+        # Ignore QBID here, it requires SALT.
+        deductions_if_not_itemizing = tax_unit("standard_deduction", period)
 
-        # Decide by non-SALT deduction size
-        return itemized_deductions > deductions_if_not_itemizing
-
-        tax_if_itemizing = tax_unit("tax_liability_if_itemizing", period)
-        tax_if_not_itemizing = tax_unit(
-            "tax_liability_if_not_itemizing", period
-        )
-        return tax_if_itemizing < tax_if_not_itemizing
+        if parameters(period).simulation.branch_to_determine_itemization:
+            tax_if_itemizing = tax_unit("tax_liability_if_itemizing", period)
+            tax_if_not_itemizing = tax_unit(
+                "tax_liability_if_not_itemizing", period
+            )
+            return tax_if_itemizing < tax_if_not_itemizing
+        else:
+            # Decide by non-SALT deduction size.
+            return itemized_deductions > deductions_if_not_itemizing


### PR DESCRIPTION
Fixes #2279

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d0cbfc7</samp>

### Summary
🆕📄📝

<!--
1.  🆕 for adding a new feature
2.  📄 for adding a new parameter file
3.  📝 for modifying a formula
-->
This pull request adds a new feature to `policyengine_us` that lets users choose how to determine itemization for tax units. It introduces a new parameter `branch_to_determine_itemization` and updates the formula of the variable `tax_unit_itemizes` accordingly.

> _`itemizes` changes_
> _branch by tax or deduction_
> _a new feature blooms_

### Walkthrough
*  Add a new parameter `branch_to_determine_itemization` to control the logic of itemization ([link](https://github.com/PolicyEngine/policyengine-us/pull/2280/files?diff=unified&w=0#diff-79c583fb8215e029826c95500c52dfa9560118b9e820a3cc44502a1ccd9ace1bR1-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2280/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Update the formula of `tax_unit_itemizes` to use the new parameter and compare tax liability or deduction size ([link](https://github.com/PolicyEngine/policyengine-us/pull/2280/files?diff=unified&w=0#diff-231f2ba940b4a659f9db3b6a452d6536910d15bcdcf47e6d6f19355d46f00cf3L33-R44))
*  Add a changelog entry for the new feature and bump the minor version ([link](https://github.com/PolicyEngine/policyengine-us/pull/2280/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


