### PR TITLE
Eliminate numpy array divide warning in ma_limited_income_tax_credit formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in ma_limited_income_tax_credit module.

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
@@ -1,8 +1,5 @@
 from policyengine_us.model_api import *
-import warnings
-
-warnings.filterwarnings("ignore")
-warnings.simplefilter("ignore")
+import numpy as np
 
 
 class ma_limited_income_tax_credit(Variable):
@@ -20,12 +17,12 @@ class ma_limited_income_tax_credit(Variable):
             "ma_income_tax_exemption_threshold", period
         )
         income_over_threshold = max_(0, agi - exemption_threshold)
-        income_ratio = agi / exemption_threshold
-        lic = parameters(
-            period
-        ).gov.states.ma.tax.income.credits.limited_income_credit
-        eligible = income_ratio <= lic.income_limit
-        tax_cap = lic.percent * income_over_threshold
+        income_ratio = np.ones_like(agi) * np.inf
+        mask = exemption_threshold > 0
+        income_ratio[mask] = agi[mask] / exemption_threshold[mask]
+        p = parameters(period).gov.states.ma.tax.income.credits
+        eligible = income_ratio <= p.limited_income_credit.income_limit
+        tax_cap = p.limited_income_credit.percent * income_over_threshold
         income_tax = tax_unit("ma_income_tax_before_credits", period)
         excess_tax = max_(0, income_tax - tax_cap)
         return eligible * excess_tax

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
@@ -1,5 +1,4 @@
 from policyengine_us.model_api import *
-import numpy as np
 
 
 class ma_limited_income_tax_credit(Variable):

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
@@ -16,6 +16,8 @@ class ma_limited_income_tax_credit(Variable):
             "ma_income_tax_exemption_threshold", period
         )
         income_over_threshold = max_(0, agi - exemption_threshold)
+        # Compute AGI as a share of the exemption threshold.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to inf.
         income_ratio = np.ones_like(agi) * np.inf
         mask = exemption_threshold > 0
         income_ratio[mask] = agi[mask] / exemption_threshold[mask]


### PR DESCRIPTION
Fixes #2498.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ed5c422</samp>

### Summary
🐛🚀🧹

<!--
1.  🐛 for fixing a bug or warning
2.  🚀 for improving performance or efficiency
3.  🧹 for cleaning up or refactoring code
-->
This pull request fixes a bug and improves the code quality of the `ma_limited_income_tax_credit` module. It also updates the changelog file with the relevant information.

> _A warning was raised by `numpy`_
> _When dividing by zero, how sloppy!_
> _The module `ma_limited_income_tax_credit`_
> _Was refactored to make it more legit_
> _And the patch version was bumped up promptly_

### Walkthrough
* Fix divide by zero warning in `ma_limited_income_tax_credit` formula by using numpy array operations to create a mask of non-zero exemption_threshold values and assign income_ratio accordingly ([link](https://github.com/PolicyEngine/policyengine-us/pull/2499/files?diff=unified&w=0#diff-afafcf5215966fc55a31b2b6b85dd5fc44dcf27b39515f5512432ce1c58ba767L23-R25))
* Simplify access to parameters object in `ma_limited_income_tax_credit` formula by using a shorter alias ([link](https://github.com/PolicyEngine/policyengine-us/pull/2499/files?diff=unified&w=0#diff-afafcf5215966fc55a31b2b6b85dd5fc44dcf27b39515f5512432ce1c58ba767L23-R25))
* Replace import of warnings module with import of numpy module in `ma_limited_income_tax_credit` module, as warnings module is no longer needed and numpy module is needed for array operations ([link](https://github.com/PolicyEngine/policyengine-us/pull/2499/files?diff=unified&w=0#diff-afafcf5215966fc55a31b2b6b85dd5fc44dcf27b39515f5512432ce1c58ba767L2-R4))
* Add changelog entry for patch version bump and fixed issue in `changelog_entry.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2499/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3))


