### PR TITLE
Add interest from u.s. obligation & student loan interest to Vermont subtractions list

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Vermont interest from u.s. obligation & student loan interest agi subtraction.

--- a/policyengine_us/parameters/gov/states/vt/tax/income/agi/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/agi/subtractions.yaml
@@ -1,12 +1,9 @@
 description: Vermont subtracts these sources from adjusted gross income.
 values:
   2021-01-01:
-    # Comment out waiting for other pull requests
-    # - us_govt_interest
+    - us_govt_interest
     - vt_medical_expense_deduction
-    # - student_loan_interest
-    # - vt_capital_gain_exclusion
-    # - vt_retirement_income_exemption
+    - student_loan_interest
 
 metadata:
   unit: list


### PR DESCRIPTION
Relates #2624 
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa2477a</samp>

### Summary
:memo::sparkles::wrench:

<!--
1.  :memo: - This emoji represents a change to documentation, such as the changelog entry.
2.  :sparkles: - This emoji represents a new feature or enhancement, such as the addition of Vermont interest adjustments to the policy engine.
3.  :wrench: - This emoji represents a change to configuration or settings, such as the parameters file for Vermont income tax subtractions.
-->
This pull request adds support for two adjustments to gross income for Vermont state income tax: `U.S. government interest` and `student loan interest`. It updates the `changelog_entry.yaml` file and the `subtractions.yaml` file under `policyengine_us/parameters/gov/states/vt/tax/income/agi`.

> _`Vermont` subtracts more_
> _Interest from loans and bonds_
> _Fall tax time is near_

### Walkthrough
*  Enable Vermont income tax subtractions for U.S. government interest and student loan interest ([link](https://github.com/PolicyEngine/policyengine-us/pull/3113/files?diff=unified&w=0#diff-8299b4ee7331e5c8c2dfaf432847d46016da57b0dc4fc86cb0cf63b94c52bd46L4-R6))
* Update changelog entry to reflect new minor version and new features ([link](https://github.com/PolicyEngine/policyengine-us/pull/3113/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


