### PR TITLE
Eliminate array divide warning in ok_child_care_child_tax_credit module

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Numpy array divide warning in ok_child_care_child_tax_credit module.

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
@@ -26,6 +26,9 @@ class ok_child_care_child_tax_credit(Variable):
         ok_ctc = us_ctc * p.child.ctc_fraction
         # determine prorated fraction
         ok_agi = tax_unit("ok_agi", period)
-        prorate = min_(1, max_(0, where(us_agi != 0, ok_agi / us_agi, 0)))
+        agi_ratio = np.zeros_like(us_agi)
+        mask = us_agi != 0
+        agi_ratio[mask] = ok_agi[mask] / us_agi[mask]
+        prorate = min_(1, max_(0, agi_ratio))
         # receive greater of OK cdcc or OK ctc amounts prorated if AGI eligible
         return agi_eligible * prorate * max_(ok_cdcc, ok_ctc)

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
@@ -26,6 +26,8 @@ class ok_child_care_child_tax_credit(Variable):
         ok_ctc = us_ctc * p.child.ctc_fraction
         # determine prorated fraction
         ok_agi = tax_unit("ok_agi", period)
+        # Compute OK AGI as a share of US AGI.
+        # Use a mask rather than where to avoid a divide-by-zero warning.
         agi_ratio = np.zeros_like(us_agi)
         mask = us_agi != 0
         agi_ratio[mask] = ok_agi[mask] / us_agi[mask]


### PR DESCRIPTION
Fixes #2519.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5c81e18</samp>

### Summary
🐛🧮📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the `ok_child_care_child_tax_credit` module. The bug fix resolves a warning that could affect the accuracy of the credit calculation and the user experience.
2.  🧮 - This emoji represents a calculation or formula, which is the core component of the `ok_child_care_child_tax_credit` class. The change modifies the formula function to use a different method of handling zero values and to use a clearer variable name.
3.  📝 - This emoji represents documentation or comments, which is the secondary purpose of the change to the `ok_child_care_child_tax_credit` module. The change adds a new entry to the changelog file, which documents the bug fix and the version bump.
-->
This pull request fixes a bug in the `ok_child_care_child_tax_credit` module that caused a warning when dividing by zero. It also improves the code quality and readability of the module by using a mask and a descriptive variable name.

> _`ok_child_care`_
> _fixes bug with zero-divide_
> _autumn leaves no trace_

### Walkthrough
* Fix bug in `ok_child_care_child_tax_credit` module that caused warning when dividing by zero ([link](https://github.com/PolicyEngine/policyengine-us/pull/2520/files?diff=unified&w=0#diff-e43600e4138d3eca0afa5a0a6ee2a198c2a21b86336ff1d2874904e8f3aa1ccaL29-R32), [link](https://github.com/PolicyEngine/policyengine-us/pull/2520/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


