### PR TITLE
Add new state income tax variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-    - `household_state_income_tax` variable to solve circular dependencies.
+    - household_state_income_tax variable to solve circular dependencies.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - `household_state_income_tax` variable to solve circular dependencies.

--- a/policyengine_us/variables/household/income/household/household_state_income_tax.py
+++ b/policyengine_us/variables/household/income/household/household_state_income_tax.py
@@ -1,0 +1,54 @@
+from policyengine_us.model_api import *
+
+
+class household_state_income_tax(Variable):
+    # This definition contains all modelled states, and exists to solve circular dependencies in state_income_tax.
+    value_type = float
+    entity = TaxUnit
+    label = "household State tax"
+    unit = USD
+    definition_period = YEAR
+    adds = [
+        "ca_income_tax_before_refundable_credits",
+        "dc_income_tax_before_refundable_credits",
+        "ia_income_tax_before_refundable_credits",
+        "il_total_tax",
+        "ks_income_tax_before_refundable_credits",
+        "me_income_tax_before_refundable_credits",
+        "ma_income_tax_before_refundable_credits",
+        "md_income_tax_before_refundable_credits",
+        "mn_income_tax_before_refundable_credits",
+        "mo_income_tax_before_refundable_credits",
+        "nd_income_tax_before_refundable_credits",
+        "ne_income_tax_before_refundable_credits",
+        "nh_income_tax_before_refundable_credits",
+        "ny_income_tax_before_refundable_credits",
+        "or_income_tax_before_refundable_credits",
+        "pa_income_tax",
+        "wa_income_tax_before_refundable_credits",
+        "nyc_income_tax_before_refundable_credits",
+        "ut_income_tax_before_refundable_credits",
+        "wi_income_tax_before_refundable_credits",
+    ]
+    subtracts = [
+        "ca_refundable_credits",  # California.
+        "dc_refundable_credits",  # District of Columbia.
+        "ia_refundable_credits",  # Iowa.
+        "il_refundable_credits",  # Illinois.
+        "ks_refundable_credits",  # Kansas.
+        "ma_refundable_credits",  # Massachusetts.
+        "me_refundable_credits",  # Maine.
+        "md_refundable_credits",  # Maryland.
+        "mn_refundable_credits",  # Minnesota.
+        "mo_refundable_credits",  # Missouri.
+        "nd_refundable_credits",  # North Dakota.
+        "ne_refundable_credits",  # Nebraska.
+        "nh_refundable_credits",  # New Hampshire.
+        "ny_refundable_credits",  # New York.
+        "or_refundable_credits",  # Oregon.
+        # Skip PA, which has no refundable credits.
+        "wa_refundable_credits",  # Washington.
+        "nyc_refundable_credits",  # New York City.
+        "ut_refundable_credits",  # Utah.
+        "wi_refundable_credits",  # Wisconsin.
+    ]


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2707412</samp>

### Summary
📝🆕🗺️

<!--
1.  📝 - This emoji represents documentation or writing, and can be used for the changelog update.
2.  🆕 - This emoji represents something new or added, and can be used for the new variable definition.
3.  🗺️ - This emoji represents a map or geography, and can be used for the state-level calculations.
-->
This pull request adds a new variable `household_state_income_tax` to the policyengine_us package, which computes the total state income tax for each household. This variable helps to simplify and improve the accuracy of the state income tax calculations, which vary by state and depend on other taxes.

> _New variable_
> _`household_state_income_tax`_
> _Solves circularity_

### Walkthrough
*  Introduce a new variable `household_state_income_tax` to aggregate state income tax liabilities for each household ([link](https://github.com/PolicyEngine/policyengine-us/pull/2696/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dR1-R54))
* Update the changelog entry to reflect the minor version bump and the new variable ([link](https://github.com/PolicyEngine/policyengine-us/pull/2696/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


