### PR TITLE
Catch divide-by-zero in ia_prorate_fraction

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Divide-by-zero error in ia_prorate_fraction.

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_prorate_fraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_prorate_fraction.yaml
@@ -16,3 +16,25 @@
         state_code: IA
   output:
     ia_prorate_fraction: [0.2, 0.8]
+
+- name: If no net income and single, assign entirely to them as head.
+  period: 2021
+  input:
+    state_code: IA
+  output:
+    ia_prorate_fraction: 1
+
+- name: If no net income, assign to head.
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+      person2:
+        is_tax_unit_spouse: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IA
+  output:
+    ia_prorate_fraction: [1, 0]

--- a/policyengine_us/variables/gov/states/ia/tax/income/net_income/ia_prorate_fraction.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/net_income/ia_prorate_fraction.py
@@ -18,4 +18,9 @@ class ia_prorate_fraction(Variable):
     def formula(person, period, parameters):
         net_income = person("ia_net_income", period)
         total_net_income = person.tax_unit.sum(net_income)
-        return net_income / total_net_income
+        # If no net income, then assign entirely to head.
+        return where(
+            total_net_income == 0,
+            person("is_tax_unit_head", period),
+            net_income / total_net_income,
+        )


### PR DESCRIPTION
Fixes #2338

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 57dc065</samp>

### Summary
🐛🧪📝

<!--
1.  🐛 for the bug fix in the changelog entry and the formula.
2.  🧪 for the test cases added to the variable.
3.  📝 for the documentation update in the changelog entry.
-->
This pull request fixes a bug in the `ia_prorate_fraction` variable that caused a divide-by-zero error when there was no net income for the tax unit. It also adds tests for this variable and updates the changelog entry accordingly.

> _`ia_prorate_fraction`_
> _Divide-by-zero bug fixed_
> _Autumn leaves fall fast_

### Walkthrough
* Fix bug in `ia_prorate_fraction` variable that caused divide-by-zero error when tax unit had no net income ([link](https://github.com/PolicyEngine/policyengine-us/pull/2340/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2340/files?diff=unified&w=0#diff-6e0beb527ec2fc4a857bf4aeee01b8e67e0a6b5921273d306bbcce5b42004165L21-R26))
* Add test cases for `ia_prorate_fraction` variable to check behavior when tax unit has no net income ([link](https://github.com/PolicyEngine/policyengine-us/pull/2340/files?diff=unified&w=0#diff-5427254d6a8add0746c17b7e276d09b70e5b9d718d0ec33463fec29212454e0eR19-R40))


