### PR TITLE
Make New Mexico tax parameters visible

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - New Mexico income tax parameter visibility.

--- a/policyengine_us/parameters/gov/states/nm/index.yaml
+++ b/policyengine_us/parameters/gov/states/nm/index.yaml
@@ -1,4 +1,0 @@
-metadata:
-  propagate_metadata_to_children: true
-  economy: false
-  household: false

--- a/policyengine_us/variables/gov/states/nm/tax/income/credits/nm_ctc.py
+++ b/policyengine_us/variables/gov/states/nm/tax/income/credits/nm_ctc.py
@@ -6,6 +6,7 @@ class nm_ctc(Variable):
     entity = TaxUnit
     label = "New Mexico child income tax credit"
     definition_period = YEAR
+    unit = USD
     reference = "https://nmonesource.com/nmos/nmsa/en/item/4340/index.do#!fragment/zoupio-_Toc140503818/BQCwhgziBcwMYgK4DsDWszIQewE4BUBTADwBdoAvbRABwEtsBaAfX2zgEYAWABgFYeAZgAcHYQEoANMmylCEAIqJCuAJ7QA5BskRCYXAiUr1WnXoMgAynlIAhdQCUAogBknANQCCAOQDCTyVIwACNoUnZxcSA"
     defined_for = StateCode.NM
 


### PR DESCRIPTION
Fixes #2726
Fixes #2717

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6117632</samp>

### Summary
📝🆕📐

<!--
1.  📝 - This emoji can be used to signify that a change involves documentation, such as updating the changelog or adding comments to the code. In this case, the changelog entry is a form of documentation that describes the purpose and impact of the pull request.
2.  🆕 - This emoji can be used to signify that a change introduces a new feature, functionality, or option to the project. In this case, the visibility of the New Mexico income tax parameter in the web interface is a new feature that enhances the user experience and the flexibility of the model.
3.  📐 - This emoji can be used to signify that a change involves adding or modifying units, dimensions, or measurements to the project. In this case, the unit attribute for the nm_ctc variable is a modification that adds clarity and consistency to the variable definition and usage.
-->
This pull request implements the New Mexico income tax parameter and credit in the PolicyEngine web interface. It deletes the unused `index.yaml` file, adds a unit attribute to the `nm_ctc` variable, and updates the changelog entry.

> _`nm_ctc` has unit_
> _web interface shows new tax_
> _autumn release soon_

### Walkthrough
* Bump minor version and add feature for New Mexico income tax parameter visibility ([link](https://github.com/PolicyEngine/policyengine-us/pull/2728/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Add unit attribute to New Mexico child tax credit variable `nm_ctc` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2728/files?diff=unified&w=0#diff-5716e07761f413690d446c3a9f76a0edcbc79b11bb51cd14d61d826c22ad695cR9))
* Delete unused file `policyengine_us/parameters/gov/states/nm/index.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2728/files?diff=unified&w=0#diff-04055374b7b38f7c5cfdfe72bb6f3218543179b8b52f85f6228295fa1b475f77))


