### PR TITLE
Add Colorado to the household_state_income_tax variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Add Colorado to household_state_income_tax variable.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     added:
-    - Add Colorado to household_state_income_tax variable.
+    - Add Colorado to the household_state_income_tax variable.

--- a/policyengine_us/variables/household/income/household/household_state_income_tax.py
+++ b/policyengine_us/variables/household/income/household/household_state_income_tax.py
@@ -10,6 +10,7 @@ class household_state_income_tax(Variable):
     definition_period = YEAR
     adds = [
         "ca_income_tax_before_refundable_credits",
+        "co_income_tax_before_refundable_credits",
         "dc_income_tax_before_refundable_credits",
         "ia_income_tax_before_refundable_credits",
         "il_total_tax",
@@ -34,6 +35,7 @@ class household_state_income_tax(Variable):
     ]
     subtracts = [
         "ca_refundable_credits",  # California.
+        "co_refundable_credits",  # Colorado
         "dc_refundable_credits",  # District of Columbia.
         "ia_refundable_credits",  # Iowa.
         "il_refundable_credits",  # Illinois.


### PR DESCRIPTION
Fixes #2975

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3bc5ade</samp>

### Summary
📝🆕🗺️

<!--
1.  📝 - This emoji can be used to signify that a changelog entry has been updated or added, as it represents a memo or a document.
2.  🆕 - This emoji can be used to signify that a new feature has been added, as it represents the word "new" or something novel.
3.  🗺️ - This emoji can be used to signify that a new state has been included in the policy engine, as it represents a map or a geographic area. Alternatively, one could use the flag emoji for Colorado (🇺🇸🇨🇴) to be more specific, but this might not be as widely supported or recognized by different platforms or devices.
-->
This pull request adds support for Colorado income tax and refundable credits to the `household_state_income_tax` variable. It also updates the changelog entry to reflect the new feature and the patch version bump.

> _We're sailing to Colorado with a new feature in our code_
> _We've added in their income tax and credits to our load_
> _So heave away, me hearties, heave away with all your might_
> _We'll bump the patch version and update the changelog tonight_

### Walkthrough
*  Add support for Colorado tax calculations ([link](https://github.com/PolicyEngine/policyengine-us/pull/2976/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dR13), [link](https://github.com/PolicyEngine/policyengine-us/pull/2976/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dR38))
  - Include `Colorado.income_tax_before_refundable_credits` in the sum of state income taxes for `household_state_income_tax` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2976/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dR13))
  - Subtract `Colorado.refundable_credits` from the `household_state_income_tax` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2976/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dR38))
* Update changelog entry to reflect new feature and patch version bump ([link](https://github.com/PolicyEngine/policyengine-us/pull/2976/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
  - Indicate that Colorado is now included in `household_state_income_tax` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2976/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


