### PR TITLE
Fix North Carolina income tax rate for 2022

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - North Carolina income tax rate for 2022.

--- a/policyengine_us/parameters/gov/states/nc/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/rate.yaml
@@ -1,15 +1,20 @@
-description: North Carolina taxes the personal income at this rate.
+description: North Carolina taxes individual taxable income at this rate.
+metadata:
+  unit: /1
+  period: year
+  label: North Carolina individual income tax rate
+  reference:
+    - title: North Carolina Department of Revenue - Tax Rate Schedules
+      href: https://www.ncdor.gov/taxes-forms/tax-rate-schedules
+    - title: 2022 North Carolina Form D-400, Line 15
+      href: https://www.ncdor.gov/2022-d-400-handwritten-version/open#page=2
 values:
+  2015-01-01: 0.0575
+  2017-01-01: 0.05499
   2019-01-01: 0.0525
+  2022-01-01: 0.0499
   2023-01-01: 0.0475
   2024-01-01: 0.046
   2025-01-01: 0.045
   2026-01-01: 0.0425
   2027-01-01: 0.0399
-metadata:
-  unit: /1
-  period: year
-  label: North Carolina income tax rate
-  reference:
-    - title: North Carolina Department of Revenue - Tax Rate Schedules
-      href: https://www.ncdor.gov/taxes-forms/tax-rate-schedules#:~:text=For%20Tax%20Year%202023%2C%20the,is%205.25%25%20(0.0525)

--- a/policyengine_us/variables/gov/states/nc/tax/income/nc_income_tax.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/nc_income_tax.py
@@ -11,6 +11,6 @@ class nc_income_tax(Variable):
 
     def formula(tax_unit, period, parameters):
         tax_before_credits = tax_unit("nc_income_tax_before_credits", period)
-        # North Carolina does not allow for any refundable credits
+        # North Carolina provides no refundable income tax credits
         credits = tax_unit("nc_non_refundable_credits", period)
-        return max_((tax_before_credits - credits), 0)
+        return max_(0, tax_before_credits - credits)

--- a/policyengine_us/variables/gov/states/nc/tax/income/nc_income_tax_before_credits.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/nc_income_tax_before_credits.py
@@ -11,5 +11,5 @@ class nc_income_tax_before_credits(Variable):
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("nc_taxable_income", period)
-        rate = parameters(period).gov.states.nc.tax.income.rate
-        return income * rate
+        p = parameters(period).gov.states.nc.tax.income
+        return max_(0, income) * p.rate


### PR DESCRIPTION
Fixes #2917.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 42c6d07</samp>

### Summary
📝🛡️🧹

<!--
1.  📝 for adding a changelog entry
2.  🛡️ for adding a safeguard to the formula
3.  🧹 for improving the readability and logic of the formula and the parameter file
-->
This pull request fixes and simplifies the calculation of the North Carolina income tax, using updated data and sources. It also adds a changelog entry and some minor code improvements for readability and robustness.

> _We fix the rate of doom and despair_
> _We guard the formula from the negative snare_
> _We max out the logic and the style_
> _We update the `rate.yaml` file_

### Walkthrough
*  Update North Carolina income tax rate parameter for 2015, 2017, and 2022, and fix metadata and references ([link](https://github.com/PolicyEngine/policyengine-us/pull/2918/files?diff=unified&w=0#diff-e01a1b6fa1f6708bd68239b49e880b2d986a1c33efef88728923b39629ffc125L1-R15), [link](https://github.com/PolicyEngine/policyengine-us/pull/2918/files?diff=unified&w=0#diff-e01a1b6fa1f6708bd68239b49e880b2d986a1c33efef88728923b39629ffc125L9-L15))
*  Add safeguard to prevent negative taxes and simplify parameter access in `nc_income_tax_before_credits` formula ([link](https://github.com/PolicyEngine/policyengine-us/pull/2918/files?diff=unified&w=0#diff-f558c045be9f51e6db1f21a6a5f7811982e93eacf087933929a609d1e4973ffaL14-R15))
*  Improve readability and logic of `nc_income_tax` formula by using consistent comments and conventional argument order ([link](https://github.com/PolicyEngine/policyengine-us/pull/2918/files?diff=unified&w=0#diff-37a747b022edf03ae43f72e12c335f4787a71d533060a6d12bd66401b46684e5L14-R16))
*  Add changelog entry for patch-level update ([link](https://github.com/PolicyEngine/policyengine-us/pull/2918/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


