### PR TITLE
Hide Idaho and Arkansas parameter folders via `index.yaml`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Hide Idaho and Arkansas parameter folders.

--- a/policyengine_us/parameters/gov/states/ar/index.yaml
+++ b/policyengine_us/parameters/gov/states/ar/index.yaml
@@ -1,0 +1,4 @@
+metadata:
+  propagate_metadata_to_children: true
+  economy: false
+  household: false

--- a/policyengine_us/parameters/gov/states/id/index.yaml
+++ b/policyengine_us/parameters/gov/states/id/index.yaml
@@ -1,0 +1,4 @@
+metadata:
+  propagate_metadata_to_children: true
+  economy: false
+  household: false


### PR DESCRIPTION
Fixes #2787

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0ebbedf</samp>

### Summary
📝🙈🏷️

<!--
1.  📝 - This emoji represents the change to the changelog entry, as it indicates that the change is a documentation update that describes the other changes in the pull request.
2.  🙈 - This emoji represents the change to the Arkansas and Idaho parameter folders, as it indicates that the change is hiding something from the user interface that is not ready or relevant yet.
3.  🏷️ - This emoji represents the change to the metadata of the Arkansas and Idaho parameter folders, as it indicates that the change is adding or modifying labels or tags that provide information or instructions for the folders and their children.
-->
This pull request hides the `ar` and `id` parameter folders from the user interface by adding metadata to their `index.yaml` files. This is to avoid showing empty folders for states that do not have any state-specific parameters yet.

> _Hide empty folders_
> _`propagate_metadata` true_
> _Winter of parameters_

### Walkthrough
*  Hide Idaho and Arkansas parameter folders from user interface ([link](https://github.com/PolicyEngine/policyengine-us/pull/2788/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2788/files?diff=unified&w=0#diff-4ae238dbb628c00be17595d0e4304611d1495a353dfa11ef99b6d34212c8b292R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2788/files?diff=unified&w=0#diff-d5d69b4f3761679a8f50649bc28ca10af0e19005b50800bed3e0d58764fa770bR1-R4))


