### PR TITLE
Add DC income tax policy parameter to control joint-separate option

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - District of Columbia (DC) income tax policy parameter that controls whether married joint taxpayers have the option to compute DC taxes separately.

--- a/policyengine_us/parameters/gov/states/dc/tax/income/joint_separately_option.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/joint_separately_option.yaml
@@ -1,0 +1,12 @@
+description: DC offers taxpayers who file married joint on federal return the option to file separately on DC return if this parameter is true.
+metadata:
+  unit: bool
+  label: Whether DC offers filing separate option to married-joint taxpayers
+  reference:
+    - title: 2021 Form D-40 Booklet
+      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=44
+    - title: 2022 Form D-40 Booklet
+      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=44
+values:
+  2021-01-01:
+    - true

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_files_separately.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_files_separately.yaml
@@ -15,3 +15,13 @@
     state_code: DC
   output:
     dc_files_separately: false
+
+- name: dc_files_separately unit test 3
+  period: 2022
+  input:
+    gov.states.dc.tax.income.joint_separately_option: false
+    dc_income_tax_before_credits_indiv: 400
+    dc_income_tax_before_credits_joint: 500
+    state_code: DC
+  output:
+    dc_files_separately: false

--- a/policyengine_us/variables/gov/states/dc/tax/income/dc_files_separately.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/dc_files_separately.py
@@ -12,4 +12,6 @@ class dc_files_separately(Variable):
     def formula(tax_unit, period, parameters):
         itax_indiv = tax_unit("dc_income_tax_before_credits_indiv", period)
         itax_joint = tax_unit("dc_income_tax_before_credits_joint", period)
-        return itax_indiv < itax_joint
+        if parameters(period).gov.states.dc.tax.income.joint_separately_option:
+            return itax_indiv < itax_joint
+        return False


### PR DESCRIPTION
Fixes #2797.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at abac32c</samp>

### Summary
📝🆕✅

<!--
1.  📝 for updating the changelog entry
2.  🆕 for adding the new policy parameter file
3.  ✅ for adding the new unit test and modifying the formula
-->
This pull request adds a new policy parameter and a corresponding variable for DC income tax. The parameter `joint_separately_option` allows married joint taxpayers to choose whether to file separately on their DC return. The variable `dc_files_separately` indicates whether they do so. The pull request also updates the changelog, the parameter file, and the unit test for the variable.

> _`dc_files_separately`_
> _New parameter and test_
> _Autumn leaves change tax_

### Walkthrough
*  Add a new policy parameter for DC income tax that controls whether married joint taxpayers can file separately on their DC return ([link](https://github.com/PolicyEngine/policyengine-us/pull/2798/files?diff=unified&w=0#diff-49b04b2d316e6945268c2c1c110fcaa83652588ca490d9fa3b841f65a5d1894fR1-R12), [link](https://github.com/PolicyEngine/policyengine-us/pull/2798/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Modify the formula for the `dc_files_separately` variable to use the new parameter ([link](https://github.com/PolicyEngine/policyengine-us/pull/2798/files?diff=unified&w=0#diff-b89a39618365dd0d543b932595019a396e535027a3e53d6b57396a91c44dee62L15-R17))
* Add a new unit test for the `dc_files_separately` variable ([link](https://github.com/PolicyEngine/policyengine-us/pull/2798/files?diff=unified&w=0#diff-efd42f8c0340f579bdfe4ea2a81f6f1c1da99f49803e9f789610a4310901c719R18-R27))


