### PR TITLE
Arizona adjusted gross income subtractions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Arizona adjusted gross income subtractions.

--- a/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
@@ -1,13 +1,16 @@
 description: Arizona counts these sources as subtractions.
 values:
   2021-01-01:
-    # salt_refund_income
-    # - us_govt_interest
-    - az_public_pension_exclusion
-    - az_long_term_capital_gains_subtraction
-    - az_military_retirement_subtraction
+    - us_govt_interest # Line 28
+    - az_public_pension_exclusion # Line 29a
+    - az_long_term_capital_gains_subtraction # Line 20 - 24
+    - az_military_retirement_subtraction # Line 29b
+    - taxable_social_security # Line 30
+    - military_service_income # Line 32
 metadata:
   unit: list
+  period: year
+  label: Arizona adjusted gross income subtractions
   reference:
     - title: 2022 Arizona Form 140 Resident Personal Income Tax Booklet
       href: https://azdor.gov/sites/default/files/2023-03/FORMS_INDIVIDUAL_2022_140BOOKLET.pdf#page=30


### PR DESCRIPTION
Fixes #3408

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2d5e30c</samp>

### Summary
📝🆕🇺🇸

<!--
1.  📝 - This emoji can be used to represent the change to the changelog entry, as it indicates a documentation update or a minor fix.
2. 🆕 - This emoji can be used to represent the change to the list of subtractions, as it indicates a new feature or addition to the policy engine.
3. 🇺🇸 - This emoji can be used to represent the change to the Arizona state tax policy, as it indicates a country-specific or regional update. Alternatively, a flag emoji for Arizona could be used, but there is no official one in the Unicode standard.
-->
This pull request fixes the Arizona adjusted gross income subtractions in the policy engine by adding two new subtractions and updating the metadata for the existing ones. The changes are reflected in the `changelog_entry.yaml` and the `subtractions.yaml` files.

> _`AZ_subtractions`_
> _More precise and complete now_
> _Winter tax season_

### Walkthrough
*  Add two new subtractions for Arizona adjusted gross income: taxable social security and military service income ([link](https://github.com/PolicyEngine/policyengine-us/pull/3415/files?diff=unified&w=0#diff-f0b4564dd01615e46bba705c3dd0afb05673ed69e1d6b35cdac79acfa096250aL4-R13))
*  Add labels and references for each subtraction in `subtractions.yaml`, and specify the period and unit of the parameter ([link](https://github.com/PolicyEngine/policyengine-us/pull/3415/files?diff=unified&w=0#diff-f0b4564dd01615e46bba705c3dd0afb05673ed69e1d6b35cdac79acfa096250aL4-R13))
*  Update the changelog entry to indicate the patch-level fix for Arizona subtractions ([link](https://github.com/PolicyEngine/policyengine-us/pull/3415/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


