### PR TITLE
Fix definition of income used to calculate Maine fairness credits

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+    - Fix definition of income used to calculate Maine fairness credits.

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/income_sources.yaml
@@ -1,8 +1,8 @@
 description: Maine accounts for the following income sources for the sales and property tax credits.
 values:
   2021-01-01:
-    - adjusted_gross_income
-    - social_security
+    - me_total_income
+    - tax_exempt_social_security
     - tax_exempt_interest_income
 metadata:
   unit: list


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35a7fa0</samp>

### Summary
📝🧮📊

<!--
1.  📝 This emoji represents the update or revision of the values of the income sources for the Maine fairness credit, as well as the definitions used by the state tax form.
2.  🧮 This emoji represents the calculation or computation of the `me_total_income`, `tax_exempt_social_security`, and `tax_exempt_interest_income` variables, which involve adding or subtracting different income components.
3.  📊 This emoji represents the improvement or enhancement of the accuracy and consistency of the policy simulation, which may affect the output or results of the analysis.
-->
Updated income sources for Maine fairness credit to align with state tax form definitions. Improved policy simulation accuracy and consistency.

> _`me_total_income`_
> _More precise and consistent_
> _Leaves fall in Maine tax_

### Walkthrough
* Update the income sources for the Maine fairness credit to match the state tax form definitions ([link](https://github.com/PolicyEngine/policyengine-us/pull/3316/files?diff=unified&w=0#diff-04a4b7b071ef6eddf78ccfa1a6ab2d40053448c78f69f7b768eb90c5b2dc00feL4-R5))


