### PR TITLE
Fix array divide-by-zero warnings in Iowa income tax code

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Array divide-by-zero warning in IA income tax code.

--- a/policyengine_us/variables/gov/states/ia/tax/income/deductions/ia_qbi_deduction.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/deductions/ia_qbi_deduction.py
@@ -19,9 +19,10 @@ class ia_qbi_deduction(Variable):
         fed_indv_qbid = person("qbid_amount", period)
         tax_unit = person.tax_unit
         fed_unit_qbid = tax_unit("qualified_business_income_deduction", period)
-        reduction_factor = where(
-            fed_indv_qbid > 0, fed_unit_qbid / fed_indv_qbid, 1.0
-        )
+        # avoid divide-by-zero warnings by not using where() function
+        reduction_factor = np.ones_like(fed_indv_qbid)
+        mask = fed_indv_qbid > 0
+        reduction_factor[mask] = fed_unit_qbid[mask] / fed_indv_qbid[mask]
         fed_qbid = fed_indv_qbid * reduction_factor
         p = parameters(period).gov.states.ia.tax.income
         return fed_qbid * p.deductions.qualified_business_income.fraction

--- a/policyengine_us/variables/gov/states/ia/tax/income/net_income/ia_prorate_fraction.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/net_income/ia_prorate_fraction.py
@@ -18,9 +18,13 @@ class ia_prorate_fraction(Variable):
     def formula(person, period, parameters):
         net_income = person("ia_net_income", period)
         total_net_income = person.tax_unit.sum(net_income)
-        # If no net income, then assign entirely to head.
+        # avoid divide-by-zero warnings when using where() function
+        fraction = np.zeros_like(total_net_income)
+        mask = total_net_income != 0
+        fraction[mask] = net_income[mask] / total_net_income[mask]
+        # if no net income, then assign entirely to head.
         return where(
             total_net_income == 0,
             person("is_tax_unit_head", period),
-            net_income / total_net_income,
+            fraction,
         )


### PR DESCRIPTION
Fixes #2548.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 535abbe</samp>

### Summary
🐛🧮🧮

<!--
1.  🐛 for the bug fix to the IA income tax code.
2.  🧮 for the formula modification to the IA qualified business income deduction.
3.  🧮 for the formula modification to the IA prorate fraction.
-->
This pull request fixes a bug in the `IA income tax` code that could cause divide-by-zero warnings. It changes the formulas for the `ia_qbi_deduction` and the `ia_prorate_fraction` variables in the files `ia_qbi_deduction.py` and `ia_prorate_fraction.py` to use numpy arrays and masks instead of the `where` function.

> _No more warnings now_
> _`where` function is replaced_
> _Winter bug is fixed_

### Walkthrough
*  Fix a bug in the IA income tax code that could cause divide-by-zero warnings ([link](https://github.com/PolicyEngine/policyengine-us/pull/2547/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2547/files?diff=unified&w=0#diff-ecda8539612014649096b46039966e5b32acbd3064ee3aa805056ea72376a651L22-R25), [link](https://github.com/PolicyEngine/policyengine-us/pull/2547/files?diff=unified&w=0#diff-6e0beb527ec2fc4a857bf4aeee01b8e67e0a6b5921273d306bbcce5b42004165L21-R29))


