### PR TITLE
Test: Downgrade Pytest to 7.3.2 to allow Windows CI tests to pass

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+    - Downgraded Pytest to 7.3.2 in setup.py

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pandas",
         "pathlib",
         "policyengine-core>=2.1,<3",
-        "pytest",
+        "pytest==7.3.2",
         "pytest-dependency",
         "pyyaml",
         "requests",


### PR DESCRIPTION
Please don't merge this request.

This downgrades Pytest to version 7.3.2, but leaves all other packages as written, to determine if it is causing Windows CI tests to fail, as mentioned in #2522. 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f3265de</samp>

### Summary
📝🔧🚨

<!--
1.  📝 - This emoji represents documentation changes, such as updating the changelog entry.
2.  🔧 - This emoji represents tooling or configuration changes, such as modifying the setup.py file.
3.  🚨 - This emoji represents testing changes, such as fixing or adjusting the tests to work with a different Pytest version.
-->
Downgraded `pytest` version to fix test failures. Updated `changelog_entry.yaml` and `setup.py` to reflect this change.

> _Pytest downgraded_
> _`setup.py` changed for tests_
> _Winter of bugfix_

### Walkthrough
*  Downgrade Pytest version to 7.3.2 to fix compatibility issues with tests ([link](https://github.com/PolicyEngine/policyengine-us/pull/2537/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L41-R41), [link](https://github.com/PolicyEngine/policyengine-us/pull/2537/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3))
  * Specify Pytest version in `setup.py` file ([link](https://github.com/PolicyEngine/policyengine-us/pull/2537/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L41-R41))
  * Add changelog entry to document the change ([link](https://github.com/PolicyEngine/policyengine-us/pull/2537/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3))


