### PR TITLE
Update to 2022 CPS

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+      - CPS updated to 2022 from 2021.

--- a/policyengine_us/data/datasets/__init__.py
+++ b/policyengine_us/data/datasets/__init__.py
@@ -5,6 +5,7 @@ from .cps import (
     CPS_2023,
     RawCPS_2020,
     RawCPS_2021,
+    RawCPS_2022,
     CalibratedCPS_2023,
 )
 

--- a/policyengine_us/data/datasets/cps/__init__.py
+++ b/policyengine_us/data/datasets/cps/__init__.py
@@ -5,6 +5,6 @@ from .cps import (
     CPS_2023,
 )
 
-from .raw_cps import RawCPS_2020, RawCPS_2021
+from .raw_cps import RawCPS_2020, RawCPS_2021, RawCPS_2022
 
 from .calibrated_cps import CalibratedCPS_2023

--- a/policyengine_us/data/datasets/cps/cps.py
+++ b/policyengine_us/data/datasets/cps/cps.py
@@ -4,6 +4,7 @@ import h5py
 from policyengine_us.data.datasets.cps.raw_cps import (
     RawCPS_2020,
     RawCPS_2021,
+    RawCPS_2022,
     RawCPS,
 )
 from policyengine_us.data.datasets.cps.uprated_cps import UpratedCPS
@@ -354,18 +355,17 @@ class CPS_2021(CPS):
     file_path = STORAGE_FOLDER / "cps_2021.h5"
     time_period = 2021
 
+class CPS_2022(CPS):
+    name = "cps_2022"
+    label = "CPS 2022"
+    raw_cps = RawCPS_2022
+    file_path = STORAGE_FOLDER / "cps_2022.h5"
+    time_period = 2022
+    # url = None
 
-CPS_2022 = UpratedCPS.from_dataset(
-    CPS_2021,
-    2022,
-    "cps_2022",
-    "CPS 2022",
-    STORAGE_FOLDER / "cps_2022.h5",
-    new_url="release://policyengine/policyengine-us/cps-2022/cps_2022.h5",
-)
 
 CPS_2023 = UpratedCPS.from_dataset(
-    CPS_2021,
+    CPS_2022,
     2023,
     "cps_2023",
     "CPS 2023",

--- a/policyengine_us/data/datasets/cps/cps.py
+++ b/policyengine_us/data/datasets/cps/cps.py
@@ -355,6 +355,7 @@ class CPS_2021(CPS):
     file_path = STORAGE_FOLDER / "cps_2021.h5"
     time_period = 2021
 
+
 class CPS_2022(CPS):
     name = "cps_2022"
     label = "CPS 2022"

--- a/policyengine_us/data/datasets/cps/raw_cps.py
+++ b/policyengine_us/data/datasets/cps/raw_cps.py
@@ -219,6 +219,7 @@ class RawCPS_2021(RawCPS):
     label = "Raw CPS 2021"
     file_path = STORAGE_FOLDER / "raw_cps_2021.h5"
 
+
 class RawCPS_2022(RawCPS):
     time_period = 2022
     name = "raw_cps_2022"

--- a/policyengine_us/data/datasets/cps/raw_cps.py
+++ b/policyengine_us/data/datasets/cps/raw_cps.py
@@ -129,6 +129,7 @@ class RawCPS(Dataset):
         CPS_URL_BY_YEAR = {
             2020: "https://www2.census.gov/programs-surveys/cps/datasets/2021/march/asecpub21csv.zip",
             2021: "https://www2.census.gov/programs-surveys/cps/datasets/2022/march/asecpub22csv.zip",
+            2022: "https://www2.census.gov/programs-surveys/cps/datasets/2023/march/asecpub23csv.zip",
         }
 
         if self.time_period not in CPS_URL_BY_YEAR:
@@ -217,3 +218,9 @@ class RawCPS_2021(RawCPS):
     name = "raw_cps_2021"
     label = "Raw CPS 2021"
     file_path = STORAGE_FOLDER / "raw_cps_2021.h5"
+
+class RawCPS_2022(RawCPS):
+    time_period = 2022
+    name = "raw_cps_2022"
+    label = "Raw CPS 2022"
+    file_path = STORAGE_FOLDER / "raw_cps_2022.h5"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9625c07</samp>

### Summary
📈📦🧮

<!--
1.  📈 - This emoji represents the minor version bump and the improvement in the CPS data source, which could lead to more accurate and updated results for users of the policy engine.
2. 📦 - This emoji represents the import of the `RawCPS_2022` class in the `__init__.py` files of the `datasets` and `cps` packages, which makes the new data source available for other modules to use and simplifies the import statements.
3. 🧮 - This emoji represents the introduction of the new `CPS_2022` class and the modification of the `CPS_2023` class, which use the raw CPS data for 2022 as their source and allow for more consistent uprating of the CPS data for future years. This emoji also represents the support for the 2022 CPS data file as a raw data source for the policy engine, which involves downloading and processing the new data and defining a new `RawCPS_2022` class.
-->
This pull request updates the policy engine to use the 2022 CPS data as the default data source for simulations and analysis. It adds new classes and modules to handle the raw and processed 2022 CPS data and modifies existing classes to inherit from them.

> _`CPS_2022`_
> _New data source for engine_
> _Winter of updates_

### Walkthrough
*  Bump minor version and update CPS data source to 2022 ([link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Add `RawCPS_2022` class to represent the raw data for the 2022 CPS ([link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-e4e272ad68129c561f2ccd3120f2330724cf40523c651614c0a8b39c44ec63eeR8), [link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-905fe99210feb5f8159fad979a644b97ca76897cdd37402480b5709ce1efb542L8-R8), [link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-ea01f98a40de3b4fc4939adfb8832e10f87a99b4ca95dab82043999738adbc96R132), [link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-ea01f98a40de3b4fc4939adfb8832e10f87a99b4ca95dab82043999738adbc96R221-R227))
*  Replace `UpratedCPS.from_dataset` method with custom `CPS_2022` class that inherits from `CPS` and uses `RawCPS_2022` as its raw data source ([link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-9c4707f888a0cbbd2aa190681c7a6a13161e1587942d2c7bf4635c3201d948bcR7), [link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-9c4707f888a0cbbd2aa190681c7a6a13161e1587942d2c7bf4635c3201d948bcL358-R369))
*  Update `CPS_2023` class to use `CPS_2022` as its base dataset instead of `CPS_2021` ([link](https://github.com/PolicyEngine/policyengine-us/pull/2997/files?diff=unified&w=0#diff-9c4707f888a0cbbd2aa190681c7a6a13161e1587942d2c7bf4635c3201d948bcL358-R369))


