### PR TITLE
Add and inflation-index remaining SPM components

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+      - Added remaining components to SPM net income.
+      - Inflation-index SPM-related variables.

--- a/policyengine_us/data/datasets/cps/cps.py
+++ b/policyengine_us/data/datasets/cps/cps.py
@@ -416,17 +416,17 @@ def add_previous_year_income(self, cps: h5py.File) -> None:
     )
     df["in_sample"] = cps_cur_record_in_sample
     df["employment_income_prev"] = np.ones(len(df)) * np.nan
-    df["employment_income_prev"][
-        cps_cur_record_in_sample
-    ] = cps_previous_year.loc[
-        cps_current_year.index[cps_cur_record_in_sample]
-    ].WSAL_VAL.values
+    df["employment_income_prev"][cps_cur_record_in_sample] = (
+        cps_previous_year.loc[
+            cps_current_year.index[cps_cur_record_in_sample]
+        ].WSAL_VAL.values
+    )
     df["self_employment_income_prev"] = np.ones(len(df)) * np.nan
-    df["self_employment_income_prev"][
-        cps_cur_record_in_sample
-    ] = cps_previous_year.loc[
-        cps_current_year.index[cps_cur_record_in_sample]
-    ].SEMP_VAL.values
+    df["self_employment_income_prev"][cps_cur_record_in_sample] = (
+        cps_previous_year.loc[
+            cps_current_year.index[cps_cur_record_in_sample]
+        ].SEMP_VAL.values
+    )
 
     X = cps_current_year[PREDICTORS][~cps_cur_record_in_sample]
     X = X.rename(columns={x: x + "_cur" for x in PREDICTORS})

--- a/policyengine_us/data/datasets/cps/cps.py
+++ b/policyengine_us/data/datasets/cps/cps.py
@@ -308,7 +308,7 @@ def add_spm_variables(cps: h5py.File, spm_unit: DataFrame) -> None:
         spm_unit_payroll_tax_reported="SPM_FICA",
         spm_unit_federal_tax_reported="SPM_FEDTAX",
         spm_unit_state_tax_reported="SPM_STTAX",
-        spm_unit_work_childcare_expenses="SPM_CAPWKCCXPNS",
+        spm_unit_capped_work_childcare_expenses="SPM_CAPWKCCXPNS",
         spm_unit_medical_expenses="SPM_MEDXPNS",
         spm_unit_spm_threshold="SPM_POVTHRESHOLD",
         spm_unit_net_income_reported="SPM_RESOURCES",
@@ -416,17 +416,17 @@ def add_previous_year_income(self, cps: h5py.File) -> None:
     )
     df["in_sample"] = cps_cur_record_in_sample
     df["employment_income_prev"] = np.ones(len(df)) * np.nan
-    df["employment_income_prev"][cps_cur_record_in_sample] = (
-        cps_previous_year.loc[
-            cps_current_year.index[cps_cur_record_in_sample]
-        ].WSAL_VAL.values
-    )
+    df["employment_income_prev"][
+        cps_cur_record_in_sample
+    ] = cps_previous_year.loc[
+        cps_current_year.index[cps_cur_record_in_sample]
+    ].WSAL_VAL.values
     df["self_employment_income_prev"] = np.ones(len(df)) * np.nan
-    df["self_employment_income_prev"][cps_cur_record_in_sample] = (
-        cps_previous_year.loc[
-            cps_current_year.index[cps_cur_record_in_sample]
-        ].SEMP_VAL.values
-    )
+    df["self_employment_income_prev"][
+        cps_cur_record_in_sample
+    ] = cps_previous_year.loc[
+        cps_current_year.index[cps_cur_record_in_sample]
+    ].SEMP_VAL.values
 
     X = cps_current_year[PREDICTORS][~cps_cur_record_in_sample]
     X = X.rename(columns={x: x + "_cur" for x in PREDICTORS})

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -18,7 +18,7 @@ from policyengine_us.reforms import create_structural_reforms_from_parameters
 
 COUNTRY_DIR = Path(__file__).parent
 
-CURRENT_YEAR = 2023
+CURRENT_YEAR = 2024
 year_start = str(CURRENT_YEAR) + "-01-01"
 
 

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_benefits.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_benefits.yaml
@@ -10,9 +10,11 @@
     free_school_meals: 0
     reduced_price_school_meals: 0
     spm_unit_broadband_subsidy: 0
+    spm_unit_energy_subsidy: 0
     tanf: 0
     high_efficiency_electric_home_rebate: 0
     residential_efficiency_electrification_rebate: 0
+    unemployment_compensation: 0
     basic_income: 0
   output:
     spm_unit_benefits: 1
@@ -30,9 +32,11 @@
     free_school_meals: 0
     reduced_price_school_meals: 0
     spm_unit_broadband_subsidy: 0
+    spm_unit_energy_subsidy: 0
     tanf: 0
     high_efficiency_electric_home_rebate: 0
     residential_efficiency_electrification_rebate: 0
+    unemployment_compensation: 0
     basic_income: 0
   output:
     spm_unit_benefits: 0

--- a/policyengine_us/variables/household/expense/child_support/child_support_expense.py
+++ b/policyengine_us/variables/household/expense/child_support/child_support_expense.py
@@ -8,3 +8,4 @@ class child_support_expense(Variable):
     unit = USD
     documentation = "Legally mandated child support expenses."
     definition_period = YEAR
+    uprating = "gov.bls.cpi.c_cpi_u"

--- a/policyengine_us/variables/household/expense/child_support/child_support_received.py
+++ b/policyengine_us/variables/household/expense/child_support/child_support_received.py
@@ -8,3 +8,4 @@ class child_support_received(Variable):
     unit = USD
     documentation = "Value of child support benefits received."
     definition_period = YEAR
+    uprating = "gov.bls.cpi.c_cpi_u"

--- a/policyengine_us/variables/household/expense/childcare/spm_unit_capped_work_childcare_expenses.py
+++ b/policyengine_us/variables/household/expense/childcare/spm_unit_capped_work_childcare_expenses.py
@@ -7,3 +7,4 @@ class spm_unit_capped_work_childcare_expenses(Variable):
     label = "SPM unit work and childcare expenses"
     definition_period = YEAR
     unit = USD
+    uprating = "gov.bls.cpi.c_cpi_u"

--- a/policyengine_us/variables/household/expense/health/medical_out_of_pocket_expenses.py
+++ b/policyengine_us/variables/household/expense/health/medical_out_of_pocket_expenses.py
@@ -7,3 +7,4 @@ class medical_out_of_pocket_expenses(Variable):
     label = "Medical out of pocket expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "gov.bls.cpi.c_cpi_u"

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -24,7 +24,6 @@ class spm_unit_benefits(Variable):
             "free_school_meals",
             "reduced_price_school_meals",
             "spm_unit_broadband_subsidy",
-            "spm_unit_capped_housing_subsidy",
             "spm_unit_energy_subsidy",
             "tanf",
             "high_efficiency_electric_home_rebate",

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -24,6 +24,8 @@ class spm_unit_benefits(Variable):
             "free_school_meals",
             "reduced_price_school_meals",
             "spm_unit_broadband_subsidy",
+            "spm_unit_capped_housing_subsidy",
+            "spm_unit_energy_subsidy",
             "tanf",
             "high_efficiency_electric_home_rebate",
             "residential_efficiency_electrification_rebate",

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_broadband_subsidy_reported.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_broadband_subsidy_reported.py
@@ -7,3 +7,4 @@ class spm_unit_broadband_subsidy_reported(Variable):
     label = "SPM unit reported broadband subsidy"
     definition_period = YEAR
     unit = USD
+    uprating = "gov.bls.cpi.c_cpi_u"

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_capped_housing_subsidy_reported.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_capped_housing_subsidy_reported.py
@@ -7,3 +7,4 @@ class spm_unit_capped_housing_subsidy_reported(Variable):
     label = "SPM unit capped housing subsidy"
     definition_period = YEAR
     unit = USD
+    uprating = "gov.bls.cpi.c_cpi_u"

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_energy_subsidy_reported.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_energy_subsidy_reported.py
@@ -7,3 +7,4 @@ class spm_unit_energy_subsidy_reported(Variable):
     label = "SPM unit school energy subsidy (reported)"
     definition_period = YEAR
     unit = USD
+    uprating = "gov.bls.cpi.c_cpi_u"

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_net_income.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_net_income.py
@@ -9,4 +9,4 @@ class spm_unit_net_income(Variable):
     unit = USD
 
     adds = ["spm_unit_market_income", "spm_unit_benefits"]
-    subtracts = ["spm_unit_taxes"]
+    subtracts = ["spm_unit_taxes", "spm_unit_spm_expenses"]

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class spm_unit_spm_expenses(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "SPM unit's SPM expenses (other than taxes)"
+    definition_period = YEAR
+    unit = USD
+
+    adds = [
+        "child_support_expense",
+        "medical_out_of_pocket_expense",
+        "spm_unit_capped_work_childcare_expenses",
+    ]

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_threshold.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_threshold.py
@@ -7,3 +7,4 @@ class spm_unit_spm_threshold(Variable):
     label = "SPM unit's SPM poverty threshold"
     definition_period = YEAR
     unit = USD
+    uprating = "gov.bls.cpi.c_cpi_u"


### PR DESCRIPTION
Fixes #3686
Fixes #3658
Fixes #3691

Updating the table in #3686:

Item Name | Type | PolicyEngine variable | Description | How it enters `spm_unit_net_income`
-- | -- | -- | -- | --
`SPM_TOTVAL` | Addition | `spm_unit_market_income` | Total cash income | `spm_unit_market_income` + some elements of `spm_unit_benefits` like `unemployment_compensation`
`SPM_SNAPSUB` | Addition | `snap` | SNAP | `spm_unit_benefits`
`SPM_SCHLUNCH` | Addition | `free_school_meals + reduced_price_school_meals` | School lunch subsidy | `spm_unit_benefits`
`SPM_WICVAL` | Addition | `wic` | WIC | `spm_unit_benefits`
`SPM_CAPHOUSESUB` | Addition | `spm_unit_capped_housing_subsidy` | Capped housing subsidy | `spm_unit_benefits`
`SPM_ENGVAL` | Addition | `spm_unit_energy_subsidy` | Energy subsidy | `spm_unit_benefits`
`SPM_BBSUBVAL` | Addition | `spm_unit_broadband_subsidy` | Broadband/Internet Subsidy | `spm_unit_benefits`
`SPM_FEDTAX` | Subtraction | `income_tax` | Federal tax after credits | `spm_unit_taxes`
`SPM_STTAX` | Subtraction | `state_income_tax` | State tax after credits | `spm_unit_taxes`
`SPM_FICA` | Subtraction | `payroll_tax` | FICA contributions | `spm_unit_taxes`
`SPM_CHILDSUPPD` | Subtraction | `child_support_expense` | Child support paid | `spm_unit_spm_expenses`
`SPM_MEDXPNS` | Subtraction | `medical_out_of_pocket_expenses` | Medical Out-of-Pocket (MOOP) and Medicare Part B subsidy | `spm_unit_spm_expenses`
`SPM_CAPWKCCXPNS` | Subtraction | N/A | Capped work and child care expenses | `spm_unit_spm_expenses`
