### PR TITLE
Eliminate array divide warning in mo_taxable_income module

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in mo_taxable_income module.

--- a/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_taxable_income.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_taxable_income.py
@@ -45,9 +45,6 @@ class mo_taxable_income(Variable):
         unit_taxinc = max_(0, unit_mo_agi - unit_mo_deductions)
 
         # allocate unit taxable income by each individual's share of unit AGI
-        """
-        ind_agi_share = where(unit_mo_agi > 0, mo_agi / unit_mo_agi, 0)
-        """
         ind_agi_share = np.zeros_like(unit_mo_agi)
         mask = unit_mo_agi > 0
         ind_agi_share[mask] = mo_agi[mask] / unit_mo_agi[mask]

--- a/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_taxable_income.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_taxable_income.py
@@ -45,5 +45,11 @@ class mo_taxable_income(Variable):
         unit_taxinc = max_(0, unit_mo_agi - unit_mo_deductions)
 
         # allocate unit taxable income by each individual's share of unit AGI
+        """
         ind_agi_share = where(unit_mo_agi > 0, mo_agi / unit_mo_agi, 0)
+        """
+        ind_agi_share = np.zeros_like(unit_mo_agi)
+        mask = unit_mo_agi > 0
+        ind_agi_share[mask] = mo_agi[mask] / unit_mo_agi[mask]
+
         return ind_agi_share * unit_taxinc

--- a/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_taxable_income.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_taxable_income.py
@@ -44,7 +44,8 @@ class mo_taxable_income(Variable):
         # calculate taxable income for tax unit
         unit_taxinc = max_(0, unit_mo_agi - unit_mo_deductions)
 
-        # allocate unit taxable income by each individual's share of unit AGI
+        # Allocate tax unit taxable income by each individual's share of unit AGI.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to zero.
         ind_agi_share = np.zeros_like(unit_mo_agi)
         mask = unit_mo_agi > 0
         ind_agi_share[mask] = mo_agi[mask] / unit_mo_agi[mask]


### PR DESCRIPTION
Fixes #2515.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 72d32dd</samp>

### Summary
🐛📝🧮

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of these changes. The bug fix resolves a warning that could affect the accuracy or stability of the mo_taxable_income module.
2.  📝 - This emoji represents a documentation update, which is a secondary effect of these changes. The documentation update reflects the change in the changelog entry and the formula for calculating the individual share of Missouri taxable income.
3.  🧮 - This emoji represents a calculation or formula change, which is another secondary effect of these changes. The calculation change modifies the way the individual share of Missouri taxable income is computed using a mask instead of a where function.
-->
This pull request fixes a bug in the `mo_taxable_income` module that could cause incorrect or undefined behavior when dividing numpy arrays with zero elements. It also updates the changelog entry to reflect the patch version bump and the bug fix.

> _`mo_taxable_income`_
> _Bug fix for zero division_
> _Changelog says: patch_

### Walkthrough
* Fix bug in `mo_taxable_income` formula that caused warning when dividing by zero ([link](https://github.com/PolicyEngine/policyengine-us/pull/2516/files?diff=unified&w=0#diff-710f63c1f31b7411b5f4a02e5770d55903379ba8d766a460914ed4f54ce7c397L48-R54))
* Update changelog entry to indicate patch version bump and bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/2516/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


