### PR TITLE
Equivalised household net income is SPM-unit based, not household-based

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Equivalised household income is household income-based rather than SPM income-based.

--- a/policyengine_us/variables/household/income/household/equiv_household_net_income.py
+++ b/policyengine_us/variables/household/income/household/equiv_household_net_income.py
@@ -7,4 +7,8 @@ class equiv_household_net_income(Variable):
     label = "equivalised net income"
     definition_period = YEAR
     unit = USD
-    adds = ["spm_unit_oecd_equiv_net_income"]
+
+    def formula(household, period, parameters):
+        number_of_people = household.nb_persons()
+        net_income = household("household_net_income", period)
+        return net_income / (number_of_people**0.5)


### PR DESCRIPTION
Fixes #2754

copilot:all
