### PR TITLE
Add Oregon Child Tax Credit

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Oregon Child Tax Credit.

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/amount.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/amount.yaml
@@ -1,0 +1,19 @@
+description: Oregon provides this Child Tax Credit amount based on the child's age.
+brackets:
+  - threshold:
+      0000-01-01: 0
+    amount:
+      0000-01-01: 0
+      2023-01-01: 1_000
+  - threshold:
+      0000-01-01: 6
+    amount:
+      0000-01-01: 0
+metadata:
+  type: single_amount
+  threshold_unit: year
+  amount_unit: currency-USD
+  label: Oregon Child Tax Credit amount
+  reference:
+    - title: 2023R1 House Bill 3235 Section 2 (1)(a) [age] and (3)(a) [amount]
+      href: https://olis.oregonlegislature.gov/liz/2023R1/Downloads/MeasureDocument/HB3235/Enrolled#page=1

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/amount.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/amount.yaml
@@ -1,19 +1,10 @@
-description: Oregon provides this Child Tax Credit amount based on the child's age.
-brackets:
-  - threshold:
-      0000-01-01: 0
-    amount:
-      0000-01-01: 0
-      2023-01-01: 1_000
-  - threshold:
-      0000-01-01: 6
-    amount:
-      0000-01-01: 0
+description: Oregon provides this maximum Child Tax Credit per qualifying child.
+values:
+  0000-01-01: 0
+  2023-01-01: 1_000
 metadata:
-  type: single_amount
-  threshold_unit: year
-  amount_unit: currency-USD
+  unit: currency-USD
   label: Oregon Child Tax Credit amount
   reference:
-    - title: 2023R1 House Bill 3235 Section 2 (1)(a) [age] and (3)(a) [amount]
+    - title: 2023R1 House Bill 3235 Section 2 (3)(a)
       href: https://olis.oregonlegislature.gov/liz/2023R1/Downloads/MeasureDocument/HB3235/Enrolled#page=1

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/child_limit.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/child_limit.yaml
@@ -1,0 +1,9 @@
+description: Oregon caps its Child Tax Credit at this number of children per filer.
+values:
+  0000-01-01: 5
+metadata:
+  unit: person
+  label: Oregon Child Tax Credit child limit
+  reference:
+    - title: 2023R1 House Bill 3235 Section 2 (2)
+      href: https://olis.oregonlegislature.gov/liz/2023R1/Downloads/MeasureDocument/HB3235/Enrolled#page=1

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/ineligible_age.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/ineligible_age.yaml
@@ -1,0 +1,9 @@
+description: Oregon provides this Child Tax Credit to children below this age.
+values:
+  0000-01-01: 6
+metadata:
+  unit: year
+  label: Oregon Child Tax Credit ineligible age
+  reference:
+    - title: 2023R1 House Bill 3235 Section 2 (1)(a)
+      href: https://olis.oregonlegislature.gov/liz/2023R1/Downloads/MeasureDocument/HB3235/Enrolled#page=1

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/reduction/start.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/reduction/start.yaml
@@ -1,0 +1,9 @@
+description: Oregon reduces its Child Tax Credit for filers with Oregon adjusted gross income exceeding this amount.
+values:
+  0000-01-01: 25_000
+metadata:
+  unit: currency-USD
+  label: Oregon Child Tax Credit phase-out start
+  reference:
+    - title: 2023R1 House Bill 3235 Section 2 (3)(a)
+      href: https://olis.oregonlegislature.gov/liz/2023R1/Downloads/MeasureDocument/HB3235/Enrolled#page=1

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/reduction/width.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/ctc/reduction/width.yaml
@@ -1,0 +1,9 @@
+description: Oregon reduces its Child Tax Credit over this income range exceeding the phase-out start.
+values:
+  0000-01-01: 5_000
+metadata:
+  unit: currency-USD
+  label: Oregon Child Tax Credit phase-out width
+  reference:
+    - title: 2023R1 House Bill 3235 Section 2 (4)
+      href: https://olis.oregonlegislature.gov/liz/2023R1/Downloads/MeasureDocument/HB3235/Enrolled#page=2

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/refundable.yaml
@@ -3,6 +3,10 @@ values:
   2019-01-01:
   - or_eitc
   - or_kicker
+  2023-01-01:
+  - or_eitc
+  - or_kicker
+  - or_ctc
 metadata:
   unit: list
   label: OR refundable tax credits

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/refundable.yaml
@@ -7,6 +7,10 @@ values:
   - or_eitc
   - or_kicker
   - or_ctc
+  # Child Tax Credit legislation ends in 2029.
+  2029-01-01:
+  - or_eitc
+  - or_kicker
 metadata:
   unit: list
   label: OR refundable tax credits

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
@@ -35,7 +35,7 @@
     is_tax_unit_dependent: true
     or_income_after_subtractions: 0
   output:
-    or_ctc: 1_000
+    or_ctc: 0
 
 - name: Fully phases out at $30,000.
   period: 2023

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
@@ -12,7 +12,7 @@
   input:
     state_code: OR
     age: 5
-    is_dependent: true
+    is_tax_unit_dependent: true
     or_income_after_subtractions: 0
   output:
     or_ctc: 1_000
@@ -22,7 +22,7 @@
   input:
     state_code: CA
     age: 5
-    is_dependent: true
+    is_tax_unit_dependent: true
     or_income_after_subtractions: 0
   output:
     or_ctc: 0
@@ -32,7 +32,7 @@
   input:
     state_code: OR
     age: 6
-    is_dependent: true
+    is_tax_unit_dependent: true
     or_income_after_subtractions: 0
   output:
     or_ctc: 1_000
@@ -42,7 +42,7 @@
   input:
     state_code: OR
     age: 5
-    is_dependent: true
+    is_tax_unit_dependent: true
     or_income_after_subtractions: 30_000
   output:
     or_ctc: 0
@@ -52,7 +52,7 @@
   input:
     state_code: OR
     age: 5
-    is_dependent: true
+    is_tax_unit_dependent: true
     or_income_after_subtractions: 100_000
   output:
     or_ctc: 0
@@ -62,7 +62,7 @@
   input:
     state_code: OR
     age: 5
-    is_dependent: true
+    is_tax_unit_dependent: true
     or_income_after_subtractions: 27_500
   output:
     or_ctc: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
@@ -1,0 +1,87 @@
+- name: Was not in effect in 2022.
+  period: 2022
+  input:
+    state_code: OR
+    age: 5
+    or_income_after_subtractions: 0
+  output:
+    or_ctc: 0
+
+- name: $1,000 maximum in 2023.
+  period: 2023
+  input:
+    state_code: OR
+    age: 5
+    is_dependent: true
+    or_income_after_subtractions: 0
+  output:
+    or_ctc: 1_000
+
+- name: Only in Oregon.
+  period: 2023
+  input:
+    state_code: CA
+    age: 5
+    is_dependent: true
+    or_income_after_subtractions: 0
+  output:
+    or_ctc: 0
+
+- name: Age six is disqualified.
+  period: 2023
+  input:
+    state_code: OR
+    age: 6
+    is_dependent: true
+    or_income_after_subtractions: 0
+  output:
+    or_ctc: 1_000
+
+- name: Fully phases out at $30,000.
+  period: 2023
+  input:
+    state_code: OR
+    age: 5
+    is_dependent: true
+    or_income_after_subtractions: 30_000
+  output:
+    or_ctc: 0
+
+- name: Halfway phased out at $27,500.
+  period: 2023
+  input:
+    state_code: OR
+    age: 5
+    is_dependent: true
+    or_income_after_subtractions: 27_500
+  output:
+    or_ctc: 500
+
+- name: Maximum of five qualifying children.
+  period: 2023
+  input:
+    people:
+      parent:
+        age: 30
+      child1:
+        age: 5
+      child2:
+        age: 5
+      child3:
+        age: 5
+      child4:
+        age: 5
+      child5:
+        age: 5
+      child6:
+        age: 5
+    households:
+      household:
+        members: [parent, child1, child2, child3, child4, child5, child6]
+        state_code: OR
+    tax_units:
+      tax_unit:
+        members: [parent, child1, child2, child3, child4, child5, child6]
+        or_income_after_subtractions: 25_000
+  output:
+    or_ctc: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml
@@ -47,6 +47,16 @@
   output:
     or_ctc: 0
 
+- name: Check we're not creating a negative value.
+  period: 2023
+  input:
+    state_code: OR
+    age: 5
+    is_dependent: true
+    or_income_after_subtractions: 100_000
+  output:
+    or_ctc: 0
+
 - name: Halfway phased out at $27,500.
   period: 2023
   input:

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/or_ctc.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/or_ctc.py
@@ -14,7 +14,7 @@ class or_ctc(Variable):
         # Get age and dependent status of all people in the tax unit.
         person = tax_unit.members
         age = person("age", period)
-        dependent = person("is_dependent", period)
+        dependent = person("is_tax_unit_dependent", period)
         # Get the number of qualifying dependents in the tax unit.
         p = parameters(period).gov.states["or"].tax.income.credits.ctc
         age_eligible = age < p.ineligible_age

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/or_ctc.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/or_ctc.py
@@ -1,0 +1,33 @@
+from policyengine_us.model_api import *
+
+
+class or_ctc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Oregon Child Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://olis.oregonlegislature.gov/liz/2023R1/Downloads/MeasureDocument/HB3235/Enrolled"
+    defined_for = StateCode.OR
+
+    def formula(tax_unit, period, parameters):
+        # Get age and dependent status of all people in the tax unit.
+        person = tax_unit.members
+        age = person("age", period)
+        dependent = person("is_dependent", period)
+        # Get the number of qualifying dependents in the tax unit.
+        p = parameters(period).gov.states["or"].tax.income.credits.ctc
+        age_eligible = age < p.ineligible_age
+        eligible = age_eligible & dependent
+        count_eligible = tax_unit.sum(eligible)
+        # Cap the number of qualifying dependents.
+        capped_count_eligible = min(count_eligible, p.child_limit)
+        # Get maximum credit amount.
+        max_credit = p.amount * capped_count_eligible
+        # Get Oregon adjusted gross income.
+        or_agi = tax_unit("or_income_after_subtractions", period)
+        # Reduce credit amount over the phaseout range.
+        excess_agi = max(or_agi - p.reduction.start, 0)
+        percent_reduction = min_(excess_agi / p.reduction.width, 1)
+        # Return reduced amount.
+        return max_credit * (1 - percent_reduction)

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/or_ctc.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/or_ctc.py
@@ -21,13 +21,13 @@ class or_ctc(Variable):
         eligible = age_eligible & dependent
         count_eligible = tax_unit.sum(eligible)
         # Cap the number of qualifying dependents.
-        capped_count_eligible = min(count_eligible, p.child_limit)
+        capped_count_eligible = min_(count_eligible, p.child_limit)
         # Get maximum credit amount.
         max_credit = p.amount * capped_count_eligible
         # Get Oregon adjusted gross income.
         or_agi = tax_unit("or_income_after_subtractions", period)
         # Reduce credit amount over the phaseout range.
-        excess_agi = max(or_agi - p.reduction.start, 0)
+        excess_agi = max_(or_agi - p.reduction.start, 0)
         percent_reduction = min_(excess_agi / p.reduction.width, 1)
         # Return reduced amount.
         return max_credit * (1 - percent_reduction)


### PR DESCRIPTION
Fixes #2790

I recorded myself creating this PR https://www.loom.com/share/f210354c8f3643c1945f670b0c8d4c07

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0b47045</samp>

### Summary
:sparkles::page_facing_up::test_tube:

<!--
1.  :sparkles: This emoji represents the addition of a new feature, such as the Oregon Child Tax Credit, to the model. It is commonly used in changelogs to indicate new functionality or enhancements.
2. :page_facing_up: This emoji represents the addition of new parameter files, which contain the data and metadata for the model parameters. It is commonly used in changelogs to indicate new or updated documentation or configuration files.
3. :test_tube: This emoji represents the addition of new test cases, which verify the logic and values of the model variables. It is commonly used in changelogs to indicate new or improved tests or code quality checks.
-->
This pull request adds a new feature to the PolicyEngine US model: the Oregon Child Tax Credit. It creates new parameter files, a new variable file, and a new test file for the credit, following the legislation and the model API conventions. It also updates the changelog entry to reflect the new feature.

> _`Oregon Child Tax`_
> _A new feature for the fall_
> _`PolicyEngine` grows_

### Walkthrough
*  Add the Oregon Child Tax Credit (OR-CTC) as a new feature to the model ([link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-e725d64491c3228cb47eaf93ca76db2eb3ffa78e1b4639c3a7ee700a60337b24R1-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-091cc39981e486b839ab60845bfa8a42f097e6f1a2a9decca51a2412e22d9844R1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-f2835919189492f47b1ca20145ffbc20441ccf14bbcc4203cff345c78862f0b0R1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-70c7a796810367f1f7790a379cd3e14d0313c85f1065bf759ceb37584221d05cR1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-5abcfbd88db6662d2fe8fb7d3b382dd647cebb6bfe30a0711cc5179f3d721279R1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-064bc2a7402e0e490362a3e0f77244c913fc47bc533faa064c2834e9e0bb4126R1-R97), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-1bd528c4adb9cc5f0422903b44738d0a65e279946ba1860ea9922084cf123a2fR1-R33))
  * Define the `or_ctc` variable in `policyengine_us/variables/gov/states/or/tax/income/credits/or_ctc.py` using the parameters and other variables ([link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-1bd528c4adb9cc5f0422903b44738d0a65e279946ba1860ea9922084cf123a2fR1-R33))
  * Add the parameter files for the amount, child limit, ineligible age, phase-out start, and phase-out width of the OR-CTC in `policyengine_us/parameters/gov/states/or/tax/income/credits/ctc` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-e725d64491c3228cb47eaf93ca76db2eb3ffa78e1b4639c3a7ee700a60337b24R1-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-091cc39981e486b839ab60845bfa8a42f097e6f1a2a9decca51a2412e22d9844R1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-f2835919189492f47b1ca20145ffbc20441ccf14bbcc4203cff345c78862f0b0R1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-70c7a796810367f1f7790a379cd3e14d0313c85f1065bf759ceb37584221d05cR1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-5abcfbd88db6662d2fe8fb7d3b382dd647cebb6bfe30a0711cc5179f3d721279R1-R9))
  * Add the test file for the OR-CTC in `policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_ctc.yaml` with several test cases ([link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-064bc2a7402e0e490362a3e0f77244c913fc47bc533faa064c2834e9e0bb4126R1-R97))
  * Update the changelog entry to indicate the new feature and the minor version bump ([link](https://github.com/PolicyEngine/policyengine-us/pull/2792/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


