### PR TITLE
Divide by zero in NYC CDCC

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Divide by zero in NYC CDCC.

--- a/policyengine_us/tests/policy/baseline/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_age_restricted_expenses.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_age_restricted_expenses.yaml
@@ -20,3 +20,10 @@
         in_nyc: true
   output:
     nyc_cdcc_age_restricted_expenses: 4_000
+
+- name: If no childcare expenses, should be zero.
+  period: 2022
+  input:
+    in_nyc: true
+  output:
+    nyc_cdcc_age_restricted_expenses: 0

--- a/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_age_restricted_expenses.py
+++ b/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_age_restricted_expenses.py
@@ -23,4 +23,7 @@ class nyc_cdcc_age_restricted_expenses(Variable):
         tax_unit_childcare_expenses = tax_unit(
             "tax_unit_childcare_expenses", period
         )
-        return qualifying_children * tax_unit_childcare_expenses / children
+        qualifying_child_share = where(
+            children > 0, qualifying_children / children, 0
+        )
+        return tax_unit_childcare_expenses * qualifying_child_share

--- a/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_applicable_percentage.py
+++ b/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_applicable_percentage.py
@@ -26,6 +26,4 @@ class nyc_cdcc_applicable_percentage(Variable):
         excess = max_(income - p.phaseout_start, 0)
         capped_excess = min_(excess, phase_out_width)
         percent_excess = capped_excess / phase_out_width
-        applicable_percentage = p.max_rate * (1 - percent_excess)
-
-        return applicable_percentage
+        return p.max_rate * (1 - percent_excess)


### PR DESCRIPTION
Fixes #2341

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at def0e10</samp>

### Summary
🐛🧪🧹

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the NYC CDCC formula and the changelog entry. The bug fix emoji is commonly used to indicate that a change resolves an issue or error in the code or the functionality of the model.
2.  🧪 - This emoji represents a test case, which is the main purpose of the change to the tests folder. The test case emoji is commonly used to indicate that a change adds or modifies a test or a test suite to verify the correctness or the performance of the code or the model.
3.  🧹 - This emoji represents a cleanup or a refactoring, which is the main purpose of the change to the NYC CDCC applicable percentage formula. The cleanup emoji is commonly used to indicate that a change improves the readability, the style, or the structure of the code or the model, without changing its logic or its output.
-->
This pull request fixes a bug in the `nyc_cdcc_age_restricted_expenses` variable that caused a divide by zero error for some tax units. It also adds a test case for this variable and simplifies the formulas for `nyc_cdcc_age_restricted_expenses` and `nyc_cdcc_applicable_percentage`.

> _`NYC CDCC` fixed_
> _No more divide by zero_
> _Fall leaves no errors_

### Walkthrough
* Fix bug in NYC CDCC age-restricted expenses formula that caused division by zero error for tax units with no children ([link](https://github.com/PolicyEngine/policyengine-us/pull/2342/files?diff=unified&w=0#diff-486c0d034869d5818b0f72c28be4529678e963996713cc200357bd2136faacb1L26-R29))
* Add test case for NYC CDCC age-restricted expenses variable to check zero expenses scenario ([link](https://github.com/PolicyEngine/policyengine-us/pull/2342/files?diff=unified&w=0#diff-d3882e69db84b824f221a5ad1456da8e7b40010e29e3a8ac4d04f8a27a78f572R23-R29))
* Simplify NYC CDCC applicable percentage formula by removing unnecessary variable assignment ([link](https://github.com/PolicyEngine/policyengine-us/pull/2342/files?diff=unified&w=0#diff-181b1aeb2154496d409fe11efa16dfa4a40170f057418ef56b7ff53fc3a241d4L29-R29))
* Update changelog entry to indicate patch-level update and bug fix for NYC CDCC ([link](https://github.com/PolicyEngine/policyengine-us/pull/2342/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


