### PR TITLE
Reform Abolish Net Investment Tax

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Reform for the Tax Foundation growth and opportunity plan to repeal investment income tax.

--- a/policyengine_us/parameters/gov/contrib/tax_foundation/growth_and_opportunity/remove_net_investment_tax.yaml
+++ b/policyengine_us/parameters/gov/contrib/tax_foundation/growth_and_opportunity/remove_net_investment_tax.yaml
@@ -1,0 +1,9 @@
+description: The tax on net investment income is repealed if this is true.
+values:
+  2000-01-01: false
+metadata:
+  unit: bool
+  label: Tax Foundation growth and opportunity plan repeal net investment tax
+  reference:
+    - title: Tax Foundation Details and Analysis of a Tax Reform Plan for Growth and Opportunity
+      href: https://taxfoundation.org/research/all/federal/growth-opportunity-us-tax-reform-plan/#Revenue

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -4,6 +4,9 @@ from .winship import create_eitc_winship_reform
 from .dc_tax_threshold_joint_ratio import (
     create_dc_tax_threshold_joint_ratio_reform,
 )
+from .tax_foundation.growth_and_opportunity.remove_net_investment_tax import (
+    create_remove_net_investment_tax_reform,
+)
 from policyengine_core.reforms import Reform
 import warnings
 
@@ -17,12 +20,15 @@ def create_structural_reforms_from_parameters(parameters, period):
     dc_tax_threshold_joint_ratio_reform = (
         create_dc_tax_threshold_joint_ratio_reform(parameters, period)
     )
-
+    remove_net_investment_income_reform = (
+        create_remove_net_investment_tax_reform(parameters, period)
+    )
     reforms = [
         afa_reform,
         winship_reform,
         dc_kccatc_reform,
         dc_tax_threshold_joint_ratio_reform,
+        remove_net_investment_income_reform,
     ]
     reforms = tuple(filter(lambda x: x is not None, reforms))
 

--- a/policyengine_us/reforms/tax_foundation/growth_and_opportunity/__init__.py
+++ b/policyengine_us/reforms/tax_foundation/growth_and_opportunity/__init__.py
@@ -1,0 +1,3 @@
+from .remove_net_investment_tax import (
+    create_remove_net_investment_tax,
+)

--- a/policyengine_us/reforms/tax_foundation/growth_and_opportunity/remove_net_investment_tax.py
+++ b/policyengine_us/reforms/tax_foundation/growth_and_opportunity/remove_net_investment_tax.py
@@ -1,0 +1,57 @@
+from policyengine_us.model_api import *
+
+
+def create_remove_net_investment_tax() -> Reform:
+    class net_investment_income_tax(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "Repeal of investment income tax"
+        unit = USD
+        documentation = "The repeal of investment income tax under the tax foundation growth and opportunity plan"
+        definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.irs.investment.net_investment_income_tax
+        threshold = p.threshold[tax_unit("filing_status", period)]
+        excess_agi = max_(
+            0, tax_unit("adjusted_gross_income", period) - threshold
+        )
+        base = min_(
+            max_(0, tax_unit("net_investment_income", period)),
+            excess_agi,
+        )
+        if (
+            parameters(
+                period
+            ).gov.contrib.tax_foundation.growth_and_opportunity.remove_net_investment_tax
+            == True
+        ):
+            investment_income_tax = 0
+        else:
+            investment_income_tax = p.rate * base
+        return investment_income_tax
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(net_investment_income_tax)
+
+    return reform
+
+
+def create_remove_net_investment_tax_reform(
+    parameters, period, bypass: bool = False
+):
+    if bypass:
+        return create_remove_net_investment_tax()
+
+    p = parameters(period).gov.contrib.tax_foundation.growth_and_opportunity
+
+    if p.remove_net_investment_tax == True:
+        return create_remove_net_investment_tax()
+    else:
+        return None
+
+
+remove_net_investment_income = create_remove_net_investment_tax_reform(
+    None, None, bypass=True
+)


### PR DESCRIPTION
Fixes #3177

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 042ccd9</samp>

### Summary
:sparkles::page_facing_up::hammer:

<!--
1.  :sparkles: This emoji is used to indicate the addition of a new feature or enhancement, such as adding a new reform option and a new parameter file.
2. :page_facing_up: This emoji is used to indicate the addition or modification of documentation, such as adding a new entry to the changelog file and providing descriptions and references for the new parameter and variable.
3. :hammer: This emoji is used to indicate the addition or modification of code or infrastructure, such as adding a new module and a new variable class and updating the import statements and the reform creation function.
-->
This pull request adds a new reform option to the PolicyEngine US model, based on the Tax Foundation's Growth and Opportunity Act, which repeals the net investment income tax. It creates a new parameter, a new variable, and a new function to generate the reform, and adds them to the relevant modules and files. It also updates the changelog and the list of structural reforms.

> _A new feature was added with flair_
> _To remove the investment income tax share_
> _It used a new module_
> _And a parameter toggle_
> _And updated the changelog with care_

### Walkthrough
*  Add a reform for the Tax Foundation growth and opportunity plan to repeal the investment income tax ([link](https://github.com/PolicyEngine/policyengine-us/pull/3178/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Define a new parameter `remove_net_investment_tax` that controls the reform, with metadata and reference ([link](https://github.com/PolicyEngine/policyengine-us/pull/3178/files?diff=unified&w=0#diff-3dff099af7ab805589839cb40e29c2f41344ecc0f38f64d426171428cc2ff678R1-R9))
*  Create a new module `remove_net_investment_tax.py` that implements the reform logic, using a custom variable `net_investment_income_tax` that overrides the existing one in the model ([link](https://github.com/PolicyEngine/policyengine-us/pull/3178/files?diff=unified&w=0#diff-d97976751bb98e0144c7ed35277f91be4d4df63e13c7f241d6fb5ae788ab3072R1-R57))
*  Import the reform function and variable from the new module in the package `__init__.py` file ([link](https://github.com/PolicyEngine/policyengine-us/pull/3178/files?diff=unified&w=0#diff-4e9d02babed545dde6927fb44143a91cb570bb3a05ff35045f0d2b887de25804R1-R3))
*  Call the reform function and add the reform object to the list of structural reforms in the `reforms.py` file ([link](https://github.com/PolicyEngine/policyengine-us/pull/3178/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R7-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/3178/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226L20-R25), [link](https://github.com/PolicyEngine/policyengine-us/pull/3178/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R31))


