### PR TITLE
Eliminate numpy array divide warning in md_two_income_subtraction formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in md_two_income_subtraction module.

--- a/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/md_two_income_subtraction.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/md_two_income_subtraction.py
@@ -1,5 +1,4 @@
 from policyengine_us.model_api import *
-import numpy as np
 
 
 class md_two_income_subtraction(Variable):

--- a/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/md_two_income_subtraction.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/md_two_income_subtraction.py
@@ -1,4 +1,5 @@
 from policyengine_us.model_api import *
+import numpy as np
 
 
 class md_two_income_subtraction(Variable):
@@ -26,9 +27,9 @@ class md_two_income_subtraction(Variable):
         couple_gross_income = tax_unit.sum(
             where(is_head | is_spouse, gross_income, 0)
         )
-        head_frac = where(
-            couple_gross_income > 0, head_gross_income / couple_gross_income, 1
-        )
+        head_frac = np.ones_like(couple_gross_income)
+        mask = couple_gross_income > 0
+        head_frac[mask] = head_gross_income[mask] / couple_gross_income[mask]
         head_us_agi = head_frac * us_agi
         spouse_us_agi = (1 - head_frac) * us_agi
 

--- a/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/md_two_income_subtraction.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/md_two_income_subtraction.py
@@ -26,6 +26,8 @@ class md_two_income_subtraction(Variable):
         couple_gross_income = tax_unit.sum(
             where(is_head | is_spouse, gross_income, 0)
         )
+        # Compute the head's share of the couple's cross income.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to one.
         head_frac = np.ones_like(couple_gross_income)
         mask = couple_gross_income > 0
         head_frac[mask] = head_gross_income[mask] / couple_gross_income[mask]


### PR DESCRIPTION
Fixes #2500.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dcc7b8d</samp>

### Summary
🐛🧮📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request. The numpy array divide warning was a bug that could affect the accuracy and reliability of the module's calculations.
2.  🧮 - This emoji represents a calculation or math-related change, which is also relevant for this pull request. The use of numpy for array operations and the handling of zero income cases are both related to the mathematical logic of the module.
3.  📝 - This emoji represents a documentation change, which is a minor but useful aspect of this pull request. The changelog entry is a form of documentation that helps users and developers keep track of the project's history and progress.
-->
This pull request fixes a bug in the `md_two_income_subtraction` module that caused a warning when dividing by zero income. It also improves the performance and readability of the code by using numpy arrays. The changes are reflected in the changelog entry as a patch-level update.

> _The module `md_two_income_subtraction`_
> _Had a warning that caused some distraction_
> _So they used numpy_
> _To divide arrays safely_
> _And updated the changelog with satisfaction_

### Walkthrough
*  Avoid numpy warning when calculating Maryland two-income subtraction ([link](https://github.com/PolicyEngine/policyengine-us/pull/2501/files?diff=unified&w=0#diff-c5d1660309382d7e9058c37430c363dbe00b9b4367ade793d7479ffbf480c5d3L29-R32))
   - Import numpy library in `md_two_income_subtraction.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2501/files?diff=unified&w=0#diff-c5d1660309382d7e9058c37430c363dbe00b9b4367ade793d7479ffbf480c5d3R2))
   - Replace division with masked assignment in formula function ([link](https://github.com/PolicyEngine/policyengine-us/pull/2501/files?diff=unified&w=0#diff-c5d1660309382d7e9058c37430c363dbe00b9b4367ade793d7479ffbf480c5d3L29-R32))
* Update changelog entry for patch-level change ([link](https://github.com/PolicyEngine/policyengine-us/pull/2501/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


