### PR TITLE
Make DC filing joint separately option a bool instead of list

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Make DC married filing separately on same return option a bool instead of list.

--- a/policyengine_us/parameters/gov/states/dc/tax/income/joint_separately_option.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/joint_separately_option.yaml
@@ -8,5 +8,4 @@ metadata:
     - title: 2022 Form D-40 Booklet
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=44
 values:
-  2021-01-01:
-    - true
+  2021-01-01: true


### PR DESCRIPTION
Fixes #2800

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa6d7f6</samp>

### Summary
🐛📝🚑

<!--
1.  🐛 - This emoji represents a bug fix, and is appropriate for the changelog entry and the parameter fix.
2. 📝 - This emoji represents documentation, and is appropriate for the changelog entry, since it mentions the documentation of the parameter.
3. 🚑 - This emoji represents a critical or urgent fix, and is appropriate for the parameter fix, since it prevents errors and enables correct simulations.
-->
This pull request fixes a bug in the `joint_separately_option` parameter for DC income tax, and updates the changelog accordingly. The bug caused errors when using the parameter in simulations, and was due to an incorrect data type.

> _`DC_MFJOSR` bug_
> _Fixed by changing list to bool_
> _A patch for autumn_

### Walkthrough
* Fix bug in DC married filing separately on same return option parameter ([link](https://github.com/PolicyEngine/policyengine-us/pull/2801/files?diff=unified&w=0#diff-49b04b2d316e6945268c2c1c110fcaa83652588ca490d9fa3b841f65a5d1894fL11-R11))
* Update changelog entry for the pull request ([link](https://github.com/PolicyEngine/policyengine-us/pull/2801/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


