### PR TITLE
New Mexico income tax integration test failure

### DIFF
--- a/policyengine_us/parameters/gov/states/nm/tax/income/credits/working_families_tax/age_eligibility.yaml
+++ b/policyengine_us/parameters/gov/states/nm/tax/income/credits/working_families_tax/age_eligibility.yaml
@@ -22,5 +22,7 @@ metadata:
       href: https://klvg4oyd4j.execute-api.us-west-2.amazonaws.com/prod/PublicFiles/34821a9573ca43e7b06dfad20f5183fd/856ebf4b-3814-49dd-8631-ebe579d6a42b/Personal%20Income%20Tax.pdf 
     - title: New Mexico Income Tax, Title 3, Chapter 7, 7-2-18.15 - Working families tax credit
       href: https://nmonesource.com/nmos/nmsa/en/item/4340/index.do#!fragment/zoupio-_Toc140503780/BQCwhgziBcwMYgK4DsDWszIQewE4BUBTADwBdoAvbRABwEtsBaAfX2zgEYAWABgFYeAZgDsADh4BKADTJspQhACKiQrgCe0AOSapEQmFwJlqjdt37DIAMp5SAIQ0AlAKIAZZwDUAggDkAws5SpGAARtCk7BISQA
+    # Tax form shows that it includes 18- to 24-year olds, where the federal EITC does not.
+    # It does not mention age 65, which is inherited from the federal.
     - title: 2022 Personal Income Tax Form Packet 
       href: https://klvg4oyd4j.execute-api.us-west-2.amazonaws.com/prod/PublicFiles/34821a9573ca43e7b06dfad20f5183fd/1afc56af-ea90-4d48-82e5-1f9aeb43255a/PITbook2022.pdf 

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_integration_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_integration_test.yaml
@@ -1,0 +1,40 @@
+- name: Tax unit with taxsimid 86990 in p21.its.csv and p21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        employment_income: 1010
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        is_tax_unit_spouse: true
+        age: 66
+        employment_income: 8010
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+        state_sales_tax: 0  # not in TAXSIM35
+        nm_2021_income_rebate: 0  # not in TAXSIM35
+        nm_additional_2021_income_rebate: 0  # not in TAXSIM35
+        nm_supplemental_2021_income_rebate: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NM
+  output:  # expected results from patched TAXSIM35 2023-07-27 version
+    nm_income_tax_before_refundable_credits: 0.00
+    nm_income_tax: -941.01


### PR DESCRIPTION
Fixes #2729

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b398bf3</samp>

### Summary
📝✅🌵

<!--
1.  📝 - This emoji can be used to represent the change that adds a comment to explain the difference between the age eligibility for the two tax credits, since it is a documentation-related change.
2.  ✅ - This emoji can be used to represent the change that adds a test case for the New Mexico income tax system, since it is a testing-related change that verifies the correctness of the model output.
3.  🌵 - This emoji can be used to represent the change that specifies the state code as NM for the household, since it is a state-specific change that affects the tax calculation and the cactus is a symbol of New Mexico.
-->
This pull request adds documentation and testing for the New Mexico income tax system. It includes a comment in `age_eligibility.yaml` to clarify the state-specific parameter, and a test case in `nm_integration_test.yaml` to compare the policyengine-us model with the TAXSIM35 validation data.

> _`New Mexico` code_
> _Comment and test case added_
> _Autumn leaves fall fast_

### Walkthrough
* Add a comment to clarify the age eligibility for the New Mexico Working Families Tax Credit ([link](https://github.com/PolicyEngine/policyengine-us/pull/2731/files?diff=unified&w=0#diff-954dff2181d7845b74e3ea0e0a00cc4079194f5ed0c36f8cb72e51d3c91b811aR25-R26))


