### PR TITLE
Add formula for the ky_taxable_income variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Add formula for the ky_taxable_income variable.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c751aa1</samp>

### Summary
:sparkles::page_facing_up::us:

<!--
1.  :sparkles: This emoji is commonly used to indicate a new feature or enhancement. In this case, it represents the addition of a formula for a new variable.
2. :page_facing_up: This emoji is often used to indicate a documentation update or improvement. In this case, it represents the update to the changelog entry, which is part of the documentation for the pull request.
3. :us: This emoji is used to indicate a country-specific change or feature. In this case, it represents the fact that the formula is specific to the state of Kentucky, which is part of the United States.
-->
Add formula for `ky_taxable_income` variable. This change implements the state income tax calculation for Kentucky based on the official tax tables and brackets.

> _`ky_taxable_income`_
> _A new formula added_
> _Springtime for taxes_

### Walkthrough
*  Add a formula for `ky_taxable_income` based on the state tax brackets and tables ([link](https://github.com/PolicyEngine/policyengine-us/pull/3343/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R3),                            F1L30R


