### PR TITLE
Re-add EITC alias

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Re-added earned_income_tax_credit variable alias.

--- a/policyengine_us/variables/gov/irs/credits/earned_income/eitc.py
+++ b/policyengine_us/variables/gov/irs/credits/earned_income/eitc.py
@@ -16,3 +16,12 @@ class eitc(Variable):
         reduction = tax_unit("eitc_reduction", period)
         limitation = max_(0, maximum - reduction)
         return min_(phased_in, limitation)
+
+
+class earned_income_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "EITC"
+    unit = USD
+    definition_period = YEAR
+    adds = ["eitc"]


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4dd17e7</samp>

### Summary
🐛🇺🇸💵

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It also matches the changelog entry that uses the word "fix".
2. 🇺🇸 - This emoji represents the US flag, which is relevant for this change since it adds a variable that is specific to the US federal tax system. It also matches the name of the package that is modified, `policyengine_us`.
3. 💵 - This emoji represents money, which is relevant for this change since it adds a variable that affects the income and tax liability of tax units. It also matches the label and unit of the variable, which are both related to money.
-->
This pull request fixes a bug where the `earned_income_tax_credit` variable alias was missing from the `policyengine_us` package. It adds the variable to the `eitc.py` file and updates the changelog accordingly.

> _`eitc` was missing_
> _A patch restores the alias_
> _Winter tax relief_

### Walkthrough
*  Add `earned_income_tax_credit` variable to `policyengine_us` package ([link](https://github.com/PolicyEngine/policyengine-us/pull/3239/files?diff=unified&w=0#diff-1f5ab8f2ff2953251d634d64e11a5c723f436ec3a936594fe7c31f2d5c3d4591R19-R27))
* Update changelog entry for the pull request ([link](https://github.com/PolicyEngine/policyengine-us/pull/3239/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


