### PR TITLE
Fix numpy array divide-by-zero warnings in tax_unit_childcare_expenses code

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Array divide-by-zero warnings in tax_unit_childcare_expenses formula.

--- a/policyengine_us/tests/policy/baseline/household/expense/childcare/tax_unit_childcare_expenses.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/childcare/tax_unit_childcare_expenses.yaml
@@ -1,4 +1,4 @@
-- name: tax_unit_childcare_expenses unit test 1, default is zero
+- name: tax_unit_childcare_expenses unit test 1 (default is zero)
   period: 2022
   output:
     tax_unit_childcare_expenses: 0

--- a/policyengine_us/tests/policy/baseline/household/expense/childcare/tax_unit_childcare_expenses.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/childcare/tax_unit_childcare_expenses.yaml
@@ -1,4 +1,4 @@
-- name: tax_unit_childcare_expenses unit test 1: default is zero
+- name: tax_unit_childcare_expenses unit test 1, default is zero
   period: 2022
   output:
     tax_unit_childcare_expenses: 0

--- a/policyengine_us/tests/policy/baseline/household/expense/childcare/tax_unit_childcare_expenses.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/childcare/tax_unit_childcare_expenses.yaml
@@ -1,4 +1,31 @@
-- name: Default is zero.
+- name: tax_unit_childcare_expenses unit test 1: default is zero
   period: 2022
   output:
     tax_unit_childcare_expenses: 0
+
+- name: tax_unit_childcare_expenses unit test 2
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 35
+      person2:
+        age: 5
+      person3:
+        age: 30
+      person4:
+        age: 4
+      person5:
+        age: 3
+    tax_units:
+      tax_unit1:
+        members: [person1, person2]
+      tax_unit2:
+        members: [person3, person4, person5]
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5]
+        childcare_expenses: 900
+  output:
+    tax_unit_childcare_expenses: [300, 600]

--- a/policyengine_us/variables/household/expense/childcare/tax_unit_childcare_expenses.py
+++ b/policyengine_us/variables/household/expense/childcare/tax_unit_childcare_expenses.py
@@ -9,14 +9,18 @@ class tax_unit_childcare_expenses(Variable):
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
-        # Distribute the childcare expenses evenly across the SPM unit's members.
+        # distribute the SPM unit's childcare expenses evenly across
+        # children in SPM unit's Tax units
         spm_unit = tax_unit.spm_unit
         spm_unit_childcare = spm_unit("childcare_expenses", period)
         spm_unit_count_children = add(spm_unit, period, ["is_child"])
         tax_unit_count_children = add(tax_unit, period, ["is_child"])
-        child_ratio = where(
-            spm_unit_count_children > 0,
-            tax_unit_count_children / spm_unit_count_children,
-            0,
+        # avoid array divide-by-zero warning by not using where() function
+        # see the following GitHub issue for more details:
+        # https://github.com/PolicyEngine/policyengine-us/issues/2494
+        child_ratio = np.zeros_like(spm_unit_count_children)
+        mask = spm_unit_count_children > 0
+        child_ratio[mask] = (
+            tax_unit_count_children[mask] / spm_unit_count_children[mask]
         )
         return spm_unit_childcare * child_ratio


### PR DESCRIPTION
Adds a meaningful `tax_unit_childcare_expenses` unit test and fixes #2490.
