### PR TITLE
CA TANF income disregards are currently monthly but should be aggregated to yearly

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - CA TANF monthly applicant income disregards.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/tanf/cash/income/ca_tanf_countable_income_applicant.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/tanf/cash/income/ca_tanf_countable_income_applicant.yaml
@@ -2,18 +2,28 @@
   period: 2023
   input:
     state_code: CA
-    ca_tanf_earned_income: 451
+    ca_tanf_earned_income: 5_412 # 451 monthly
     ca_tanf_db_unearned_income: 1_000
     ca_tanf_other_unearned_income: 2_000
   output:
-    ca_tanf_countable_income_applicant: 3_001
+    ca_tanf_countable_income_applicant: 3_012
 
 - name: Test that the flat $450 disregard is only subtracted (with floor $0) from earned income as opposed to from the total sum.
   period: 2023
   input:
     state_code: CA
-    ca_tanf_earned_income: 449
+    ca_tanf_earned_income: 5_388 # 449 monthly
     ca_tanf_db_unearned_income: 1_000
     ca_tanf_other_unearned_income: 2_000
   output:
     ca_tanf_countable_income_applicant: 3_000
+
+- name: Test that the flat $450 disregard is only subtracted (with floor $0) from earned income.
+  period: 2023
+  input:
+    state_code: CA
+    ca_tanf_earned_income: 5_388 # 449 monthly
+    ca_tanf_db_unearned_income: 0
+    ca_tanf_other_unearned_income: 0
+  output:
+    ca_tanf_countable_income_applicant: 0

--- a/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/income/ca_tanf_countable_income_applicant.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/income/ca_tanf_countable_income_applicant.py
@@ -14,8 +14,9 @@ class ca_tanf_countable_income_applicant(Variable):
         p = parameters(
             period
         ).gov.states.ca.cdss.tanf.cash.income.disregards.applicant
+        yearly_exclusion = p.flat * MONTHS_IN_YEAR
         countable_earned = max_(
-            spm_unit("ca_tanf_earned_income", period) - p.flat, 0
+            spm_unit("ca_tanf_earned_income", period) - yearly_exclusion, 0
         )
         db_unearned = spm_unit("ca_tanf_db_unearned_income", period)
         other_unearned = spm_unit("ca_tanf_other_unearned_income", period)

--- a/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/income/ca_tanf_countable_income_applicant.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/income/ca_tanf_countable_income_applicant.py
@@ -14,9 +14,9 @@ class ca_tanf_countable_income_applicant(Variable):
         p = parameters(
             period
         ).gov.states.ca.cdss.tanf.cash.income.disregards.applicant
-        yearly_exclusion = p.flat * MONTHS_IN_YEAR
+        yearly_disregard = p.flat * MONTHS_IN_YEAR
         countable_earned = max_(
-            spm_unit("ca_tanf_earned_income", period) - yearly_exclusion, 0
+            spm_unit("ca_tanf_earned_income", period) - yearly_disregard, 0
         )
         db_unearned = spm_unit("ca_tanf_db_unearned_income", period)
         other_unearned = spm_unit("ca_tanf_other_unearned_income", period)


### PR DESCRIPTION
Fixes #3700