### PR TITLE
Fix itemization bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - A bug causing itemization to be too frequently chosen.

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
@@ -25,11 +25,7 @@ class tax_unit_itemizes(Variable):
                 "qualified_business_income_deduction",
             ]
         ]
-        filing_status = tax_unit("filing_status", period)
-        salt_cap = ded.itemized.salt_and_real_estate.cap[filing_status]
-        itemized_deductions = (
-            add(tax_unit, period, deductions_if_itemizing) + salt_cap
-        )
+        itemized_deductions = add(tax_unit, period, deductions_if_itemizing)
         # Ignore QBID here, it requires SALT.
         deductions_if_not_itemizing = tax_unit("standard_deduction", period)
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 83f4f57</samp>

### Summary
🐛📝🔥

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the changelog entry. It also conveys that the issue was affecting the accuracy of the model output.
2.  📝 - This emoji represents a documentation update, which is the secondary purpose of the change to the changelog entry. It also conveys that the change is informative and descriptive of the pull request.
3.  🔥 - This emoji represents a removal or deletion of code, which is the purpose of the change to the itemized deductions calculation. It also conveys that the code was unnecessary or redundant for the current scenario.
-->
This pull request fixes a bug in the tax unit model that caused itemization to be overestimated, and removes the SALT and real estate cap from the itemized deductions formula. These changes improve the accuracy and simplicity of the model for the current policy scenario.

> _`itemize` bug fixed_
> _No need for SALT or cap_
> _Winter of changes_

### Walkthrough
* Fix bug that caused itemization to be too frequently chosen by the tax unit model ([link](https://github.com/PolicyEngine/policyengine-us/pull/2345/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Remove SALT and real estate cap from itemized deductions calculation in `tax_unit_itemizes.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2345/files?diff=unified&w=0#diff-231f2ba940b4a659f9db3b6a452d6536910d15bcdcf47e6d6f19355d46f00cf3L28-R28))


