### PR TITLE
Automatically set CCAP to entry process

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Automatically set entry process to true for CCAP.

--- a/policyengine_us/variables/gov/states/co/ccap/entry/co_ccap_is_in_entry_process.py
+++ b/policyengine_us/variables/gov/states/co/ccap/entry/co_ccap_is_in_entry_process.py
@@ -7,3 +7,4 @@ class co_ccap_is_in_entry_process(Variable):
     label = "Whether applicants are in the entry process of the Colorado Child Care Assistance Program"
     definition_period = MONTH
     # defined_for = StateCode.CO
+    default_value = True


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dc891e8</samp>

### Summary
🐛📝🛠️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It also conveys a sense of urgency and attention to detail.
2.  📝 - This emoji represents a documentation update, which is what the changelog entry is. It also conveys a sense of transparency and communication.
3.  🛠️ - This emoji represents a tool or configuration change, which is what the default value of the variable is. It also conveys a sense of improvement and functionality.
-->
This pull request fixes a bug related to the CCAP entry process in Colorado. It updates the `co_ccap_is_in_entry_process` variable to have a default value of True and adds a changelog entry for the patch.

> _`co_ccap` fix_
> _Default to entry process_
> _Winter bug is gone_

### Walkthrough
* Fix a bug related to the CCAP entry process ([link](https://github.com/PolicyEngine/policyengine-us/pull/3217/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/3217/files?diff=unified&w=0#diff-306965ccacc339f5dbb024599c5d9c502bb364ae963d847fee06706a8bba34c7R10))
  - Update the changelog entry to indicate a patch-level update ([link](https://github.com/PolicyEngine/policyengine-us/pull/3217/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
  - Set the default value of `co_ccap_is_in_entry_process` to True in `policyengine_us/variables/gov/states/co/ccap/entry/co_ccap_is_in_entry_process.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/3217/files?diff=unified&w=0#diff-306965ccacc339f5dbb024599c5d9c502bb364ae963d847fee06706a8bba34c7R10))


