### PR TITLE
Disable Maine tax

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Disable Maine Tax.

--- a/policyengine_us/parameters/gov/states/me/index.yaml
+++ b/policyengine_us/parameters/gov/states/me/index.yaml
@@ -1,0 +1,4 @@
+metadata:
+  propagate_metadata_to_children: true
+  economy: false
+  household: false


### PR DESCRIPTION
Fixes #3249

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8146cac</samp>

### Summary
📝🐛🌐

<!--
1.  📝 - This emoji means "memo" or "document" and can be used to signify a change that updates or improves documentation, such as a changelog entry or a metadata file.
2.  🐛 - This emoji means "bug" or "fix" and can be used to signify a change that resolves an issue or error, such as a bug in the tax policy logic or a typo in the code.
3.  🌐 - This emoji means "globe" or "world" and can be used to signify a change that affects or relates to a specific region or location, such as a state-level policy or a country-specific data source.
-->
This pull request fixes an issue with the Maine tax policy and improves the metadata of the `policyengine_us/parameters/gov/states/me/index.yaml` file. It also updates the `changelog_entry.yaml` file to reflect the patch-level update.

> _`Maine` tax policy_
> _Fixed with a patch and metadata_
> _Autumn leaves inherit_

### Walkthrough
*  Update the changelog entry for the pull request ([link](https://github.com/PolicyEngine/policyengine-us/pull/3254/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Add metadata to the Maine state parameters file ([link](https://github.com/PolicyEngine/policyengine-us/pull/3254/files?diff=unified&w=0#diff-d0d9b6027d08af3a5dd8a9350939b34bde0a848b04e9af615bf7275764059e22R1-R4))


