### PR TITLE
Downgrade policyengine-core to 2.9.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Downgrade policyengine-core to fix Microsimulation bug.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "microdf_python",
         "pandas",
         "pathlib",
-        "policyengine-core>=2.7.1,<3",
+        "policyengine-core>=2.7.1,<2.10",
         "pytest",
         "pytest-dependency",
         "pyyaml",


### PR DESCRIPTION
Fixes #3311

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d6d5259</samp>

### Summary
🐛📝🔒

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request and the changelog entry.
2.  📝 - This emoji represents a documentation update, which is what the changelog entry is, as well as a way of communicating the change to the users and developers of the package.
3.  🔒 - This emoji represents a security or dependency update, which is what the setup.py modification is, as it prevents the package from installing an incompatible version of the policyengine-core package that could cause errors or unexpected behavior.
-->
This pull request fixes a bug related to the `Microsimulation` class by updating the changelog and the `policyengine-core` dependency in `setup.py`.

> _`Microsimulation`_
> _Bug fixed with patch and range_
> _Autumn of errors_

### Walkthrough
*  Restrict policyengine-core version to avoid breaking change ([link](https://github.com/PolicyEngine/policyengine-us/pull/3312/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L40-R40))
*  Add changelog entry for patch-level bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/3312/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


