### PR TITLE
Fix two self-employment-related bugs in Iowa deduction logic

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Incorrect handling of federal self-employment tax in Iowa federal tax deduction logic.
+    - Incorrect handling of federal QBID (qualified business income deduction) in Iowa QBID logic.

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_fedtax_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_fedtax_deduction.yaml
@@ -18,14 +18,15 @@
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
-        income_tax_before_refundable_credits: 21_000
         additional_medicare_tax: 1_000
+        income_tax_before_refundable_credits: 21_200
     households:
       household:
         members: [person1, person2, person3]
         state_code: IA
   output:
-    ia_fedtax_deduction: [14_800, 5_000, 0]
+    self_employment_tax: [200, 0, 0]
+    ia_fedtax_deduction: [15_000, 5_000, 0]
 
 - name: IA federal income tax deduction unit test 2
   absolute_error_margin: 0.01
@@ -35,8 +36,8 @@
       person1:
         is_tax_unit_head: true
         age: 40
-        ia_net_income: 300_000
-        self_employment_tax: 200
+        ia_net_income: 400_000
+        self_employment_tax: 700
       person2:
         is_tax_unit_spouse: true
         age: 38
@@ -47,11 +48,11 @@
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
-        income_tax_before_refundable_credits: 21_000
-        additional_medicare_tax: 1_000
+        additional_medicare_tax: 2_000
+        income_tax_before_refundable_credits: 22_700
     households:
       household:
         members: [person1, person2, person3]
         state_code: IA
   output:
-    ia_fedtax_deduction: [14_800, 5_000, 0]
+    ia_fedtax_deduction: [16_000, 4_000, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_integration.yaml
@@ -182,3 +182,123 @@
     ia_income_tax_before_credits: 598.81
     ia_exemption_credit: 120
     ia_income_tax: 478.81  # the incorrect TAXSIM35 result is 430.85
+
+- name: Tax unit with taxsimid 4731 in j21.its.csv and j21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 71
+        employment_income: 6_010
+        qualified_dividend_income: 505.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 1_505.0
+        rental_income: 505.0
+        taxable_private_pension_income: 1_500.0
+        social_security: 4_500.0
+        rent: 3_000
+        self_employment_income: 93_010
+        business_is_qualified: true
+        business_is_sstb: false
+        w2_wages_from_qualified_business: 100e6
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_spouse: true
+        age: 71
+        employment_income: 1_010
+        qualified_dividend_income: 505.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 1_505.0
+        rental_income: 505.0
+        taxable_private_pension_income: 1_500.0
+        social_security: 4_500.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IA
+  output:  # expected ia_income_tax from patched TAXSIM35 2023-06-22 version
+    ia_income_tax: 5_620.59
+
+- name: Tax unit with taxsimid 2782 in j21.its.csv and j21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 67
+        qualified_dividend_income: 1_005.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 5_005.0
+        rental_income: 2_005.0
+        taxable_private_pension_income: 1_000.0
+        rent: 19_000
+        self_employment_income: 46_010
+        business_is_qualified: true
+        business_is_sstb: true
+        w2_wages_from_qualified_business: 100e6
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_spouse: true
+        age: 67
+        qualified_dividend_income: 1_005.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 5_005.0
+        rental_income: 2_005.0
+        taxable_private_pension_income: 1_000.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person3:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person4:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person5:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5]
+        state_code: IA
+  output:  # expected ia_income_tax from patched TAXSIM35 2023-06-22 version
+    qbid_amount: [8_551.90, 0, 0, 0, 0]
+    qualified_business_income_deduction: 6_395.90
+    ia_qbi_deduction: [3_197.95, 0, 0, 0, 0]
+    ia_income_tax: 2_648.36

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
@@ -1,7 +1,7 @@
 - name: IA qualified business income (QBI) deduction unit test 1
   period: 2021
   input:
-    qbid_amount: 10_000
+    qbid_amount: 11_000
     qualified_business_income_deduction: 10_000
     state_code: IA
   output:
@@ -10,7 +10,7 @@
 - name: IA qualified business income (QBI) deduction unit test 2
   period: 2022
   input:
-    qbid_amount: 10_000
+    qbid_amount: 11_000
     qualified_business_income_deduction: 10_000
     state_code: IA
   output:

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
@@ -2,6 +2,7 @@
   period: 2021
   input:
     qbid_amount: 10_000
+    qualified_business_income_deduction: 10_000
     state_code: IA
   output:
     ia_qbi_deduction: 5_000
@@ -10,6 +11,7 @@
   period: 2022
   input:
     qbid_amount: 10_000
+    qualified_business_income_deduction: 10_000
     state_code: IA
   output:
     ia_qbi_deduction: 7_500

--- a/policyengine_us/variables/gov/states/ia/tax/income/deductions/ia_qbi_deduction.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/deductions/ia_qbi_deduction.py
@@ -16,6 +16,12 @@ class ia_qbi_deduction(Variable):
     defined_for = StateCode.IA
 
     def formula(person, period, parameters):
-        fed_qbid = person("qbid_amount", period)
+        fed_indv_qbid = person("qbid_amount", period)
+        tax_unit = person.tax_unit
+        fed_unit_qbid = tax_unit("qualified_business_income_deduction", period)
+        reduction_factor = where(
+            fed_indv_qbid > 0, fed_unit_qbid / fed_indv_qbid, 1.0
+        )
+        fed_qbid = fed_indv_qbid * reduction_factor
         p = parameters(period).gov.states.ia.tax.income
         return fed_qbid * p.deductions.qualified_business_income.fraction


### PR DESCRIPTION
After fixing these two bugs, the PolicyEngine-US Iowa income tax module passes 700,000 integration tests in the `p21`, `e21`, `f21`, `g21`, `h21`, `i21`, and `j21` test samples (see issue #993 for details on the nature of these samples).  The expected `ia_income_tax` amounts in these integration tests are generated by the 2023-06-22 patch version of TAXSIM35.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b38376e</samp>

### Summary
🐛🧪📝

<!--
1.  🐛 for bug fixes
2.  🧪 for adding tests
3.  📝 for updating documentation
-->
This pull request fixes two issues with the Iowa income tax calculations, related to the federal tax deduction and the qualified business income deduction (QBID). It updates the formulas for `ia_fedtax_deduction` and `ia_qbi_deduction` in `policyengine_us/variables`, and adds or modifies unit tests and integration tests in `policyengine_us/tests` to verify the correctness of the changes. It also updates the changelog file and bumps the patch version of the package.

> _We'll fix the `ia_fedtax_deduction` with a simple tweak_
> _And make the `ia_qbi_deduction` fair and neat_
> _We'll write some tests to check our work and then we'll bump the patch_
> _So heave away, me hearties, heave away and catch_

### Walkthrough
*  Simplify and correct the formula for the `ia_fedtax_deduction` by removing the unnecessary subtraction of the `self_employment_tax` and using the `add` function ([link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-63d8464d46e6a6a34886f154dcfd0efe2083c41afd7f24423715f739afe424d9L30-R40))
*  Add a reduction factor to the formula for the `ia_qbi_deduction` to adjust the individual `qbid_amount` based on the ratio of the tax unit `qualified_business_income_deduction` to the sum of the individual `qbid_amounts` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-ecda8539612014649096b46039966e5b32acbd3064ee3aa805056ea72376a651L19-R25))
*  Update the unit tests for the `ia_fedtax_deduction` and the `ia_qbi_deduction` to reflect the changes in the formulas and the inputs ([link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-806b6b44e5044dbe0f865a514797a278d5f06a16878541152e887f265e300249L21-R22), [link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-806b6b44e5044dbe0f865a514797a278d5f06a16878541152e887f265e300249L28-R29), [link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-806b6b44e5044dbe0f865a514797a278d5f06a16878541152e887f265e300249L38-R40), [link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-806b6b44e5044dbe0f865a514797a278d5f06a16878541152e887f265e300249L50-R52), [link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-806b6b44e5044dbe0f865a514797a278d5f06a16878541152e887f265e300249L57-R58), [link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-a846fba50f3f4e7608035743c137a7220dd8d922c236b50381bfefa1e99fb1d8L4-R5), [link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-a846fba50f3f4e7608035743c137a7220dd8d922c236b50381bfefa1e99fb1d8L12-R14))
*  Add two new integration tests for the Iowa income tax using data from the TAXSIM35 model and comparing the expected `ia_income_tax` with the output of the policy engine ([link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-1325cd6ac8ec01735d6e6bc0df645cc737f4ec493c1949f7a5c28081271b4aaeR185-R304))
*  Add a new entry to the `changelog_entry.yaml` file, indicating that the patch version of the package has been bumped and that two fixes have been made to the Iowa federal tax deduction and the Iowa QBID logic ([link](https://github.com/PolicyEngine/policyengine-us/pull/2483/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R5))


