### PR TITLE
Reform: Increase Taxable Earnings Subject to Social Security Payroll Taxes

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Reform for the Taxable Earnings for Social Security Payroll Taxes, including an upper threshold and increasing the taxable amount.

--- a/policyengine_us/parameters/gov/contrib/cbo/payroll/secondary_earnings_threshold.yaml
+++ b/policyengine_us/parameters/gov/contrib/cbo/payroll/secondary_earnings_threshold.yaml
@@ -1,9 +1,9 @@
-description: Subject earnings greater than this amount to payroll taxes, in addition to earnings below the maximum taxable amount under current law.
+description: The US levies payroll taxes on earnings greater than this amount, in addition to earnings below the maximum taxable amount under current law.
 values:
   2021-01-01: .inf
 metadata:
   unit: USD
-  label: Earnings Upper Threshold Subject to Social Security Payroll Taxes
+  label: Social Security payroll tax secondary earnings threshold
   reference:
     - title: Increase the Maximum Taxable Earnings That Are Subject to Social Security Payroll Taxes, option alternative 2
       href: https://www.cbo.gov/budget-options/58630

--- a/policyengine_us/parameters/gov/contrib/cbo/payroll/taxable_earnings_upper_threshold.yaml
+++ b/policyengine_us/parameters/gov/contrib/cbo/payroll/taxable_earnings_upper_threshold.yaml
@@ -1,0 +1,9 @@
+description: Subject earnings greater than this amount to payroll taxes, in addition to earnings below the maximum taxable amount under current law.
+values:
+  2021-01-01: .inf
+metadata:
+  unit: USD
+  label: Earnings Upper Threshold Subject to Social Security Payroll Taxes
+  reference:
+    - title: Increase the Maximum Taxable Earnings That Are Subject to Social Security Payroll Taxes, option alternative 2
+      href: https://www.cbo.gov/budget-options/58630

--- a/policyengine_us/reforms/cbo/payroll/__init__.py
+++ b/policyengine_us/reforms/cbo/payroll/__init__.py
@@ -1,0 +1,3 @@
+from .increase_taxable_earnings_for_social_security import (
+    create_increase_taxable_earnings_for_social_security_reform,
+)

--- a/policyengine_us/reforms/cbo/payroll/increase_taxable_earnings_for_social_security.py
+++ b/policyengine_us/reforms/cbo/payroll/increase_taxable_earnings_for_social_security.py
@@ -1,5 +1,4 @@
 from policyengine_us.model_api import *
-import numpy as np
 
 
 def create_increase_taxable_earnings_for_social_security() -> Reform:

--- a/policyengine_us/reforms/cbo/payroll/increase_taxable_earnings_for_social_security.py
+++ b/policyengine_us/reforms/cbo/payroll/increase_taxable_earnings_for_social_security.py
@@ -1,0 +1,46 @@
+from policyengine_us.model_api import *
+
+
+def create_increase_taxable_earnings_for_social_security() -> Reform:
+    class taxable_earnings_for_social_security(Variable):
+        value_type = float
+        entity = Person
+        label = "Taxable gross earnings for OASDI FICA"
+        definition_period = YEAR
+        unit = USD
+
+        def formula(person, period, parameters):
+            cap = parameters(period).gov.irs.payroll.social_security.cap
+            upper_threshold = parameters(
+                period
+            ).gov.contrib.cbo.payroll.taxable_earnings_upper_threshold
+            return min_(cap, person("payroll_tax_gross_wages", period)) + max_(
+                0, person("payroll_tax_gross_wages", period) - upper_threshold
+            )
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(taxable_earnings_for_social_security)
+
+    return reform
+
+
+def create_increase_taxable_earnings_for_social_security_reform(
+    parameters, period, bypass: bool = False
+):
+    if bypass:
+        return create_increase_taxable_earnings_for_social_security()
+
+    p = parameters(period).gov.contrib.cbo.payroll
+
+    if p.taxable_earnings_upper_threshold < 9999999999999999999999999:
+        return create_increase_taxable_earnings_for_social_security()
+    else:
+        return None
+
+
+increase_taxable_earnings_for_social_security = (
+    create_increase_taxable_earnings_for_social_security_reform(
+        None, None, bypass=True
+    )
+)

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -4,6 +4,9 @@ from .winship import create_eitc_winship_reform
 from .dc_tax_threshold_joint_ratio import (
     create_dc_tax_threshold_joint_ratio_reform,
 )
+from .cbo.payroll import (
+    create_increase_taxable_earnings_for_social_security_reform,
+)
 from policyengine_core.reforms import Reform
 import warnings
 
@@ -17,12 +20,18 @@ def create_structural_reforms_from_parameters(parameters, period):
     dc_tax_threshold_joint_ratio_reform = (
         create_dc_tax_threshold_joint_ratio_reform(parameters, period)
     )
+    increase_taxable_earnings_for_social_security_reform = (
+        create_increase_taxable_earnings_for_social_security_reform(
+            parameters, period
+        )
+    )
 
     reforms = [
         afa_reform,
         winship_reform,
         dc_kccatc_reform,
         dc_tax_threshold_joint_ratio_reform,
+        increase_taxable_earnings_for_social_security_reform,
     ]
     reforms = tuple(filter(lambda x: x is not None, reforms))
 


### PR DESCRIPTION
#3188 
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d7e25a</samp>

### Summary
:memo::gear::wrench:

<!--
1.  :memo: This emoji represents the addition of a changelog entry, which is a form of documentation or communication about the changes.
2. :gear: This emoji represents the addition of a new parameter file, which is a form of configuration or setting for the model.
3. :wrench: This emoji represents the addition of a new function and a new variable, which are forms of implementation or modification of the model logic.
-->
This pull request adds a new reform option that increases the taxable earnings for social security payroll taxes, based on the CBO option 6. It adds a new parameter file, a new variable, and a new function to create and apply the reform. It also updates the `reforms.py` file and the changelog.

> _To model a CBO option_
> _We added a new parameter option_
> _We imported a function_
> _That made a construction_
> _Of a reform for social security taxation_

### Walkthrough
*  Add a reform for increasing the taxable earnings for social security payroll taxes ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-9093e863d515afed5c95f9d0813b76e11830cdda241c362900beafed2a2ecd3bR1-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-747d1153afbb800168041eec63e9c90cdda566a299986272a07c02b593e4479fR1-R3), [link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-cf3902b740190f956e67e07c87560fc66bf9c866bf2224db6a6a70e240ad555dR1-R46), [link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R7-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R23-R27), [link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R34))
  - Create a new parameter file `taxable_earnings_upper_threshold.yaml` for the earnings upper threshold subject to social security payroll taxes ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-9093e863d515afed5c95f9d0813b76e11830cdda241c362900beafed2a2ecd3bR1-R9))
  - Define a new variable `taxable_earnings_for_social_security` that calculates the amount of earnings that are subject to the OASDI FICA tax in `increase_taxable_earnings_for_social_security.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-cf3902b740190f956e67e07c87560fc66bf9c866bf2224db6a6a70e240ad555dR1-R46))
  - Define a reform class that updates the variable in the model and a helper function that creates the reform based on the parameter values or bypasses the parameter check ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-cf3902b740190f956e67e07c87560fc66bf9c866bf2224db6a6a70e240ad555dR1-R46))
  - Import the helper function into `reforms.py` and call it within the main function that creates structural reforms from parameters ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R7-R9), [link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R23-R27))
  - Add the reform to the list of reforms that are composed into a single reform ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-923a45e47f29804b67bd8951728325386f17992b7d1c4dfcea6e784554a47226R34))
  - Import the function that creates the reform into the `__init__.py` file of the `cbo.payroll` submodule ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-747d1153afbb800168041eec63e9c90cdda566a299986272a07c02b593e4479fR1-R3))
  - Add a changelog entry for the new reform in `changelog_entry.yaml` ([link](https://github.com/PolicyEngine/policyengine-us/pull/3189/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


