### PR TITLE
Lowercase Age

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Lowercase Age variable.

--- a/policyengine_us/variables/household/demographic/age/age.py
+++ b/policyengine_us/variables/household/demographic/age/age.py
@@ -4,6 +4,6 @@ from policyengine_us.model_api import *
 class age(Variable):
     value_type = float
     entity = Person
-    label = "Age"
+    label = "age"
     definition_period = YEAR
     default_value = 40


### PR DESCRIPTION
Fixes #2557

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8d81f44</samp>

### Summary
📝🎨🚨

<!--
1.  📝 for updating the changelog entry
2.  🎨 for improving the code formatting or style
3.  🚨 for fixing a linter warning or error
-->
This pull request fixes the casing of the `age` variable label to use lowercase, as per the OpenFisca naming convention. This affects the `changelog_entry.yaml` file and the `policyengine_us/variables/household/demographic/age/age.py` file.

> _`Age` variable_
> _lowercased for clarity_
> _a winter cleaning_

### Walkthrough
*  Update changelog entry to use lowercase for Age variable ([link](https://github.com/PolicyEngine/policyengine-us/pull/2559/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Change label attribute of age class to lowercase in `policyengine_us/variables/household/demographic/age/age.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2559/files?diff=unified&w=0#diff-f3b7c3a14229ecf1c7f34668b9ff29f753a67b8130124e27ec50c2726eea82ceL7-R7))


