### PR TITLE
Confusing New Mexico variable and parameter name

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Eliminated the use of the term subtractions in the New Mexico metadata.

--- a/policyengine_us/parameters/gov/states/nm/tax/income/other_deductions_and_exemptions.yaml
+++ b/policyengine_us/parameters/gov/states/nm/tax/income/other_deductions_and_exemptions.yaml
@@ -1,4 +1,4 @@
-description: New Mexico other deduction and subtraction elements.
+description: New Mexico other deduction and exemptions elements.
 values:
   2021-01-01:
     - us_govt_interest

--- a/policyengine_us/variables/gov/states/nm/tax/income/nm_other_deductions_and_exemptions.py
+++ b/policyengine_us/variables/gov/states/nm/tax/income/nm_other_deductions_and_exemptions.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class nm_other_deductions_and_exemptions(Variable):
     value_type = float
     entity = TaxUnit
-    label = "New Mexico other income deductions and subtractions"
+    label = "New Mexico other income deductions and exemptions"
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.NM


### PR DESCRIPTION
Fixes #2767

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eb65a04</samp>

### Summary
📝🚚🎨

<!--
1.  📝 - This emoji represents a documentation change, which is appropriate for the changelog entry and the description of the parameter file.
2.  🚚 - This emoji represents a removal or relocation of code, which is appropriate for the removal of the term subtractions from the variable label.
3.  🎨 - This emoji represents an improvement or update of the format or structure of the code, which is appropriate for the alignment of the variable label with the parameter file and the tax code.
-->
This pull request removes the term subtractions from the New Mexico income tax metadata, parameter file, and variable label. This improves the clarity and accuracy of the policy model and the changelog entry.

> _`subtractions` gone_
> _New Mexico tax code clear_
> _autumn of errors_

### Walkthrough
*  Remove the term subtractions from the New Mexico income tax metadata, parameter file, and variable label to avoid confusion and inconsistency with the tax code ([link](https://github.com/PolicyEngine/policyengine-us/pull/2784/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2784/files?diff=unified&w=0#diff-a7297a6c2a78453f7983ffb78e7e57144cb695f9ad728f7eeb1f524dcf81a41eL1-R1), [link](https://github.com/PolicyEngine/policyengine-us/pull/2784/files?diff=unified&w=0#diff-95f9a2fc3602b0fc4f23962322d0a1199b7bdb99f8990115ec87bc24aee44746L7-R7))
* Update the changelog entry to reflect the patch version bump and the rationale for the change ([link](https://github.com/PolicyEngine/policyengine-us/pull/2784/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


