### PR TITLE
Avoid numpy array divide warning in taxable_social_security formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in taxable_social_security.py module.

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/mo_pension_and_ss_or_ssd_deduction_section_b.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/mo_pension_and_ss_or_ssd_deduction_section_b.yaml
@@ -92,7 +92,7 @@
     taxable_private_pension_income: 10_000
     state_code: MO
   output:
-    mo_pension_and_ss_or_ssd_deduction_section_b: 0
+    mo_pension_and_ss_or_ssd_deduction_section_b: 3_000
 
 - name: AGI above threshold, private pension income, no taxable social security income, joint
   period: 2021
@@ -104,4 +104,4 @@
     taxable_private_pension_income: 10_000
     state_code: MO
   output:
-    mo_pension_and_ss_or_ssd_deduction_section_b: 0.0
+    mo_pension_and_ss_or_ssd_deduction_section_b: 0

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/taxable_social_security.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/taxable_social_security.py
@@ -1,4 +1,5 @@
 from policyengine_us.model_api import *
+import numpy as np
 
 
 class taxable_social_security(Variable):
@@ -11,16 +12,16 @@ class taxable_social_security(Variable):
     def formula(person, period, parameters):
         unit_tss = person.tax_unit("tax_unit_taxable_social_security", period)
         # allocate unit_tss to head and spouse in proportion to social_security
-        unit_socsec = person.tax_unit("tax_unit_social_security", period)
-        unit_has_socsec = unit_socsec > 0
         ind_socsec = person("social_security", period)
+        unit_socsec = person.tax_unit("tax_unit_social_security", period)
+        person_frac = np.zeros_like(unit_socsec)
+        mask = unit_socsec > 0
+        person_frac[mask] = ind_socsec[mask] / unit_socsec[mask]
         is_spouse = person("is_tax_unit_spouse", period)
-        spouse_frac = min_(
-            1, where(is_spouse & unit_has_socsec, ind_socsec / unit_socsec, 0)
-        )
+        spouse_frac = min_(1, where(is_spouse, person_frac, 0))
         unit_spouse_frac = person.tax_unit.sum(spouse_frac)
         is_head = person("is_tax_unit_head", period)
-        head_frac = where(is_head & unit_has_socsec, 1 - unit_spouse_frac, 0)
+        head_frac = where(is_head, 1 - unit_spouse_frac, 0)
         unit_head_frac = person.tax_unit.sum(head_frac)
         return unit_tss * select(
             [is_head, is_spouse], [unit_head_frac, unit_spouse_frac], default=0

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/taxable_social_security.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/taxable_social_security.py
@@ -1,5 +1,4 @@
 from policyengine_us.model_api import *
-import numpy as np
 
 
 class taxable_social_security(Variable):

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/taxable_social_security.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/taxable_social_security.py
@@ -13,6 +13,8 @@ class taxable_social_security(Variable):
         # allocate unit_tss to head and spouse in proportion to social_security
         ind_socsec = person("social_security", period)
         unit_socsec = person.tax_unit("tax_unit_social_security", period)
+        # Compute each person's share of tax unit's Social Security benefits.
+        # Use mask instead of where to avoid divide-by-zero warnings. Default to zero.
         person_frac = np.zeros_like(unit_socsec)
         mask = unit_socsec > 0
         person_frac[mask] = ind_socsec[mask] / unit_socsec[mask]


### PR DESCRIPTION
Even though this change left hundreds of thousands of US and MO (issue #993) integration tests unchanged, it did require a change in one MO unit test.  This PR fixes #2496.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0479fb8</samp>

### Summary
🐛🧪🚀

<!--
1.  🐛 for the bug fix in the changelog file.
2.  🧪 for the test case updates.
3.  🚀 for the performance and readability improvement in the module.
-->
This pull request fixes a bug in the `taxable_social_security` module, updates some test cases for the Missouri pension deduction, and adds a changelog entry. The changes improve the accuracy, performance, and readability of the code.

> _Sing, O Muse, of the skillful coder who fixed the bug_
> _That caused the numpy array to warn of a divide by zero_
> _And who improved the tests and logic of the pension deduction_
> _With clear and elegant code that pleased the reviewers._

### Walkthrough
* Fix a bug in the `taxable_social_security` formula that caused a numpy array divide warning and optimize the logic of allocating the tax unit taxable social security amount to the head and spouse ([link](https://github.com/PolicyEngine/policyengine-us/pull/2497/files?diff=unified&w=0#diff-b2d66c6c59fff54a57175787d72aea96a5c2e42cac51ba06159a0198ebb871c8R2), [link](https://github.com/PolicyEngine/policyengine-us/pull/2497/files?diff=unified&w=0#diff-b2d66c6c59fff54a57175787d72aea96a5c2e42cac51ba06159a0198ebb871c8L14-R24))
* Update the expected outputs of two test cases for the Missouri pension and social security or SSD deduction, section B, to match the correct policy values and formatting ([link](https://github.com/PolicyEngine/policyengine-us/pull/2497/files?diff=unified&w=0#diff-987d5dba5790cc195ae07c9242577f621766c092ab033c31b6c4ed124ef6b568L95-R95), [link](https://github.com/PolicyEngine/policyengine-us/pull/2497/files?diff=unified&w=0#diff-987d5dba5790cc195ae07c9242577f621766c092ab033c31b6c4ed124ef6b568L107-R107))
* Add a new entry to the changelog file to document the patch version bump and the bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/2497/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


