### PR TITLE
Eliminate numpy array divide warning in ok_eitc module

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in ok_eitc module.

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_eitc.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_eitc.py
@@ -16,7 +16,10 @@ class ok_eitc(Variable):
     def formula(tax_unit, period, parameters):
         us_agi = tax_unit("adjusted_gross_income", period)
         ok_agi = tax_unit("ok_agi", period)
-        prorate = min_(1, max_(0, where(us_agi != 0, ok_agi / us_agi, 0)))
+        agi_ratio = np.zeros_like(us_agi)
+        mask = us_agi != 0
+        agi_ratio[mask] = ok_agi[mask] / us_agi[mask]
+        prorate = min_(1, max_(0, agi_ratio))
         us_eitc = tax_unit("earned_income_tax_credit", period)
         p = parameters(period).gov.states.ok.tax.income.credits.earned_income
         return prorate * p.eitc_fraction * us_eitc


### PR DESCRIPTION
Fixes #2517.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d8b9b7c</samp>

### Summary
📝🐛📈

<!--
1.  📝 for the changelog entry, as this emoji is often used to indicate documentation or writing.
2. 🐛 for the formula function modification, as this emoji is often used to indicate bug fixes or error handling.
3. 📈 for the ok_eitc calculation improvement, as this emoji is often used to indicate performance or enhancement.
-->
This pull request updates the `ok_eitc` formula to handle zero values in the US adjusted gross income array, and adds a changelog entry to document the fix. This pull request resolves the numpy array divide warning issue and bumps the patch version of the package.

> _`ok_eitc` fixed_
> _No more divide by zero_
> _Changelog updated_

### Walkthrough
* Fix numpy array divide warning in ok_eitc module ([link](https://github.com/PolicyEngine/policyengine-us/pull/2518/files?diff=unified&w=0#diff-6cee2b365a2ab5c4f5216f4ecef3af4ffce949c3eefebadd0d066b64d0fa5b24L19-R22))
* Update changelog file with patch version bump and fixed issue ([link](https://github.com/PolicyEngine/policyengine-us/pull/2518/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


