### PR TITLE
Add six states to list used by state_income_tax formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Old Age Pension
+- Colorado Old Age Pension
 
 ## [0.329.4] - 2023-05-30 06:23:37
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Add six states to list used by state_income_tax formula.

--- a/policyengine_us/variables/gov/states/tax/income/state_income_tax.py
+++ b/policyengine_us/variables/gov/states/tax/income/state_income_tax.py
@@ -13,18 +13,24 @@ class state_income_tax(Variable):
         # "ia_income_tax",  --- activating will cause circular logic errors
         "il_income_tax",
         "ks_income_tax",
+        "ky_income_tax",
         "ma_income_tax",
         "md_income_tax",
         "mn_income_tax",
+        "mt_income_tax",
         # "mo_income_tax",  --- activating will cause circular logic errors
-        # "ne_income_tax",  --- activating will cause circular logic errors
+        "nc_income_tax",
         # "nd_income_tax",  --- activating will cause circular logic errors
+        # "ne_income_tax",  --- activating will cause circular logic errors
+        "nh_income_tax",
+        "nj_income_tax",
         "ny_income_tax",
         "ok_income_tax",
         "or_income_tax",
         "pa_income_tax",
-        "wa_income_tax",
+        "ri_income_tax",
         "ut_income_tax",
+        "wa_income_tax",
     ]
 
     def formula(tax_unit, period, parameters):


### PR DESCRIPTION
Add six states that have `??_income_tax` variables defined to the list of state income taxes in the `state_income_tax.py` module.   Adding these six states makes it possible to test them against TAXSIM35 (see issue #993) as they move towards completion.  The state income tax logic in four of the added states is skeletal, and so it is too soon to post validation test results.  But two of the six states --- NH and NJ --- are far enough along in their development that validation test results for those two states will be able to be added to issue #993 after this pull request is merged.


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d2692f</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 for the bug fix of the state income tax formula
2.  📝 for the documentation update of the changelog entry for the Old Age Pension
3.  🚀 for the feature addition of the six states to the state income tax class
-->
This pull request fixes the state income tax formula for six more states and updates the changelog accordingly. It also clarifies the scope of the Old Age Pension policy in Colorado.

> _`state_income_tax`_
> _Six more states join the formula_
> _A patch for autumn_

### Walkthrough
*  Added state income tax formulas for six more states: Kentucky, Montana, North Carolina, New Hampshire, New Jersey, and Rhode Island ([link](https://github.com/PolicyEngine/policyengine-us/pull/2357/files?diff=unified&w=0#diff-af0d2b84ba0adacb1b6e826175576659344b80a34710502f7791da61cbd9c600L16-R33), [link](https://github.com/PolicyEngine/policyengine-us/pull/2357/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Updated changelog entry for Colorado Old Age Pension to clarify that it is state-specific ([link](https://github.com/PolicyEngine/policyengine-us/pull/2357/files?diff=unified&w=0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL12-R12))


