### PR TITLE
Fix multi-child CCAP handling

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - CCAP fix for multi-child households (previously had index errors).

--- a/policyengine_us/variables/gov/states/co/ccap/co_ccap_parent_fee.py
+++ b/policyengine_us/variables/gov/states/co/ccap/co_ccap_parent_fee.py
@@ -70,9 +70,13 @@ class co_ccap_parent_fee(Variable):
         rate = p.parent_fee_rate_by_child_care_hours.calc(
             childcare_hours_per_day, right=True
         )
-        unrounded_non_discounted_fee = spm_unit.sum(
-            child_age_eligible * (base_parent_fee + add_on_parent_fee) * rate
+        childs_parent_fee = spm_unit.project(
+            base_parent_fee + add_on_parent_fee
         )
+        unrounded_non_discounted_fee = spm_unit.sum(
+            child_age_eligible * childs_parent_fee * rate
+        )
+
         non_discounted_fee = np.round(unrounded_non_discounted_fee, 2)
         # Rating of child care facilities also affects parent fee.
         # For households utilizing multiple child care providers, only one
@@ -84,7 +88,7 @@ class co_ccap_parent_fee(Variable):
         discount_eligible = (
             spm_unit.sum(
                 p.is_quality_rating_discounted.calc(rating)
-                & child_age_eligible
+                * child_age_eligible
             )
             > 0
         )


### PR DESCRIPTION
I found some issues (oddly, failed only in the action for the last PR) with multi-child handling (not projecting to person-level parent fees). Fixes in this PR.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7bac698</samp>

### Summary
🐛🧒🌟

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request.
2.  🧒 - This emoji represents a child, which is the target population of the CCAP program and the source of the index errors in the previous calculation.
3.  🌟 - This emoji represents a star, which is a common symbol for quality ratings, and a factor that affects the parent fee in the CCAP calculation.
-->
This pull request fixes a bug in the `co_ccap_parent_fee` variable that caused errors for multi-child households applying for the Colorado Child Care Assistance Program (CCAP). It also updates the changelog entry to reflect this patch.

> _A bug in the CCAP calculation_
> _Caused index errors and frustration_
> _The parent fee was wrong_
> _But the fix didn't take long_
> _Just some tweaks to the `quality_rating` and `child` relation_

### Walkthrough
* Fix bug in CCAP parent fee calculation for multi-child households ([link](https://github.com/PolicyEngine/policyengine-us/pull/3219/files?diff=unified&w=0#diff-d92d7ab3bb41d6cef23fbe10b49458ad446e252cf453557b9029e20ce299056eL73-R79), [link](https://github.com/PolicyEngine/policyengine-us/pull/3219/files?diff=unified&w=0#diff-d92d7ab3bb41d6cef23fbe10b49458ad446e252cf453557b9029e20ce299056eL87-R91))
  - Project base and add-on fees to child level instead of summing across spm_unit ([link](https://github.com/PolicyEngine/policyengine-us/pull/3219/files?diff=unified&w=0#diff-d92d7ab3bb41d6cef23fbe10b49458ad446e252cf453557b9029e20ce299056eL73-R79))
  - Use multiplication operator instead of logical and operator to apply quality rating discount ([link](https://github.com/PolicyEngine/policyengine-us/pull/3219/files?diff=unified&w=0#diff-d92d7ab3bb41d6cef23fbe10b49458ad446e252cf453557b9029e20ce299056eL87-R91))
* Update changelog entry for patch-level update ([link](https://github.com/PolicyEngine/policyengine-us/pull/3219/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
  - Indicate bug fix in `co_ccap_parent_fee.py` and potential index errors ([link](https://github.com/PolicyEngine/policyengine-us/pull/3219/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


