### PR TITLE
Use exemptions in NH taxable income calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: minor
+  changes:
+    added:
+    - Subtraction of exemptions in calculation of NH taxable income.
+    fixed:
+    - Calculation of NH old-age exemption amount.

--- a/policyengine_us/variables/gov/states/nh/tax/income/exemptions/nh_old_age_exemption.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/exemptions/nh_old_age_exemption.py
@@ -13,20 +13,14 @@ class nh_old_age_exemption(Variable):
         # Then get the NH old age exemptions part of the parameter tree.
         p = parameters(period).gov.states.nh.tax.income.exemptions
 
-        # Get the individual age.
-        age_head = tax_unit("age_head", period)
-
         # Check if the individual's eligiblity.
-        head_eligible = tax_unit.sum(age_head >= p.old_age_eligibility).astype(
-            int
-        )
-
-        # Get the individual's spouse age.
-        age_spouse = tax_unit("age_spouse", period)
+        head_eligible = (
+            tax_unit("age_head", period) >= p.old_age_eligibility
+        ).astype(int)
 
         # Check if the individual spouse's eligiblity.
-        spouse_eligible = tax_unit.sum(
-            age_spouse >= p.old_age_eligibility
+        spouse_eligible = (
+            tax_unit("age_spouse", period) >= p.old_age_eligibility
         ).astype(int)
 
         # Calculate total blind exemption.

--- a/policyengine_us/variables/gov/states/nh/tax/income/nh_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/nh_income_tax_before_refundable_credits.py
@@ -10,6 +10,6 @@ class nh_income_tax_before_refundable_credits(Variable):
     defined_for = StateCode.NH
 
     def formula(tax_unit, period, parameters):
-        income = tax_unit("nh_taxable_income", period)
+        income = max_(0, tax_unit("nh_taxable_income", period))
         rate = parameters(period).gov.states.nh.tax.income.rate
         return income * rate

--- a/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
@@ -7,7 +7,7 @@ class nh_taxable_income(Variable):
     label = "New Hampshire taxable income"
     unit = USD
     definition_period = YEAR
-    reference = "https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm "
+    reference = ("https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm", "https://www.revenue.nh.gov/forms/2023/documents/dp-10-2022-print.pdf")
     defined_for = StateCode.NH
 
     # New Hampshire allows for negative taxable income.

--- a/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
@@ -9,5 +9,8 @@ class nh_taxable_income(Variable):
     definition_period = YEAR
     reference = "https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm "
     defined_for = StateCode.NH
+
+    # New Hampshire allows for negative taxable income.
+    # It limits tax to nonnegative values in the tax computation instead.
     adds = ["dividend_income", "interest_income"]
     subtracts = ["nh_total_exemptions"]

--- a/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
@@ -10,3 +10,4 @@ class nh_taxable_income(Variable):
     reference = "https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm "
     defined_for = StateCode.NH
     adds = ["dividend_income", "interest_income"]
+    subtracts = ["nh_total_exemptions"]

--- a/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
@@ -9,7 +9,7 @@ class nh_taxable_income(Variable):
     definition_period = YEAR
     reference = (
         "https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm",
-        "https://www.revenue.nh.gov/forms/2023/documents/dp-10-2022-print.pdf"
+        "https://www.revenue.nh.gov/forms/2023/documents/dp-10-2022-print.pdf",
     )
     defined_for = StateCode.NH
 

--- a/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
@@ -7,7 +7,10 @@ class nh_taxable_income(Variable):
     label = "New Hampshire taxable income"
     unit = USD
     definition_period = YEAR
-    reference = ("https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm", "https://www.revenue.nh.gov/forms/2023/documents/dp-10-2022-print.pdf")
+    reference = (
+        "https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm",
+        "https://www.revenue.nh.gov/forms/2023/documents/dp-10-2022-print.pdf"
+    )
     defined_for = StateCode.NH
 
     # New Hampshire allows for negative taxable income.


### PR DESCRIPTION
Fixes #2566.  This pull request completes the development of the New Hampshire state income tax.   Given the changes in this pull request, the NH tax module generates tax liabilities that are the same as those generated by TAXSIM35 in 900,000 randomly-generated integration tests (see issue #993 for details on the `p21` through `x21` samples).


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 42cdd55</samp>

### Summary
:sparkles::bug::zap:

<!--
1.  :sparkles: for adding a new feature (subtraction of exemptions)
2.  :bug: for fixing a bug (calculation of NH old-age exemption amount)
3.  :zap: for improving performance or readability (simplifying eligibility check and preventing negative income tax)
-->
This pull request improves the accuracy and readability of the NH income tax calculation. It adds a feature to subtract exemptions from the federal adjusted gross income, fixes a bug in the old-age exemption amount, and prevents negative taxable income. It modifies the files `nh_taxable_income.py`, `nh_old_age_exemption.py`, and `nh_income_tax_before_refundable_credits.py`, and updates the changelog entry.

> _`nh_taxable_income`_
> _Subtracts exemptions, fixes bugs_
> _A minor update_

### Walkthrough
*  Subtract NH total exemptions from federal adjusted gross income to calculate NH taxable income (`[link](https://github.com/PolicyEngine/policyengine-us/pull/2567/files?diff=unified&w=0#diff-edf788fd2a34b0ee889533055cbb838de4e53a39afa9663732371e573a9f39a3R13)`, `[link](https://github.com/PolicyEngine/policyengine-us/pull/2567/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R6)`)


