### PR TITLE
Fix bug in LA general relief

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Bug in LA general relief.

--- a/policyengine_us/variables/gov/local/ca/la/general_relief/la_general_relief_gross_income.py
+++ b/policyengine_us/variables/gov/local/ca/la/general_relief/la_general_relief_gross_income.py
@@ -10,4 +10,4 @@ class la_general_relief_gross_income(Variable):
     defined_for = "in_la"
     reference = "https://drive.google.com/file/d/1Oc7UuRFxJj-eDwTeox92PtmRVGnG9RjW/view?usp=sharing"
 
-    adds = "gov.local.la.general_relief.income_sources"
+    adds = "gov.local.ca.la.general_relief.income_sources"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c63fb4c</samp>

### Summary
🐛📝✏️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the patch version bump and the changelog entry. It also matches the `fixed` category of the conventional commits format.
2. 📝 - This emoji represents a documentation update, which is what the changelog entry is. It also indicates that the change does not affect the code functionality, but rather the communication of the project history and features.
3. ✏️ - This emoji represents a typo fix, which is what the correction of the `adds` attribute value is. It also implies a minor and non-breaking change that improves the accuracy and readability of the code.
-->
This pull request fixes a bug in the LA general relief policy and updates the changelog accordingly. The bug was caused by a missing `ca` state code in the `adds` attribute of the `la_general_relief_gross_income` variable class.

> _`la_general_relief`_
> _Fixes typo, adds changelog_
> _Autumn bug hunting_

### Walkthrough
* Fix a bug in the LA general relief policy that caused incorrect income calculations ([link](https://github.com/PolicyEngine/policyengine-us/pull/3369/files?diff=unified&w=0#diff-ac81d3327ea0490cd4593c63dbc0d4998ac8482b6f8ea51dca7d0338fd73f899L13-R13))
* Add a changelog entry for the patch version bump that documents the bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/3369/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


