### PR TITLE
Add DC KCCATC reforms

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Contributed reforms to the DC Keep Child Care Affordable Tax Credit.

--- a/policyengine_us/parameters/gov/contrib/dc_kccatc/README.md
+++ b/policyengine_us/parameters/gov/contrib/dc_kccatc/README.md
@@ -1,0 +1,3 @@
+# DC KCCATC
+
+Reforms that affect the Keep Child Care Affordable Tax Credit.

--- a/policyengine_us/parameters/gov/contrib/dc_kccatc/active.yaml
+++ b/policyengine_us/parameters/gov/contrib/dc_kccatc/active.yaml
@@ -1,0 +1,6 @@
+description: Whether to reform the DC KCCATC in line with the parameters in this folder.
+values:
+  2020-01-01: false
+metadata:
+  unit: bool
+  label: DC KCCATC custom reforms active

--- a/policyengine_us/parameters/gov/contrib/dc_kccatc/expenses/max.yaml
+++ b/policyengine_us/parameters/gov/contrib/dc_kccatc/expenses/max.yaml
@@ -1,0 +1,7 @@
+description: DC caps the KCCATC at this amount per eligible child.
+values:
+  2000-01-01: 0
+metadata:
+  unit: currency-USD
+  period: year
+  label: DC KCCATC maximum

--- a/policyengine_us/parameters/gov/contrib/dc_kccatc/expenses/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/dc_kccatc/expenses/rate.yaml
@@ -1,0 +1,6 @@
+description: The DC KCCATC covers this percentage of child care expenses for the tax unit.
+values:
+  2000-01-01: 0.00
+metadata:
+  unit: /1
+  label: DC KCCATC expense share

--- a/policyengine_us/parameters/gov/contrib/dc_kccatc/phase_out/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/dc_kccatc/phase_out/rate.yaml
@@ -1,0 +1,7 @@
+description: DC phases out the KCCATC at this rate of AGI above the threshold.
+values:
+  2000-01-01: 0.00
+metadata:
+  unit: /1
+  period: year
+  label: DC KCCATC phase-out rate

--- a/policyengine_us/parameters/gov/contrib/dc_kccatc/phase_out/threshold.yaml
+++ b/policyengine_us/parameters/gov/contrib/dc_kccatc/phase_out/threshold.yaml
@@ -1,0 +1,15 @@
+description: AGI after this amount phases out the DC KCCATC.
+SINGLE:
+  2000-01-01: 0
+JOINT:
+  2000-01-01: 0
+SEPARATE:
+  2000-01-01: 0
+HEAD_OF_HOUSEHOLD:
+  2000-01-01: 0
+WIDOW:
+  2000-01-01: 0
+metadata:
+  breakdown: filing_status
+  unit: currency-USD
+  label: DC KCCATC phase-out threshold

--- a/policyengine_us/reforms/dc_kccatc.py
+++ b/policyengine_us/reforms/dc_kccatc.py
@@ -47,7 +47,6 @@ def create_dc_kccatc_reform(parameters, period, bypass=False):
                 ]
                 income_over_threshold = max_(agi - threshold, 0)
                 phase_out_rate = reform_parameters.phase_out.rate
-                print("phase_out_rate", phase_out_rate)
                 phase_out_amount = income_over_threshold * phase_out_rate
 
                 return max_(0, amount_covered - phase_out_amount)
@@ -88,7 +87,10 @@ def create_dc_kccatc_reform(parameters, period, bypass=False):
         def apply(self):
             self.update_variable(dc_kccatc)
 
-    if parameters(period).gov.contrib.dc_kccatc.active or bypass:
+    if bypass or parameters(period).gov.contrib.dc_kccatc.active:
         return reform
     else:
         return None
+
+
+dc_kccatc_reform = create_dc_kccatc_reform(None, None, True)

--- a/policyengine_us/reforms/dc_kccatc.py
+++ b/policyengine_us/reforms/dc_kccatc.py
@@ -1,0 +1,94 @@
+from policyengine_us.model_api import *
+
+
+def create_dc_kccatc_reform(parameters, period, bypass=False):
+    class dc_kccatc(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "DC keep child care affordable tax credit"
+        unit = USD
+        definition_period = YEAR
+        reference = (
+            "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=67"
+            "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=59"
+        )
+        defined_for = StateCode.DC
+
+        def formula(tax_unit, period, parameters):
+            reform_parameters = parameters(period).gov.contrib.dc_kccatc
+
+            if reform_parameters.active:
+                # Eligible expenses
+
+                expenses = tax_unit("tax_unit_childcare_expenses", period)
+                cdcc = parameters(period).gov.irs.credits.cdcc
+                # Cap at number of children based on federal CDCC limit.
+                count_eligible = min_(
+                    cdcc.eligibility.max,
+                    tax_unit("count_cdcc_eligible", period),
+                )
+
+                # Maximum covered expenses
+                max_expenses_per_child = reform_parameters.expenses.max
+                max_expenses = max_expenses_per_child * count_eligible
+                eligible_capped_expenses = min_(expenses, max_expenses)
+
+                # Percent covered
+
+                amount_covered = (
+                    eligible_capped_expenses * reform_parameters.expenses.rate
+                )
+
+                # Phase-out
+                agi = tax_unit("adjusted_gross_income", period)
+                filing_status = tax_unit("filing_status", period)
+                threshold = reform_parameters.phase_out.threshold[
+                    filing_status
+                ]
+                income_over_threshold = max_(agi - threshold, 0)
+                phase_out_rate = reform_parameters.phase_out.rate
+                print("phase_out_rate", phase_out_rate)
+                phase_out_amount = income_over_threshold * phase_out_rate
+
+                return max_(0, amount_covered - phase_out_amount)
+            else:
+                p = parameters(period).gov.states.dc.tax.income.credits
+                # determine tax unit's income eligibility status
+                taxinc = tax_unit("dc_taxable_income_joint", period)
+                filing_status = tax_unit("filing_status", period)
+                income_eligible = (
+                    taxinc <= p.kccatc.income_limit[filing_status]
+                )
+                # determine count of KCCATC age eligible children
+                person = tax_unit.members
+                is_dependent = person("is_tax_unit_dependent", period)
+                age = person("age", period)
+                kccatc_age_eligible = is_dependent & (age <= p.kccatc.max_age)
+                kccatc_eligible_count = tax_unit.sum(kccatc_age_eligible)
+                # determine count of federal CDCC age eligible children
+                cdcc = parameters(period).gov.irs.credits.cdcc.eligibility
+                cdcc_age_eligible = is_dependent & (age < cdcc.child_age)
+                cdcc_eligible_count = tax_unit.sum(cdcc_age_eligible)
+                # calculate KCCATC amount
+                max_kccatc = kccatc_eligible_count * p.kccatc.max_amount
+                total_care_expenses = tax_unit(
+                    "tax_unit_childcare_expenses", period
+                )
+                ratio = np.zeros_like(cdcc_eligible_count)
+                mask = cdcc_eligible_count > 0
+                ratio[mask] = (
+                    kccatc_eligible_count[mask] / cdcc_eligible_count[mask]
+                )
+                kccatc_care_expenses = total_care_expenses * ratio
+                kccatc = min_(kccatc_care_expenses, max_kccatc)
+                # return calculated kccatc amount if income eligible
+                return income_eligible * kccatc
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(dc_kccatc)
+
+    if parameters(period).gov.contrib.dc_kccatc.active or bypass:
+        return reform
+    else:
+        return None

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -1,4 +1,5 @@
 from .congress.delauro import create_american_family_act_with_baby_bonus_reform
+from .dc_kccatc import create_dc_kccatc_reform
 from .winship import create_eitc_winship_reform
 from policyengine_core.reforms import Reform
 import warnings
@@ -9,6 +10,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         parameters, period
     )
     winship_reform = create_eitc_winship_reform(parameters, period)
+    dc_kccatc_reform = create_dc_kccatc_reform(parameters, period)
 
     if afa_reform is not None:
         if winship_reform is not None:
@@ -18,3 +20,5 @@ def create_structural_reforms_from_parameters(parameters, period):
         return afa_reform
     elif winship_reform is not None:
         return winship_reform
+    elif dc_kccatc_reform is not None:
+        return dc_kccatc_reform

--- a/policyengine_us/tests/policy/contrib/dc_kccatc.yaml
+++ b/policyengine_us/tests/policy/contrib/dc_kccatc.yaml
@@ -1,0 +1,44 @@
+- name: DC KCCATC for a single parent of three with $12k in child care expenses
+  period: 2023
+  reforms: policyengine_us.reforms.dc_kccatc.dc_kccatc_reform
+  input:
+    gov.contrib.dc_kccatc.active: true
+    gov.contrib.dc_kccatc.expenses.max: 12_000
+    gov.contrib.dc_kccatc.expenses.rate: 0.5
+    gov.contrib.dc_kccatc.phase_out.rate: 0.1
+    gov.contrib.dc_kccatc.phase_out.threshold.HEAD_OF_HOUSEHOLD: 200_000
+    gov.contrib.dc_kccatc.phase_out.threshold.JOINT: 400_000
+    gov.contrib.dc_kccatc.phase_out.threshold.SEPARATE: 200_000
+    gov.contrib.dc_kccatc.phase_out.threshold.SINGLE: 200_000
+    gov.contrib.dc_kccatc.phase_out.threshold.WIDOW: 200_000
+    # Household
+    count_cdcc_eligible: 3
+    filing_status: HEAD_OF_HOUSEHOLD
+    tax_unit_childcare_expenses: 12_000
+    adjusted_gross_income: 150_000
+    state_code: DC
+  output:
+    dc_kccatc: 6_000
+
+
+- name: DC KCCATC for a single parent of three with $12k in child care expenses in the phase-out region
+  period: 2023
+  reforms: policyengine_us.reforms.dc_kccatc.dc_kccatc_reform
+  input:
+    gov.contrib.dc_kccatc.active: true
+    gov.contrib.dc_kccatc.expenses.max: 12_000
+    gov.contrib.dc_kccatc.expenses.rate: 0.5
+    gov.contrib.dc_kccatc.phase_out.rate: 0.1
+    gov.contrib.dc_kccatc.phase_out.threshold.HEAD_OF_HOUSEHOLD: 200_000
+    gov.contrib.dc_kccatc.phase_out.threshold.JOINT: 400_000
+    gov.contrib.dc_kccatc.phase_out.threshold.SEPARATE: 200_000
+    gov.contrib.dc_kccatc.phase_out.threshold.SINGLE: 200_000
+    gov.contrib.dc_kccatc.phase_out.threshold.WIDOW: 200_000
+    # Household
+    count_cdcc_eligible: 3
+    filing_status: HEAD_OF_HOUSEHOLD
+    tax_unit_childcare_expenses: 12_000
+    adjusted_gross_income: 230_000
+    state_code: DC
+  output:
+    dc_kccatc: 3_000


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c35e7df</samp>

### Summary
:sparkles::memo::white_check_mark:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement to the model, such as the new structural reform option and the new parameter files.
2.  :memo: - This emoji represents the addition of documentation or comments to the code, such as the new README file and the changelog entry.
3.  :white_check_mark: - This emoji represents the addition of tests or validation to the code, such as the new YAML file and the test cases.
-->
This pull request adds a new reform option to the model that modifies the child tax credit and the earned income tax credit for residents of Washington DC, based on the DC Keep Child Care Affordable Tax Credit (KCCATC). It creates new parameter files, a new variable, a new reform class, and a new test file for the reforms. It also updates the `reforms.py` file and the changelog file to integrate the new option.

> _To help DC families afford care_
> _We added a new credit to share_
> _With `dc_kccatc`_
> _And a `reform` class_
> _We can model the impact with flair_

### Walkthrough
*  Add a new entry to the changelog file for the DC KCCATC reforms ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Add a new README file explaining the purpose and scope of the DC KCCATC reforms ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-85d09cb33c9404ce325b9a4ddf4cfa405477a3121184a9beda0ff29319397026R1-R3))
*  Add a new Python file defining a new variable and a reform class for the DC KCCATC reforms, as well as a helper function and a global instance for testing ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-2a75d4ab89879e73d7b5f85622564c74e58719010133bd77012a1bf402dfb828R1-R96))
*  Add a new parameter file for the DC KCCATC reforms, defining a boolean value that determines whether the reforms are active or not ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-4ff35c8bc10b7c61021919cc40cd9dbafd295e715cdd2df44e99ab831567d1f6R1-R6))
*  Add four new parameter files for the DC KCCATC reforms, defining the maximum amount, the percentage, the phase-out rate, and the phase-out threshold of the credit ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-7f125cbcfd69b0c645629e78ecab38620a9ff9d3b43581720a20e7068caf9f52R1-R7), [link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-87a049bf6a59423f0cad727cdaf5b47fd382a6e7487a94cc75de65535978c505R1-R6), [link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-1a1eae008156996458275a58a42fa50aa909a2a01a5431cd789a5c3d310c87e8R1-R7), [link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-34a1f248b010b7ed5688452a447f41fb1a51457eead5a46f90eac5ae1e73812aR1-R15))
*  Import the helper function from the new Python file into the existing `reforms.py` file ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R2))
*  Call the helper function inside the `create_structural_reforms_from_parameters` function and assign the result to a variable ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R13))
*  Add a new conditional branch to the `create_structural_reforms_from_parameters` function, returning the reform class if not None ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R23-R24))
*  Add a new YAML file for testing the DC KCCATC reforms, containing two test cases that check the output of the `dc_kccatc` variable for different inputs and reform parameters ([link](https://github.com/PolicyEngine/policyengine-us/pull/2852/files?diff=unified&w=0#diff-2f8ea1b075b1ef6e6dedd0f530950c581003a167e67057863e8efba091b4d7aaR1-R44))


