### PR TITLE
Use `tax_unit_dependents` instead `eitc_child_count` in New Mexico deduction for certain dependents

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Base New Mexico deduction for certain dependents on total dependents, rather than child dependents.

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/deductions/certain_dependents/nm_deduction_for_certain_dependents.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/deductions/certain_dependents/nm_deduction_for_certain_dependents.yaml
@@ -1,8 +1,8 @@
-- name: No children
+- name: No dependents
   period: 2021
   input:
     filing_status: HEAD_OF_HOUSEHOLD
-    eitc_child_count: 0
+    tax_unit_dependents: 0
     nm_deduction_for_certain_dependents_eligible: true
   output:
     nm_deduction_for_certain_dependents: 0
@@ -11,7 +11,7 @@
   period: 2021
   input:
     filing_status: HEAD_OF_HOUSEHOLD
-    eitc_child_count: 1
+    tax_unit_dependents: 1
     nm_deduction_for_certain_dependents_eligible: true
   output:
     nm_deduction_for_certain_dependents: 0
@@ -34,7 +34,7 @@
   output:
     nm_deduction_for_certain_dependents: 0
 
-- name: Two children
+- name: Two dependents
   period: 2021
   input:
     filing_status: JOINT
@@ -43,11 +43,11 @@
   output:
     nm_deduction_for_certain_dependents: 4_000
 
-- name: Five children
+- name: Five dependents
   period: 2021
   input:
     filing_status: HEAD_OF_HOUSEHOLD
-    eitc_child_count: 5
+    tax_unit_dependents: 5
     nm_deduction_for_certain_dependents_eligible: true
   output:
     nm_deduction_for_certain_dependents: 16_000

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/deductions/certain_dependents/nm_deduction_for_certain_dependents.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/deductions/certain_dependents/nm_deduction_for_certain_dependents.yaml
@@ -21,7 +21,7 @@
   input:
     filing_status: SINGLE
     nm_deduction_for_certain_dependents_eligible: true
-    eitc_child_count: 3
+    tax_unit_dependents: 3
   output:
     nm_deduction_for_certain_dependents: 0
 
@@ -29,7 +29,7 @@
   period: 2021
   input:
     filing_status: HEAD_OF_HOUSEHOLD
-    eitc_child_count: 3
+    tax_unit_dependents: 3
     nm_deduction_for_certain_dependents_eligible: false
   output:
     nm_deduction_for_certain_dependents: 0
@@ -38,7 +38,7 @@
   period: 2021
   input:
     filing_status: JOINT
-    eitc_child_count: 2
+    tax_unit_dependents: 2
     nm_deduction_for_certain_dependents_eligible: true
   output:
     nm_deduction_for_certain_dependents: 4_000

--- a/policyengine_us/variables/gov/states/nm/tax/income/deductions/certain_dependents/nm_deduction_for_certain_dependents.py
+++ b/policyengine_us/variables/gov/states/nm/tax/income/deductions/certain_dependents/nm_deduction_for_certain_dependents.py
@@ -15,11 +15,11 @@ class nm_deduction_for_certain_dependents(Variable):
         p = parameters(
             period
         ).gov.states.nm.tax.income.deductions.certain_dependents
-        # The law 7-2-18.34(J)(2) defines qualifying children as those from IRC 152(c).
-        # IRC 152(c) refers to the EITC qualifying children.
-        # https://www.law.cornell.edu/uscode/text/26/152#c
-        children = tax_unit("eitc_child_count", period)
+        # The law 7-2-39(D) defines dependents as those from IRC 152.
+        # IRC 152 refers to all dependents.
+        # https://www.law.cornell.edu/uscode/text/26/152
+        dependents = tax_unit("tax_unit_dependents", period)
         # New Mexico reduces the number of claimable dependents by one.
-        eligible_children = max_(children - 1, 0)
-        amount_per_child = p.amount[filing_status]
-        return amount_per_child * eligible_children
+        countable_dependents = max_(dependents - 1, 0)
+        amount_per_dependent = p.amount[filing_status]
+        return amount_per_dependent * countable_dependents


### PR DESCRIPTION
Fixes #2743

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 55dea95</samp>

### Summary
🐛📝🧪

<!--
1.  🐛 for fixing a bug
2.  📝 for updating documentation and citations
3.  🧪 for modifying test cases
-->
This pull request fixes a bug in the `nm_deduction_for_certain_dependents` variable and its test cases, by using the correct variable and terminology for dependents. It also updates the changelog and the package version accordingly.

> _Oh we're the crew of the tax-calc ship_
> _And we sail the code with skill and wit_
> _We fix the bugs in the `NM_deduction`_
> _Heave away, me hearties, heave away!_

### Walkthrough
*  Fix a bug in the New Mexico deduction for certain dependents by using the correct variable and citation ([link](https://github.com/PolicyEngine/policyengine-us/pull/2744/files?diff=unified&w=0#diff-38ff537fc5161ed5773a787cca687c427548062417718dfe35f3e2bc50a9631fL18-R25), [link](https://github.com/PolicyEngine/policyengine-us/pull/2744/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Update and rename the test cases for the New Mexico deduction to reflect the broader definition of dependents ([link](https://github.com/PolicyEngine/policyengine-us/pull/2744/files?diff=unified&w=0#diff-a4b50e90d129f8ed651c9178c6761b4ffa5e358b78c87034770fccd56999bf79L1-R5), [link](https://github.com/PolicyEngine/policyengine-us/pull/2744/files?diff=unified&w=0#diff-a4b50e90d129f8ed651c9178c6761b4ffa5e358b78c87034770fccd56999bf79L14-R14), [link](https://github.com/PolicyEngine/policyengine-us/pull/2744/files?diff=unified&w=0#diff-a4b50e90d129f8ed651c9178c6761b4ffa5e358b78c87034770fccd56999bf79L37-R37), [link](https://github.com/PolicyEngine/policyengine-us/pull/2744/files?diff=unified&w=0#diff-a4b50e90d129f8ed651c9178c6761b4ffa5e358b78c87034770fccd56999bf79L46-R50))
* Bump the patch version of the package in the changelog entry ([link](https://github.com/PolicyEngine/policyengine-us/pull/2744/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


