### PR TITLE
Support Python 3.10

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Python 3.10 support.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pandas",
         "pathlib",
         "policyengine-core>=2.1,<3",
-        "pytest==5.4.3",
+         "pytest",
         "pytest-dependency",
         "pyyaml",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pandas",
         "pathlib",
         "policyengine-core>=2.1,<3",
-         "pytest",
+        "pytest",
         "pytest-dependency",
         "pyyaml",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "microdf_python",
         "pandas",
         "pathlib",
-        "policyengine-core>=2.0.4,<3",
+        "policyengine-core>=2.1,<3",
         "pytest==5.4.3",
         "pytest-dependency",
         "pyyaml",
@@ -68,7 +68,7 @@ setup(
         ],
     },
     # Windows CI requires Python 3.9.
-    python_requires=">=3.7,<3.10",
+    python_requires=">=3.7",
     entry_points={
         "console_scripts": [
             "policyengine-us = policyengine_us.tools.cli:main",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a22963</samp>

### Summary
:sparkles::arrow_up::snake:

<!--
1.  :sparkles: This emoji is often used to denote new features or enhancements, and in this case it reflects the addition of Python 3.10 support to the package.
2.  :arrow_up: This emoji is commonly used to indicate dependency updates or upgrades, and in this case it reflects the bump in the `policyengine-core` version.
3.  :snake: This emoji is a playful way to represent Python, the programming language used by the package, and in this case it also highlights the compatibility with the latest version of Python.
-->
This pull request updates the `policyengine-core` dependency and adds Python 3.10 support for the `policyengine-us` package. This is a new feature that will be part of the next minor release.

> _The core of the engine is burning bright_
> _We're ready for the future, Python 3.10 in sight_
> _A minor bump, but a major leap_
> _We're the policy makers, we sow what we reap_

### Walkthrough
* Add Python 3.10 support as a new feature for the next minor release ([link](https://github.com/PolicyEngine/policyengine-us/pull/2303/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2303/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L40-R40), [link](https://github.com/PolicyEngine/policyengine-us/pull/2303/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L71-R71))
  - Update `policyengine-core` dependency to version 2.1, which supports Python 3.10 and has bug fixes and improvements ([link](https://github.com/PolicyEngine/policyengine-us/pull/2303/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L40-R40))
  - Allow installation on any Python version above 3.7, instead of excluding 3.10, in `setup.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2303/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L71-R71))
  - Add a new entry to the changelog file with the feature and the version bump ([link](https://github.com/PolicyEngine/policyengine-us/pull/2303/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


