### PR TITLE
Add legal code references and historical parameters for DC Keep Child Care Affordable Credit

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added: 
+      - Legal code references and historical parameters for DC Keep Child Care Affordable Tax Credit.

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/kccatc/income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/kccatc/income_limit.yaml
@@ -1,30 +1,46 @@
 description: DC limits the keep child care affordable tax credit to those whose DC taxable income does not exceed this limit.
 metadata:
   unit: year
-  label: DC KCCATC DC taxable income limit for eligibility
+  label: DC KCCATC DC taxable income limit
   breakdown:
     - filing_status
   period: year
   reference:
-    - title: Code of the District of Columbia § 47–1806.15
-      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.15
+    - title: Code of the District of Columbia § 47–1806.15(d)(5)
+      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.15#(d)(5)
+    - title: 2020 DC Schedule ELC
+      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2020_Schedule_ELC.pdf#page=2
     - title: 2021 DC Form D-40 Booklet, Schedule ELC
-      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=67
+      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=68
     - title: 2022 DC Form D-40 Booklet, Schedule ELC
-      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=59
+      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=60
 
 SINGLE:
+  2018-01-01: 750_000 # (A)
+  2019-01-01: 150_000 # (B)
   2021-01-01: 153_400
   2022-01-01: 157_200
 JOINT:
+  2018-01-01: 750_000 # (A)
+  2019-01-01: 150_000 # (B)
+  2020-01-01: 151_900
   2021-01-01: 153_400
   2022-01-01: 157_200
 SEPARATE:
+  2018-01-01: 375_000 # (A)
+  2019-01-01: 75_000 # (B)
+  2020-01-01: 151_900
   2021-01-01: 76_700
   2022-01-01: 78_600
 HEAD_OF_HOUSEHOLD:
+  2018-01-01: 750_000 # (A)
+  2019-01-01: 150_000 # (B)
+  2020-01-01: 151_900
   2021-01-01: 153_400
   2022-01-01: 157_200
 WIDOW:
+  2018-01-01: 750_000 # (A)
+  2019-01-01: 150_000 # (B)
+  2020-01-01: 151_900
   2021-01-01: 153_400
   2022-01-01: 157_200

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/kccatc/max_age.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/kccatc/max_age.yaml
@@ -4,11 +4,11 @@ metadata:
   label: DC KCCATC maximum child age
   period: year
   reference:
-    - title: Code of the District of Columbia § 47–1806.15
-      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.15
+    - title: Code of the District of Columbia § 47–1806.15(a)(3)
+      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.15#(a)(3)
     - title: 2021 DC Form D-40 Booklet, Schedule ELC
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=67
     - title: 2022 DC Form D-40 Booklet, Schedule ELC
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=59
 values:
-  2021-01-01: 3
+  2018-01-01: 3

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/kccatc/max_amount.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/kccatc/max_amount.yaml
@@ -4,12 +4,16 @@ metadata:
   label: DC KCCATC maximum amount per eligible child
   period: year
   reference:
-    - title: Code of the District of Columbia § 47–1806.15
-      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.15
+    - title: Code of the District of Columbia § 47–1806.15(b)(2)(B)
+      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.15#(b)(2)(B)
+    - title: 2020 DC Schedule ELC
+      href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2020_Schedule_ELC.pdf#page=1
     - title: 2021 DC Form D-40 Booklet, Schedule ELC
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=67
     - title: 2022 DC Form D-40 Booklet, Schedule ELC
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=59
 values:
+  2018-01-01: 1_000
+  2020-01-01: 1_010
   2021-01-01: 1_020
   2022-01-01: 1_045


### PR DESCRIPTION
Fixes #2873

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b35209</samp>

### Summary
:memo::wrench::bulb:

<!--
1.  :memo: for adding a new entry to the changelog
2. :wrench: for updating the metadata and values of the income limit parameter
3. :bulb: for improving the accuracy and documentation of the max_age and max_amount parameters
-->
This pull request adds legal code references and historical values for the parameters of the DC Keep Child Care Affordable Tax Credit (`KCCATC`), a tax credit for child and dependent care expenses. It modifies the `max_age`, `max_amount`, and `income_limit` parameters in the `policyengine_us/parameters/gov/states/dc/tax/income/credits/kccatc` folder, and updates the changelog accordingly. These changes improve the accuracy and documentation of the policy engine.

> _Some changes were made to the `KCCATC`_
> _A credit for child care in DC_
> _The parameters were tweaked_
> _With references and history_
> _To make the policy engine more precise and complete_

### Walkthrough
*  Add legal code references and historical parameters for the DC Keep Child Care Affordable Tax Credit (KCCATC) to the policy engine ([link](https://github.com/PolicyEngine/policyengine-us/pull/2874/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Update the income limit parameter for the KCCATC, adding more specific references and historical values for 2018 and 2019 ([link](https://github.com/PolicyEngine/policyengine-us/pull/2874/files?diff=unified&w=0#diff-30cdc743dcde3a30d624f6c6838c403cd20fe04f5ab7335fb3035f7fb54a39e6L4-R44))
*  Update the max age parameter for the KCCATC, adding the specific reference and the historical value for 2018 ([link](https://github.com/PolicyEngine/policyengine-us/pull/2874/files?diff=unified&w=0#diff-e80601c7a17e7ab8accdc04dd1983cc4ccc8da74bbf6dda41ef7c69103b31ea2L7-R8), [link](https://github.com/PolicyEngine/policyengine-us/pull/2874/files?diff=unified&w=0#diff-e80601c7a17e7ab8accdc04dd1983cc4ccc8da74bbf6dda41ef7c69103b31ea2L14-R14))
*  Update the max amount parameter for the KCCATC, adding the specific reference and the historical values for 2018 and 2020 ([link](https://github.com/PolicyEngine/policyengine-us/pull/2874/files?diff=unified&w=0#diff-8b686d03d02937f45e7f780aa350c6ba2ad7ce90772de623a23199cb23ecae42L7-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2874/files?diff=unified&w=0#diff-8b686d03d02937f45e7f780aa350c6ba2ad7ce90772de623a23199cb23ecae42R16-R17))


