### PR TITLE
Downgrade SciPy to 1.10.1 to allow Windows CI tests to pass

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+    - Added scipy as explicit dependency and fixed version to downgraded 1.10.1

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "pytest-dependency",
         "pyyaml",
         "requests",
+        "scipy==1.10.1",
         "synthimpute",
         "tables",
         "tabulate",


### PR DESCRIPTION
This adds SciPy as an explicit dependency to `setup.py`, fixed to a downgraded version 1.10.1, which passed previously. This is a temporary fix/workaround for #2522.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b1d36a</samp>

### Summary
:sparkles::bug::package:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the case for adding scipy as an explicit dependency and fixing its version. This also implies a minor version bump, as indicated by the changelog entry.
2. :bug: This emoji represents the fixing of a bug or issue, which is the case for resolving the compatibility issues with newer versions of scipy that cause some tests to fail. This also improves the reliability and stability of the package.
3. :package: This emoji represents the updating or changing of dependencies, which is the case for modifying the install_requires list in setup.py. This also affects the installation and distribution of the package.
-->
This pull request fixes a test failure caused by a newer version of `scipy` by pinning it to 1.10.1 in `setup.py` and `changelog_entry.yaml`.

> _`scipy` version fixed_
> _to avoid test failures now_
> _a minor update_

### Walkthrough
* Fix compatibility issues with scipy by pinning its version to 1.10.1 ([link](https://github.com/PolicyEngine/policyengine-us/pull/2538/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3), [link](https://github.com/PolicyEngine/policyengine-us/pull/2538/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R45))
* Update `changelog_entry.yaml` to reflect the minor version bump and the dependency change ([link](https://github.com/PolicyEngine/policyengine-us/pull/2538/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3))


