### PR TITLE
Add variables needed to defined Georgia taxable income

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Several placeholder Georgia income-related variables to allow integration testing.

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_taxable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_taxable_income.yaml
@@ -1,0 +1,9 @@
+- name: ga_taxable_income unit test 1
+  period: 2021
+  input:
+    state_code: GA
+    ga_agi: 800
+    ga_deductions: 600
+    ga_exemptions: 300
+  output:
+    ga_taxable_income: 0

--- a/policyengine_us/variables/gov/states/ga/tax/income/additions/ga_agi_additions.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/additions/ga_agi_additions.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class ga_agi_additions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia additions to federal AGI"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA

--- a/policyengine_us/variables/gov/states/ga/tax/income/deductions/ga_deductions.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/deductions/ga_deductions.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class ga_deductions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia deductions"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_agi.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_agi.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class ga_agi(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia adjusted gross income"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA
+    adds = ["adjusted_gross_income", "ga_agi_additions"]
+    subtracts = ["ga_agi_subtractions"]

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_taxable_income.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_taxable_income.py
@@ -8,3 +8,9 @@ class ga_taxable_income(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.GA
+
+    def formula(tax_unit, period, parameters):
+        agi = tax_unit("ga_agi", period)
+        deductions = tax_unit("ga_deductions", period)
+        exemptions = tax_unit("ga_exemptions", period)
+        return max_(0, agi - deductions - exemptions)

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_taxable_income.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_taxable_income.py
@@ -7,6 +7,11 @@ class ga_taxable_income(Variable):
     label = "Georgia taxable income"
     unit = USD
     definition_period = YEAR
+    reference = (
+        "https://dor.georgia.gov/it-511-individual-income-tax-booklet"
+        # above reference provides access to booklets for all years
+        # definition of Georgia taxable income starts on page 12
+    )
     defined_for = StateCode.GA
 
     def formula(tax_unit, period, parameters):

--- a/policyengine_us/variables/gov/states/ga/tax/income/subtractions/ga_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/subtractions/ga_agi_subtractions.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class ga_agi_subtractions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia subtractions from federal AGI"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA


### PR DESCRIPTION
Fixes #2910.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at af85745</samp>

### Summary
📝✅➕

<!--
1.  📝 - This emoji represents the change to the changelog entry, which is a documentation update.
2.  ✅ - This emoji represents the addition of the unit test, which is a quality assurance improvement.
3.  ➕ - This emoji represents the addition of the new variables and formulas, which are new features for the Georgia income tax calculation.
-->
This PR adds several placeholder variables and a unit test for Georgia state income tax. It also updates the changelog entry to reflect the minor version bump.

> _`ga_taxable_income`_
> _Adding, subtracting, testing_
> _Fall leaves turn to gold_

### Walkthrough
*  Add several placeholder Georgia income-related variables to allow integration testing ([link](https://github.com/PolicyEngine/policyengine-us/pull/2911/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/2911/files?diff=unified&w=0#diff-d7746e65d8764c073341c5d7310966a2d4bf38131f7f992562900fefd23762bcR1-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2911/files?diff=unified&w=0#diff-7ef3e9de887da156ba72c8866cec2dec2a7edb273c341eb5914977d20fc4ad42R1-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2911/files?diff=unified&w=0#diff-a12fe04f66bb2d49e2ed0df3f2aad9c31c9587bd40944ab54fc478a6a91f2ba6R1-R10))
*  Implement `ga_agi` variable as the sum of federal AGI and Georgia additions and subtractions ([link](https://github.com/PolicyEngine/policyengine-us/pull/2911/files?diff=unified&w=0#diff-de54b3bc03c10447db967f4209112ebef3e3d672ca39a4eca07bf714b0fbbc61R1-R12))
*  Implement `ga_taxable_income` variable as the difference between `ga_agi` and Georgia deductions and exemptions, with a minimum of zero ([link](https://github.com/PolicyEngine/policyengine-us/pull/2911/files?diff=unified&w=0#diff-75a595f1328d51366d484f949575bf5fdccd9b8705c586d0dc63b30bbdc2ede0R11-R16))
*  Add a unit test for `ga_taxable_income` variable in `policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_taxable_income.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2911/files?diff=unified&w=0#diff-6bd3bdbab553a5e93dab80ac779750dd44fe1e70c76b42a906f74c7c0655bc6bR1-R9))


