### PR TITLE
Subtract only positive long-term captial gains to get Arizona AGI

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Arizona AGI long-term capital gains subtraction.

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/capital_gains/az_long_term_capital_gains_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/capital_gains/az_long_term_capital_gains_subtraction.yaml
@@ -13,3 +13,11 @@
     long_term_capital_gains: 0
   output:
     az_long_term_capital_gains_subtraction: 0
+
+- name: Long term capital gains can not be negative
+  period: 2023
+  input:
+    state_code: AZ
+    long_term_capital_gains: -1_000
+  output:
+    az_long_term_capital_gains_subtraction: 0

--- a/policyengine_us/variables/gov/states/az/tax/income/subtractions/capital_gains/az_long_term_capital_gains_subtraction.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/subtractions/capital_gains/az_long_term_capital_gains_subtraction.py
@@ -19,4 +19,4 @@ class az_long_term_capital_gains_subtraction(Variable):
             tax_unit, period, ["long_term_capital_gains"]
         )
 
-        return long_term_capital_gains * p.rate
+        return max_(0, long_term_capital_gains) * p.rate


### PR DESCRIPTION
Fixes #3425

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d7dd48</samp>

### Summary
🐛🧪📝

<!--
1.  🐛 for fixing a bug
2.  🧪 for adding a test case
3.  📝 for modifying a formula
-->
This pull request fixes a bug in the `az_long_term_capital_gains_subtraction` variable that caused it to return negative values in some cases. It updates the changelog, the formula, and the test case for this variable.

> _`max_` fixes bug_
> _Arizona gains subtract_
> _Fall leaves turn to zero_

### Walkthrough
* Fix bug in `az_long_term_capital_gains_subtraction` that allowed negative values ([link](https://github.com/PolicyEngine/policyengine-us/pull/3443/files?diff=unified&w=0#diff-028b9a5a2af82599e434b5cfd2834955307f20f6c926ee572c23394be1b9d57eL22-R22))
* Add test case to check that subtraction is zero if input is negative ([link](https://github.com/PolicyEngine/policyengine-us/pull/3443/files?diff=unified&w=0#diff-2aac03c7bb440e9a51455f25c50d4fe033ed7c48f63f3d8286feb541b8540116R16-R23))
* Update changelog entry to indicate patch-level change and bug fix ([link](https://github.com/PolicyEngine/policyengine-us/pull/3443/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8R1-R4))


