### PR TITLE
Fix numpy array divide-by-zero warnings in ssi_unearned_income_deemed_from_ineligible_parent code

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Array divide-by-zero warnings in ssi_unearned_income_deemed_from_ineligible_parent formula.

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/income/deemed/from_ineligible_parent/ssi_unearned_income_deemed_from_ineligible_parent.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/income/deemed/from_ineligible_parent/ssi_unearned_income_deemed_from_ineligible_parent.py
@@ -55,8 +55,12 @@ class ssi_unearned_income_deemed_from_ineligible_parent(Variable):
         )
 
         count_eligible_children = tax_unit.sum(eligible_child)
-        return where(
-            count_eligible_children > 0,
-            net_parental_deemed_income / count_eligible_children,
-            0,
+        # avoid array divide-by-zero warnings by not using where() function
+        # see the following GitHub issue for more details:
+        # https://github.com/PolicyEngine/policyengine-us/issues/2494
+        income = np.zeros_like(count_eligible_children)
+        mask = count_eligible_children > 0
+        income[mask] = (
+            net_parental_deemed_income[mask] / count_eligible_children[mask]
         )
+        return income


### PR DESCRIPTION
Fixes #2491.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca6e247</samp>

### Summary
🐛📝🧮

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It indicates that the change resolves an issue that caused incorrect or unexpected behavior in the codebase.
2.  📝 - This emoji represents a documentation update, which is the secondary purpose of the pull request. It indicates that the change improves the clarity and accuracy of the changelog entry for the pull request, as well as adding a comment to the code explaining the logic behind the change.
3.  🧮 - This emoji represents a calculation or formula update, which is the specific type of bug fix that the pull request implements. It indicates that the change modifies the mathematical expression or function that computes the output of the formula.
-->
This pull request fixes a bug in the `ssi_unearned_income_deemed_from_ineligible_parent` formula that caused array divide-by-zero warnings. It changes the `where` function to a mask and indexing approach and updates the changelog entry accordingly.

> _`where` function gone_
> _mask and index fix the bug_
> _autumn leaves no trace_

### Walkthrough
* Fix bug related to array divide-by-zero warnings in `ssi_unearned_income_deemed_from_ineligible_parent` formula ([link](https://github.com/PolicyEngine/policyengine-us/pull/2553/files?diff=unified&w=0#diff-56bc77421841270c18e66beda23da266d13988d23c1c3381be32adefc910d981L58-R66), [link](https://github.com/PolicyEngine/policyengine-us/pull/2553/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


