### PR TITLE
Fix numpy array divide-by-zero warnings in NYC CDCC code

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Array divide-by-zero warnings in NYC local income tax code.

--- a/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_age_restricted_expenses.py
+++ b/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_age_restricted_expenses.py
@@ -23,7 +23,10 @@ class nyc_cdcc_age_restricted_expenses(Variable):
         tax_unit_childcare_expenses = tax_unit(
             "tax_unit_childcare_expenses", period
         )
-        qualifying_child_share = where(
-            children > 0, qualifying_children / children, 0
+        # avoid divide-by-zero warnings by not using where() function
+        qualifying_child_share = np.zeros_like(children)
+        mask = children > 0
+        qualifying_child_share[mask] = (
+            qualifying_children[mask] / children[mask]
         )
         return tax_unit_childcare_expenses * qualifying_child_share

--- a/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_share_qualifying_childcare_expenses.py
+++ b/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/cdcc/nyc_cdcc_share_qualifying_childcare_expenses.py
@@ -16,17 +16,17 @@ class nyc_cdcc_share_qualifying_childcare_expenses(Variable):
         childcare_expenses_for_children_under_four = tax_unit(
             "nyc_cdcc_age_restricted_expenses", period
         )
-
         # Get the total childcare expenses.
         # Line 3a on Form IT-216.
         tax_unit_childcare_expenses = tax_unit(
             "tax_unit_childcare_expenses", period
         )
-
         # Return the share of childcare expenses for children under age four
-        return where(
-            tax_unit_childcare_expenses == 0,
-            0,
-            childcare_expenses_for_children_under_four
-            / tax_unit_childcare_expenses,
+        # avoiding array divide-by-zero warning by not using where() function
+        share = np.zeros_like(tax_unit_childcare_expenses)
+        mask = tax_unit_childcare_expenses > 0
+        share[mask] = (
+            childcare_expenses_for_children_under_four[mask]
+            / tax_unit_childcare_expenses[mask]
         )
+        return share


### PR DESCRIPTION
Fixes #2550.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 796e073</samp>

### Summary
🐛🧮🎨

<!--
1.  🐛 for fixing a bug
2.  🧮 for improving a formula
3.  🎨 for improving code style
-->
This pull request fixes a bug and improves the code style for the New York City Child and Dependent Care Credit calculation. It updates the formulas and code style for `nyc_cdcc_share_qualifying_childcare_expenses` and `nyc_cdcc_age_restricted_expenses`, and adds a changelog entry in `changelog_entry.yaml`.

> _No more warnings from the array_
> _We fixed the bug in the tax code today_
> _We changed the formula and the style_
> _We made the credit calculation worthwhile_

### Walkthrough
*  Fix array divide-by-zero warnings in NYC local income tax code ([link](https://github.com/PolicyEngine/policyengine-us/pull/2549/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2549/files?diff=unified&w=0#diff-486c0d034869d5818b0f72c28be4529678e963996713cc200357bd2136faacb1L26-R30), [link](https://github.com/PolicyEngine/policyengine-us/pull/2549/files?diff=unified&w=0#diff-77769243510c59cc6ea3db37c40eb68d9f15e169736084d667d4efd68deeb874L25-R32))
* Remove empty line from `nyc_cdcc_share_qualifying_childcare_expenses` file ([link](https://github.com/PolicyEngine/policyengine-us/pull/2549/files?diff=unified&w=0#diff-77769243510c59cc6ea3db37c40eb68d9f15e169736084d667d4efd68deeb874L19))


