### PR TITLE
Adjust label and documentation military_retirement_pay variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
-    added:
-      - Michigan standard deduction and pension benefit. 
+    fixed:
+      - Military retirement pay variable. 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Military retirement pay variable. 

--- a/policyengine_us/variables/household/income/person/pensions/military_retirement_pay.py
+++ b/policyengine_us/variables/household/income/person/pensions/military_retirement_pay.py
@@ -4,8 +4,8 @@ from policyengine_us.model_api import *
 class military_retirement_pay(Variable):
     value_type = float
     entity = Person
-    label = "ME military retirement pay subtractions"
+    label = "Military retirement pay"
     unit = USD
     definition_period = YEAR
-    documentation = "The benefits received under a United States military retirement plan, including survivor benefits, are fully exempt from Maine income tax. See 2022 - Worksheet for Pension Income Deduction below."
-    reference = "https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_1s_ff.pdf"
+    documentation = "The benefits received under a United States military retirement plan, including survivor benefits."
+    reference = "https://militarypay.defense.gov/Pay/Retirement/"


### PR DESCRIPTION
Fixes #3116

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3fe2dd4</samp>

### Summary
🐛📝🔧

<!--
1.  🐛 for the bug fix in the military retirement pay variable
2.  📝 for the documentation update in the changelog and the variable
3.  🔧 for the refactoring of the variable label and reference
-->
This pull request fixes a bug in the `military_retirement_pay` variable and updates the changelog entry and the version bump level accordingly. It also improves the label, documentation, and reference of the `military_retirement_pay` variable to make them more generic and consistent.

> _`bump_level` fixed_
> _changelog reflects the bug_
> _patching in winter_

### Walkthrough
* Correct the versioning and changelog entry for the pull request, which fixed a bug in the military retirement pay variable ([link](https://github.com/PolicyEngine/policyengine-us/pull/3363/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L1-R4))
* Make the label, documentation, and reference of the military retirement pay variable more generic and applicable to all states, not just Maine, in `military_retirement_pay.py` ([link](https://github.com/PolicyEngine/policyengine-us/pull/3363/files?diff=unified&w=0#diff-de8b4e37e0948193856d05d8237a56cb09fc4a2f8a9a15a8e6716f60878b7635L7-R11))


