### PR TITLE
Eliminate numpy array divide warning in mo_net_state_income_taxes formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warnings in mo_net_state_income_taxes module.

--- a/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.py
@@ -24,22 +24,29 @@ class mo_net_state_income_taxes(Variable):
             "state_and_local_sales_or_income_tax", period
         )
 
-        # Technically, state and local income tax could include the "local_earnings_tax" variable,
-        # but because the definition of net_state_income_taxes is simply (state_tax + local_tax) - local_tax,
+        # Technically, state and local income tax could include the
+        # "local_earnings_tax" variable,
+        # but because the definition of net_state_income_taxes is
+        # simply (state_tax + local_tax) - local_tax,
         # it is redundant to keep it
-        # More info about local income tax from the Federal W2 on page 26 here: https://dor.mo.gov/forms/MO-1040%20Instructions_2021.pdf
+        # More info about local income tax from the Federal W2 on page 26 here:
+        # https://dor.mo.gov/forms/MO-1040%20Instructions_2021.pdf
 
         net_state_income_taxes = tax_unit("state_income_tax", period)
 
-        income_tax_to_total_ratio = (
-            net_state_income_taxes / state_and_local_sales_or_income_tax
+        tax_ratio = np.ones_like(net_state_income_taxes)
+        mask = state_and_local_sales_or_income_tax != 0
+        tax_ratio[mask] = (
+            net_state_income_taxes[mask]
+            / state_and_local_sales_or_income_tax[mask]
         )
 
-        # The threshold is the same as the adjustment_base_amount, i.e. the SALT cap introduced by TCJA
+        # The threshold is the same as the adjustment_base_amount,
+        # i.e. the SALT cap introduced by TCJA
         threshold = adjustment_base_amount
 
         return where(
             state_and_local_sales_or_income_tax > threshold,
-            adjustment_base_amount * (income_tax_to_total_ratio),
+            adjustment_base_amount * tax_ratio,
             net_state_income_taxes,
         )

--- a/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.py
@@ -33,7 +33,8 @@ class mo_net_state_income_taxes(Variable):
         # https://dor.mo.gov/forms/MO-1040%20Instructions_2021.pdf
 
         net_state_income_taxes = tax_unit("state_income_tax", period)
-
+        # Compute the share of SALT from net state income taxes.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to one.
         tax_ratio = np.ones_like(net_state_income_taxes)
         mask = state_and_local_sales_or_income_tax != 0
         tax_ratio[mask] = (


### PR DESCRIPTION
Fixes #2505.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b9ad7d9</samp>

### Summary
🐛🧮📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It conveys that the change resolves an issue that was causing incorrect or unexpected behavior in the code.
2.  🧮 - This emoji represents a calculator, which is a symbol of mathematical or numerical operations. It conveys that the change involves modifying a formula or calculation, which is the core of the mo_net_state_income_taxes module.
3.  📝 - This emoji represents a memo or a document, which is a symbol of writing or editing text. It conveys that the change involves updating the changelog entry, as well as adding comments and breaking lines to improve the code readability.
-->
This pull request fixes a bug that caused numpy array divide warnings in the `mo_net_state_income_taxes` module. It also updates the changelog entry and improves the code readability.

> _Fix `nan` bug in_
> _`mo_net_state_income_taxes`_
> _Winter code is clear_

### Walkthrough
* Fix bug related to numpy array divide warnings in mo_net_state_income_taxes module ([link](https://github.com/PolicyEngine/policyengine-us/pull/2506/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2506/files?diff=unified&w=0#diff-17a9f97821a7743446c6e7cdacb4a8ad7cad7bf1a084c94b634ab81a84127182L27-R50))
  - Avoid dividing by zero by creating a tax_ratio array that is one by default and only updates for tax units with positive state_and_local_sales_or_income_tax ([link](https://github.com/PolicyEngine/policyengine-us/pull/2506/files?diff=unified&w=0#diff-17a9f97821a7743446c6e7cdacb4a8ad7cad7bf1a084c94b634ab81a84127182L27-R50))
  - Improve readability of `mo_net_state_income_taxes.py` by breaking long lines and adding comments ([link](https://github.com/PolicyEngine/policyengine-us/pull/2506/files?diff=unified&w=0#diff-17a9f97821a7743446c6e7cdacb4a8ad7cad7bf1a084c94b634ab81a84127182L27-R50))
  - Update changelog entry with patch bump type and bug fix description ([link](https://github.com/PolicyEngine/policyengine-us/pull/2506/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


