### PR TITLE
Fix IA exemption credit bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
     fixed:
-      - West Virginia personal exemption.
+    - Iowa exemption credit logic for head-of-household filing units.

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_exemption_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_exemption_credit.yaml
@@ -19,7 +19,7 @@
         members: [person1, person2]
         state_code: IA
   output:
-    ia_exemption_credit: 100  # = 40 + 20 + 40
+    ia_exemption_credit: 140  # = 40(adult) + 40(hoh) + 20(child) + 40(aged)
 
 - name: IA exemption credit unit test 2
   period: 2022

--- a/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_exemption_credit.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_exemption_credit.py
@@ -20,7 +20,7 @@ class ia_exemption_credit(Variable):
         hoh_status = filing_status.possible_values.HEAD_OF_HOUSEHOLD
         hoh_bonus = where(filing_status == hoh_status, 1, 0)
         dependent_count = tax_unit("tax_unit_dependents", period)
-        # count extra adults exemptions based on being elderly and/or blind
+        # count extra adult exemptions based on being elderly and/or blind
         p = parameters(period).gov.states.ia.tax.income
         exemption = p.credits.exemption
         elder_head = tax_unit("age_head", period) >= exemption.elderly_age

--- a/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_exemption_credit.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_exemption_credit.py
@@ -14,9 +14,13 @@ class ia_exemption_credit(Variable):
     defined_for = StateCode.IA
 
     def formula(tax_unit, period, parameters):
+        # count adult and dependent exemptions
         adult_count = tax_unit("num", period)
+        filing_status = tax_unit("filing_status", period)
+        hoh_status = filing_status.possible_values.HEAD_OF_HOUSEHOLD
+        hoh_bonus = where(filing_status == hoh_status, 1, 0)
         dependent_count = tax_unit("tax_unit_dependents", period)
-        # count additional exemptions based on being elderly and/or blind
+        # count extra adults exemptions based on being elderly and/or blind
         p = parameters(period).gov.states.ia.tax.income
         exemption = p.credits.exemption
         elder_head = tax_unit("age_head", period) >= exemption.elderly_age
@@ -27,7 +31,7 @@ class ia_exemption_credit(Variable):
         blind_count = blind_head.astype(int) + blind_spouse.astype(int)
         additional_count = elder_count + blind_count
         return (
-            adult_count * exemption.personal
+            (adult_count + hoh_bonus) * exemption.personal
             + additional_count * exemption.additional
             + dependent_count * exemption.dependent
         )


### PR DESCRIPTION
This PR fixes an Iowa income tax bug that miscalculated the nonrefundable exemption credit for those with head-of-household filing status.  The incorrect code neglected to give such filing units an extra adult exemption credit.  The changes in this PR correct that and also fix an incorrect unit test.  The IA 1040 form (Step 3 a) makes it clear that such an extra adult exemption is given to head-of-household filing units:

<img width="1224" alt="Screenshot 2023-06-17 at 3 01 43 PM" src="https://github.com/PolicyEngine/policyengine-us/assets/12170745/94018344-ac3e-4775-a183-415b5753d7eb">

This bug fix reduces the number of `p21` sample IA income tax differences to 46 (out of 100,000) integration cases when using the 2023-06-17 patch of TAXSIM35 (see issue #993).   The largest tax difference among the 46 test cases is less than eighteen dollars ($17.63).

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 180cf4d</samp>

### Summary
📝🧪🐛

<!--
1.  📝 for updating the changelog entry
2.  🧪 for updating the unit test
3.  🐛 for fixing the bug in the formula
-->
Fixed a bug in the `ia_exemption_credit` formula that affected head-of-household filers in Iowa. Updated the changelog, the unit test, and the code file to reflect the correct logic and output.

> _Sing, O Muse, of the valiant coder who fixed the flaw_
> _In the Iowa exemption credit, that cunning tax device_
> _That grants a boon to mortal filers, based on their status and their kin_
> _And how he changed the formula, adding `hoh_bonus` like a wise Athena_

### Walkthrough
* Fix Iowa exemption credit logic for head-of-household filers ([link](https://github.com/PolicyEngine/policyengine-us/pull/2459/files?diff=unified&w=0#diff-5411d27642e1459857db6168bf2c3dee2c7aac9f0055ea9b9f626091a6a338e1L17-R23), [link](https://github.com/PolicyEngine/policyengine-us/pull/2459/files?diff=unified&w=0#diff-5411d27642e1459857db6168bf2c3dee2c7aac9f0055ea9b9f626091a6a338e1L30-R34))
* Update unit test for Iowa exemption credit to match new logic ([link](https://github.com/PolicyEngine/policyengine-us/pull/2459/files?diff=unified&w=0#diff-3bf486e30579fade90ef6ed21bb60f8c1c01bc909661d01170b02fade915eaa0L22-R22))
* Update changelog entry to reflect bug fix and patch level ([link](https://github.com/PolicyEngine/policyengine-us/pull/2459/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R4))


