### PR TITLE
Fix formula for the tax_unit_medicaid_income_level variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Formula for tax_unit_medicaid_income_level variable.

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
@@ -1,33 +1,12 @@
-- name: Single person at 200% FPL, MA.
+- name: Single person at 160% FPL, MA.
+  relative_error_margin: 0.0002  # two-hundredths of one percent
   period: 2022
-  relative_error_margin: 0.05
   input:
-    zip_code: "01101"
-    state_code: MA
-    medicaid_income: 13_590 * 2
     age: 21
-    second_lowest_silver_plan_cost: 4_133
+    state_code: MA
+    zip_code: "01101"
+    medicaid_income: 1.6 * 12_880
+    second_lowest_silver_plan_cost: 4_133  # per 2022 KFF ACA calculator
   output:
-    premium_tax_credit: 301 * 12
-
-- name: Single parent at 250% FPL, MA.
-  period: 2022
-  relative_error_margin: 0.05
-  input:
-    households:
-      household:
-        zip_code: "01101"
-        state_code: MA
-        members: [parent, child]
-    tax_units:
-      tax_unit:
-        medicaid_income: 45_775
-        second_lowest_silver_plan_cost: 7_118
-        members: [parent, child]
-    people:
-      parent:
-        age: 32
-      child:
-        age: 5
-  output:
-    premium_tax_credit: 459 * 12
+    medicaid_income_level: 1.6
+    premium_tax_credit: 4_050   # per 2022 KFF ACA calculator

--- a/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
@@ -9,11 +9,14 @@ class tax_unit_medicaid_income_level(Variable):
     )
     unit = "/1"
     documentation = (
-        "Medicaid/CHIP/ACA-related MAGI as a fraction of federal poverty line."
+        "Medicaid/CHIP/ACA-related MAGI as fraction of federal poverty line."
+        "Documentation in the following reference:"
+        "  title: 2022 IRS Form 8962 (ACA PTC) instructions for line 4"
+        "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=7"
     )
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("medicaid_income", period)
-        fpg = tax_unit("tax_unit_fpg", period)
+        fpg = tax_unit("tax_unit_fpg", period.last_year)
         return income / fpg

--- a/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
@@ -10,13 +10,16 @@ class tax_unit_medicaid_income_level(Variable):
     unit = "/1"
     documentation = (
         "Medicaid/CHIP/ACA-related MAGI as fraction of federal poverty line."
-        "Documentation in the following reference:"
-        "  title: 2022 IRS Form 8962 (ACA PTC) instructions for line 4"
+        "Documentation on use of prior-year FPL in the following reference:"
+        "  title: 2022 IRS Form 8962 (ACA PTC) instructions, Line 4"
         "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=7"
+        "Documentation on truncation of fraction in the following reference:"
+        "  title: 2022 IRS Form 8962 instructions, Line 5 Worksheet 2"
+        "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=8"
     )
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("medicaid_income", period)
         fpg = tax_unit("tax_unit_fpg", period.last_year)
-        return income / fpg
+        return 0.01 * np.floor(100.0 * income / fpg)


### PR DESCRIPTION
Fixes #3154 and fixes #3157.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3b1590b</samp>

### Summary
📝🧪🐛

<!--
1.  📝 for updating the changelog entry and the documentation
2.  🧪 for replacing and improving the tests
3.  🐛 for fixing the formula bug
-->
This pull request fixes the `tax_unit_medicaid_income_level` variable to match the IRS rules for the ACA premium tax credit, and updates the tests and the changelog accordingly. It also improves the documentation of the variable and its sources.

> _We're fixing up the code for the `tax_unit_medicaid_income_level`_
> _We're making sure it matches the IRS rules, oh well_
> _We're testing it with realistic income and a finer error margin_
> _We're heaving on the line, one, two, three, and then we're done_

### Walkthrough
* Fix the formula for `tax_unit_medicaid_income_level` to use the prior-year FPL and truncate the fraction to two decimal places, as per the IRS instructions for the ACA premium tax credit ([link](https://github.com/PolicyEngine/policyengine-us/pull/3155/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL18-R25), [link](https://github.com/PolicyEngine/policyengine-us/pull/3155/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL12-R18))
* Update the test for `premium_tax_credit` to use a more realistic income level and a more precise relative error margin, and to reference the 2022 KFF ACA calculator as the expected output ([link](https://github.com/PolicyEngine/policyengine-us/pull/3155/files?diff=unified&w=0#diff-a210923204f2cc207ce13f80763d1aa2ef74eb0cadd7436aa9264604008d770eL1-R12))
* Update the changelog entry for the pull request, indicating the fix and the patch version bump ([link](https://github.com/PolicyEngine/policyengine-us/pull/3155/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


