### PR TITLE
Avoid divide-by-zero in Pell Grant calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Avoid divide by zero in Pell Grant EFC formula.

--- a/policyengine_us/variables/gov/ed/pell_grant/efc/dependent/pell_grant_dependent_contribution.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/efc/dependent/pell_grant_dependent_contribution.py
@@ -13,6 +13,6 @@ class pell_grant_dependent_contribution(Variable):
         income = person("pell_grant_dependent_available_income", period)
         allowances = person("pell_grant_dependent_allowances", period)
         p = parameters(period).gov.ed.pell_grant.efc.dependent
-        ajusted_income = (income - allowances) * p.income_assessment_rate
-        ajusted_assets = assets * p.asset_assessment_rate * ~simplified
-        return ajusted_income + ajusted_assets
+        adjusted_income = (income - allowances) * p.income_assessment_rate
+        adjusted_assets = assets * p.asset_assessment_rate * ~simplified
+        return adjusted_income + adjusted_assets

--- a/policyengine_us/variables/gov/ed/pell_grant/efc/head/pell_grant_head_contribution.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/efc/head/pell_grant_head_contribution.py
@@ -26,4 +26,8 @@ class pell_grant_head_contribution(Variable):
         total = where(
             formula == "B", available_income, total_head_contribution
         )
-        return total / dependents
+        # Return amount per dependent, using a mask to avoid division by zero.
+        amount_per_dependent = np.zeros_like(total)
+        mask = dependents > 0
+        amount_per_dependent[mask] = total[mask] / dependents[mask]
+        return amount_per_dependent

--- a/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_formula.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_formula.py
@@ -17,16 +17,15 @@ class pell_grant_formula(Variable):
 
     def formula(person, period, parameters):
         tax_unit = person.tax_unit
-        count_dependents = tax_unit("tax_unit_dependents", period)
-        has_dependents = count_dependents >= 1
+        has_dependents = tax_unit("tax_unit_dependents", period) > 0
         is_head = person("is_tax_unit_head", period)
         is_spouse = person("is_tax_unit_spouse", period)
-        in_head = is_head | is_spouse
+        head_or_spouse = is_head | is_spouse
         return select(
             [
-                has_dependents & ~in_head,
-                ~has_dependents & in_head,
-                has_dependents & in_head,
+                has_dependents & ~head_or_spouse,
+                ~has_dependents & head_or_spouse,
+                has_dependents & head_or_spouse,
             ],
             [PellGrantFormula.A, PellGrantFormula.B, PellGrantFormula.C],
         )

--- a/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_formula.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_formula.py
@@ -25,7 +25,10 @@ class pell_grant_formula(Variable):
             [
                 has_dependents & ~head_or_spouse,
                 ~has_dependents & head_or_spouse,
-                has_dependents & head_or_spouse,
             ],
-            [PellGrantFormula.A, PellGrantFormula.B, PellGrantFormula.C],
+            [PellGrantFormula.A, PellGrantFormula.B],
+            # C formula applies for `has_dependents & head_or_spouse`.
+            # Technically this also catches `~has_dependents & ~head_or_spouse`
+            # but that's not a valid combination.
+            default=PellGrantFormula.C,
         )

--- a/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_formula.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_formula.py
@@ -16,8 +16,7 @@ class pell_grant_formula(Variable):
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        tax_unit = person.tax_unit
-        has_dependents = tax_unit("tax_unit_dependents", period) > 0
+        has_dependents = person.tax_unit("tax_unit_dependents", period) > 0
         is_head = person("is_tax_unit_head", period)
         is_spouse = person("is_tax_unit_spouse", period)
         head_or_spouse = is_head | is_spouse

--- a/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_simplified_formula_applies.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_simplified_formula_applies.py
@@ -12,5 +12,6 @@ class pell_grant_simplified_formula_applies(Variable):
         head_income = tax_unit("pell_grant_primary_income", period)
         p = parameters(period).gov.ed.pell_grant.efc.simplified
         income_eligible = head_income < p.income_limit
-        has_benefits = add(tax_unit, period, p.benefits) > 0
+        total_benefits = add(tax_unit, period, p.benefits)
+        has_benefits = np.any(total_benefits > 0)
         return income_eligible & has_benefits

--- a/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_simplified_formula_applies.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/efc/pell_grant_simplified_formula_applies.py
@@ -12,6 +12,5 @@ class pell_grant_simplified_formula_applies(Variable):
         head_income = tax_unit("pell_grant_primary_income", period)
         p = parameters(period).gov.ed.pell_grant.efc.simplified
         income_eligible = head_income < p.income_limit
-        total_benefits = add(tax_unit, period, p.benefits)
-        has_benefits = np.any(total_benefits > 0)
+        has_benefits = add(tax_unit, period, p.benefits) > 0
         return income_eligible & has_benefits


### PR DESCRIPTION
Fixes #2871 and other minor Pell Grant cleanup

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 630b2fe</samp>

### Summary
🐛🖊️♻️

<!--
1.  🐛 - This emoji represents a bug fix, and can be used for the first change, which updates the changelog entry for the pull request, indicating that it fixes a bug that could cause a divide by zero error in the Pell Grant EFC formula for some students.
2. 🖊️ - This emoji represents a typo fix, and can be used for the second change, which fixes a typo in the variable names `ajusted_income` and `ajusted_assets` to `adjusted_income` and `adjusted_assets` in the Pell Grant dependent contribution formula.
3. ♻️ - This emoji represents a refactor, and can be used for the third, fourth, and fifth changes, which simplify the logic for determining which Pell Grant formula applies to a student, whether the simplified Pell Grant formula applies to a student, and add a mask to avoid dividing by zero when calculating the head contribution. These changes do not alter the functionality or output of the code, but make it more readable and maintainable.
-->
This pull request fixes a bug in the `pell_grant_formula` that could cause a divide by zero error, and improves the readability and accuracy of the code for calculating the Pell Grant expected family contribution (EFC) and the simplified formula eligibility. It also updates the changelog entry for the pull request.

> _Pell Grant formulas_
> _Fix bugs, typos, and logic_
> _Aid for students grows_

### Walkthrough
* Fix a bug that could cause a divide by zero error in the Pell Grant EFC formula for some students ([link](https://github.com/PolicyEngine/policyengine-us/pull/2872/files?diff=unified&w=0#diff-25af8249807fcdcc967c08a29dd8d094fb7a7b8e7f37fe4e9bff7dd7a56d34e6L29-R33))
* Simplify the logic for determining which Pell Grant formula applies to a student based on their tax unit and dependency status, in `pell_grant_formula.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2872/files?diff=unified&w=0#diff-bb44a8de3d9bb38736ef01c28539aaca713dd1c36a059228baff0e1cffa8db52L20-R28))
* Simplify the logic for determining whether the simplified Pell Grant formula applies to a student based on their income and benefits, in `pell_grant_simplified_formula_applies.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2872/files?diff=unified&w=0#diff-5cdd2e2b5fd2129ae2684238ae530d845c64e5ba40900862ab3d1075c44c41b2L15-R15))
* Fix typos in the variable names `adjusted_income` and `adjusted_assets` in the Pell Grant dependent contribution formula, in `pell_grant_dependent_contribution.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2872/files?diff=unified&w=0#diff-051460b64964497714009b347033aa3a05af48d58fa47aee6ca58a3e078f2be9L16-R18))
* Update the changelog entry for the pull request, in `changelog_entry.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2872/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


