### PR TITLE
Vermont AGI

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-      - Vermont AGI
+      - Vermont AGI.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Vermont AGI

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/vt_agi.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/vt_agi.yaml
@@ -1,0 +1,32 @@
+- name: Outside Maine, no Vermont AGI
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    state_code: NY
+    filing_status: SINGLE
+  output:
+    vt_agi: 0
+
+- name: If $0 income and $0 mods, Vermont agi is $0. 
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    state_code: VT
+    filing_status: SINGLE
+    adjusted_gross_income: 0
+    vt_agi_additions: 0
+    vt_agi_subtractions: 0
+  output:
+    vt_agi: 0
+
+- name: If $100_000 income and $10_000 add mods and $20_000 sub mods, Vermont AGI is $90_000. 
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    state_code: VT
+    filing_status: JOINT
+    adjusted_gross_income: 100_000  
+    vt_agi_additions: 10_000
+    vt_agi_subtractions: 20_000
+  output:
+    vt_agi: 90_000

--- a/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/vt_agi.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/vt_agi.py
@@ -1,0 +1,14 @@
+from policyengine_us.model_api import *
+
+
+class vt_agi(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Vermont adjusted gross income"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.VT
+    reference = "https://tax.vermont.gov/sites/tax/files/documents/IN-111-2022.pdf (Line 3)"
+
+    adds = ["adjusted_gross_income", "vt_agi_additions"]
+    subtracts = ["vt_agi_subtractions"]

--- a/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/vt_agi_additions.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/vt_agi_additions.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class vt_agi_additions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "VT AGI additions"
+    unit = USD
+    documentation = "Additions to VT AGI over federal AGI."
+    definition_period = YEAR
+    defined_for = StateCode.VT
+    reference = dict(
+        title="2022 Schedule IN-112 Vermont Tax Adjustments and Credits, PART 1 ADDITIONS TO FEDERAL ADJUSTED GROSS INCOME",
+        href="https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf",
+    )

--- a/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/vt_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/vt_agi_subtractions.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class vt_agi_subtractions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "VT AGI subtractions"
+    unit = USD
+    documentation = "Subtractions from VT AGI over federal AGI."
+    definition_period = YEAR
+    defined_for = StateCode.VT
+    reference = dict(
+        title="2022 Schedule IN-112 Vermont Tax Adjustments and Credits, PART 1 SUBTRACTIONS FROM FEDERAL ADJUSTED GROSS INCOME",
+        href="https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf",
+    )


### PR DESCRIPTION
Fixes #2296
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fb2226c</samp>

### Summary
:sparkles::white_check_mark::memo:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement to the model, which is the Vermont AGI variable. This emoji is commonly used to indicate minor version bumps and new functionality in changelogs and commit messages.
2. :white_check_mark: This emoji represents the addition of new tests or the passing of existing tests for the model, which are the three test cases for the Vermont AGI variable. This emoji is commonly used to indicate quality assurance and reliability in changelogs and commit messages.
3. :memo: This emoji represents the addition of documentation or comments to the model, which are the reference, label, unit, and documentation attributes of the Vermont AGI variable and its components. This emoji is commonly used to indicate documentation and explanation in changelogs and commit messages.
-->
This pull request adds Vermont adjusted gross income (AGI) as a new variable in the policy engine model. It defines the variable and its components in `policyengine_us/variables`, adds test cases in `policyengine_us/tests`, and updates the changelog entry in `changelog_entry.yaml`.

> _`Vermont AGI`_
> _New variable in model_
> _Autumn tax season_

### Walkthrough
*  Bump minor version and add Vermont AGI feature to changelog ([link](https://github.com/PolicyEngine/policyengine-us/pull/2360/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Define Vermont AGI variable as a subclass of `Variable` with reference, adds, and subtracts attributes ([link](https://github.com/PolicyEngine/policyengine-us/pull/2360/files?diff=unified&w=0#diff-c174b78e440841750174c9f041ab5510a7b82fe4158a8c204e567d494ce3bb78R1-R14))
* Define Vermont AGI additions and subtractions variables as subclasses of `Variable` with reference attributes ([link](https://github.com/PolicyEngine/policyengine-us/pull/2360/files?diff=unified&w=0#diff-9607167322e3dd36673936107c0b12f2013663edf35628c1577240fbb9389617R1-R15), [link](https://github.com/PolicyEngine/policyengine-us/pull/2360/files?diff=unified&w=0#diff-3d3e0e0508b8f3ca30470933ed023041247e2764151f8a7753d06b4ff9d4a842R1-R15))
* Add test cases for Vermont AGI variable in `policyengine_us/tests/policy/baseline/gov/states/vt/vt_agi.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2360/files?diff=unified&w=0#diff-32428c52c28bd131b3cd5a599dc76e2cdc25ec6f817e380f8fd8b2ec87b6d5aaR1-R32))

