### PR TITLE
Use Hawaii AGI in the Hawaii renter credit calculation as opposed to federal AGI

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Hawaii renter credit calculation.

--- a/policyengine_us/parameters/gov/states/hi/tax/income/credits/lihrtc/eligibility/agi_limit.yaml
+++ b/policyengine_us/parameters/gov/states/hi/tax/income/credits/lihrtc/eligibility/agi_limit.yaml
@@ -16,4 +16,3 @@ metadata:
       href: https://files.hawaii.gov/tax/forms/2022/schx_i.pdf#page=1
     - title: Schedule X (FORM N-11/N-15) Tax credits for Hawaii residents Rev.2021
       href: https://files.hawaii.gov/tax/forms/2021/schx_i.pdf#page=1
-

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_low_income_household_renters/hi_tax_credit_for_low_income_household_renters_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_low_income_household_renters/hi_tax_credit_for_low_income_household_renters_eligible.yaml
@@ -3,7 +3,7 @@
   input:
     state_code: HI
     head_is_dependent_elsewhere: false
-    adjusted_gross_income: 29_000
+    hi_agi: 29_000
     rent: 1_100
   output:
     hi_tax_credit_for_low_income_household_renters_eligible: true
@@ -13,7 +13,7 @@
   input:
     state_code: HI
     head_is_dependent_elsewhere: false
-    adjusted_gross_income: 31_000
+    hi_agi: 31_000
     rent: 1_100
   output:
     hi_tax_credit_for_low_income_household_renters_eligible: false
@@ -23,7 +23,7 @@
   input:
     state_code: HI
     head_is_dependent_elsewhere: false
-    adjusted_gross_income: 29_000
+    hi_agi: 29_000
     rent: 900
   output:
     hi_tax_credit_for_low_income_household_renters_eligible: false
@@ -33,7 +33,7 @@
   input:
     state_code: HI
     head_is_dependent_elsewhere: false
-    adjusted_gross_income: 32_000
+    hi_agi: 32_000
     rent: 900
   output:
     hi_tax_credit_for_low_income_household_renters_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_low_income_household_renters/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_low_income_household_renters/integration.yaml
@@ -1,0 +1,61 @@
+- name: Tax unit with taxsimid 79840 in g21.its.csv and g21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 73
+        employment_income: 1010
+        taxable_interest_income: 5505
+        taxable_private_pension_income: 4000
+        social_security_retirement: 2000
+        rent: 9000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person2:
+        age: 73
+        employment_income: 10010
+        taxable_interest_income: 5505
+        taxable_private_pension_income: 4000
+        social_security_retirement: 2000
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person3:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person4:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person5:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+      person6:
+        age: 16
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+        state_sales_tax: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5, person6]
+        state_fips: 15  # HI
+  output:  # expected results from patched TAXSIM35 2024-01-29 version
+    hi_income_tax: -485.10

--- a/policyengine_us/variables/gov/states/hi/tax/income/credits/hi_low_income_household_renters/hi_tax_credit_for_low_income_household_renters_eligible.py
+++ b/policyengine_us/variables/gov/states/hi/tax/income/credits/hi_low_income_household_renters/hi_tax_credit_for_low_income_household_renters_eligible.py
@@ -12,7 +12,7 @@ class hi_tax_credit_for_low_income_household_renters_eligible(Variable):
     def formula(tax_unit, period, parameters):
         dependent_elsewhere = tax_unit("head_is_dependent_elsewhere", period)
         p = parameters(period).gov.states.hi.tax.income.credits.lihrtc
-        agi = tax_unit("adjusted_gross_income", period)
+        agi = tax_unit("hi_agi", period)
         rent = add(tax_unit, period, ["rent"])
         return (
             (rent > p.eligibility.rent_threshold)


### PR DESCRIPTION
Fixes #3733