### PR TITLE
Fix axes bug with ZIP codes

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - ZIP code bug for households with axes.

--- a/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
+++ b/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
@@ -42,4 +42,4 @@ class zip_code(Variable):
                 )
             household_zip_code = pd.Series(household_zip_code)
 
-            return household_zip_code.astype(str).str.zfill(5)
+        return household_zip_code.astype(str).str.zfill(5)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a3ff762</samp>

### Summary
🐛📝🎨

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request and the changelog entry. It conveys that a problem that was affecting the functionality or performance of the code has been resolved.
2. 📝 - This emoji represents a documentation update, which is what the changelog entry is. It conveys that some information or explanation about the code or the project has been added or modified, but not the code itself.
3. 🎨 - This emoji represents a code style improvement, which is what the indentation fix is. It conveys that some aspect of the code's readability, consistency, or formatting has been enhanced, but not the logic or functionality.
-->
This pull request fixes a bug related to `zip_code` formatting for households with axes and updates the changelog accordingly. The bug was caused by a misaligned return statement in the `zip_code` class.

> _`policyengine-us`_
> _Fixing ZIP code bug now_
> _Changelog updated_

### Walkthrough
* Fix ZIP code bug for households with axes ([link](https://github.com/PolicyEngine/policyengine-us/pull/3228/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4), [link](https://github.com/PolicyEngine/policyengine-us/pull/3228/files?diff=unified&w=0#diff-83fde405c0dab5c2dc7ef354e34ec2f6c8c7234470ab4d73ab3b95b51b4bef12L45-R45))


