### PR TITLE
Improve ZIP code handling

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - ZIP codes are sampled from the state, and axes-containing simulations don't vary the ZIP code.

--- a/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
+++ b/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
@@ -30,10 +30,15 @@ class zip_code(Variable):
         else:
             household_zip_code = np.empty_like(state_code, dtype=object)
             for state in ZIP_CODE_DATASET.state.unique():
+                count_households_in_state = (state_code == state).sum()
                 household_zip_code[state_code == state] = (
                     ZIP_CODE_DATASET[ZIP_CODE_DATASET.state == state]
-                    .sample(1, weights="population")
-                    .zip_code.iloc[0]
+                    .sample(
+                        count_households_in_state,
+                        weights="population",
+                        replace=True,
+                    )
+                    .zip_code
                 )
             household_zip_code = pd.Series(household_zip_code)
 

--- a/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
+++ b/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
@@ -28,12 +28,13 @@ class zip_code(Variable):
             )
 
         else:
-            zip_codes = np.empty_like(state_code, dtype=object)
+            household_zip_code = np.empty_like(state_code, dtype=object)
             for state in ZIP_CODE_DATASET.state.unique():
-                zip_codes[state_code == state] = (
+                household_zip_code[state_code == state] = (
                     ZIP_CODE_DATASET[ZIP_CODE_DATASET.state == state]
                     .sample(1, weights="population")
                     .zip_code.iloc[0]
                 )
+            household_zip_code = pd.Series(household_zip_code)
 
             return household_zip_code.astype(str).str.zfill(5)


### PR DESCRIPTION
cc @MaxGhenis 

This PR changes the automatic zip code handling, which can cause large fluctuations in MTR charts.

**Current logic**: ZIP codes are randomly sampled from the entire US for every household in the simulation (including axis variation households.

**New logic**:

* For axes-containing simulations: ZIP code is sampled from the household's state and repeated for all households (in that state).
* For other simulations: ZIP code is sampled from the household's state.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ce77ab1</samp>

### Summary
📝🐛🗺️

<!--
1.  📝 - This emoji represents documentation or writing, and can be used to indicate that the changelog entry has been updated.
2. 🐛 - This emoji represents a bug or an error, and can be used to indicate that the zip code sampling logic has been fixed to avoid inconsistencies and randomness.
3. 🗺️ - This emoji represents a map or a location, and can be used to indicate that the zip code variable has been modified to use state codes and population weights.
-->
This pull request fixes a bug in the `zip_code` variable formula that caused inconsistent and random zip codes for households. It also updates the changelog entry to reflect the bug fix and the minor version bump.

> _`zip_code` formula_
> _changed to match state and axes_
> _fall leaves no errors_

### Walkthrough
*  Update changelog entry to reflect minor version bump and bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/3227/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Fix zip code sampling logic to match state code and handle axes ([link](https://github.com/PolicyEngine/policyengine-us/pull/3227/files?diff=unified&w=0#diff-83fde405c0dab5c2dc7ef354e34ec2f6c8c7234470ab4d73ab3b95b51b4bef12L12-R39))


