### PR TITLE
Add integration tests for CARE and FERA

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - California CARE and FERA integration tests.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cpuc/fera/ca_fera_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cpuc/fera/ca_fera_eligible.yaml
@@ -9,7 +9,7 @@
   output:
     ca_fera_eligible: true
 
-- name: A two-peson household with an income equal to 250% of poverty line is not eligible.
+- name: A two-person household with an income equal to 250% of poverty line is not eligible.
   period: 2023
   input:
     household_size: 2

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cpuc/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cpuc/integration.yaml
@@ -1,49 +1,49 @@
-# - name: A four person household with an income of $69k is qualified for FERA, but not for CARE.
-#   period: 2022
-#   input:
-#     state_code: CA
-#     household_size: 4
-#     household_market_income: 69_000
-#     electricity_expense: 100
-#     ca_care_categorically_eligible: false
-#   output:
-#     ca_care_income_eligible: false
-#     ca_care_amount_if_eligible: 32.5
-#     ca_care: 0
-#     ca_fera_eligible: true
-#     ca_fera_amount_if_eligible: 18
-#     ca_fera: 18
+- name: A four person household with an income of $69k is qualified for FERA, but not for CARE.
+  period: 2022
+  input:
+    state_code: CA
+    household_size: 4
+    household_market_income: 69_000
+    electricity_expense: 100
+    ca_care_categorically_eligible: false
+  output:
+    ca_care_income_eligible: false
+    ca_care_amount_if_eligible: 32.5
+    ca_care: 0
+    ca_fera_eligible: true
+    ca_fera_amount_if_eligible: 18
+    ca_fera: 18
 
-# # Failed integration test above shows that even when a person is not income eligible for CARE, a discount is still being awarded.
+# Failed integration test above shows that even when a person is not income eligible for CARE, a discount is still being awarded.
 
-# - name: A four person household with an income of $40k is qualified for CARE but not for FERA
-#   period: 2022
-#   input:
-#     state_code: CA
-#     household_size: 4
-#     household_market_income: 40_000
-#     electricity_expense: 100
-#     ca_care_categorically_eligible: false
-#   output:
-#     ca_care_income_eligible: true
-#     ca_care_amount_if_eligible: 32.5
-#     ca_care: 32.5
-#     ca_fera_eligible: false
-#     ca_fera_amount_if_eligible: 18
-#     ca_fera: 0
+- name: A four person household with an income of $40k is qualified for CARE but not for FERA
+  period: 2022
+  input:
+    state_code: CA
+    household_size: 4
+    household_market_income: 40_000
+    electricity_expense: 100
+    ca_care_categorically_eligible: false
+  output:
+    ca_care_income_eligible: true
+    ca_care_amount_if_eligible: 32.5
+    ca_care: 32.5
+    ca_fera_eligible: false
+    ca_fera_amount_if_eligible: 18
+    ca_fera: 0
 
-# - name: A three-person household with an income between 200% and 250% of the poverty line is ineligible for CARE and eligible for FERA.
-#   period: 2023
-#   input:
-#   # if the following line is not included, then the test fails. The program is assuming categorical care eligibility.
-#     # ca_care_categorically_eligible: false 
-#     household_size: 3
-#     employment_income: 60_000 # ~240% of poverty line
-#     state_code: CA
-#   output:
-#     ca_care_categorically_eligible: false
-#     ca_care_eligible: false
-#     ca_fera_eligible: true
+- name: A three-person household with an income between 200% and 250% of the poverty line is ineligible for CARE and eligible for FERA.
+  period: 2023
+  input:
+  # if the following line is not included, then the test fails. The program is assuming categorical care eligibility.
+    # ca_care_categorically_eligible: false 
+    household_size: 3
+    employment_income: 60_000 # ~240% of poverty line
+    state_code: CA
+  output:
+    ca_care_categorically_eligible: false
+    ca_care_eligible: false
+    ca_fera_eligible: true
 
 - name: A three-person household with an income between 200% and 250% of the poverty line is ineligible for CARE and eligible for FERA.
   period: 2023
@@ -66,8 +66,34 @@
         members: [parent, child1, child2]
         state_code: CA
   output:
-    snap: 0
-    # ca_care_categorically_eligible: false
-    # ca_care_eligible: false
-    # ca_fera_eligible: true
-    # ca_fera: 18
+    # Eligible due to child Medicaid.
+    ca_care_categorically_eligible: true
+    ca_care_eligible: true
+    ca_fera_eligible: false
+
+- name: A three-person household with an income between 200% and 250% of the poverty line is ineligible for CARE and eligible for FERA.
+  period: 2023
+  input:
+  # if the following line is not included, then the test fails. The program is assuming categorical care eligibility.
+    # ca_care_categorically_eligible: false 
+    people:
+      adult1:
+        age: 30
+        employment_income: 60_000 # ~240% of poverty line
+      adult2:
+        age: 30
+      adult3:
+        age: 30
+    spm_units:
+      spm_unit:
+        members: [adult1, adult2, adult3]
+        electricity_expense: 100
+    households:
+      household:
+        members: [adult1, adult2, adult3]
+        state_code: CA
+  output:
+    ca_care_categorically_eligible: false
+    ca_care_eligible: false
+    ca_fera_eligible: true
+    ca_fera: 18

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cpuc/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cpuc/integration.yaml
@@ -1,0 +1,73 @@
+# - name: A four person household with an income of $69k is qualified for FERA, but not for CARE.
+#   period: 2022
+#   input:
+#     state_code: CA
+#     household_size: 4
+#     household_market_income: 69_000
+#     electricity_expense: 100
+#     ca_care_categorically_eligible: false
+#   output:
+#     ca_care_income_eligible: false
+#     ca_care_amount_if_eligible: 32.5
+#     ca_care: 0
+#     ca_fera_eligible: true
+#     ca_fera_amount_if_eligible: 18
+#     ca_fera: 18
+
+# # Failed integration test above shows that even when a person is not income eligible for CARE, a discount is still being awarded.
+
+# - name: A four person household with an income of $40k is qualified for CARE but not for FERA
+#   period: 2022
+#   input:
+#     state_code: CA
+#     household_size: 4
+#     household_market_income: 40_000
+#     electricity_expense: 100
+#     ca_care_categorically_eligible: false
+#   output:
+#     ca_care_income_eligible: true
+#     ca_care_amount_if_eligible: 32.5
+#     ca_care: 32.5
+#     ca_fera_eligible: false
+#     ca_fera_amount_if_eligible: 18
+#     ca_fera: 0
+
+# - name: A three-person household with an income between 200% and 250% of the poverty line is ineligible for CARE and eligible for FERA.
+#   period: 2023
+#   input:
+#   # if the following line is not included, then the test fails. The program is assuming categorical care eligibility.
+#     # ca_care_categorically_eligible: false 
+#     household_size: 3
+#     employment_income: 60_000 # ~240% of poverty line
+#     state_code: CA
+#   output:
+#     ca_care_categorically_eligible: false
+#     ca_care_eligible: false
+#     ca_fera_eligible: true
+
+- name: A three-person household with an income between 200% and 250% of the poverty line is ineligible for CARE and eligible for FERA.
+  period: 2023
+  input:
+  # if the following line is not included, then the test fails. The program is assuming categorical care eligibility.
+    # ca_care_categorically_eligible: false 
+    people:
+      parent:
+        employment_income: 60_000 # ~240% of poverty line
+      child1:
+        age: 10
+      child2:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [parent, child1, child2]
+        electricity_expense: 100
+    households:
+      household:
+        members: [parent, child1, child2]
+        state_code: CA
+  output:
+    snap: 0
+    # ca_care_categorically_eligible: false
+    # ca_care_eligible: false
+    # ca_fera_eligible: true
+    # ca_fera: 18

--- a/policyengine_us/variables/gov/states/ca/cpuc/fera/ca_fera_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/cpuc/fera/ca_fera_eligible.py
@@ -18,13 +18,13 @@ class ca_fera_eligible(Variable):
         care_eligible = household("ca_care_eligible", period)
         # Check at least 3 people in household
         n = household("household_size", period)
-        # TODO: Make 3 a parameter.
         p = parameters(period).gov.states.ca.cpuc.fera.eligibility
-        n_eligible = n >= p.minimum_household_size
+        eligible_household_size = n >= p.minimum_household_size
         # Check income eligibility with respect to percent of the poverty line.
         # Must be above 200% of the poverty line (CARE requirements), but less
         # than or equal to 250% of the poverty line.
         income = household("household_market_income", period)
         ca_care_poverty_line = household("ca_care_poverty_line", period)
-        income_eligible = income <= (ca_care_poverty_line * p.fpl_limit)
-        return (income_eligible) & (n_eligible) & (~care_eligible)
+        income_limit = ca_care_poverty_line * p.fpl_limit
+        income_eligible = income <= income_limit
+        return income_eligible & eligible_household_size & ~care_eligible


### PR DESCRIPTION


Fixes #1857

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 60b5665</samp>

### Summary
🐛✅♻️

<!--
1.  🐛 for fixing a typo in the test name, since this is a minor bug fix.
2.  ✅ for adding a new integration test, since this is a way of verifying the functionality and correctness of the code.
3.  ♻️ for refactoring the formula for FERA eligibility, since this is a way of improving the code quality and structure.
-->
This pull request improves the implementation and testing of the FERA program in California. It refactors the formula for FERA eligibility in `ca_fera_eligible.py`, fixes a typo in a test name in `ca_fera_eligible.yaml`, and adds a new integration test in `integration.yaml`.

> _Sing, O Muse, of the code that was changed by the skillful programmers_
> _Who sought to improve the policy engine for the FERA program_
> _That gives a generous discount to the low-income households of California_
> _And helps them pay their electric bills with less hardship and sorrow._

### Walkthrough
* Fix a typo in the test name for a two-person household's FERA eligibility ([link](https://github.com/PolicyEngine/policyengine-us/pull/3431/files?diff=unified&w=0#diff-da0b8d2f91ca134718c45447c306472c4c2b6382b6025b2a3f937bad6e0cc6a7L12-R12))
* Add a new integration test for a three-person household's FERA eligibility and benefit amount, and comment out some failing or incomplete tests ([link](https://github.com/PolicyEngine/policyengine-us/pull/3431/files?diff=unified&w=0#diff-0b631d68c53f1f2ccd6b16212f0468b70cc705e0a2fea9ef33f6a379d633e3c0R1-R73))
* Rename the variable `n_eligible` to `eligible_household_size` and remove the TODO comment in the `ca_fera_eligible` formula ([link](https://github.com/PolicyEngine/policyengine-us/pull/3431/files?diff=unified&w=0#diff-ef7f009f5dc7b772d24411fcd1514650257d7131dabe860b1826ecafc9e0f27eL21-R22))
* Introduce a new variable `income_limit` and use the bitwise operator `&` and the renamed variable `eligible_household_size` in the `ca_fera_eligible` formula ([link](https://github.com/PolicyEngine/policyengine-us/pull/3431/files?diff=unified&w=0#diff-ef7f009f5dc7b772d24411fcd1514650257d7131dabe860b1826ecafc9e0f27eL29-R30))


