### PR TITLE
Eliminate array divide warning in MO schedule C pension deduction calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in mo_pension_and_ss_or_ssd_deduction_section_c module.

--- a/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_c.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_c.py
@@ -25,9 +25,7 @@ class mo_pension_and_ss_or_ssd_deduction_section_c(Variable):
         ind_taxable_ben = person("taxable_social_security", period)
         unit_taxable_ben = tax_unit.sum(ind_taxable_ben)
         unit_deduction = max_(0, unit_taxable_ben - unit_agi_over_allowance)
-        ind_frac = where(
-            ind_taxable_ben > 0,
-            ind_taxable_ben / unit_taxable_ben,
-            0,
-        )
+        ind_frac = np.zeros_like(ind_taxable_ben)
+        mask = ind_taxable_ben > 0
+        ind_frac[mask] = ind_taxable_ben[mask] / unit_taxable_ben[mask]
         return ind_frac * unit_deduction

--- a/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_c.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction_section_c.py
@@ -25,6 +25,8 @@ class mo_pension_and_ss_or_ssd_deduction_section_c(Variable):
         ind_taxable_ben = person("taxable_social_security", period)
         unit_taxable_ben = tax_unit.sum(ind_taxable_ben)
         unit_deduction = max_(0, unit_taxable_ben - unit_agi_over_allowance)
+        # Compute the individual's share of the tax unit's taxable benefits.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to zero.
         ind_frac = np.zeros_like(ind_taxable_ben)
         mask = ind_taxable_ben > 0
         ind_frac[mask] = ind_taxable_ben[mask] / unit_taxable_ben[mask]


### PR DESCRIPTION
Fixes #2509.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5964db2</samp>

### Summary
🐛🧮🧹

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It indicates that the change resolves an issue or error that was affecting the functionality or performance of the package.
2.  🧮 - This emoji represents a calculation or formula, which is the specific aspect of the package that the change modifies. It indicates that the change involves a mathematical or logical operation or expression, and that it affects the output or result of the package.
3.  🧹 - This emoji represents a cleanup or refactoring, which is a secondary effect of the change. It indicates that the change improves the quality or readability of the code, and that it removes unnecessary or redundant elements.
-->
This pull request updates the `policyengine-us` package with a patch version, and fixes a numpy warning in the `mo_pension_and_ss_or_ssd_deduction_section_c` module. It also adds a changelog entry to document the change.

> _`policyengine-us`_
> _Fixes numpy warning now_
> _Winter of zero_

### Walkthrough
*  Fix numpy warning when dividing by zero in Missouri pension and social security or disability deduction ([link](https://github.com/PolicyEngine/policyengine-us/pull/2510/files?diff=unified&w=0#diff-6fe7f3002c1f829e3ab3d35dbc253c218bc8176af4c8810101762cdd3e81e860L28-R30))
* Update changelog file with patch version and change summary ([link](https://github.com/PolicyEngine/policyengine-us/pull/2510/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


