### PR TITLE
Fix Core reform-handling bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - Bug preventing reforms from working with a Core update.

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -32,9 +32,8 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
     ]
     modelled_policies = COUNTRY_DIR / "modelled_policies.yaml"
 
-    def __init__(self):
-        # We initialize our tax and benefit system with the general constructor
-        super().__init__(entities)
+    def __init__(self, reform=None):
+        super().__init__(entities, reform=reform)
 
         reform = create_structural_reforms_from_parameters(
             self.parameters, "2023-01-01"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "microdf_python",
         "pandas",
         "pathlib",
-        "policyengine-core>=2.7.1,<2.10",
+        "policyengine-core>=2.10,<3",
         "pytest",
         "pytest-dependency",
         "pyyaml",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1777863</samp>

### Summary
🐛🛠️⬆️

<!--
1.  🐛 for fixing a bug
2.  🛠️ for improving the system's flexibility and customizability
3.  ⬆️ for updating a dependency version
-->
This pull request fixes a bug that prevented reforms from working with the latest Core update, and adds a new feature to allow passing reforms to the US tax and benefit system. It also updates the changelog and the dependency version of `policyengine-core` in `setup.py`.

> _`policyengine-us`_
> _More reforms, Core update_
> _Autumn of changes_

### Walkthrough
*  Allow passing reforms to the US tax and benefit system ([link](https://github.com/PolicyEngine/policyengine-us/pull/3317/files?diff=unified&w=0#diff-f2deb8455dee110904a880c69b48192cc1ff8e561bc84c5a3abd212b6ae2591aL35-R36))
*  Update policyengine-core dependency to be compatible with latest update ([link](https://github.com/PolicyEngine/policyengine-us/pull/3317/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L40-R40))
*  Fix bug preventing reforms from working with Core update ([link](https://github.com/PolicyEngine/policyengine-us/pull/3317/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
*  Update changelog entry to reflect minor version bump and bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/3317/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))



Fixes #3315 