### PR TITLE
Correct faulty logic in tax_unit_itemizes formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+bump: patch
+changes:
+  fixed:
+  - Incorrect logic in federal tax_unit_itemizes formula.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-bump: - patch
-changes:
-  fixed:
-  - Incorrect logic in federal tax_unit_itemizes formula.
+- bump: patch
+  changes:
+    fixed:
+    - Incorrect logic in federal tax_unit_itemizes formula.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-bump: patch
+bump: - patch
 changes:
   fixed:
   - Incorrect logic in federal tax_unit_itemizes formula.

--- a/policyengine_us/tests/policy/baseline/gov/irs/integration/us-itemize.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/integration/us-itemize.yaml
@@ -1,0 +1,57 @@
+- name: Single homeowner living in Texas
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 40
+        employment_income: 100_000
+        interest_expense: 12_000
+        real_estate_taxes: 11_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX  # no state income tax
+  output:
+    state_income_tax: 0
+    adjusted_gross_income: 100_000
+    taxable_income_deductions_if_not_itemizing: 12_550
+    taxable_income_deductions_if_itemizing: 12_000 + 10_000
+    tax_unit_itemizes: true
+    taxable_income: 100_000 - 22_000
+
+- name: Single homeowner living in Illinois
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 40
+        employment_income: 100_000
+        interest_expense: 8_000
+        real_estate_taxes: 6_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IL  # state income tax that does not depend on US tax
+  output:
+    state_income_tax: 4_576.44
+    adjusted_gross_income: 100_000
+    taxable_income_deductions_if_not_itemizing: 12_550
+    taxable_income_deductions_if_itemizing: 8_000 + 10_000
+    tax_unit_itemizes: true
+    taxable_income: 100_000 - 18_000

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
@@ -15,7 +15,7 @@ class tax_unit_itemizes(Variable):
             tax_liability_if_itemizing = tax_unit(
                 "tax_liability_if_itemizing", period
             )
-            tax_liabilityif_not_itemizing = tax_unit(
+            tax_liability_if_not_itemizing = tax_unit(
                 "tax_liability_if_not_itemizing", period
             )
             return tax_liability_if_itemizing < tax_liability_if_not_itemizing

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
@@ -22,9 +22,9 @@ class tax_unit_itemizes(Variable):
         else:
             # determine federal itemization behavior by comparing deductions
             standard_deduction = tax_unit("standard_deduction", period)
-            # ... itemized deductions cannot be accurately calculated because
-            #     the state_income_tax part of the salt_deduction must be
-            #     ignored in order to avoid circular logic errors
+            # itemized deductions cannot be accurately calculated because
+            #   the state_income_tax part of the salt_deduction must be
+            #   ignored in order to avoid circular logic errors
             p = parameters(period).gov.irs.deductions
             deductions = [
                 deduction
@@ -32,8 +32,8 @@ class tax_unit_itemizes(Variable):
                 if deduction not in ["salt_deduction"]
             ]
             partial_itemized_deductions = add(tax_unit, period, deductions)
-            # ... add back the possibly capped local real estate taxes,
-            #     which have no circular logic problems
+            # add back the possibly capped local real estate taxes,
+            #   which have no circular logic problems
             filing_status = tax_unit("filing_status", period)
             itemized_deductions = partial_itemized_deductions + min_(
                 add(tax_unit, period, ["real_estate_taxes"]),

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.py
@@ -35,9 +35,8 @@ class tax_unit_itemizes(Variable):
             # ... add back the possibly capped local real estate taxes,
             #     which have no circular logic problems
             filing_status = tax_unit("filing_status", period)
-            salt_cap = p.itemized.salt_and_real_estate.cap[filing_status]
-            local_property_taxes = tax_unit("real_estate_taxes", period)
             itemized_deductions = partial_itemized_deductions + min_(
-                salt_cap, local_property_taxes
+                add(tax_unit, period, ["real_estate_taxes"]),
+                p.itemized.salt_and_real_estate.cap[filing_status],
             )
             return itemized_deductions > standard_deduction


### PR DESCRIPTION
The two added tests fail unless the `tax_unit_itemizes` formula is corrected as in this PR.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1e87bf0</samp>

### Summary
🐛🧪🧹

<!--
1.  🐛 for fixing a bug in the logic of the `tax_unit_itemizes` formula.
2.  🧪 for adding two test cases to the integration test file for the `tax_unit_itemizes` formula.
3.  🧹 for simplifying and refactoring the code of the `tax_unit_itemizes` formula.
-->
This patch fixes a bug in the `tax_unit_itemizes` formula, which determines whether a tax unit chooses to itemize deductions or take the standard deduction for federal income tax. It updates the changelog, adds integration tests, and simplifies and refactors the code of the formula.

> _`tax_unit_itemizes`_
> _bug fixed, tests added, code clear_
> _autumn leaves falling_

### Walkthrough
* Fix bug in `tax_unit_itemizes` formula that could cause incorrect itemization decision ([link](https://github.com/PolicyEngine/policyengine-us/pull/2351/files?diff=unified&w=0#diff-231f2ba940b4a659f9db3b6a452d6536910d15bcdcf47e6d6f19355d46f00cf3L9-R30))
* Simplify and refactor code of `tax_unit_itemizes` formula to remove unnecessary and irrelevant assumptions and functions ([link](https://github.com/PolicyEngine/policyengine-us/pull/2351/files?diff=unified&w=0#diff-231f2ba940b4a659f9db3b6a452d6536910d15bcdcf47e6d6f19355d46f00cf3L9-R30))
* Add integration tests for `tax_unit_itemizes` formula to cover two scenarios of single homeowners with different levels of interest expense and real estate taxes ([link](https://github.com/PolicyEngine/policyengine-us/pull/2351/files?diff=unified&w=0#diff-6c11b41dbb8ebfc045ad8f1a7d895356d6df80a884ec7c0aa69e22bddb6cfa18R1-R57))
* Update changelog entry to reflect bug fix and refactoring ([link](https://github.com/PolicyEngine/policyengine-us/pull/2351/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


