### PR TITLE
Fix definition of income used to calculate Maine fairness credits

### DIFF
--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/income_sources.yaml
@@ -1,7 +1,7 @@
 description: Maine accounts for the following income sources for the sales and property tax credits.
 values:
   2021-01-01:
-    - adjusted_gross_income
+    - irs_gross_income
     - social_security
     - tax_exempt_interest_income
 metadata:


### PR DESCRIPTION
Fixes #3248

copilot:all
