### PR TITLE
Removed the redundant reassignments of adds and subtracts

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Removed extraneous add/subtract pairs in income_tax calculation logic
+    - Removed extraneous add/subtract pairs in income_tax calculation logic.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Removed extraneous add/subtract pairs in income_tax calculation logic

--- a/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
@@ -8,22 +8,18 @@ class income_tax(Variable):
     unit = USD
     label = "Federal income tax"
     documentation = "Total federal individual income tax liability."
-    adds = [
-        "income_tax_before_credits",
-        "income_tax_before_refundable_credits"
-    ]
-    subtracts = [
-        "income_tax_refundable_credits",
-        "income_tax_capped_non_refundable_credits",
-        "income_tax_refundable_credits"
-    ]
 
     def formula(person, period, parameters):
-        if parameters(
-            period
-        ).gov.contrib.ubi_center.flat_tax.abolish_federal_income_tax:
+        if parameters(period).gov.contrib.ubi_center.flat_tax.abolish_federal_income_tax:
             return 0
         else:
-            added_components = add(person, period, income_tax.adds)
-            subtracted_components = add(person, period, income_tax.subtracts)
+            added_components = add(person, period, [
+                "income_tax_before_credits",
+                "income_tax_before_refundable_credits"
+            ])
+            subtracted_components = add(person, period, [
+                "income_tax_refundable_credits",
+                "income_tax_capped_non_refundable_credits",
+                "income_tax_refundable_credits"
+            ])
             return added_components - subtracted_components

--- a/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
@@ -10,7 +10,9 @@ class income_tax(Variable):
     documentation = "Total federal individual income tax liability."
 
     def formula(person, period, parameters):
-        if parameters(period).gov.contrib.ubi_center.flat_tax.abolish_federal_income_tax:
+        if parameters(
+            period
+        ).gov.contrib.ubi_center.flat_tax.abolish_federal_income_tax:
             return 0
         else:
             added_components = add(person, period, [

--- a/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
@@ -10,14 +10,13 @@ class income_tax(Variable):
     documentation = "Total federal individual income tax liability."
     adds = [
         "income_tax_before_credits",
+        "income_tax_before_refundable_credits"
     ]
     subtracts = [
         "income_tax_refundable_credits",
         "income_tax_capped_non_refundable_credits",
+        "income_tax_refundable_credits"
     ]
-
-    adds = ["income_tax_before_refundable_credits"]
-    subtracts = ["income_tax_refundable_credits"]
 
     def formula(person, period, parameters):
         if parameters(

--- a/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
@@ -16,17 +16,9 @@ class income_tax(Variable):
             return 0
         else:
             added_components = add(
-                person,
-                period,
-                ["income_tax_before_credits", "income_tax_before_refundable_credits"],
+                person, period, ["income_tax_before_refundable_credits"]
             )
             subtracted_components = add(
-                person,
-                period,
-                [
-                    "income_tax_refundable_credits",
-                    "income_tax_capped_non_refundable_credits",
-                    "income_tax_refundable_credits",
-                ],
+                person, period, ["income_tax_refundable_credits"]
             )
             return added_components - subtracted_components

--- a/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/income_tax.py
@@ -15,13 +15,18 @@ class income_tax(Variable):
         ).gov.contrib.ubi_center.flat_tax.abolish_federal_income_tax:
             return 0
         else:
-            added_components = add(person, period, [
-                "income_tax_before_credits",
-                "income_tax_before_refundable_credits"
-            ])
-            subtracted_components = add(person, period, [
-                "income_tax_refundable_credits",
-                "income_tax_capped_non_refundable_credits",
-                "income_tax_refundable_credits"
-            ])
+            added_components = add(
+                person,
+                period,
+                ["income_tax_before_credits", "income_tax_before_refundable_credits"],
+            )
+            subtracted_components = add(
+                person,
+                period,
+                [
+                    "income_tax_refundable_credits",
+                    "income_tax_capped_non_refundable_credits",
+                    "income_tax_refundable_credits",
+                ],
+            )
             return added_components - subtracted_components


### PR DESCRIPTION
Reduced the redundancy in the `income_tax.py` file by removing duplicate `adds` and `subtracts` assignments. (Fixes #3533 )