### PR TITLE
Make the tax_unit_medicaid_income_level variable be correct for Medicaid/CHIP

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Formula for tax_unit_medicaid_income_level variable.

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/premium_tax_credit/premium_tax_credit.yaml
@@ -5,8 +5,8 @@
     age: 21
     state_code: MA
     zip_code: "01101"
-    medicaid_income: 1.6 * 12_880
+    medicaid_income: 1.6 * 13_590
     second_lowest_silver_plan_cost: 4_133  # per 2022 KFF ACA calculator
   output:
     medicaid_income_level: 1.6
-    premium_tax_credit: 4_050   # per 2022 KFF ACA calculator
+    premium_tax_credit: 4_046  # $4,050 per 2022 KFF ACA calculator

--- a/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class medicaid_income(Variable):
     value_type = float
     entity = TaxUnit
-    label = "Medicaid/CHIP/ACA-related MAGI"
+    label = "Medicaid/CHIP/ACA-related Modified AGI"
     unit = USD
     documentation = "Medicaid/CHIP/ACA-related modified AGI for this tax unit."
     definition_period = YEAR

--- a/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income_level.py
@@ -4,9 +4,11 @@ from policyengine_us.model_api import *
 class medicaid_income_level(Variable):
     value_type = float
     entity = Person
-    label = "Medicaid/CHIP/ACA-related income level"
+    label = "Medicaid/CHIP-related income level"
     unit = "/1"
-    documentation = "Income for Medicaid/CHIP/ACA as a fraction of the federal poverty line for this person."
+    documentation = (
+        "Modified AGI as a fraction of current-year federal poverty line."
+    )
     definition_period = YEAR
 
     def formula(person, period, parameters):

--- a/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/tax_unit_medicaid_income_level.py
@@ -4,22 +4,16 @@ from policyengine_us.model_api import *
 class tax_unit_medicaid_income_level(Variable):
     value_type = float
     entity = TaxUnit
-    label = (
-        "Medicaid/CHIP/ACA-related modified adjusted gross income (MAGI) level"
-    )
+    label = "Medicaid/CHIP-related modified adjusted gross income (MAGI) level"
     unit = "/1"
     documentation = (
-        "Medicaid/CHIP/ACA-related MAGI as fraction of federal poverty line."
-        "Documentation on use of prior-year FPL in the following reference:"
-        "  title: 2022 IRS Form 8962 (ACA PTC) instructions, Line 4"
-        "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=7"
-        "Documentation on truncation of fraction in the following reference:"
-        "  title: 2022 IRS Form 8962 instructions, Line 5 Worksheet 2"
-        "  href: https://www.irs.gov/pub/irs-pdf/i8962.pdf#page=8"
+        "Medicaid/CHIP-related MAGI as fraction of federal poverty line."
+        "Documentation: 'Federal poverty level (FPL)' at the following URL:"
+        "URL: https://www.healthcare.gov/glossary/federal-poverty-level-fpl/"
     )
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("medicaid_income", period)
-        fpg = tax_unit("tax_unit_fpg", period.last_year)
-        return 0.01 * np.floor(100.0 * income / fpg)
+        fpg = tax_unit("tax_unit_fpg", period)
+        return income / fpg


### PR DESCRIPTION
Fixes #3180.
There will be a lagged ratio variable for ACA use in a forthcoming pull request.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c661732</samp>

### Summary
🐛📝🎨

<!--
1.  🐛 for fixing a bug in the calculation of the federal poverty line and the premium tax credit.
2.  📝 for updating the changelog entry, the test case, and the documentation of the variables.
3.  🎨 for simplifying the label and capitalizing the acronym of the `medicaid_income` variable.
-->
This pull request fixes a bug in the calculation of the `tax_unit_medicaid_income_level` variable, which affects the premium tax credit and the Medicaid and CHIP eligibility. It also improves the labels and the documentation of some related variables.

> _Oh we're the coders of the open source_
> _And we fix the bugs with skill and force_
> _We pull and push and test and merge_
> _And we make the `federal_poverty_line` converge_

### Walkthrough
* Fix the formula of the `tax_unit_medicaid_income_level` variable to use the current-year FPL and to remove the truncation of the fraction, which was causing errors in the calculation of the premium tax credit and the Medicaid eligibility based on the FPL ([link](https://github.com/PolicyEngine/policyengine-us/pull/3181/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL24-R19))
* Update the test case for the premium tax credit in Massachusetts to use the correct FPL for 2022 and the corresponding premium tax credit amount, which reflects the fixed formula ([link](https://github.com/PolicyEngine/policyengine-us/pull/3181/files?diff=unified&w=0#diff-a210923204f2cc207ce13f80763d1aa2ef74eb0cadd7436aa9264604008d770eL8-R12))
* Simplify the label and the documentation of the `medicaid_income_level` and `tax_unit_medicaid_income_level` variables to remove the reference to the ACA, since the variables are only used for Medicaid and CHIP eligibility, and update the documentation URL to point to a more relevant source ([link](https://github.com/PolicyEngine/policyengine-us/pull/3181/files?diff=unified&w=0#diff-c0faa16a33fe97e0663829b70aea075de12b80a306bd0130d1a94d65b0481602L7-R11), [link](https://github.com/PolicyEngine/policyengine-us/pull/3181/files?diff=unified&w=0#diff-c9ecc255a55fd5bbefa9ba3d116336f9041c98d694fb1610163ffdfe85429bfeL7-R12))
* Capitalize the acronym MAGI in the label of the `medicaid_income` variable for consistency and clarity ([link](https://github.com/PolicyEngine/policyengine-us/pull/3181/files?diff=unified&w=0#diff-14575fb62e4482af692ebc0be74226652d62486e88c5949ab92b0420868f995fL7-R7))
* Update the changelog entry to indicate a patch-level bump and a fixed formula for the `tax_unit_medicaid_income_level` variable ([link](https://github.com/PolicyEngine/policyengine-us/pull/3181/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


