### PR TITLE
Eliminate array divide warning in MO schedule B pension deduction calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in mo_pension_and_ss_or_ssd_deduction_section_b module.

--- a/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
@@ -30,16 +30,13 @@ class mo_pension_and_ss_or_ssd_deduction_section_b(Variable):
                 - p.mo_private_pension_deduction_allowance[filing_status]
             ),
         )
-        ind_pvt_pension_amt = person("taxable_private_pension_income", period)
-        ind_pvt_pension_val = min_(
-            ind_pvt_pension_amt,
-            p.mo_max_private_pension,
-        )
-        unit_pvt_pension_val = tax_unit.sum(ind_pvt_pension_val)  # line8
-        unit_deduction = max_(0, unit_pvt_pension_val - excess_agi)  # line9
-        ind_share_of_unit_deduction = where(
-            ind_pvt_pension_val > 0,
-            ind_pvt_pension_val / unit_pvt_pension_val,
-            0,
-        )
-        return ind_share_of_unit_deduction * unit_deduction
+        ind_pvt_pen_amt = person("taxable_private_pension_income", period)
+        ind_pvt_pen_val = min_(ind_pvt_pen_amt, p.mo_max_private_pension)
+        unit_pvt_pen_val = tax_unit.sum(ind_pvt_pen_val)  # line8
+        unit_deduction = max_(0, unit_pvt_pen_val - excess_agi)  # line9
+
+        ind_share = np.zeros_like(ind_pvt_pen_val)
+        mask = ind_pvt_pen_val > 0
+        ind_share[mask] = ind_pvt_pen_val[mask] / unit_pvt_pen_val[mask]
+
+        return ind_share * unit_deduction

--- a/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
@@ -34,7 +34,8 @@ class mo_pension_and_ss_or_ssd_deduction_section_b(Variable):
         ind_pvt_pen_val = min_(ind_pvt_pen_amt, p.mo_max_private_pension)
         unit_pvt_pen_val = tax_unit.sum(ind_pvt_pen_val)  # line8
         unit_deduction = max_(0, unit_pvt_pen_val - excess_agi)  # line9
-
+    # Compute the individual's share of the tax unit's taxable private pension income.
+    # Use a mask rather than where to avoid a divide-by-zero warning.
         ind_share = np.zeros_like(ind_pvt_pen_val)
         mask = ind_pvt_pen_val > 0
         ind_share[mask] = ind_pvt_pen_val[mask] / unit_pvt_pen_val[mask]

--- a/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
@@ -35,7 +35,7 @@ class mo_pension_and_ss_or_ssd_deduction_section_b(Variable):
         unit_pvt_pen_val = tax_unit.sum(ind_pvt_pen_val)  # line8
         unit_deduction = max_(0, unit_pvt_pen_val - excess_agi)  # line9
     # Compute the individual's share of the tax unit's taxable private pension income.
-    # Use a mask rather than where to avoid a divide-by-zero warning.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to zero.
         ind_share = np.zeros_like(ind_pvt_pen_val)
         mask = ind_pvt_pen_val > 0
         ind_share[mask] = ind_pvt_pen_val[mask] / unit_pvt_pen_val[mask]

--- a/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_b.py
@@ -34,7 +34,7 @@ class mo_pension_and_ss_or_ssd_deduction_section_b(Variable):
         ind_pvt_pen_val = min_(ind_pvt_pen_amt, p.mo_max_private_pension)
         unit_pvt_pen_val = tax_unit.sum(ind_pvt_pen_val)  # line8
         unit_deduction = max_(0, unit_pvt_pen_val - excess_agi)  # line9
-    # Compute the individual's share of the tax unit's taxable private pension income.
+        # Compute the individual's share of the tax unit's taxable private pension income.
         # Use a mask rather than where to avoid a divide-by-zero warning. Default to zero.
         ind_share = np.zeros_like(ind_pvt_pen_val)
         mask = ind_pvt_pen_val > 0


### PR DESCRIPTION
Fixes #2507.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 192d867</samp>

### Summary
🐛♻️📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It indicates that the change resolves an issue or error in the code.
2.  ♻️ - This emoji represents a refactor, which is the secondary purpose of the pull request. It indicates that the change improves the structure, design, or quality of the code without changing its functionality or behavior.
3.  📝 - This emoji represents a documentation update, which is the tertiary purpose of the pull request. It indicates that the change adds or modifies information in the changelog, comments, or other documentation files.
-->
This pull request fixes a numpy warning in the `mo_pension_and_ss_or_ssd_deduction_section_b` module by refactoring the formula with a numpy mask. It also updates the changelog entry and renames some variables for clarity.

> _`mo_pension` fixed_
> _No more numpy warnings_
> _Winter code is clean_

### Walkthrough
* Fix numpy array divide warning in `mo_pension_and_ss_or_ssd_deduction_section_b` module by using numpy mask and indexing instead of `where` function ([link](https://github.com/PolicyEngine/policyengine-us/pull/2508/files?diff=unified&w=0#diff-fe660e13c23d9d35bd16d4ffeefaa3d60925a688185beecdfb0ef86157702b5cL33-R42))
* Update changelog entry to indicate patch-level bump and bug fix for `mo_pension_and_ss_or_ssd_deduction_section_b` module ([link](https://github.com/PolicyEngine/policyengine-us/pull/2508/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


