### PR TITLE
CCCAP isn't USD

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Added USD metadata to co_ccap_subsidy.

--- a/policyengine_us/variables/gov/states/co/ccap/co_ccap_subsidy.py
+++ b/policyengine_us/variables/gov/states/co/ccap/co_ccap_subsidy.py
@@ -5,7 +5,7 @@ class co_ccap_subsidy(Variable):
     value_type = float
     entity = SPMUnit
     label = "Colorado Child Care Assistance Program"
-    reference = ""
+    unit = USD
     definition_period = MONTH
     defined_for = "co_ccap_eligible"
 


### PR DESCRIPTION
Fixes #3220

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2561493</samp>

### Summary
📝🐛💵

<!--
1.  📝 - This emoji represents documentation or writing, and can be used to indicate the changelog update.
2. 🐛 - This emoji represents a bug or an error, and can be used to indicate the fix for the missing metadata attribute.
3. 💵 - This emoji represents money or currency, and can be used to indicate the unit of the `co_ccap_subsidy` variable.
-->
This pull request fixes a bug in the Colorado Child Care Assistance Program (CCAP) subsidy variable by adding a missing `unit` attribute. It also updates the changelog entry to reflect this patch.

> _`co_ccap_subsidy`_
> _Fixed metadata, unit added_
> _A patch for autumn_

### Walkthrough
* Add unit attribute to `co_ccap_subsidy` variable to fix missing metadata ([link](https://github.com/PolicyEngine/policyengine-us/pull/3221/files?diff=unified&w=0#diff-8a067bcca5f94628b764ae522224e93c7a341abdf701c75f3133c2d25026c108L8-R8))
* Update changelog entry to reflect patch-level update ([link](https://github.com/PolicyEngine/policyengine-us/pull/3221/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


