### PR TITLE
Fix bug in person allocation of tax-unit real estate taxes in Iowa AMT formulas

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Incorrect handling of federal self-employment tax in Iowa federal tax deduction logic.
+    - Incorrect handling of federal QBID (qualified business income deduction) in Iowa QBID logic.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,5 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Incorrect handling of federal self-employment tax in Iowa federal tax deduction logic.
-    - Incorrect handling of federal QBID (qualified business income deduction) in Iowa QBID logic.
+    - Incorrect allocation of tax-unit real estate taxes to persons in Iowa AMT logic.

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_fedtax_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_fedtax_deduction.yaml
@@ -18,14 +18,15 @@
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
-        income_tax_before_refundable_credits: 21_000
         additional_medicare_tax: 1_000
+        income_tax_before_refundable_credits: 21_200
     households:
       household:
         members: [person1, person2, person3]
         state_code: IA
   output:
-    ia_fedtax_deduction: [14_800, 5_000, 0]
+    self_employment_tax: [200, 0, 0]
+    ia_fedtax_deduction: [15_000, 5_000, 0]
 
 - name: IA federal income tax deduction unit test 2
   absolute_error_margin: 0.01
@@ -35,8 +36,8 @@
       person1:
         is_tax_unit_head: true
         age: 40
-        ia_net_income: 300_000
-        self_employment_tax: 200
+        ia_net_income: 400_000
+        self_employment_tax: 700
       person2:
         is_tax_unit_spouse: true
         age: 38
@@ -47,11 +48,11 @@
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
-        income_tax_before_refundable_credits: 21_000
-        additional_medicare_tax: 1_000
+        additional_medicare_tax: 2_000
+        income_tax_before_refundable_credits: 22_700
     households:
       household:
         members: [person1, person2, person3]
         state_code: IA
   output:
-    ia_fedtax_deduction: [14_800, 5_000, 0]
+    ia_fedtax_deduction: [16_000, 4_000, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_integration.yaml
@@ -302,3 +302,43 @@
     qualified_business_income_deduction: 6_395.90
     ia_qbi_deduction: [3_197.95, 0, 0, 0, 0]
     ia_income_tax: 2_648.36
+
+- name: Tax unit with taxsimid 64550 in q21.its.csv and q21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 59
+        employment_income: 144_010
+        social_security: 4_500
+        real_estate_taxes: 24_000
+        interest_expense: 4_000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_spouse: true
+        age: 59
+        employment_income: 157_010
+        social_security: 4_500
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IA
+  output:  # expected ia_income_tax from patched TAXSIM35 2023-06-23 version
+    ia_income_tax: 14_590.43

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_integration.yaml
@@ -182,3 +182,123 @@
     ia_income_tax_before_credits: 598.81
     ia_exemption_credit: 120
     ia_income_tax: 478.81  # the incorrect TAXSIM35 result is 430.85
+
+- name: Tax unit with taxsimid 4731 in j21.its.csv and j21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 71
+        employment_income: 6_010
+        qualified_dividend_income: 505.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 1_505.0
+        rental_income: 505.0
+        taxable_private_pension_income: 1_500.0
+        social_security: 4_500.0
+        rent: 3_000
+        self_employment_income: 93_010
+        business_is_qualified: true
+        business_is_sstb: false
+        w2_wages_from_qualified_business: 100e6
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_spouse: true
+        age: 71
+        employment_income: 1_010
+        qualified_dividend_income: 505.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 1_505.0
+        rental_income: 505.0
+        taxable_private_pension_income: 1_500.0
+        social_security: 4_500.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IA
+  output:  # expected ia_income_tax from patched TAXSIM35 2023-06-22 version
+    ia_income_tax: 5_620.59
+
+- name: Tax unit with taxsimid 2782 in j21.its.csv and j21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 67
+        qualified_dividend_income: 1_005.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 5_005.0
+        rental_income: 2_005.0
+        taxable_private_pension_income: 1_000.0
+        rent: 19_000
+        self_employment_income: 46_010
+        business_is_qualified: true
+        business_is_sstb: true
+        w2_wages_from_qualified_business: 100e6
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_spouse: true
+        age: 67
+        qualified_dividend_income: 1_005.0
+        taxable_interest_income: 5_505.0
+        long_term_capital_gains: 5_005.0
+        rental_income: 2_005.0
+        taxable_private_pension_income: 1_000.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person3:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person4:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person5:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5]
+        state_code: IA
+  output:  # expected ia_income_tax from patched TAXSIM35 2023-06-22 version
+    qbid_amount: [8_551.90, 0, 0, 0, 0]
+    qualified_business_income_deduction: 6_395.90
+    ia_qbi_deduction: [3_197.95, 0, 0, 0, 0]
+    ia_income_tax: 2_648.36

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
@@ -1,7 +1,7 @@
 - name: IA qualified business income (QBI) deduction unit test 1
   period: 2021
   input:
-    qbid_amount: 10_000
+    qbid_amount: 11_000
     qualified_business_income_deduction: 10_000
     state_code: IA
   output:
@@ -10,7 +10,7 @@
 - name: IA qualified business income (QBI) deduction unit test 2
   period: 2022
   input:
-    qbid_amount: 10_000
+    qbid_amount: 11_000
     qualified_business_income_deduction: 10_000
     state_code: IA
   output:

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_qbi_deduction.yaml
@@ -2,6 +2,7 @@
   period: 2021
   input:
     qbid_amount: 10_000
+    qualified_business_income_deduction: 10_000
     state_code: IA
   output:
     ia_qbi_deduction: 5_000
@@ -10,6 +11,7 @@
   period: 2022
   input:
     qbid_amount: 10_000
+    qualified_business_income_deduction: 10_000
     state_code: IA
   output:
     ia_qbi_deduction: 7_500

--- a/policyengine_us/variables/gov/states/ia/tax/income/deductions/ia_qbi_deduction.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/deductions/ia_qbi_deduction.py
@@ -16,6 +16,12 @@ class ia_qbi_deduction(Variable):
     defined_for = StateCode.IA
 
     def formula(person, period, parameters):
-        fed_qbid = person("qbid_amount", period)
+        fed_indv_qbid = person("qbid_amount", period)
+        tax_unit = person.tax_unit
+        fed_unit_qbid = tax_unit("qualified_business_income_deduction", period)
+        reduction_factor = where(
+            fed_indv_qbid > 0, fed_unit_qbid / fed_indv_qbid, 1.0
+        )
+        fed_qbid = fed_indv_qbid * reduction_factor
         p = parameters(period).gov.states.ia.tax.income
         return fed_qbid * p.deductions.qualified_business_income.fraction

--- a/policyengine_us/variables/gov/states/ia/tax/income/ia_amt_indiv.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/ia_amt_indiv.py
@@ -20,9 +20,11 @@ class ia_amt_indiv(Variable):
         reg_taxinc = person("ia_taxable_income_indiv", period)
         std_ded = person("ia_standard_deduction_indiv", period)
         itm_ded = person("ia_itemized_deductions_indiv", period)
+        prorate_frac = person("ia_prorate_fraction", period)
+        proptax = add(person.tax_unit, period, ["real_estate_taxes"])
         amt_taxinc = where(
             itm_ded > std_ded,
-            reg_taxinc + person("real_estate_taxes", period),
+            reg_taxinc + prorate_frac * proptax,
             reg_taxinc,
         )
         # compute AMT amount

--- a/policyengine_us/variables/gov/states/ia/tax/income/ia_amt_joint.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/ia_amt_joint.py
@@ -20,9 +20,11 @@ class ia_amt_joint(Variable):
         reg_taxinc = person("ia_taxable_income_joint", period)
         std_ded = person("ia_standard_deduction_joint", period)
         itm_ded = person("ia_itemized_deductions_joint", period)
+        is_head = person("is_tax_unit_head", period)
+        proptax = add(person.tax_unit, period, ["real_estate_taxes"])
         amt_taxinc = where(
             itm_ded > std_ded,
-            reg_taxinc + person("real_estate_taxes", period),
+            reg_taxinc + is_head * proptax,
             reg_taxinc,
         )
         # compute AMT amount


### PR DESCRIPTION
This pull request eliminates all significant Iowa income tax differences in the `k21` sample.
See issue #993 for details on the nature of the k21 sample.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1b0e46a</samp>

### Summary
🐛🧪📝

<!--
1.  🐛 for the bug fix to the allocation of real estate taxes to persons in the Iowa alternative minimum tax logic.
2.  🧪 for the addition of three new unit tests for the Iowa income tax, using data from the TAXSIM35 model.
3.  📝 for the update of the changelog file, indicating the patch version increment and the bug fix.
-->
This pull request fixes a bug and updates the unit tests for the Iowa income tax logic. It changes the formulas for the `ia_amt_indiv` and `ia_amt_joint` functions, and adds a test to `ia_integration.yaml`. It also adds a new entry to the `changelog_entry.yaml` file.

### Walkthrough
* Add a prorate fraction to the Iowa alternative minimum tax for individuals formula, allocating the real estate taxes across the tax unit members according to their net incomes ([link](https://github.com/PolicyEngine/policyengine-us/pull/2488/files?diff=unified&w=0#diff-d24906bc9a306903c88b7a48ca1d9b62eef8e28d06a76b641dea101a94d2a37aL23-R27))
* Add a condition to the Iowa alternative minimum tax for joint filers formula, allocating the real estate taxes to the tax unit head only ([link](https://github.com/PolicyEngine/policyengine-us/pull/2488/files?diff=unified&w=0#diff-7144e1e707117479269b7b7615098b003c19ee61f4bf57204945b867afa518a4L23-R27))
* Add a unit test for the Iowa income tax, using data from the patched TAXSIM35 model. 
* Add a new entry to the `changelog_entry.yaml` file, indicating the patch version increment and the bug fix description ([link](https://github.com/PolicyEngine/policyengine-us/pull/2488/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


