### PR TITLE
Michigan Miscellaneous subtractions related to the credit for elderly or totally and permanently disabled

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Michigan Miscellaneous subtractions section 22 income.

--- a/policyengine_us/parameters/gov/states/mi/tax/income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/subtractions.yaml
@@ -5,6 +5,7 @@ values:
     - military_retirement_pay # Line 11
     - taxable_social_security # Line 14
     - military_service_income # Line 14
+    - section_22_income # Line 22
     - mi_standard_deduction  # Line 24 & 25
     - mi_pension_benefit  # Line 26
     - mi_interest_dividends_capital_gains_deduction # Line 27


### PR DESCRIPTION
Fixes #3400

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e65a2f3</samp>

### Summary
🐛📝🧮

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It also conveys that the change is addressing an issue that was affecting the accuracy or functionality of the application.
2.  📝 - This emoji represents a documentation update, which is what the changelog entry is. It also conveys that the change is providing information or clarification for the users or developers of the application.
3.  🧮 - This emoji represents a calculation or formula update, which is what the section 22 income parameter is. It also conveys that the change is affecting the numerical or logical aspects of the application.
-->
This pull request fixes a bug in the `policyengine_us` package that caused the Michigan income tax calculation to omit section 22 income from the subtractions. It updates the `subtractions.yaml` file and the changelog entry accordingly.

> _`Section 22` fixed_
> _Michigan tax subtraction_
> _Winter bug no more_

### Walkthrough
* Fix bug in Michigan Miscellaneous subtractions section 22 income calculation ([link](https://github.com/PolicyEngine/policyengine-us/pull/3401/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))
* Add section 22 income parameter to `subtractions.yaml` and implement logic for exempt retirement income ([link](https://github.com/PolicyEngine/policyengine-us/pull/3401/files?diff=unified&w=0#diff-3d54ed01a307b589eebd0d9d1243747afa7b2dadd23e64aafcac707f3a8c3944R8))


