### PR TITLE
Illinois 2022 personal exemption amount

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-      - Montana social security benefit adjustment.
+    - Illinois 2022 personal exemption amount.

--- a/policyengine_us/parameters/gov/states/il/tax/income/exemption/dependent.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/exemption/dependent.yaml
@@ -1,11 +1,13 @@
-description: Illinois Dependent Exemption Amount
+description: Illinois provides the following exemption amount for each dependent.
 values:
   2021-01-01: 2_375
+  2022-01-01: 2_425
 metadata:
   unit: currency-USD
   period: year
-  name: il_dependent_exemption
   label: Illinois dependent exemption amount
   reference:
     - title: Illinois Department of Revenue 2021 Schedule IL-E/EIC; Step 2, Line 1, on Line 10d
       href: https://www2.illinois.gov/rev/forms/incometax/Documents/currentyear/individual/il-1040-schedule-il-e-eic.pdf
+    - title: 2022 Schedule IL-E/EIC - Illinois Exemption and Earned Income Credit
+      href: https://tax.illinois.gov/content/dam/soi/en/web/tax/forms/incometax/documents/currentyear/individual/il-1040-schedule-il-e-eic.pdf#page=1

--- a/policyengine_us/parameters/gov/states/il/tax/income/exemption/personal.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/exemption/personal.yaml
@@ -1,11 +1,13 @@
-description: Illinois personal exemption allowance
+description: Illinois provides the following personal exemption allowance amount.
 values:
   2021-01-01: 2_375
+  2022-01-01: 2_425
 metadata:
   unit: currency-USD
   period: year
-  name: il_personal_exemption
-  label: IL personal exemption
+  label: Illinois personal exemption amount
   reference:
     - title: Illinois Income Tax Act, 35 ILCS 5/204 (b)
       href: https://witnessslips.ilga.gov/legislation/ilcs/ilcs5.asp?ActID=577&ChapterID=8
+    - title: Illinois 2022 Form IL-1040 Instructions
+      href: https://tax.illinois.gov/content/dam/soi/en/web/tax/forms/incometax/documents/currentyear/individual/il-1040-instr.pdf#page=8

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/exemptions/il_dependent_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/exemptions/il_dependent_exemption.yaml
@@ -1,15 +1,23 @@
-- name: "Two dependents in household"
+- name: 2021, Two dependents in the household
   period: 2021
   input:
     tax_unit_dependents: 2
     state_code: IL
   output:
-    il_dependent_exemption: 2_375 * 2
+    il_dependent_exemption: 4_750
 
-- name: "Three dependents in household"
+- name: 2021, three dependents in the household
   period: 2021
   input:
     tax_unit_dependents: 3
     state_code: IL
   output:
-    il_dependent_exemption: 2_375 * 3
+    il_dependent_exemption: 7_125
+
+- name: Two dependents in 2022
+  period: 2022
+  input:
+    tax_unit_dependents: 2
+    state_code: IL
+  output:
+    il_dependent_exemption: 4_850

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/exemptions/il_personal_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/exemptions/il_personal_exemption.yaml
@@ -1,0 +1,23 @@
+- name: 2022 test, both partners eligible
+  period: 2022
+  input:
+    il_personal_exemption_eligibility_status: BOTH_ELIGIBLE
+    state_code: IL
+  output:
+    il_personal_exemption: 4_850
+
+- name: 2022 test, one partner eligible
+  period: 2022
+  input:
+    il_personal_exemption_eligibility_status: PARTIALLY_ELIGIBLE
+    state_code: IL
+  output:
+    il_personal_exemption: 2_425
+
+- name: 2021 test, one partner eligible
+  period: 2021
+  input:
+    il_personal_exemption_eligibility_status: PARTIALLY_ELIGIBLE
+    state_code: IL
+  output:
+    il_personal_exemption: 2_375

--- a/policyengine_us/variables/gov/states/il/tax/income/exemptions/il_dependent_exemption.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/exemptions/il_dependent_exemption.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class il_dependent_exemption(Variable):
     value_type = float
     entity = TaxUnit
-    label = "IL dependent exemption"
+    label = "Illinois dependent exemption"
     unit = USD
     definition_period = YEAR
 

--- a/policyengine_us/variables/gov/states/il/tax/income/exemptions/il_personal_exemption.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/exemptions/il_personal_exemption.py
@@ -1,11 +1,10 @@
 from policyengine_us.model_api import *
 
 
-# TODO: apparently test is required for this, even though this is directly linked to il_personal_exemption_eligibility_status?
 class il_personal_exemption(Variable):
     value_type = float
     entity = TaxUnit
-    label = "IL personal exemption amount"
+    label = "Illinois personal exemption amount"
     unit = USD
     definition_period = YEAR
 


### PR DESCRIPTION
Fixes #3463

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d7db62f</samp>

### Summary
:sparkles::memo::white_check_mark:

<!--
1.  :sparkles: for the new feature of adding the 2022 personal exemption amount parameter
2.  :memo: for the documentation and naming improvements in the parameter and variable files
3.  :white_check_mark: for the addition of the test file and the verification of the variable calculation
-->
Added the Illinois 2022 personal exemption amount parameter and updated the corresponding variable, label, and test files. This allows users to model the impact of the state income tax exemption on their tax liability and effective tax rate.

> _New feature added_
> _`IL_personal_exemption`_
> _for policy engine_

### Walkthrough
* Add a new parameter for the Illinois personal exemption amount for 2022 and update the name and label of the parameter ([link](https://github.com/PolicyEngine/policyengine-us/pull/3464/files?diff=unified&w=0#diff-d6e014646564406e421b6a569381a0e6e724ad73a280b485994902c839f30b06L1-R13), [link](https://github.com/PolicyEngine/policyengine-us/pull/3464/files?diff=unified&w=0#diff-5885042762833a4aef51405a4036067e4e6aefa7a5091a2987d1d9d1fc2647e8L4-R4))
* Implement a variable to calculate the Illinois personal exemption amount based on the eligibility status and the state code of the tax unit ([link](https://github.com/PolicyEngine/policyengine-us/pull/3464/files?diff=unified&w=0#diff-6efbccd86d5dbdb60f1a534cded96982fe91d6f18fdf7810632925b8940e07b5L4-R7))
* Add a test file to verify the correct calculation of the variable for different scenarios in 2021 and 2022 ([link](https://github.com/PolicyEngine/policyengine-us/pull/3464/files?diff=unified&w=0#diff-56aee222d1818c58dc2d08631130f165247e180f12a06303c91e52bcbe5d7eaeR1-R23))


