### PR TITLE
Fix NYC School Tax Credit Rate Reduction Income Limit Label

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix NYC School Tax Credit Rate Reduction Amount Income Limit parameter label.

--- a/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/school/rate_reduction/income_limit.yaml
+++ b/policyengine_us/parameters/gov/local/ny/nyc/tax/income/credits/school/rate_reduction/income_limit.yaml
@@ -1,7 +1,7 @@
 description: NYC limits its School Tax Credit Rate Reduction Amount to filers with NY AGI of this amount or less.
 metadata:
   unit: currency-USD
-  label: NYC School Tax Credit Fixed Amount Income Limit
+  label: NYC School Tax Credit Rate Reduction Amount Income Limit
   reference:
     - title: Instructions for Form IT-201
       href: https://www.tax.ny.gov/pdf/2022/printable-pdfs/inc/it201i-2022.pdf#page=27


### PR DESCRIPTION
Fixes #3359

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1b2c775</samp>

### Summary
📝🐛🚀

<!--
1.  📝 - This emoji is often used to indicate documentation updates or changes to text files, such as the changelog entry.
2. 🐛 - This emoji is commonly used to represent bug fixes or code corrections, such as the parameter label fix.
3. 🚀 - This emoji is frequently used to signify a new release or version bump, such as the patch version increase.
-->
This pull request fixes a bug in the label of the `NYC School Tax Credit` parameter and updates the changelog entry accordingly. The bug caused confusion and inconsistency between the code and the reference document.

> _`NYC School Tax`_
> _Label fixed in YAML file_
> _A bug in autumn_

### Walkthrough
* Fix the parameter label for the NYC School Tax Credit to match the reference document ([link](https://github.com/PolicyEngine/policyengine-us/pull/3361/files?diff=unified&w=0#diff-9bbf2a7dc47d9b7ba90f11d6e1f8ad2b2ad66e2a0d76e35838ffa3464cd03d65L4-R4))
* Update the changelog entry to indicate a patch version bump and a bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/3361/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


