### PR TITLE
Revenue-affecting reforms over state refundable credits are misalloca…

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Misallocation of state refundable tax credit-affecting reforms' revenues.

--- a/policyengine_us/variables/household/income/household/household_state_income_tax.py
+++ b/policyengine_us/variables/household/income/household/household_state_income_tax.py
@@ -67,4 +67,6 @@ class household_state_income_tax(Variable):
                 0,
             )
         else:
-            return add(tax_unit, period, household_state_income_tax.adds)
+            return add(
+                tax_unit, period, household_state_income_tax.adds
+            ) - add(tax_unit, period, household_state_income_tax.subtracts)


### PR DESCRIPTION
…ted to federal taxes in the app

Fixes #2847

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fe2ea1f</samp>

### Summary
🐛📝📈

<!--
1.  🐛 for bug fix
2.  📝 for documentation update
3.  📈 for formula improvement
-->
This pull request fixes a bug in the calculation of `household_state_income_tax` that ignored the effect of refundable state tax credits. It updates the formula for the variable in `household_state_income_tax.py` and adds a changelog entry in `changelog_entry.yaml`.

> _`state_income_tax`_
> _Fixed bug with refundable credits_
> _Autumn leaves fall fast_

### Walkthrough
* Fix bug in household state income tax calculation by subtracting refundable state tax credits ([link](https://github.com/PolicyEngine/policyengine-us/pull/2848/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dL70-R72))
* Update changelog file with patch version increment and bug fix description ([link](https://github.com/PolicyEngine/policyengine-us/pull/2848/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


