### PR TITLE
Hook up Oklahoma income tax variables to net income tree

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Oklahoma income tax to net income tree.

--- a/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
+++ b/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
@@ -29,6 +29,7 @@ class household_refundable_tax_credits(Variable):
         "nj_refundable_credits",  # New Jersey.
         "nm_refundable_credits",  # New Mexico.
         "ny_refundable_credits",  # New York.
+        "ok_refundable_credits",  # Oklahoma.
         "or_refundable_credits",  # Oregon.
         # Skip PA, which has no refundable credits.
         "wa_refundable_credits",  # Washington.

--- a/policyengine_us/variables/household/income/household/household_state_income_tax.py
+++ b/policyengine_us/variables/household/income/household/household_state_income_tax.py
@@ -28,6 +28,7 @@ class household_state_income_tax(Variable):
         "nh_income_tax_before_refundable_credits",
         "nj_income_tax_before_refundable_credits",
         "ny_income_tax_before_refundable_credits",
+        "ok_income_tax_before_refundable_credits",
         "or_income_tax_before_refundable_credits",
         "pa_income_tax",
         "wa_income_tax_before_refundable_credits",
@@ -54,6 +55,7 @@ class household_state_income_tax(Variable):
         "ne_refundable_credits",  # Nebraska.
         "nh_refundable_credits",  # New Hampshire.
         "ny_refundable_credits",  # New York.
+        "ok_refundable_credits",  # Oklahoma.
         "or_refundable_credits",  # Oregon.
         # Skip PA, which has no refundable credits.
         "wa_refundable_credits",  # Washington.

--- a/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
@@ -33,6 +33,7 @@ class household_tax_before_refundable_credits(Variable):
         "nm_income_tax_before_refundable_credits",
         "ny_income_tax_before_refundable_credits",
         "or_income_tax_before_refundable_credits",
+        "ok_income_tax_before_refundable_credits",
         "pa_income_tax",  # PA has no refundable credits.
         "wa_income_tax_before_refundable_credits",
         "flat_tax",


### PR DESCRIPTION
Fixes #3190

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3bd9765</samp>

### Summary
:sparkles::moneybag::wrench:

<!--
1.  :sparkles: - This emoji is often used to indicate new features or enhancements, and can be used to represent the addition of Oklahoma income tax to the net income tree and the changelog entry.
2.  :moneybag: - This emoji is often used to indicate financial or monetary changes, and can be used to represent the addition of the `ok_refundable_credits` variable and the logic to calculate the net income of a household in Oklahoma after taxes and benefits.
3.  :wrench: - This emoji is often used to indicate fixes or adjustments, and can be used to represent the addition of the `ok_income_tax_before_refundable_credits` variable and the modification of the existing variable `household_state_income_tax`.
-->
This pull request adds the logic to calculate Oklahoma state income tax and refundable tax credits in PolicyEngine US. It modifies the `household_state_income_tax` variable and adds new variables `ok_income_tax_before_refundable_credits` and `ok_refundable_credits` to the `household` module. It also updates the changelog entry and the net income tree accordingly.

> _We're sailing to Oklahoma, me hearties, yo ho ho_
> _We've got to calculate the taxes, before we go_
> _We'll use the `ok_refundable_credits` to lower what we owe_
> _And the `ok_income_tax_before_refundable_credits` to know_

### Walkthrough
*  Bump minor version and add Oklahoma income tax to changelog ([link](https://github.com/PolicyEngine/policyengine-us/pull/3191/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Add `ok_refundable_credits` variable to household refundable tax credits ([link](https://github.com/PolicyEngine/policyengine-us/pull/3191/files?diff=unified&w=0#diff-28e128ad3fd8429524f8495cd0b0234b2279bfaafa470fb357954d3fb35cc4a0R32))
*  Add `ok_income_tax_before_refundable_credits` variable to household state income tax ([link](https://github.com/PolicyEngine/policyengine-us/pull/3191/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dR31))
*  Subtract `ok_refundable_credits` from `household_state_income_tax` ([link](https://github.com/PolicyEngine/policyengine-us/pull/3191/files?diff=unified&w=0#diff-7866c3345c8faae089db272d4e5d135c90597066ec1e2a3678d7a195bf47cd6dR58))
*  Add `ok_income_tax_before_refundable_credits` to household tax before refundable credits ([link](https://github.com/PolicyEngine/policyengine-us/pull/3191/files?diff=unified&w=0#diff-b8a8391fff3db4b71c3c0aca8ce7d7f4c87628b6a98c3c90ae90dd6eec143639R36))


