### PR TITLE
Added HDF5 to the conda environment file

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Resolved HDF5 installation error in Python 3.9 Conda environment (Issue #1988).
+    - Add hdf5 to conda environment to avoid installation errors.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Resolved HDF5 installation error in Python 3.9 Conda environment (Issue #1988).

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: policyengine-us
 dependencies:
   - python=3.9
+  - hdf5  # Added HDF5
   - pip:
     - policyengine-us

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: policyengine-us
 dependencies:
   - python=3.9
-  - hdf5  # Added HDF5
+  - hdf5
   - pip:
     - policyengine-us


### PR DESCRIPTION
Resolved installation error in Python 3.9 Conda environment by adding 'hdf5' package (Fixes #1988).

