### PR TITLE
Remove `capital_gains_excluded_from_taxable_income` from the rhode island property tax credit income sources

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Remove capital_gains_excluded_from_taxable_income from the rhode island property tax credit income sources.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Remove capital_gains_excluded_from_taxable_income from the rhode island property tax credit income sources.
+    - Remove capital_gains_excluded_from_taxable_income from the Rhode Island property tax credit income sources.

--- a/policyengine_us/parameters/gov/states/ri/tax/income/credits/property_tax/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/credits/property_tax/income_sources.yaml
@@ -6,7 +6,6 @@ values:
     - tax_exempt_interest_income
     - tax_exempt_social_security
     - tax_exempt_unemployment_compensation
-    - capital_gains_excluded_from_taxable_income
     - alimony_income
     - tanf
     - child_support_received

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/property_tax/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/property_tax/integration.yaml
@@ -75,3 +75,20 @@
     ri_property_tax_credit_eligible: true
     ri_property_tax_credit: 415
     ri_income_tax: -415.00
+
+- name: Property tax income test
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      you:
+        long_term_capital_gains: 1_000
+        qualified_dividend_income: 2_000
+    households:
+      household:
+        members: [you]
+        state_code: RI
+  output:
+    capital_gains_excluded_from_taxable_income: 3_000
+    adjusted_gross_income: 3_000
+    ri_property_tax_household_income: 3_000


### PR DESCRIPTION
Fixes #3775