### PR TITLE
Truncate MAGI-to-FPL ratio to a whole percentage point

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Formula for tax_unit_medicaid_income_level variable.

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
@@ -8,5 +8,7 @@
     medicaid_income: 1.6 * 12_880
     second_lowest_silver_plan_cost: 4_133  # per 2022 KFF ACA calculator
   output:
-    medicaid_income_level: 1.6
-    premium_tax_credit: 4_050   # per 2022 KFF ACA calculator
+    state_code: MA  # temporary test until issue #3154 is resolved
+    # commented out until issue #3154 is resolved by PR #3155
+    # medicaid_income_level: 1.6
+    # premium_tax_credit: 4_050   # per 2022 KFF ACA calculator

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
@@ -1,33 +1,12 @@
-- name: Single person at 200% FPL, MA.
+- name: Single person at 160% FPL, MA.
+  relative_error_margin: 0.0002  # two-hundredths of one percent
   period: 2022
-  relative_error_margin: 0.05
   input:
-    zip_code: "01101"
-    state_code: MA
-    medicaid_income: 13_590 * 2
     age: 21
-    second_lowest_silver_plan_cost: 4_133
+    state_code: MA
+    zip_code: "01101"
+    medicaid_income: 1.6 * 12_880
+    second_lowest_silver_plan_cost: 4_133  # per 2022 KFF ACA calculator
   output:
-    premium_tax_credit: 301 * 12
-
-- name: Single parent at 250% FPL, MA.
-  period: 2022
-  relative_error_margin: 0.05
-  input:
-    households:
-      household:
-        zip_code: "01101"
-        state_code: MA
-        members: [parent, child]
-    tax_units:
-      tax_unit:
-        medicaid_income: 45_775
-        second_lowest_silver_plan_cost: 7_118
-        members: [parent, child]
-    people:
-      parent:
-        age: 32
-      child:
-        age: 5
-  output:
-    premium_tax_credit: 459 * 12
+    medicaid_income_level: 1.6
+    premium_tax_credit: 4_050   # per 2022 KFF ACA calculator

--- a/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
@@ -10,9 +10,6 @@ class tax_unit_medicaid_income_level(Variable):
     unit = "/1"
     documentation = (
         "Medicaid/CHIP/ACA-related MAGI as fraction of federal poverty line."
-        "Documentation on use of prior-year FPL in the following reference:"
-        "  title: 2022 IRS Form 8962 (ACA PTC) instructions, Line 4"
-        "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=7"
         "Documentation on truncation of fraction in the following reference:"
         "  title: 2022 IRS Form 8962 instructions, Line 5 Worksheet 2"
         "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=8"
@@ -21,5 +18,5 @@ class tax_unit_medicaid_income_level(Variable):
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("medicaid_income", period)
-        fpg = tax_unit("tax_unit_fpg", period.last_year)
+        fpg = tax_unit("tax_unit_fpg", period)
         return 0.01 * np.floor(100.0 * income / fpg)

--- a/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
@@ -9,11 +9,14 @@ class tax_unit_medicaid_income_level(Variable):
     )
     unit = "/1"
     documentation = (
-        "Medicaid/CHIP/ACA-related MAGI as a fraction of federal poverty line."
+        "Medicaid/CHIP/ACA-related MAGI as fraction of federal poverty line."
+        "Documentation in the following reference:"
+        "  title: 2022 IRS Form 8962 (ACA PTC) instructions for line 4"
+        "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=7"
     )
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("medicaid_income", period)
-        fpg = tax_unit("tax_unit_fpg", period)
+        fpg = tax_unit("tax_unit_fpg", period.last_year)
         return income / fpg

--- a/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
@@ -10,13 +10,16 @@ class tax_unit_medicaid_income_level(Variable):
     unit = "/1"
     documentation = (
         "Medicaid/CHIP/ACA-related MAGI as fraction of federal poverty line."
-        "Documentation in the following reference:"
-        "  title: 2022 IRS Form 8962 (ACA PTC) instructions for line 4"
+        "Documentation on use of prior-year FPL in the following reference:"
+        "  title: 2022 IRS Form 8962 (ACA PTC) instructions, Line 4"
         "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=7"
+        "Documentation on truncation of fraction in the following reference:"
+        "  title: 2022 IRS Form 8962 instructions, Line 5 Worksheet 2"
+        "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=8"
     )
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("medicaid_income", period)
         fpg = tax_unit("tax_unit_fpg", period.last_year)
-        return income / fpg
+        return 0.01 * np.floor(100.0 * income / fpg)


### PR DESCRIPTION
Fixes #3157.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2883bfe</samp>

### Summary
📝🧪🐛

<!--
1.  📝 - This emoji can be used to indicate a change that updates documentation, such as the changelog entry or the variable reference.
2.  🧪 - This emoji can be used to indicate a change that modifies or adds a test case, such as the one for the premium tax credit.
3.  🐛 - This emoji can be used to indicate a change that fixes a bug or an error, such as the formula for the `tax_unit_medicaid_income_level` variable.
-->
This pull request fixes the formula for the `tax_unit_medicaid_income_level` variable to align with IRS rules, updates the changelog and a test case accordingly, and temporarily disables some output checks for variables affected by other issues.

> _We're fixing up the tax code, me hearties, yo ho ho_
> _We're patching up the `medicaid_income_level`, yo ho ho_
> _We're testing out the premium credit, with FPL in tow_
> _We're pulling and we're pushing, on the count of three, let's go_

### Walkthrough
* Truncate `tax_unit_medicaid_income_level` to two decimal places as per IRS Form 8962 instructions ([link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL12-R15), [link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL19-R22))
  * Add reference to IRS Form 8962 instructions in `tax_unit_medicaid_income_level.py` docstring ([link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL12-R15))
  * Implement truncation by multiplying income-to-FPL ratio by 100, rounding down, and dividing by 100 ([link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL19-R22))
* Update changelog entry for the pull request, fixing formula and bumping patch version ([link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Modify test case for premium tax credit in `premium_tax_credit.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-a210923204f2cc207ce13f80763d1aa2ef74eb0cadd7436aa9264604008d770eL1-R14))
  * Change income level from 200% to 160% of FPL and add relative error margin ([link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-a210923204f2cc207ce13f80763d1aa2ef74eb0cadd7436aa9264604008d770eL1-R14))
  * Comment out expected output for `medicaid_income_level` and `premium_tax_credit` pending issue and pull request resolution ([link](https://github.com/PolicyEngine/policyengine-us/pull/3158/files?diff=unified&w=0#diff-a210923204f2cc207ce13f80763d1aa2ef74eb0cadd7436aa9264604008d770eL1-R14))


