### PR TITLE
Fix CCAP bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Colorado CCAP bug with individual simulations.

--- a/policyengine_us/variables/gov/states/co/ccap/entry/co_ccap_hhs_fpg_eligible.py
+++ b/policyengine_us/variables/gov/states/co/ccap/entry/co_ccap_hhs_fpg_eligible.py
@@ -30,7 +30,11 @@ class co_ccap_hhs_fpg_eligible(Variable):
         county = spm_unit.household("county_str", period.this_year)
         hhs_fpg_rate = np.zeros_like(county, dtype=float)
         mask = state_eligible
-        if hasattr(spm_unit.simulation, "dataset"):
+
+        # Current fix for counties not in the dataset.
+        try:
+            p.entry.entry_fpg_rate[county[mask]]
+        except:
             county = np.array(
                 ["DENVER_COUNTY_CO"] * len(county),
             )


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e1794a7</samp>

### Summary
🐛🗺️🚧

<!--
1.  🐛 - This emoji represents a bug fix, and can be used to highlight the changelog entry that mentions the issue with individual simulations for CCAP.
2.  🗺️ - This emoji represents a map or a location, and can be used to indicate the change that involves county names and CCAP eligibility.
3.  🚧 - This emoji represents a construction or a work in progress, and can be used to signal the change that introduces a temporary workaround until the dataset is improved.
-->
This pull request fixes a bug that caused individual simulations for the `co_ccap` policy to fail when the county name was missing. It updates the changelog entry and adds a default value of `Denver County` in `co_ccap_hhs_fpg_eligible.py`.

> _`CCAP` bug fixed_
> _Try-except for county name_
> _Fall leaves in Denver_

### Walkthrough
* Fix a bug with individual simulations for CCAP policy ([link](https://github.com/PolicyEngine/policyengine-us/pull/3205/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/3205/files?diff=unified&w=0#diff-98c8376f309b896ca349e53f5bfc0778990e50cff3d466c59b134ed62befd5c3L33-R37))
  - Handle missing county names in `co_ccap_hhs_fpg_eligible.py` by using Denver County as a default ([link](https://github.com/PolicyEngine/policyengine-us/pull/3205/files?diff=unified&w=0#diff-98c8376f309b896ca349e53f5bfc0778990e50cff3d466c59b134ed62befd5c3L33-R37))
  - Update changelog entry to reflect the bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/3205/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


