### PR TITLE
Idaho non refundable credits file

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Idaho non refundable credits file.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-    - Idaho non refundable credits file.
+    - Idaho non-refundable credits file.

--- a/policyengine_us/parameters/gov/states/id/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/id/tax/income/credits/non_refundable.yaml
@@ -1,0 +1,8 @@
+description: Idaho non-refundable tax credits.
+metadata:
+  unit: list
+  label: Idaho non-refundable credits
+
+values:
+  2021-01-01:
+    - id_ctc

--- a/policyengine_us/parameters/gov/states/id/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/id/tax/income/credits/non_refundable.yaml
@@ -2,6 +2,14 @@ description: Idaho non-refundable tax credits.
 metadata:
   unit: list
   label: Idaho non-refundable credits
+  reference:
+  - title: Idaho Form 40 2022 
+    href: https://tax.idaho.gov/wp-content/uploads/forms/EFO00089/EFO00089_12-30-2022.pdf
+  - title: Idaho Form 40 2021 Instructions
+    href: https://tax.idaho.gov/wp-content/uploads/forms/EIN00046/EIN00046_11-15-2021.pdf
+  # CTC reference
+  - title: IDAHO STATUTES - TITLE 63 - 067 - SECTION 63-3029L (1)
+    href: https://legislature.idaho.gov/statutesrules/idstat/Title63/T63CH30/SECT63-3029L/
 
 values:
   2021-01-01:

--- a/policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py
@@ -9,4 +9,4 @@ class id_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.ID
 
-    adds = ".gov.states.id.tax.income.credits.non_refundable"
+    adds = "gov.states.id.tax.income.credits.non_refundable"

--- a/policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py
@@ -8,3 +8,5 @@ class id_non_refundable_credits(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.ID
+
+    adds = ".gov.states.id.tax.income.credits.non_refundable"


### PR DESCRIPTION
Fixes #1162

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e76e1f4</samp>

### Summary
📝🆕🛠️

<!--
1.  📝 for updating the changelog entry
2.  🆕 for creating a new parameter file
3.  🛠️ for modifying the import statement
-->
This pull request adds a new feature to the policy engine: the ability to calculate Idaho non refundable tax credits. It updates the changelog, creates a new parameter file for the credits, and fixes an import statement in the variable file.

> _`id_ctc` added_
> _New feature for Idaho_
> _Changelog updated_

### Walkthrough
* Create a new parameter file for Idaho non refundable tax credits ([link](https://github.com/PolicyEngine/policyengine-us/pull/3246/files?diff=unified&w=0#diff-8189b4448e2bd1c40f6de4905ddd2f80fe5e9257c6d36b9b86b956d382bb5112R1-R8))
* Update the changelog entry to indicate a minor version bump and the new feature ([link](https://github.com/PolicyEngine/policyengine-us/pull/3246/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Modify the import statement in the Idaho non refundable credits variable file to use a relative path ([link](https://github.com/PolicyEngine/policyengine-us/pull/3246/files?diff=unified&w=0#diff-b40ded0f73d1d117034d781747ef4fafcc94f685e38cae397b367e929b74caf6R11-R12))


