### PR TITLE
Add unemployment compensation to benefits

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Add unemployment compensation to list of benefits.

--- a/policyengine_us/variables/household/income/household/household_benefits.py
+++ b/policyengine_us/variables/household/income/household/household_benefits.py
@@ -26,6 +26,7 @@ class household_benefits(Variable):
         "tanf",
         "high_efficiency_electric_home_rebate",
         "residential_efficiency_electrification_rebate",
+        "unemployment_compensation",
         # Contributed.
         "basic_income",
         "spm_unit_capped_housing_subsidy",

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -26,6 +26,7 @@ class spm_unit_benefits(Variable):
             "tanf",
             "high_efficiency_electric_home_rebate",
             "residential_efficiency_electrification_rebate",
+            "unemployment_compensation",
             # Contributed.
             "basic_income",
         ]


### PR DESCRIPTION
Fixes #3120

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b85613b</samp>

### Summary
📝🐛✨

<!--
1.  📝 for updating the changelog entry
2.  🐛 for fixing a bug in the benefit list
3.  ✨ for adding a new feature to the benefit aggregation
-->
This pull request fixes a bug that excluded unemployment compensation from the income calculations for the Supplemental Poverty Measure. It updates the changelog entry and modifies the `household_benefits` and `spm_unit_benefits` variables in `policyengine_us/variables`.

> _`unemployment`_
> _added to benefits list_
> _fix for poverty_

### Walkthrough
*  Update changelog entry to reflect patch version and fix for SPM ([link](https://github.com/PolicyEngine/policyengine-us/pull/3121/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Include unemployment compensation in household and SPM unit benefits ([link](https://github.com/PolicyEngine/policyengine-us/pull/3121/files?diff=unified&w=0#diff-5a317555b540bcb7f268e0e2ce5fcaca1f1424a137ab68ab3b2210e15cd6d89fR29), [link](https://github.com/PolicyEngine/policyengine-us/pull/3121/files?diff=unified&w=0#diff-0725491194f70b0c3736cf11a62db314635733f761fc30a10001674d2ea422dcR29))
   *  Modify `household_benefits` variable in `household_benefits.py` to add unemployment compensation to household income ([link](https://github.com/PolicyEngine/policyengine-us/pull/3121/files?diff=unified&w=0#diff-5a317555b540bcb7f268e0e2ce5fcaca1f1424a137ab68ab3b2210e15cd6d89fR29))
   *  Modify `spm_unit_benefits` variable in `spm_unit_benefits.py` to add unemployment compensation to SPM unit income ([link](https://github.com/PolicyEngine/policyengine-us/pull/3121/files?diff=unified&w=0#diff-0725491194f70b0c3736cf11a62db314635733f761fc30a10001674d2ea422dcR29))


