### PR TITLE
Eliminate divide warnings in mo_qualified_health_insurance_premiums module

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warnings in mo_qualified_health_insurance_premiums module.

--- a/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
@@ -51,12 +51,12 @@ class mo_qualified_health_insurance_premiums(Variable):
         # Cap at federal taxable income.
         taxable_income = tax_unit("taxable_income", period)
         # Allocate proportionally across people in the tax unit based on share
-        # of premiums. Use where statement to avoid dividing by zero.
-        person_share_of_tax_unit_premiums = where(
-            tax_unit_premiums > 0, person_premiums / tax_unit_premiums, 0
-        )
+        # of premiums.
+        person_share = np.zeros_like(tax_unit_premiums)
+        mask = tax_unit_premiums > 0
+        person_share[mask] = person_premiums[mask] / tax_unit_premiums[mask]
 
-        return person_share_of_tax_unit_premiums * where(
+        return person_share * where(
             itemizes,
             min_(itemized_premiums_amount, taxable_income),
             min_(tax_unit_premiums, taxable_income),

--- a/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
@@ -37,11 +37,10 @@ class mo_qualified_health_insurance_premiums(Variable):
             period,
             ["medical_out_of_pocket_expenses", "health_insurance_premiums"],
         )
-        # Apply a where statement to avoid division by zero.
-        med_expense_ratio = where(
-            tax_unit_health_expenses > 0,
-            med_expense_deduction / tax_unit_health_expenses,
-            0,
+        med_expense_ratio = np.zeros_like(tax_unit_health_expenses)
+        mask = tax_unit_health_expenses > 0
+        med_expense_ratio[mask] = (
+            med_expense_deduction[mask] / tax_unit_health_expenses[mask]
         )
 
         person_premiums = person("health_insurance_premiums", period)

--- a/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
@@ -8,9 +8,9 @@ class mo_qualified_health_insurance_premiums(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://dor.mo.gov/forms/5695.pdf",  # Form MO 5695
-        "https://www.irs.gov/pub/irs-pdf/f1040sa.pdf",  # Federal Form 1040 Schedule A
-        "https://www.irs.gov/pub/irs-pdf/f1040.pdf",  # Federal Form 1040
+        "https://dor.mo.gov/forms/5695.pdf",  # MO Form 5695
+        "https://www.irs.gov/pub/irs-pdf/f1040sa.pdf",  # US Form 1040 Sch A
+        "https://www.irs.gov/pub/irs-pdf/f1040.pdf",  # US Form 1040
     )
     defined_for = StateCode.MO
 
@@ -18,15 +18,19 @@ class mo_qualified_health_insurance_premiums(Variable):
         # Variable involves person- and tax unit-level variables.
         tax_unit = person.tax_unit
 
-        # total_health_insurance_premiums is also a primary input to the MO side of calculation, MO Form 5695, Line 8
+        # total_health_insurance_premiums is also a primary input to
+        # the MO side of calculation, MO Form 5695, Line 8
         # Federal Schedule A, Line 4
         med_expense_deduction = add(
             tax_unit, period, ["medical_expense_deduction"]
         )
 
-        # the ratio of federal medical expense deduction to total medical expenses (out of pocket + premiums)
-        # need division because med_dental_out_of_pocket is in federal tax, but no MO tax
-        # this ratio is then used to scale the health_insurance_premium amount that can be claimed
+        # the ratio of federal medical expense deduction to
+        # total medical expenses (out of pocket + premiums)
+        # need division because med_dental_out_of_pocket is
+        # in federal tax, but no MO tax
+        # this ratio is then used to scale the health_insurance_premium
+        # amount that can be claimed
         # IRS Schedule A Line 1
         tax_unit_health_expenses = add(
             tax_unit,
@@ -34,7 +38,7 @@ class mo_qualified_health_insurance_premiums(Variable):
             ["medical_out_of_pocket_expenses", "health_insurance_premiums"],
         )
         # Apply a where statement to avoid division by zero.
-        med_expense_deducted_ratio = where(
+        med_expense_ratio = where(
             tax_unit_health_expenses > 0,
             med_expense_deduction / tax_unit_health_expenses,
             0,
@@ -43,8 +47,9 @@ class mo_qualified_health_insurance_premiums(Variable):
         person_premiums = person("health_insurance_premiums", period)
         tax_unit_premiums = tax_unit.sum(person_premiums)
 
-        # Line 13 of MO Form 5695, represents the portion of medical expenses already deducted via federal tax itemization
-        deducted_portion = tax_unit_premiums * med_expense_deducted_ratio
+        # Line 13 of MO Form 5695, represents the portion of
+        # medical expenses already deducted via federal tax itemization
+        deducted_portion = tax_unit_premiums * med_expense_ratio
         # subtracts the portion of premiums already deducted from federal tax
         itemized_premiums_amount = tax_unit_premiums - deducted_portion
         itemizes = tax_unit("tax_unit_itemizes", period)

--- a/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/subtractions/mo_qualified_health_insurance_premiums.py
@@ -56,6 +56,7 @@ class mo_qualified_health_insurance_premiums(Variable):
         taxable_income = tax_unit("taxable_income", period)
         # Allocate proportionally across people in the tax unit based on share
         # of premiums.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to zero.
         person_share = np.zeros_like(tax_unit_premiums)
         mask = tax_unit_premiums > 0
         person_share[mask] = person_premiums[mask] / tax_unit_premiums[mask]


### PR DESCRIPTION
Fixes #2511.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ff3fa10</samp>

### Summary
🐛🧮📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It conveys that the change resolves an issue that was affecting the functionality or accuracy of the code.
2.  🧮 - This emoji represents a calculation or formula, which is the core component of the change in the mo_qualified_health_insurance_premiums module. It conveys that the change involves mathematical operations or expressions that affect the output of the code.
3.  📝 - This emoji represents a comment or documentation, which is the secondary component of the change in the mo_qualified_health_insurance_premiums module. It conveys that the change adds or improves the explanation or annotation of the code.
-->
This pull request fixes a bug in the `mo_qualified_health_insurance_premiums` module that caused numpy array divide warnings. It also updates the changelog entry to reflect the patch-level change.

> _`mo_qualified` fix_
> _No more divide by zero_
> _Fall leaves no warning_

### Walkthrough
* Fix bug related to numpy array divide warnings in `mo_qualified_health_insurance_premiums` module ([link](https://github.com/PolicyEngine/policyengine-us/pull/2512/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2512/files?diff=unified&w=0#diff-8e1b8131f7c4d44cc4e94131ca6534402ae4a00604f55fd39aad25838a1252cbL54-R59))
  - Replace where statement with mask and array assignment to avoid dividing by zero when tax unit has no premiums ([link](https://github.com/PolicyEngine/policyengine-us/pull/2512/files?diff=unified&w=0#diff-8e1b8131f7c4d44cc4e94131ca6534402ae4a00604f55fd39aad25838a1252cbL54-R59))
  - Add comments to explain allocation and subtraction logic ([link](https://github.com/PolicyEngine/policyengine-us/pull/2512/files?diff=unified&w=0#diff-8e1b8131f7c4d44cc4e94131ca6534402ae4a00604f55fd39aad25838a1252cbL54-R59))
  - Update changelog entry with bump keyword and bug description ([link](https://github.com/PolicyEngine/policyengine-us/pull/2512/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


