### PR TITLE
Fix numpy array divide-by-zero warnings in hud_income_level code

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Array divide-by-zero warnings in hud_income_level formula.

--- a/policyengine_us/variables/gov/hud/hud_income_level.py
+++ b/policyengine_us/variables/gov/hud/hud_income_level.py
@@ -25,7 +25,12 @@ class hud_income_level(Variable):
         size = spm_unit("spm_unit_size", period)
         # Get area median income.
         ami = spm_unit("ami", period)
-        income_ami_ratio = annual_income / ami
+        # avoid array divide-by-zero warning by not using where() function
+        # see following GitHub issue for more details:
+        # https://github.com/PolicyEngine/policyengine-us/issues/2496
+        income_ami_ratio = np.zeros_like(ami)
+        mask = ami != 0
+        income_ami_ratio[mask] = annual_income[mask] / ami[mask]
         # Look up thresholds for each income level.
         p = parameters(period).gov.hud.ami_limit
         size_limit = p.family_size


### PR DESCRIPTION
Fixes #2493.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 673c17c</samp>

### Summary
🐛📝🧮

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It indicates that the change resolves an error or problem in the code that affected the output or performance of the package.
2. 📝 - This emoji represents a documentation update, which is the secondary purpose of the pull request. It indicates that the change improves the clarity or accuracy of the changelog entry for the pull request, which helps users and developers understand the history and impact of the change.
3. 🧮 - This emoji represents a formula or calculation update, which is the specific type of bug fix that the pull request implements. It indicates that the change modifies the mathematical or logical expression that determines the value of a variable or parameter in the package.
-->
This pull request fixes a bug in the `hud_income_level` formula that caused array divide-by-zero warnings. It changes the `policyengine_us/variables/gov/hud/hud_income_level.py` file and updates the `changelog_entry.yaml` file accordingly.

> _`hud_income_level`_
> _Fixes array warnings now_
> _Autumn bug hunting_

### Walkthrough
* Fix bug that caused array divide-by-zero warnings in `hud_income_level` formula ([link](https://github.com/PolicyEngine/policyengine-us/pull/2561/files?diff=unified&w=0#diff-ebc77e07e4ead60398da8784be27f8785950996f4a2f9130a0e8cdb3fa6fec36L28-R33), [link](https://github.com/PolicyEngine/policyengine-us/pull/2561/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


