### PR TITLE
More descriptive variable names

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,5 +1,5 @@
 - bump: patch
   changes:
     fixed:
-    - Replace arcane AMT-related variable names with more descriptive names.
+    - Replace several arcane variable names with more descriptive names.
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Replace arcane AMT-related variable names with more descriptive names.
+

--- a/policyengine_us/parameters/gov/states/mn/tax/income/additions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/mn/tax/income/additions/sources.yaml
@@ -1,7 +1,7 @@
 description: Minnesota adds these variables to US AGI when computing its taxable income.
 values:
   2021-01-01:
-    - c05700  # lump-sum distributions from federal Form 4972
+    - form_4972_lumpsum_distributions
 
 metadata:
   unit: variable

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/additions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/additions/sources.yaml
@@ -1,7 +1,7 @@
 description: North Dakota adds these variables to US taxable income when computing its taxable income.
 values:
   2021-01-01:
-    - c05700  # lump-sum distributions from federal Form 4972
+    - form_4972_lumpsum_distributions
 
 metadata:
   unit: variable

--- a/policyengine_us/parameters/gov/states/wi/tax/income/additions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/additions/sources.yaml
@@ -3,7 +3,7 @@ values:
   2021-01-01:
     - tax_exempt_interest_income
     - wi_capital_gain_loss_addition
-    - c05700  # lump-sum distributions from federal Form 4972
+    - form_4972_lumpsum_distributions
 
 metadata:
   unit: variable

--- a/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax.py
@@ -20,7 +20,7 @@ class amt_income(Variable):
             salt_deduction,
             standard_deduction,
         )
-        amt_income = taxable_income + excluded_deductions
+        amt_inc = taxable_income + excluded_deductions
         amt = parameters(period).gov.irs.income.amt
         filing_status = tax_unit("filing_status", period)
         separate_addition = max_(
@@ -28,13 +28,10 @@ class amt_income(Variable):
             min_(
                 amt.exemption.amount[filing_status],
                 amt.exemption.phase_out.rate
-                * max_(0, amt_income - amt.exemption.separate_limit),
+                * max_(0, amt_inc - amt.exemption.separate_limit),
             ),
         ) * (filing_status == filing_status.possible_values.SEPARATE)
-        return amt_income + separate_addition
-
-
-c62100 = variable_alias("c62100", amt_income)
+        return amt_inc + separate_addition
 
 
 class regular_tax_before_credits(Variable):
@@ -117,7 +114,7 @@ class regular_tax_before_credits(Variable):
         return where(hasqdivltcg, dwks45, dwks44)
 
 
-class c09600(Variable):
+class alternative_minimum_tax(Variable):
     value_type = float
     entity = TaxUnit
     definition_period = YEAR
@@ -126,7 +123,7 @@ class c09600(Variable):
     documentation = "Alternative Minimum Tax (AMT) liability"
 
     def formula(tax_unit, period, parameters):
-        c62100 = tax_unit("c62100", period)
+        amt_income = tax_unit("amt_income", period)
         # Form 6251, Part II top
         amt = parameters(period).gov.irs.income.amt
         phase_out = amt.exemption.phase_out
@@ -136,7 +133,7 @@ class c09600(Variable):
             (
                 amt.exemption.amount[filing_status]
                 - phase_out.rate
-                * max_(0, c62100 - phase_out.start[filing_status])
+                * max_(0, amt_income - phase_out.start[filing_status])
             ),
         )
         age_head = tax_unit("age_head", period)
@@ -148,7 +145,7 @@ class c09600(Variable):
             min_(line29, tax_unit("filer_earned", period) + child.amount),
             line29,
         )
-        line30 = max_(0, c62100 - line29)
+        line30 = max_(0, amt_income - line29)
         brackets = amt.brackets
         amount_over_threshold = line30 - brackets.thresholds["1"] / tax_unit(
             "sep", period
@@ -238,6 +235,3 @@ class c09600(Variable):
                 ),
             ),
         )
-
-
-alternative_minimum_tax = variable_alias("alternative_minimum_tax", c09600)

--- a/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax.py
@@ -214,14 +214,9 @@ class alternative_minimum_tax(Variable):
         line62 = line42 + cgtax1 + cgtax2 + cgtax3 + line61
         line64 = min_(line3163, line62)
         line31 = where(form_6251_part_iii_required, line64, line3163)
-        foreign_tax_credit = tax_unit("foreign_tax_credit", period)
 
         # Form 6251, Part II bottom
-        line32 = where(
-            tax_unit("amt_form_completed", period),
-            tax_unit("foreign_tax_credit", period),
-            foreign_tax_credit,
-        )
+        line32 = tax_unit("foreign_tax_credit", period)
         line33 = line31 - line32
         return max_(
             0,
@@ -230,7 +225,7 @@ class alternative_minimum_tax(Variable):
                 0,
                 (
                     tax_unit("regular_tax_before_credits", period)
-                    - foreign_tax_credit
+                    - line32
                     - tax_unit("form_4972_lumpsum_distributions", period)
                 ),
             ),

--- a/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax.py
@@ -231,7 +231,7 @@ class alternative_minimum_tax(Variable):
                 (
                     tax_unit("regular_tax_before_credits", period)
                     - foreign_tax_credit
-                    - tax_unit("c05700", period)
+                    - tax_unit("form_4972_lumpsum_distributions", period)
                 ),
             ),
         )

--- a/policyengine_us/variables/gov/irs/taxcalc/outputs.py
+++ b/policyengine_us/variables/gov/irs/taxcalc/outputs.py
@@ -123,16 +123,6 @@ tax_unit_net_capital_gains = variable_alias(
 )
 
 
-class c05700(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = (
-        "search taxcalc/calcfunctions.py for how calculated and used"
-    )
-    unit = USD
-
-
 class c07240(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/mn/tax/income/subtractions/mn_elderly_disabled_subtraction.py
+++ b/policyengine_us/variables/gov/states/mn/tax/income/subtractions/mn_elderly_disabled_subtraction.py
@@ -50,14 +50,8 @@ class mn_elderly_disabled_subtraction(Variable):
         # ... subtract benefits from base amount
         amount = max_(0, base_amount - benefits)
         # ... determine net agi
-        agi = add(
-            tax_unit,
-            period,
-            [
-                "adjusted_gross_income",
-                "c05700",  # lump-sum Form 4972 distributions
-            ],
-        )
+        fed_agi = tax_unit("adjusted_gross_income", period)
+        agi = fed_agi + tax_unit("form_4972_lumpsum_distributions", period)
         agi_offset_base = p.agi_offset_base[filing_status]
         joint = filing_status == filing_status.possible_values.JOINT
         head_eligible = tax_unit.any(elderly_head | disabled_head)

--- a/policyengine_us/variables/household/income/tax_unit/form_4972_lumpsum_distributions.py
+++ b/policyengine_us/variables/household/income/tax_unit/form_4972_lumpsum_distributions.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class form_4972_lumpsum_distributions(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Lump-sum distributions reported on IRS Form 4972"
+    unit = USD
+    definition_period = YEAR
+    documentation = "Lump-sum distributions reported on IRS Form 4972."


### PR DESCRIPTION
Fixes #2955 and renames at least one other variable.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 57a3ecc</samp>

### Summary
🐛🚚📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It indicates that the previous variable names were causing some confusion or errors in the AMT calculation, and that the change resolves them.
2. 🚚 - This emoji represents a file or code move or rename, which is a secondary effect of this change. It indicates that some variables and classes were renamed to improve readability and clarity, and that an alias was removed to avoid duplication.
3. 📝 - This emoji represents a documentation update, which is a tertiary effect of this change. It indicates that the changelog file was updated to reflect the change and the version bump.
-->
This pull request fixes some variable names related to the `alternative_minimum_tax.py` file and updates the changelog accordingly. It improves the readability and consistency of the code and the documentation.

> _`AMT` renamed_
> _A clearer code for tax time_
> _Spring cleaning is done_

### Walkthrough
*  Rename variable and class names related to the alternative minimum tax (AMT) calculation to make them more descriptive and consistent ([link](https://github.com/PolicyEngine/policyengine-us/pull/2956/files?diff=unified&w=0#diff-847add804966d652d6163e6a12d49dd6c34303a9d2045600d8f4b5339d6db2e0L23-R23), [link](https://github.com/PolicyEngine/policyengine-us/pull/2956/files?diff=unified&w=0#diff-847add804966d652d6163e6a12d49dd6c34303a9d2045600d8f4b5339d6db2e0L31-R36), [link](https://github.com/PolicyEngine/policyengine-us/pull/2956/files?diff=unified&w=0#diff-847add804966d652d6163e6a12d49dd6c34303a9d2045600d8f4b5339d6db2e0L120-R117), [link](https://github.com/PolicyEngine/policyengine-us/pull/2956/files?diff=unified&w=0#diff-847add804966d652d6163e6a12d49dd6c34303a9d2045600d8f4b5339d6db2e0L129-R126), [link](https://github.com/PolicyEngine/policyengine-us/pull/2956/files?diff=unified&w=0#diff-847add804966d652d6163e6a12d49dd6c34303a9d2045600d8f4b5339d6db2e0L139-R136), [link](https://github.com/PolicyEngine/policyengine-us/pull/2956/files?diff=unified&w=0#diff-847add804966d652d6163e6a12d49dd6c34303a9d2045600d8f4b5339d6db2e0L151-R148), [link](https://github.com/PolicyEngine/policyengine-us/pull/2956/files?diff=unified&w=0#diff-847add804966d652d6163e6a12d49dd6c34303a9d2045600d8f4b5339d6db2e0L241-L243)) in `alternative_minimum_tax.py`


