### PR TITLE
Correct Oregon retirement income credit calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Calculation of Oregon retirement income credit.

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/nonrefundable.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/nonrefundable.yaml
@@ -2,6 +2,7 @@ description: Oregon nonrefundable tax credits.
 values:
   2019-01-01:
   - or_exemption_credit
+  - or_retirement_credit
 metadata:
   unit: list
   label: OR nonrefundable tax credits

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/integration.yaml
@@ -5,3 +5,34 @@
     state_code: OR
   output:
     or_income_tax: 0
+
+- name: Elderly OR couple with modest pension, social security, and bond income
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 67
+        taxable_interest_income: 9000.0
+        taxable_pension_income: 5000.0
+        social_security: 1000.0
+      person2:
+        is_tax_unit_spouse: true
+        age: 67
+        taxable_interest_income: 9000.0
+        taxable_pension_income: 5000.0
+        social_security: 1000.0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: OR
+  output:
+    or_income_tax_before_credits: 1349.75
+    or_exemption_credit: 426.00
+    or_retirement_credit: 900.00
+    or_income_tax: 23.75  # = 1349.75 - 426.00 - 900.00

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/retirement_credit/or_retirement_income_credit.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/retirement_credit/or_retirement_income_credit.py
@@ -7,46 +7,52 @@ class or_retirement_credit(Variable):
     label = "Oregon Retirement Income Tax Credit"
     unit = USD
     definition_period = YEAR
-    reference = "https://www.oregon.gov/dor/forms/FormsPubs/publication-or-17_101-431_2022.pdf"
+    reference = "https://www.oregon.gov/dor/forms/FormsPubs/publication-or-17_101-431_2021.pdf#page=108"
     defined_for = StateCode.OR
 
     def formula(tax_unit, period, parameters):
+        # follows twelve-line worksheet on page 108 of above reference
+
+        # Line 1, retirement income
         person = tax_unit.members
         eligible = person("or_retirement_credit_eligible", period)
-        # Line 1,  retirement income
         retirement_income = eligible * person("taxable_pension_income", period)
         total_retirement_income = tax_unit.sum(retirement_income)
+
         # Line 2, federal pension subtraction
         federal_pension_subtraction = tax_unit(
             "or_federal_pension_subtraction", period
         )
-        # The retiremnt income is reduced by the amount of federal pension income
+
+        # Line 3, retirement income reduced by federal pension subtraction
         or_taxable_pension = max_(
-            total_retirement_income - federal_pension_subtraction, 0
+            0, total_retirement_income - federal_pension_subtraction
         )
-        # Line 5, total Social Security
-        social_security = eligible * person("social_security", period)
-        total_social_security = tax_unit.sum(social_security)
-        # The base amount is reduced by the amount social security benefits received
-        # (and Tier 1 RRB which are currently not modeled)
+
+        # Line 5, total social security
+        social_security = add(tax_unit, period, ["social_security"])
+
+        # Line 6, base amount reduced by social security benefits received
         p = (
             parameters(period)
             .gov.states["or"]
             .tax.income.credits.retirement_income
         )
         filing_status = tax_unit("filing_status", period)
-        reduced_base = max_(p.base[filing_status] - total_social_security, 0)
-        # Line 7, Household income
+        reduced_base = max_(0, p.base[filing_status] - social_security)
+
+        # Line 7, household income
         household_income = tax_unit(
             "or_retirement_credit_household_income", period
         )
-        # Line 9. line 7 - income threshold
+
+        # Line 9, household income minus income threshold
         excess_household_income = max_(
-            household_income - p.income_threshold[filing_status], 0
+            0, household_income - p.income_threshold[filing_status]
         )
-        # The base credit is reduced by the excess household income
-        base_credit = max_(0, reduced_base - excess_household_income)
-        # The smaller of the pension income or the base credit will be counted
-        base_or_pension = min_(or_taxable_pension, base_credit)
-        # Line 11 * 9%
-        return base_or_pension * p.percentage
+
+        # Line 10, reduced base amount is reduced by excess household income
+        base_amount = max_(0, reduced_base - excess_household_income)
+
+        # Line 11, calculate credit
+        return min_(or_taxable_pension, base_amount) * p.percentage

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/retirement_credit/or_retirement_income_credit_eligible.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/retirement_credit/or_retirement_income_credit_eligible.py
@@ -10,15 +10,13 @@ class or_retirement_credit_eligible(Variable):
     defined_for = StateCode.OR
 
     def formula(person, period, parameters):
-        # The filer or spouse have to be over 61 for their pension income to count
+        # taxpayer or spouse must be age 62+ for their pension income to count
         age = person("age", period)
-        head = person("is_tax_unit_head", period)
-        spouse = person("is_tax_unit_spouse", period)
+        is_head = person("is_tax_unit_head", period)
+        is_spouse = person("is_tax_unit_spouse", period)
         p = (
             parameters(period)
             .gov.states["or"]
             .tax.income.credits.retirement_income
         )
-        head_eligible = (age >= p.age_eligibility) & head
-        spouse_eligible = (age >= p.age_eligibility) & spouse
-        return head_eligible | spouse_eligible
+        return (age >= p.age_eligibility) & (is_head | is_spouse)

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/retirement_credit/or_retirement_income_credit_household_income.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/retirement_credit/or_retirement_income_credit_household_income.py
@@ -10,5 +10,5 @@ class or_retirement_credit_household_income(Variable):
     reference = "https://casetext.com/statute/oregon-revised-statutes/title-29-revenue-and-taxation/chapter-316-personal-income-tax/additional-credits/retirement-income/section-316157-credit-for-retirement-income"
     defined_for = StateCode.OR
 
-    adds = ["adjusted_gross_income"]
+    adds = ["adjusted_gross_income", "tax_exempt_interest_income"]
     subtracts = ["taxable_social_security"]


### PR DESCRIPTION
Fixes #2859.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a7a94a1</samp>

### Summary
🐛📝🧪

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request. The calculation of the Oregon retirement income credit was incorrect and needed to be fixed.
2.  📝 - This emoji represents a documentation update, which is another aspect of this pull request. The changelog file was updated to reflect the bug fix and the version increment, and the code comments were improved for readability.
3.  🧪 - This emoji represents a testing update, which is also part of this pull request. A new test case was added to the integration tests for the Oregon income tax, to verify the correctness of the bug fix and the calculation of the retirement income credit.
-->
This pull request fixes and improves the calculation of the `or_retirement_credit` variable, which is a nonrefundable credit for eligible Oregon tax filers with retirement income. The changes update the code to match the latest official worksheet and instructions, add comments and tests for clarity and accuracy, and fix the age logic and income definition for eligibility.

> _A bug in the Oregon tax code_
> _Made the retirement credit erode_
> _They fixed the `age` check_
> _And the `income` spec_
> _And the changelog showed what they owed_

### Walkthrough
*  Add `or_retirement_credit` variable to calculate the Oregon retirement income credit and fix the age requirement and household income definition ([link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-6091036d4716e8e3708b2bd29d0473d127be3faf27e61dd9a692cbbe6016e85fR5), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-83d9e902339eb4805cdd1d56e3e9dc7bf639676fdf992037073efb1e5f697b9eL13-R16), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-83d9e902339eb4805cdd1d56e3e9dc7bf639676fdf992037073efb1e5f697b9eL22-R22), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-625e4f8f400216d4590039734af53d380effc7de84bf76db66986c53fe58f662L13-R13), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-16bea0b15bc0b0ab9ec2052652b6dd2a8c197257d3bf5f2915eb0c85a8676696L10-R35), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-16bea0b15bc0b0ab9ec2052652b6dd2a8c197257d3bf5f2915eb0c85a8676696L38-R58))
* Update the formula and reference URL for `or_retirement_credit` to match the 2021 worksheet and instructions, and add comments to explain each line ([link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-16bea0b15bc0b0ab9ec2052652b6dd2a8c197257d3bf5f2915eb0c85a8676696L10-R35), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-16bea0b15bc0b0ab9ec2052652b6dd2a8c197257d3bf5f2915eb0c85a8676696L38-R58))
* Simplify some expressions and rename some variables for consistency and clarity in `or_retirement_credit` and `or_retirement_credit_eligible` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-83d9e902339eb4805cdd1d56e3e9dc7bf639676fdf992037073efb1e5f697b9eL13-R16), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-83d9e902339eb4805cdd1d56e3e9dc7bf639676fdf992037073efb1e5f697b9eL22-R22), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-16bea0b15bc0b0ab9ec2052652b6dd2a8c197257d3bf5f2915eb0c85a8676696L10-R35), [link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-16bea0b15bc0b0ab9ec2052652b6dd2a8c197257d3bf5f2915eb0c85a8676696L38-R58))
* Add a new test case for the Oregon income tax with an elderly couple and check the expected values of the tax and credits ([link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-76073337717eafb787f926daeee157892d58f9767fc9d91aa3f6f5cb264789adR8-R38))
* Add a new entry to the changelog file to indicate the patch version increment and the bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/2860/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


