### PR TITLE
test: Downgrade Pytest to 7.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pandas",
         "pathlib",
         "policyengine-core>=2.1,<3",
-        "pytest",
+        "pytest==7.3.2",
         "pytest-dependency",
         "pyyaml",
         "requests",


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS REQUEST. This is a test to determine if Pytest 7.4.0 is causing PRs to fail on Windows.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd8ab24</samp>

### Summary
:pushpin::bug::test_tube:

<!--
1.  :pushpin: - This emoji can be used to indicate that a dependency was pinned to a specific version, as it suggests the idea of fixing something in place and preventing it from moving or changing.
2.  :bug: - This emoji can be used to indicate that a bug was fixed or avoided, as it suggests the idea of squashing or eliminating an error or problem.
3.  :test_tube: - This emoji can be used to indicate that something related to testing was changed or improved, as it suggests the idea of experimenting or verifying a hypothesis or outcome.
-->
Pinned `pytest` version in `setup.py` to fix failing tests. This ensures the test suite runs consistently with a compatible version of `pytest`.

> _`pytest` version fixed_
> _Avoiding broken workflow_
> _Winter of errors_

### Walkthrough
* Pin `pytest` dependency to version 7.3.2 to avoid compatibility issues ([link](https://github.com/PolicyEngine/policyengine-us/pull/2535/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L41-R41))


