### PR TITLE
Add documentation on Maryland itemized deduction rule

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Lack of documentation on Maryland itemized deduction rule.

--- a/policyengine_us/variables/gov/states/md/tax/income/deductions/md_deductions.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/deductions/md_deductions.py
@@ -7,17 +7,26 @@ class md_deductions(Variable):
     label = "MD deductions"
     unit = USD
     definition_period = YEAR
-    reference = "https://govt.westlaw.com/mdc/Document/N05479690A64A11DBB5DDAC3692B918BC?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)"
+    reference = (
+        "https://govt.westlaw.com/mdc/Document/N05479690A64A11DBB5DDAC3692B918BC?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)"
+        "https://www.marylandtaxes.gov/forms/21_forms/Resident_Booklet.pdf#page=5"
+        "https://www.marylandtaxes.gov/forms/22_forms/Resident_Booklet.pdf#page=5"
+    )
     defined_for = StateCode.MD
 
     def formula(tax_unit, period, parameters):
         itm_deds_less_salt = tax_unit("itemized_deductions_less_salt", period)
         capped_property_taxes = tax_unit("capped_property_taxes", period)
-        md_itm_ded = itm_deds_less_salt + capped_property_taxes
-        md_std_ded = tax_unit("md_standard_deduction", period)
-        us_itemizer = tax_unit("tax_unit_itemizes", period)
-        return where(
-            us_itemizer,
-            where(md_itm_ded > md_std_ded, md_itm_ded, md_std_ded),
-            md_std_ded,
-        )
+        md_itmded = itm_deds_less_salt + capped_property_taxes
+        md_stdded = tax_unit("md_standard_deduction", period)
+        # 2021 and 2022 Form 502 instructions on page 5 include this FAQ:
+        # 3. Itemized deductions.
+        #    Q: Can I claim itemized deductions on my Maryland return if
+        #       I claimed standard deduction on my federal return?
+        #    A: No. You may claim itemized deductions on your Maryland
+        #       return only if you claimed itemized deductions on your
+        #       federal return. If you claimed your itemized deductions
+        #       on your federal return, you may figure your tax using
+        #       both deduction methods to determine which is best for you.
+        federal_itemizer = tax_unit("tax_unit_itemizes", period)
+        return where(federal_itemizer, max_(md_stdded, md_itmded), md_stdded)

--- a/policyengine_us/variables/gov/states/ne/tax/income/ne_taxable_income.py
+++ b/policyengine_us/variables/gov/states/ne/tax/income/ne_taxable_income.py
@@ -26,9 +26,5 @@ class ne_taxable_income(Variable):
         federal_itemizer = tax_unit("tax_unit_itemizes", period)
         std_ded = tax_unit("ne_standard_deduction", period)
         itm_ded = tax_unit("ne_itemized_deductions", period)
-        deduction = where(
-            federal_itemizer,
-            max_(itm_ded, std_ded),
-            std_ded,
-        )
+        deduction = where(federal_itemizer, max_(itm_ded, std_ded), std_ded)
         return max_(0, agi - deduction)


### PR DESCRIPTION
Fixes #2782.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 86586b3</samp>

### Summary
📝🧹🐛

<!--
1.  📝 for the changelog entry, indicating documentation.
2.  🧹 for the removal of the redundant line break, indicating code cleanup or refactoring.
3.  🐛 for the improvement of the `md_deductions` class, indicating a bug fix.
-->
This pull request fixes a bug in the `md_deductions` class and updates its documentation, as well as tidying up the code of the `ne_taxable_income` class. The changes are reflected in the changelog file.

> _`md_deductions`_
> _Fixing bugs and docs for fall_
> _Tax code clarity_

### Walkthrough
* Fix a bug in the documentation and formula of the Maryland itemized deduction rule ([link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-eff4ce31de482b0406593d4b7b3bbbf0da7f3a5829a6b940ed618ce75b1332e5L10-R14), [link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-eff4ce31de482b0406593d4b7b3bbbf0da7f3a5829a6b940ed618ce75b1332e5L16-R32))
  - Add a changelog entry to indicate the patch version increment and the bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
  - Update the reference attribute of the `md_deductions` class to include the links to the 2021 and 2022 tax forms ([link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-eff4ce31de482b0406593d4b7b3bbbf0da7f3a5829a6b940ed618ce75b1332e5L10-R14))
  - Modify the formula of the `md_deductions` class to use the correct logic based on the FAQ from the tax forms and add a comment explaining the source and rationale ([link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-eff4ce31de482b0406593d4b7b3bbbf0da7f3a5829a6b940ed618ce75b1332e5L16-R32))
* Remove a redundant line break in the formula of the Nebraska taxable income class ([link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-d623a7c1c81c042fd52e63162bef1e3569e3224297ded86831a242680d01269dL29-R29))
  - Improve the readability and consistency of the code in `ne_taxable_income.py` by deleting an extra blank line ([link](https://github.com/PolicyEngine/policyengine-us/pull/2783/files?diff=unified&w=0#diff-d623a7c1c81c042fd52e63162bef1e3569e3224297ded86831a242680d01269dL29-R29))


