### PR TITLE
Fix numpy array divide-by-zero warnings in DOE residential_efficiency_electrification_rebate code

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Array divide-by-zero warnings in residential_efficiency_electrification_rebate formula.

--- a/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
+++ b/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
@@ -46,7 +46,7 @@ class residential_efficiency_electrification_rebate(Variable):
         reduction = np.zeros_like(average_home_energy_use_in_state)
         mask = average_home_energy_use_in_state > 0
         reduction[mask] = (
-            low_cap_per_percent / average_home_energy_use_in_state
+            low_cap_per_percent[mask] / average_home_energy_use_in_state[mask]
         )
         low_cap_per_kwh_reduction = 100 * reduction
         low_cap = low_cap_per_kwh_reduction * savings_kwh

--- a/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
+++ b/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
@@ -25,9 +25,6 @@ class residential_efficiency_electrification_rebate(Variable):
         savings_pct = np.zeros_like(current_kwh)
         mask = current_kwh > 0
         savings_pct[mask] = savings_kwh[mask] / current_kwh[mask]
-        """
-        savings_pct = savings_kwh / current_kwh
-        """
         income_ami = tax_unit.household("household_income_ami_ratio", period)
         high_cap = p.cap.high.calc(income_ami)
         medium_cap = p.cap.medium.calc(income_ami)
@@ -37,11 +34,6 @@ class residential_efficiency_electrification_rebate(Variable):
             "average_home_energy_use_in_state", period
         )
         low_cap_per_percent = p.cap.low.calc(income_ami)
-        """
-        low_cap_per_kwh_reduction = 100 * (
-            low_cap_per_percent / average_home_energy_use_in_state
-        )
-        """
         # avoid array divide-by-zero warnings by not using where() function
         reduction = np.zeros_like(average_home_energy_use_in_state)
         mask = average_home_energy_use_in_state > 0

--- a/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
+++ b/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
@@ -21,7 +21,7 @@ class residential_efficiency_electrification_rebate(Variable):
             period,
         )
         current_kwh = tax_unit.household("current_home_energy_use", period)
-        # avoid array divide-by-zero warnings by no using where() function
+        # avoid array divide-by-zero warnings by not using where() function
         savings_pct = np.zeros_like(current_kwh)
         mask = current_kwh > 0
         savings_pct[mask] = savings_kwh[mask] / current_kwh[mask]
@@ -37,9 +37,18 @@ class residential_efficiency_electrification_rebate(Variable):
             "average_home_energy_use_in_state", period
         )
         low_cap_per_percent = p.cap.low.calc(income_ami)
+        """
         low_cap_per_kwh_reduction = 100 * (
             low_cap_per_percent / average_home_energy_use_in_state
         )
+        """
+        # avoid array divide-by-zero warnings by not using where() function
+        reduction = np.zeros_like(average_home_energy_use_in_state)
+        mask = average_home_energy_use_in_state > 0
+        reduction[mask] = (
+            low_cap_per_percent / average_home_energy_use_in_state
+        )
+        low_cap_per_kwh_reduction = 100 * reduction
         low_cap = low_cap_per_kwh_reduction * savings_kwh
         # Uncapped amount is a percent of project costs
         percent = p.percent.calc(income_ami)

--- a/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
+++ b/policyengine_us/variables/gov/doe/residential_efficiency_electrification_rebate/residential_efficiency_electrification_rebate.py
@@ -21,12 +21,18 @@ class residential_efficiency_electrification_rebate(Variable):
             period,
         )
         current_kwh = tax_unit.household("current_home_energy_use", period)
+        # avoid array divide-by-zero warnings by no using where() function
+        savings_pct = np.zeros_like(current_kwh)
+        mask = current_kwh > 0
+        savings_pct[mask] = savings_kwh[mask] / current_kwh[mask]
+        """
         savings_pct = savings_kwh / current_kwh
+        """
         income_ami = tax_unit.household("household_income_ami_ratio", period)
         high_cap = p.cap.high.calc(income_ami)
         medium_cap = p.cap.medium.calc(income_ami)
-        # Low cap is a dollar amount per given percentage reduction of energy use
-        # per dwelling unit for the average home in the state.
+        # Low cap is a dollar amount per given percentage reduction of energy
+        # use per dwelling unit for the average home in the state
         average_home_energy_use_in_state = tax_unit.household(
             "average_home_energy_use_in_state", period
         )
@@ -35,7 +41,7 @@ class residential_efficiency_electrification_rebate(Variable):
             low_cap_per_percent / average_home_energy_use_in_state
         )
         low_cap = low_cap_per_kwh_reduction * savings_kwh
-        # Uncapped amount is a percent of project costs.
+        # Uncapped amount is a percent of project costs
         percent = p.percent.calc(income_ami)
         uncapped = percent * expenditures
         cap = select(


### PR DESCRIPTION
Fixes #2492.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 01d2dd0</samp>

### Summary
🐛📝💬

<!--
1.  🐛 for the bug fix
2.  📝 for the changelog update
3.  💬 for the comment style improvement
-->
This pull request fixes a bug in the `residential_efficiency_electrification_rebate` formula that caused incorrect calculations and warnings. It also updates the changelog and the comment style in the affected file.

> _Sing, O Muse, of the skillful coder who fixed the bug_
> _That plagued the `residential_efficiency_electrification_rebate`,_
> _The formula that grants rewards to those who curb their power_
> _And make their homes more green and clean, like gardens of the Hesperides._

### Walkthrough
* Fix bug in residential efficiency electrification rebate formula ([link](https://github.com/PolicyEngine/policyengine-us/pull/2554/files?diff=unified&w=0#diff-d1afe69ed5e8cbfc2edb687aa1b1c9197498ca431b657d7c35bc92dc87398eedL24-R35))
* Remove period from comment in formula for consistency ([link](https://github.com/PolicyEngine/policyengine-us/pull/2554/files?diff=unified&w=0#diff-d1afe69ed5e8cbfc2edb687aa1b1c9197498ca431b657d7c35bc92dc87398eedL38-R44))
* Add changelog entry for patch version bump and bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/2554/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


