### PR TITLE
Remove NC index file, add legislative references, fix historical standard deduction

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - North Carolina index files.
+    - North Carolina missing legislative references.

--- a/policyengine_us/parameters/gov/states/nc/index.yaml
+++ b/policyengine_us/parameters/gov/states/nc/index.yaml
@@ -1,4 +1,0 @@
-metadata:
-  propagate_metadata_to_children: true
-  economy: false
-  household: false

--- a/policyengine_us/parameters/gov/states/nc/tax/income/credits/ctc/README.md
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/credits/ctc/README.md
@@ -1,0 +1,1 @@
+# Child Tax Credit

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/head_of_household.yaml
@@ -10,6 +10,8 @@ metadata:
       href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
     - title: 2022 North Carolina Form D-401, Line 10
       href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+    - title: Code of North Carolina | § 105-153.10 (a1) 
+      href: https://law.justia.com/codes/north-carolina/2022/chapter-105/article-4/section-105-153-5/
 
 brackets:  # ranges are > lower threshold and <= upper threshold 
   - threshold:

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/joint.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/joint.yaml
@@ -10,6 +10,8 @@ metadata:
       href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
     - title: 2022 North Carolina Form D-401, Line 10
       href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+    - title: Code of North Carolina | § 105-153.10 (a1) 
+      href: https://law.justia.com/codes/north-carolina/2022/chapter-105/article-4/section-105-153-5/
 
 brackets:  # ranges are > lower threshold and <= upper threshold 
   - threshold:

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/separate.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/separate.yaml
@@ -10,6 +10,8 @@ metadata:
       href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
     - title: 2022 North Carolina Form D-401, Line 10
       href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+    - title: Code of North Carolina | § 105-153.10 (a1) 
+      href: https://law.justia.com/codes/north-carolina/2022/chapter-105/article-4/section-105-153-5/
 
 brackets:  # ranges are > lower threshold and <= upper threshold 
   - threshold:

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/single.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/single.yaml
@@ -10,6 +10,8 @@ metadata:
       href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
     - title: 2022 North Carolina Form D-401, Line 10
       href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+    - title: Code of North Carolina | § 105-153.10 (a1) 
+      href: https://law.justia.com/codes/north-carolina/2022/chapter-105/article-4/section-105-153-5/
 
 brackets:  # ranges are > lower threshold and <= upper threshold 
   - threshold:

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/widow.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/child/widow.yaml
@@ -10,6 +10,8 @@ metadata:
       href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=13
     - title: 2022 North Carolina Form D-401, Line 10
       href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=13
+    - title: Code of North Carolina | § 105-153.10 (a1) 
+      href: https://law.justia.com/codes/north-carolina/2022/chapter-105/article-4/section-105-153-5/
 
 brackets:  # ranges are > lower threshold and <= upper threshold 
   - threshold:

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/standard/amount.yaml
@@ -10,19 +10,26 @@ metadata:
     href: https://www.ncdor.gov/2021-d-401-individual-income-tax-instructions/open#page=14
   - title: 2022 North Carolina Form D-401, Line 11
     href: https://www.ncdor.gov/2022-d-401-individual-income-tax-instructions/open#page=14
+  - title: Code of North Carolina | § 105-153.10 (a) (1)
+    href: https://law.justia.com/codes/north-carolina/2022/chapter-105/article-4/section-105-153-5/
     
 SINGLE:
-  2021-01-01: 10_750
+  2019-01-01: 10_000
+  2020-01-01: 10_750
   2022-01-01: 12_750
 JOINT:
-  2021-01-01: 21_500
+  2019-01-01: 20_000
+  2020-01-01: 21_500
   2022-01-01: 25_500
 WIDOW:
-  2021-01-01: 21_500
+  2019-01-01: 20_000
+  2020-01-01: 21_500
   2022-01-01: 25_500
 SEPARATE:
-  2021-01-01: 10_750
+  2019-01-01: 10_000
+  2020-01-01: 10_750
   2022-01-01: 12_750
 HEAD_OF_HOUSEHOLD:
-  2021-01-01: 16_125
+  2019-01-01: 15_000
+  2020-01-01: 16_125
   2022-01-01: 19_125

--- a/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_standard_deduction.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/deductions/nc_standard_deduction.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class nc_standard_deduction(Variable):
     value_type = float
     entity = TaxUnit
-    label = "North Carolina standard deduction amount"
+    label = "North Carolina standard deduction"
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.NC


### PR DESCRIPTION
Fixes #3076

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 78fe1d4</samp>

### Summary
📝🐛📈

<!--
1.  📝 - This emoji represents the addition of documentation, such as the README file and the legislative references, which help explain the policy parameters and sources.
2. 🐛 - This emoji represents the fixing of bugs, such as the issues with the index files and the missing values for the standard deduction, which improve the accuracy and functionality of the model.
3. 📈 - This emoji represents the updating of data, such as the standard deduction values for 2019 and 2020, which reflect the latest available information and enhance the relevance of the model.
-->
This pull request fixes some issues with the North Carolina tax parameters, mainly by adding legislative references and missing values. It also deletes an unnecessary index file and adds a README file for the child tax credit. It updates the changelog entry to reflect these changes.

> _`North Carolina`_
> _Fixing index and labels_
> _`Child tax` in autumn_

### Walkthrough
*  Update the changelog entry for the pull request ([link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R5))
*  Add a README file for the North Carolina child tax credit parameter ([link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-e61a8605c1a69121e110a0abe7a45b2bdd4340c73ee15ae9df6b12edd7a8cfe0R1))
*  Add legislative references for the North Carolina child deduction amounts for different filing statuses ([link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-529c2643bf902023f37e7c669c211f18b01a95e39dbf308e9f979d666df322d2R13-R14), [link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-43df7bae5634c54e9de0db8e0f92df06296b65ea3ebd5b7b6e0b59ca2706388cR13-R14), [link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-8a7b3ed258ce48e577fa7742088aabd1b57245f66474e94c14f948ce7cbc7b13R13-R14), [link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-177e0cb75aab7182237608eda95504d18ccdb995ef8a97dbd3142364e02b765bR13-R14), [link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-40ef5c377c36ae75e6f628684ebf4d40f24b896c33078abb67a6b82a60aaad17R13-R14))
*  Add legislative references and missing values for the North Carolina standard deduction amount ([link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-dd5dbef27b43fca869e916be1bfe6c930c4ed9223cf47cb85afe8c9defdccb37L13-R34))
*  Edit the label of the `nc_standard_deduction` variable ([link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-2a49278c26ceed853578ec9dba925d131aba64f248da78d6e9802f8e3e4499deL7-R7))
*  Delete the `policyengine_us/parameters/gov/states/nc/index.yaml` file ([link](https://github.com/PolicyEngine/policyengine-us/pull/3077/files?diff=unified&w=0#diff-c649e95510031e98aef1bbcd366c73bd8e8b44e077557952df637fdfe484c688))



- also added mssing legislative references