### PR TITLE
Colorado main income tax rate

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Colorado Personal Income Tax Schedule.

--- a/policyengine_us/parameters/gov/states/co/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/rate.yaml
@@ -1,0 +1,13 @@
+description: Colorado provides this flat personal income tax rate.
+values:
+  1999-01-01: 0.0475
+  2000-01-01: 0.0463
+  2020-01-01: 0.0455
+metadata:
+  unit: /1
+  label: Colorado income tax rate
+  reference:
+    - title: C.R.S. 39-22-104 (1.5), (1.7) (a), (b)
+      href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=e955b1f2-53a2-4945-8329-43b06fc8738d&nodeid=ABPAACAACAABAACAAF&nodepath=%2FROOT%2FABP%2FABPAAC%2FABPAACAAC%2FABPAACAACAAB%2FABPAACAACAABAAC%2FABPAACAACAABAACAAF&level=6&haschildren=&populated=false&title=39-22-104.+Income+tax+imposed+on+individuals%2C+estates%2C+and+trusts+-+single+rate+-+report+-+legislative+declaration+-+definitions+-+repeal.&config=014FJAAyNGJkY2Y4Zi1mNjgyLTRkN2YtYmE4OS03NTYzNzYzOTg0OGEKAFBvZENhdGFsb2d592qv2Kywlf8caKqYROP5&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A683G-JJ73-CGX8-04HR-00008-00&ecomp=7gf59kk&prid=92812a4f-f678-4fa4-86b5-973c4d340142
+    - title: Colorado 2022 Individual Income Tax Form 104
+      href: https://tax.colorado.gov/sites/tax/files/documents/DR_0104_2022.pdf

--- a/policyengine_us/parameters/gov/states/co/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/rate.yaml
@@ -1,4 +1,4 @@
-description: Colorado provides this flat personal income tax rate.
+description: Colorado taxes personal income at this flat rate.
 values:
   1999-01-01: 0.0475
   2000-01-01: 0.0463
@@ -9,5 +9,3 @@ metadata:
   reference:
     - title: C.R.S. 39-22-104 (1.5), (1.7) (a), (b)
       href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=e955b1f2-53a2-4945-8329-43b06fc8738d&nodeid=ABPAACAACAABAACAAF&nodepath=%2FROOT%2FABP%2FABPAAC%2FABPAACAAC%2FABPAACAACAAB%2FABPAACAACAABAAC%2FABPAACAACAABAACAAF&level=6&haschildren=&populated=false&title=39-22-104.+Income+tax+imposed+on+individuals%2C+estates%2C+and+trusts+-+single+rate+-+report+-+legislative+declaration+-+definitions+-+repeal.&config=014FJAAyNGJkY2Y4Zi1mNjgyLTRkN2YtYmE4OS03NTYzNzYzOTg0OGEKAFBvZENhdGFsb2d592qv2Kywlf8caKqYROP5&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A683G-JJ73-CGX8-04HR-00008-00&ecomp=7gf59kk&prid=92812a4f-f678-4fa4-86b5-973c4d340142
-    - title: Colorado 2022 Individual Income Tax Form 104
-      href: https://tax.colorado.gov/sites/tax/files/documents/DR_0104_2022.pdf

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.yaml
@@ -1,0 +1,32 @@
+- name: Calculation # 4.55%
+  period: 2023
+  input:
+    state_code: CO
+    co_taxable_income: 1_000
+  output:
+    co_income_tax_before_non_refundable_credits: 45.5
+
+- name: Calculation 2019 # 4.63% 
+  absolute_error_margin: 0.01
+  period: 2019
+  input:
+    state_code: CO
+    co_taxable_income: 1_000
+  output:
+    co_income_tax_before_non_refundable_credits: 46.3
+
+- name: Calculation 1999 # 4.75%
+  period: 1999
+  input:
+    state_code: CO
+    co_taxable_income: 1_000
+  output:
+    co_income_tax_before_non_refundable_credits: 47.5
+
+- name: No income
+  period: 2023
+  input:
+    state_code: CO
+    co_taxable_income: 0
+  output:
+    co_income_tax_before_non_refundable_credits: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/co_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/co_income_tax_before_refundable_credits.yaml
@@ -1,0 +1,17 @@
+- name: Calculation 
+  period: 2023
+  input:
+    state_code: CO
+    co_income_tax_before_non_refundable_credits: 2_000
+    co_non_refundable_credits: 500
+  output:
+    co_income_tax_before_refundable_credits: 1_500
+
+- name: Capped at 0 
+  period: 2023
+  input:
+    state_code: CO
+    co_income_tax_before_non_refundable_credits: 200
+    co_non_refundable_credits: 500
+  output:
+    co_income_tax_before_refundable_credits: 0

--- a/policyengine_us/variables/gov/states/co/tax/income/co_income_tax.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_income_tax.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class co_income_tax(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Colorado income tax"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.CO
+
+    adds = ["co_income_tax_before_refundable_credits"]
+    subtracts = ["co_refundable_credits"]

--- a/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class co_income_tax_before_non_refundable_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Colorado income tax before non-refundable credits"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.CO
+
+    def formula(tax_unit, period, parameters):
+        income = tax_unit("co_taxable_income", period)
+        rate = parameters(period).gov.states.co.tax.income.rate
+        return income * rate

--- a/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_refundable_credits.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class co_income_tax_before_refundable_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Colorado income tax before refundable credits"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.CO
+
+    def formula(tax_unit, period, parameters):
+        before_non_refundable_credits = tax_unit(
+            "co_income_tax_before_non_refundable_credits", period
+        )
+        non_refundable_credits = tax_unit("co_non_refundable_credits", period)
+        return max_(before_non_refundable_credits - non_refundable_credits, 0)

--- a/policyengine_us/variables/gov/states/co/tax/income/co_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_non_refundable_credits.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class co_non_refundable_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Colorado non-refundable credits"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.CO

--- a/policyengine_us/variables/gov/states/co/tax/income/co_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_refundable_credits.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class co_refundable_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Colorado refundable credits"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.CO

--- a/policyengine_us/variables/gov/states/co/tax/income/co_taxable_income.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_taxable_income.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class co_taxable_income(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Colorado taxable income"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.CO


### PR DESCRIPTION
Fixes #2712

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 171ba91</samp>

### Summary
:sparkles::page_facing_up::white_check_mark:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, such as the Colorado Personal Income Tax Schedule.
2.  :page_facing_up: This emoji represents the addition of a new document or parameter file, such as the Colorado income tax rate file.
3.  :white_check_mark: This emoji represents the addition of a new test or validation, such as the Colorado income tax test files.
-->
This pull request adds the Colorado Personal Income Tax Schedule to the model, including parameters, variables, and tests. It creates new files for each component of the tax calculation, such as `co_income_tax.py`, `co_taxable_income.py`, and `co_refundable_credits.py`. It also updates the changelog with a new entry.

> _`Colorado` tax_
> _Added to the model code_
> _Winter of updates_

### Walkthrough
*  Add Colorado Personal Income Tax Schedule to the model ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Define Colorado income tax rate as a flat rate parameter that varies by year ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-de957260416ac3ffc9391cf840f7126a3b153eca4ef28d5908b632779f891f35R1-R13))
*  Define Colorado taxable income as the income subject to the state income tax ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-8c3fa4fd9ca7606e67c70c9f989d4a58280227d6a4fe424dc14a0bce2801dab4R1-R10))
*  Define Colorado income tax before non-refundable credits as the product of taxable income and rate ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-0ed827099de8fd58ba3aac98198f6f89d7a7a2cabdac33d49beb45bc705febd7R1-R15))
*  Define Colorado non-refundable credits as deductions from the income tax before non-refundable credits ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-6b4ce2e7c681b891e6c43a3643dcb3badeeda908a8cc9901a5dc7d59dd4a2a14R1-R10))
*  Define Colorado income tax before refundable credits as the difference between income tax before non-refundable credits and non-refundable credits, capped at zero ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-d4d138c2e8d0b92098ee317b73dd332a50fd11c952e7db7c97cb70ba969047e1R1-R17))
*  Define Colorado refundable credits as deductions from the income tax before refundable credits that can result in a negative tax liability ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-c57da359633156f43b77f62f4d36953769ac6541ff20d1cd7175179f7048f4e0R1-R10))
*  Define Colorado income tax as the final tax liability after applying the refundable credits ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-18ddb02dba539e97f2d76dfe469a20be0a76e28e49e948fcfd071432e5c32b56R1-R13))
*  Add test cases for Colorado income tax before non-refundable credits, covering different years, income levels, and error margins (`co_income_tax_before_non_refundable_credits.yaml`) ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-aa3d4754691f6c3232bea47f27de47c327fceff26e4297342277b384ebf75884R1-R32))
*  Add test cases for Colorado income tax before refundable credits, covering different credit and tax amounts (`co_income_tax_before_refundable_credits.yaml`) ([link](https://github.com/PolicyEngine/policyengine-us/pull/2714/files?diff=unified&w=0#diff-465d56468f4bc6d43ba5f7de1e6d06f8c3fd23d815b1bf56c6976b64c1defa06R1-R17))


