### PR TITLE
Add several North Carolina deduction variables

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Several North Carolina deduction variables to allow integration testing.

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/head_of_household.yaml
@@ -1,7 +1,7 @@
 description: North Carolina provides a child deduction of this amount per eligible child for head-of-household filers.
 
 metadata:
-  label: North Carolina child deduction per eligible child for head-of-household filers.
+  label: North Carolina child deduction per eligible child for head-of-household filers
   type: single_amount
   threshold_unit: currency-USD  # federal adjusted gross income
   amount_unit: currency-USD  # NC child deduction amount per eligible child

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/head_of_household.yaml
@@ -1,0 +1,48 @@
+description: North Carolina provides a child deduction of this amount per eligible child for head-of-household filers.
+
+metadata:
+  label: North Carolina child deduction per eligible child for head-of-household filers.
+  type: single_amount
+  threshold_unit: currency-USD  # federal adjusted gross income
+  amount_unit: currency-USD  # NC child deduction amount per eligible child
+  reference:
+    - title: 2021 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
+    - title: 2022 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+
+brackets:  # ranges are > lower threshold and <= upper threshold 
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 2_500
+      2022-01-01: 3_000
+  - threshold:
+      2021-01-01: 30_000
+    amount:
+      2021-01-01: 2_000
+      2022-01-01: 2_500
+  - threshold:
+      2021-01-01: 45_000
+    amount:
+      2021-01-01: 1_500
+      2022-01-01: 2_000
+  - threshold:
+      2021-01-01: 60_000
+    amount:
+      2021-01-01: 1_000
+      2022-01-01: 1_500
+  - threshold:
+      2021-01-01: 75_000
+    amount:
+      2021-01-01: 500
+      2022-01-01: 1_000
+  - threshold:
+      2021-01-01: 90_000
+    amount:
+      2021-01-01: 0
+      2022-01-01: 500
+  - threshold:
+      2021-01-01: 105_000
+    amount:
+      2021-01-01: 0

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/joint.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/joint.yaml
@@ -1,0 +1,48 @@
+description: North Carolina provides a child deduction of this amount per eligible child for joint filers.
+
+metadata:
+  label: North Carolina child deduction per eligible child for joint filers.
+  type: single_amount
+  threshold_unit: currency-USD  # federal adjusted gross income
+  amount_unit: currency-USD  # NC child deduction amount per eligible child
+  reference:
+    - title: 2021 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
+    - title: 2022 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+
+brackets:  # ranges are > lower threshold and <= upper threshold 
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 2_500
+      2022-01-01: 3_000
+  - threshold:
+      2021-01-01: 40_000
+    amount:
+      2021-01-01: 2_000
+      2022-01-01: 2_500
+  - threshold:
+      2021-01-01: 60_000
+    amount:
+      2021-01-01: 1_500
+      2022-01-01: 2_000
+  - threshold:
+      2021-01-01: 80_000
+    amount:
+      2021-01-01: 1_000
+      2022-01-01: 1_500
+  - threshold:
+      2021-01-01: 100_000
+    amount:
+      2021-01-01: 500
+      2022-01-01: 1_000
+  - threshold:
+      2021-01-01: 120_000
+    amount:
+      2021-01-01: 0
+      2022-01-01: 500
+  - threshold:
+      2021-01-01: 140_000
+    amount:
+      2021-01-01: 0

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/joint.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/joint.yaml
@@ -1,7 +1,7 @@
 description: North Carolina provides a child deduction of this amount per eligible child for joint filers.
 
 metadata:
-  label: North Carolina child deduction per eligible child for joint filers.
+  label: North Carolina child deduction per eligible child for joint filers
   type: single_amount
   threshold_unit: currency-USD  # federal adjusted gross income
   amount_unit: currency-USD  # NC child deduction amount per eligible child

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/separate.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/separate.yaml
@@ -1,0 +1,48 @@
+description: North Carolina provides a child deduction of this amount per eligible child for separate filers.
+
+metadata:
+  label: North Carolina child deduction per eligible child for separate filers.
+  type: single_amount
+  threshold_unit: currency-USD  # federal adjusted gross income
+  amount_unit: currency-USD  # NC child deduction amount per eligible child
+  reference:
+    - title: 2021 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
+    - title: 2022 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+
+brackets:  # ranges are > lower threshold and <= upper threshold 
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 2_500
+      2022-01-01: 3_000
+  - threshold:
+      2021-01-01: 20_000
+    amount:
+      2021-01-01: 2_000
+      2022-01-01: 2_500
+  - threshold:
+      2021-01-01: 30_000
+    amount:
+      2021-01-01: 1_500
+      2022-01-01: 2_000
+  - threshold:
+      2021-01-01: 40_000
+    amount:
+      2021-01-01: 1_000
+      2022-01-01: 1_500
+  - threshold:
+      2021-01-01: 50_000
+    amount:
+      2021-01-01: 500
+      2022-01-01: 1_000
+  - threshold:
+      2021-01-01: 60_000
+    amount:
+      2021-01-01: 0
+      2022-01-01: 500
+  - threshold:
+      2021-01-01: 70_000
+    amount:
+      2021-01-01: 0

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/separate.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/separate.yaml
@@ -1,7 +1,7 @@
 description: North Carolina provides a child deduction of this amount per eligible child for separate filers.
 
 metadata:
-  label: North Carolina child deduction per eligible child for separate filers.
+  label: North Carolina child deduction per eligible child for separate filers
   type: single_amount
   threshold_unit: currency-USD  # federal adjusted gross income
   amount_unit: currency-USD  # NC child deduction amount per eligible child

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/single.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/single.yaml
@@ -1,7 +1,7 @@
 description: North Carolina provides a child deduction of this amount per eligible child for single filers.
 
 metadata:
-  label: North Carolina child deduction per eligible child for single filers.
+  label: North Carolina child deduction per eligible child for single filers
   type: single_amount
   threshold_unit: currency-USD  # federal adjusted gross income
   amount_unit: currency-USD  # NC child deduction amount per eligible child

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/single.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/single.yaml
@@ -1,0 +1,48 @@
+description: North Carolina provides a child deduction of this amount per eligible child for single filers.
+
+metadata:
+  label: North Carolina child deduction per eligible child for single filers.
+  type: single_amount
+  threshold_unit: currency-USD  # federal adjusted gross income
+  amount_unit: currency-USD  # NC child deduction amount per eligible child
+  reference:
+    - title: 2021 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
+    - title: 2022 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+
+brackets:  # ranges are > lower threshold and <= upper threshold 
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 2_500
+      2022-01-01: 3_000
+  - threshold:
+      2021-01-01: 20_000
+    amount:
+      2021-01-01: 2_000
+      2022-01-01: 2_500
+  - threshold:
+      2021-01-01: 30_000
+    amount:
+      2021-01-01: 1_500
+      2022-01-01: 2_000
+  - threshold:
+      2021-01-01: 40_000
+    amount:
+      2021-01-01: 1_000
+      2022-01-01: 1_500
+  - threshold:
+      2021-01-01: 50_000
+    amount:
+      2021-01-01: 500
+      2022-01-01: 1_000
+  - threshold:
+      2021-01-01: 60_000
+    amount:
+      2021-01-01: 0
+      2022-01-01: 500
+  - threshold:
+      2021-01-01: 70_000
+    amount:
+      2021-01-01: 0

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/widow.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/widow.yaml
@@ -1,0 +1,48 @@
+description: North Carolina provides a child deduction of this amount per eligible child for widow filers.
+
+metadata:
+  label: North Carolina child deduction per eligible child for widow filers.
+  type: single_amount
+  threshold_unit: currency-USD  # federal adjusted gross income
+  amount_unit: currency-USD  # NC child deduction amount per eligible child
+  reference:
+    - title: 2021 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
+    - title: 2022 North Carolina Form D-401, Line 10
+      href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+
+brackets:  # ranges are > lower threshold and <= upper threshold 
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 2_500
+      2022-01-01: 3_000
+  - threshold:
+      2021-01-01: 40_000
+    amount:
+      2021-01-01: 2_000
+      2022-01-01: 2_500
+  - threshold:
+      2021-01-01: 60_000
+    amount:
+      2021-01-01: 1_500
+      2022-01-01: 2_000
+  - threshold:
+      2021-01-01: 80_000
+    amount:
+      2021-01-01: 1_000
+      2022-01-01: 1_500
+  - threshold:
+      2021-01-01: 100_000
+    amount:
+      2021-01-01: 500
+      2022-01-01: 1_000
+  - threshold:
+      2021-01-01: 120_000
+    amount:
+      2021-01-01: 0
+      2022-01-01: 500
+  - threshold:
+      2021-01-01: 140_000
+    amount:
+      2021-01-01: 0

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/standard/amount.yaml
@@ -1,0 +1,28 @@
+description: North Carolina provides this standard deduction amount.
+metadata:
+  label: North Carolina standard deduction amount
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: 2021 North Carolina Form D-401, Line 11
+    href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=14
+  - title: 2022 North Carolina Form D-401, Line 11
+    href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=14
+    
+SINGLE:
+  2021-01-01: 10_750
+  2022-01-01: 12_750
+JOINT:
+  2021-01-01: 21_500
+  2022-01-01: 25_500
+WIDOW:
+  2021-01-01: 21_500
+  2022-01-01: 25_500
+SEPARATE:
+  2021-01-01: 10_750
+  2022-01-01: 12_750
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 16_125
+  2022-01-01: 19_125

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_child_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_child_deduction.yaml
@@ -1,0 +1,59 @@
+- name: nc_child_deduction unit test 1
+  period: 2021
+  input:
+    state_code: NC
+    filing_status: SINGLE
+    adjusted_gross_income: 55_000
+    ctc_qualifying_children: 4
+  output:
+    nc_child_deduction: 500 * 4
+
+- name: nc_child_deduction unit test 2
+  period: 2021
+  input:
+    state_code: NC
+    filing_status: JOINT
+    adjusted_gross_income: 55_000
+    ctc_qualifying_children: 2
+  output:
+    nc_child_deduction: 2_000 * 2
+
+- name: nc_child_deduction unit test 3
+  period: 2021
+  input:
+    state_code: NC
+    filing_status: HEAD_OF_HOUSEHOLD
+    adjusted_gross_income: 55_000
+    ctc_qualifying_children: 1
+  output:
+    nc_child_deduction: 1_500 * 1
+
+- name: nc_child_deduction unit test 4
+  period: 2022
+  input:
+    state_code: NC
+    filing_status: SINGLE
+    adjusted_gross_income: 55_000
+    ctc_qualifying_children: 4
+  output:
+    nc_child_deduction: 1_000 * 4
+
+- name: nc_child_deduction unit test 5
+  period: 2022
+  input:
+    state_code: NC
+    filing_status: JOINT
+    adjusted_gross_income: 55_000
+    ctc_qualifying_children: 2
+  output:
+    nc_child_deduction: 2_500 * 2
+
+- name: nc_child_deduction unit test 6
+  period: 2022
+  input:
+    state_code: NC
+    filing_status: HEAD_OF_HOUSEHOLD
+    adjusted_gross_income: 55_000
+    ctc_qualifying_children: 1
+  output:
+    nc_child_deduction: 2_000 * 1

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_standard_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_standard_deduction.yaml
@@ -1,0 +1,23 @@
+- name: nc_standard_deduction unit test 1
+  period: 2021
+  input:
+    state_code: NC
+    filing_status: SINGLE
+  output:
+    nc_standard_deduction: 10_750
+
+- name: nc_standard_deduction unit test 2
+  period: 2022
+  input:
+    state_code: NC
+    filing_status: JOINT
+  output:
+    nc_standard_deduction: 25_500
+
+- name: nc_standard_deduction unit test 3
+  period: 2021
+  input:
+    state_code: NC
+    filing_status: HEAD_OF_HOUSEHOLD
+  output:
+    nc_standard_deduction: 16_125

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_standard_or_itemized_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_standard_or_itemized_deductions.yaml
@@ -1,0 +1,8 @@
+- name: nc_standard_or_itemized_deductions unit test 1
+  period: 2021
+  input:
+    state_code: NC
+    nc_standard_deduction: 200
+    nc_itemized_deductions: 220
+  output:
+    nc_standard_or_itemized_deductions: 220

--- a/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_child_deduction.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_child_deduction.py
@@ -1,0 +1,37 @@
+from policyengine_us.model_api import *
+
+
+class nc_child_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Carolina child deduction"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.NC
+
+    def formula(tax_unit, period, parameters):
+        # calculate deduction amount per eligible child
+        fedagi = tax_unit("adjusted_gross_income", period)
+        filing_status = tax_unit("filing_status", period)
+        statuses = filing_status.possible_values
+        p = parameters(period).gov.states.nc.tax.income.deductions.child
+        amount = select(
+            [
+                filing_status == statuses.SINGLE,
+                filing_status == statuses.SEPARATE,
+                filing_status == statuses.JOINT,
+                filing_status == statuses.WIDOW,
+                filing_status == statuses.HEAD_OF_HOUSEHOLD,
+            ],
+            [
+                p.single.calc(fedagi),
+                p.separate.calc(fedagi),
+                p.joint.calc(fedagi),
+                p.widow.calc(fedagi),
+                p.head_of_household.calc(fedagi),
+            ],
+        )
+        # calculate number of eligible children
+        children = tax_unit("ctc_qualifying_children", period)
+        # calculate NC child deduction
+        return amount * children

--- a/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_child_deduction.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_child_deduction.py
@@ -11,7 +11,7 @@ class nc_child_deduction(Variable):
 
     def formula(tax_unit, period, parameters):
         # calculate deduction amount per eligible child
-        fedagi = tax_unit("adjusted_gross_income", period)
+        federal_agi = tax_unit("adjusted_gross_income", period)
         filing_status = tax_unit("filing_status", period)
         statuses = filing_status.possible_values
         p = parameters(period).gov.states.nc.tax.income.deductions.child
@@ -24,11 +24,11 @@ class nc_child_deduction(Variable):
                 filing_status == statuses.HEAD_OF_HOUSEHOLD,
             ],
             [
-                p.single.calc(fedagi),
-                p.separate.calc(fedagi),
-                p.joint.calc(fedagi),
-                p.widow.calc(fedagi),
-                p.head_of_household.calc(fedagi),
+                p.single.calc(federal_agi, right=True),
+                p.separate.calc(federal_agi, right=True),
+                p.joint.calc(federal_agi, right=True),
+                p.widow.calc(federal_agi, right=True),
+                p.head_of_household.calc(federal_agi, right=True),
             ],
         )
         # calculate number of eligible children

--- a/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_itemized_deductions.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_itemized_deductions.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class nc_itemized_deductions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Carolina itemized deductions"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.NC

--- a/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_standard_deduction.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_standard_deduction.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class nc_standard_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Carolina standard deduction amount"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.NC
+
+    def formula(tax_unit, period, parameters):
+        filing_status = tax_unit("filing_status", period)
+        p = parameters(period).gov.states.nc.tax.income
+        return p.deductions.standard.amount[filing_status]

--- a/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_standard_or_itemized_deductions.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_standard_or_itemized_deductions.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class nc_standard_or_itemized_deductions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Carolina standard or itemized deductions amount"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=14"
+        "https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=14"
+    )
+    defined_for = StateCode.NC
+
+    def formula(tax_unit, period, parameters):
+        # From above instructions for Line 11:
+        #   You may deduct from federal adjusted gross income either
+        #   the N.C. standard deduction or N.C. itemized deductions.
+        #   In most cases, your state income tax will be less if you
+        #   take the larger of your N.C. itemized deductions or your
+        #   N.C. standard deduction.
+        stded = tax_unit("nc_standard_deduction", period)
+        itded = tax_unit("nc_itemized_deductions", period)
+        return max_(stded, itded)


### PR DESCRIPTION
Fixes #2923.

When preparing this pull request, I did not see PR #2711 (wrt NC child deduction) or PR #2481 (wrt NC standard and itemized deductions).  Sorry about that, but when so many PRs are open, it is hard to find old pending PRs when they don't have any labels.

This PR makes PR #2711 redundant.
This PR makes (the non-itemized) part of PR #2481 redundant.

So, if this PR was merged, PR #2711 could be closed without merging,
and PR #2481 could be simplified to include just a `nc_itemized_deductions` variable, parameters, and unit tests.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 543e922</samp>

### Summary
:sparkles::memo::white_check_mark:

<!--
1.  :sparkles: This emoji represents the addition of new features or variables, such as the North Carolina deduction variables and their parameter files, unit tests, and formulas.
2. :memo: This emoji represents the addition or update of documentation, such as the changelog entry, the metadata, and the references in the parameter and variable files.
3. :white_check_mark: This emoji represents the addition or update of tests, such as the unit test files for the North Carolina deduction variables and their expected outputs.
-->
This pull request adds several variables and parameters for the North Carolina income tax deductions, as well as unit tests and a changelog entry. It implements the logic for the child deduction and the standard deduction, and creates a placeholder for the itemized deduction. It also adds a variable that returns the larger of the standard or itemized deductions. These changes enable the policy engine to calculate the North Carolina income tax liability more accurately and allow integration testing.

> _`North Carolina`_
> _Deductions added to engine_
> _`Child`, `standard`, `itemized`_

### Walkthrough
*  Add North Carolina deduction variables and tests ([link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-529c2643bf902023f37e7c669c211f18b01a95e39dbf308e9f979d666df322d2R1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-43df7bae5634c54e9de0db8e0f92df06296b65ea3ebd5b7b6e0b59ca2706388cR1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-8a7b3ed258ce48e577fa7742088aabd1b57245f66474e94c14f948ce7cbc7b13R1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-177e0cb75aab7182237608eda95504d18ccdb995ef8a97dbd3142364e02b765bR1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-40ef5c377c36ae75e6f628684ebf4d40f24b896c33078abb67a6b82a60aaad17R1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-dd5dbef27b43fca869e916be1bfe6c930c4ed9223cf47cb85afe8c9defdccb37R1-R28), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-4f17f882e34acea79f93e09408380509509dac7bedbe7da4387dc95c338dd9cbR1-R59), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-6f9bfe316c422f513545f87c7fcb68538fdf530936a48117aa0c59bacfaf76e8R1-R23), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-2335e41ac9126f6042b6bd5e316f49071f752ef65eaaa11d525e67a5b0dabfa5R1-R8), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-78b28dc8da8fb258317b2e5eb280d65aac7cccbb8104995693004e17efab23ceR1-R37), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-e0aac7f1eb72838c94dc76b31f98a760e6d00a9bb851f8f7ce315e4670dac6bdR1-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-2a49278c26ceed853578ec9dba925d131aba64f248da78d6e9802f8e3e4499deR1-R15), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-05462a95c07df18c0f2f4a068c465a8e7ec53047b5bb40a2bad5787b313e394eR1-R25))
  * Create parameter files for the child deduction per eligible child by filing status (`child/head_of_household.yaml`, `child/joint.yaml`, `child/separate.yaml`, `child/single.yaml`, `child/widow.yaml`) and the standard deduction amount by filing status (`standard/amount.yaml`) with descriptions, metadata, brackets, and references ([link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-529c2643bf902023f37e7c669c211f18b01a95e39dbf308e9f979d666df322d2R1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-43df7bae5634c54e9de0db8e0f92df06296b65ea3ebd5b7b6e0b59ca2706388cR1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-8a7b3ed258ce48e577fa7742088aabd1b57245f66474e94c14f948ce7cbc7b13R1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-177e0cb75aab7182237608eda95504d18ccdb995ef8a97dbd3142364e02b765bR1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-40ef5c377c36ae75e6f628684ebf4d40f24b896c33078abb67a6b82a60aaad17R1-R48), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-dd5dbef27b43fca869e916be1bfe6c930c4ed9223cf47cb85afe8c9defdccb37R1-R28))
  * Define variable files for the child deduction (`nc_child_deduction.py`), the itemized deductions (`nc_itemized_deductions.py`), the standard deduction (`nc_standard_deduction.py`), and the standard or itemized deductions (`nc_standard_or_itemized_deductions.py`) with value types, entities, labels, units, definition periods, formulas, and references ([link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-78b28dc8da8fb258317b2e5eb280d65aac7cccbb8104995693004e17efab23ceR1-R37), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-e0aac7f1eb72838c94dc76b31f98a760e6d00a9bb851f8f7ce315e4670dac6bdR1-R10), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-2a49278c26ceed853578ec9dba925d131aba64f248da78d6e9802f8e3e4499deR1-R15), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-05462a95c07df18c0f2f4a068c465a8e7ec53047b5bb40a2bad5787b313e394eR1-R25))
  * Implement formulas for the child deduction, the standard deduction, and the standard or itemized deductions that use the parameters and other variables ([link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-78b28dc8da8fb258317b2e5eb280d65aac7cccbb8104995693004e17efab23ceR1-R37), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-2a49278c26ceed853578ec9dba925d131aba64f248da78d6e9802f8e3e4499deR1-R15), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-05462a95c07df18c0f2f4a068c465a8e7ec53047b5bb40a2bad5787b313e394eR1-R25))
  * Add unit test files for the child deduction (`nc_child_deduction.yaml`), the standard deduction (`nc_standard_deduction.yaml`), and the standard or itemized deductions (`nc_standard_or_itemized_deductions.yaml`) with test cases that cover different scenarios and check the expected outputs ([link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-4f17f882e34acea79f93e09408380509509dac7bedbe7da4387dc95c338dd9cbR1-R59), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-6f9bfe316c422f513545f87c7fcb68538fdf530936a48117aa0c59bacfaf76e8R1-R23), [link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-2335e41ac9126f6042b6bd5e316f49071f752ef65eaaa11d525e67a5b0dabfa5R1-R8))
  * Update the changelog entry to indicate the addition of the North Carolina deduction variables and the minor version bump ([link](https://github.com/PolicyEngine/policyengine-us/pull/2924/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3))


