### PR TITLE
Remove temporary earned_income_tax_credit alias variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - The temporary presence of `earned_income_tax_credit` by removing it, leaving the `eitc` variable as the sole representation of the federal Earned Income Credit.

--- a/policyengine_us/variables/gov/irs/credits/earned_income/eitc.py
+++ b/policyengine_us/variables/gov/irs/credits/earned_income/eitc.py
@@ -16,12 +16,3 @@ class eitc(Variable):
         reduction = tax_unit("eitc_reduction", period)
         limitation = max_(0, maximum - reduction)
         return min_(phased_in, limitation)
-
-
-class earned_income_tax_credit(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "EITC"
-    unit = USD
-    definition_period = YEAR
-    adds = ["eitc"]


### PR DESCRIPTION
Fixes #3250.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5a6b742</samp>

### Summary
🐛🗑️📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request. It shows that the change addresses an issue that was affecting the functionality or accuracy of the code.
2.  🗑️ - This emoji represents a removal or deletion, which is what this change does to the `earned_income_tax_credit` variable. It shows that the change cleans up the code and eliminates unnecessary or redundant elements.
3.  📝 - This emoji represents a documentation update, which is what this change does to the changelog entry. It shows that the change provides information and context about the nature and impact of the bug fix.
-->
This pull request fixes a bug where the federal Earned Income Credit was duplicated in the code as `earned_income_tax_credit` and `eitc`. It removes the redundant `earned_income_tax_credit` variable and updates the changelog accordingly.

> _`earned_income_tax_credit`_
> _A bug in the code_
> _Gone with the autumn leaves_

### Walkthrough
*  Delete the redundant `earned_income_tax_credit` variable and update references to use `eitc` instead ([link](https://github.com/PolicyEngine/policyengine-us/pull/3251/files?diff=unified&w=0#diff-1f5ab8f2ff2953251d634d64e11a5c723f436ec3a936594fe7c31f2d5c3d4591L19-L27),                                          F1L59


