### PR TITLE
Eliminate divide-by-zero warnings in Income decile calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Array divide-by-zero warnings in household/spmunit income decile variable tests by skipping the tests.
+    - Array divide-by-zero warnings in household/spmunit income decile variable tests by moving the tests.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Array divide-by-zero warnings in household/spmunit income decile variable tests by skipping the tests.

--- a/policyengine_us/tests/microsimulation/test_microsim.py
+++ b/policyengine_us/tests/microsimulation/test_microsim.py
@@ -4,3 +4,5 @@ def test_microsim_runs_cps():
     sim = Microsimulation()
     hnet = sim.calc("household_net_income")
     assert not hnet.isna().any(), "Some households have NaN net income."
+    hidecile = sim.calc("household_income_decile")
+    sidecile = sim.calc("spm_unit_income_decile")

--- a/policyengine_us/tests/test_variables.py
+++ b/policyengine_us/tests/test_variables.py
@@ -11,6 +11,8 @@ DEFAULT_SITUATION = {
 }
 
 EXEMPTIONS = (
+    "household_income_decile",  # because DEFAULT_SITUATION has no weights
+    "spm_unit_income_decile",  # because DEFAULT_SITUATION has no weights
     "tanf_max_amount",
     "tanf",
     "tanf_amount_if_eligible",


### PR DESCRIPTION
Fixes #2562.

copilot:all
