### PR TITLE
Enable South Carolina state income tax model and add it to the net income tree

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Enable South Carolina state income tax model and add it to the net income tree.

--- a/policyengine_us/modelled_policies.yaml
+++ b/policyengine_us/modelled_policies.yaml
@@ -133,6 +133,11 @@ filtered:
       - Rhode Island state income tax
       not_modelled:
       - Rhode Island TANF
+    SC:
+      modelled:
+      - South Carolina state income tax
+      not_modelled:
+      - South Carolina TANF
     UT:
       modelled:
       - Utah state income tax

--- a/policyengine_us/parameters/gov/states/sc/index.yaml
+++ b/policyengine_us/parameters/gov/states/sc/index.yaml
@@ -1,4 +1,0 @@
-metadata:
-  propagate_metadata_to_children: true
-  economy: false
-  household: false

--- a/policyengine_us/variables/gov/states/tax/income/state_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/tax/income/state_income_tax_before_refundable_credits.py
@@ -33,6 +33,7 @@ class state_income_tax_before_refundable_credits(Variable):
         "or_income_tax_before_refundable_credits",
         "pa_income_tax",  # PA has no refundable credits.
         "ri_income_tax_before_refundable_credits",
+        "sc_income_tax_before_refundable_credits",
         "vt_income_tax_before_refundable_credits",
         "wa_income_tax_before_refundable_credits",
         "wi_income_tax_before_refundable_credits",

--- a/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
+++ b/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
@@ -36,6 +36,7 @@ class household_refundable_tax_credits(Variable):
         "or_refundable_credits",  # Oregon.
         # Skip PA, which has no refundable credits.
         "ri_refundable_credits",  # Rhode Island.
+        "sc_refundable_credits",  # South Carolina.
         "wa_refundable_credits",  # Washington.
         "ut_refundable_credits",  # Utah.
         "vt_refundable_credits",  # Vermont.

--- a/policyengine_us/variables/household/income/household/household_state_income_tax.py
+++ b/policyengine_us/variables/household/income/household/household_state_income_tax.py
@@ -35,6 +35,7 @@ class household_state_income_tax(Variable):
         "or_income_tax_before_refundable_credits",
         "pa_income_tax",
         "ri_income_tax_before_refundable_credits",
+        "sc_income_tax_before_refundable_credits",
         "wa_income_tax_before_refundable_credits",
         "nyc_income_tax_before_refundable_credits",
         "ut_income_tax_before_refundable_credits",
@@ -66,6 +67,7 @@ class household_state_income_tax(Variable):
         "or_refundable_credits",  # Oregon.
         # Skip PA, which has no refundable credits.
         "ri_refundable_credits",  # Rhode Island.
+        "sc_refundable_credits",  # South Carolina.
         "wa_refundable_credits",  # Washington.
         "nyc_refundable_credits",  # New York City.
         "ut_refundable_credits",  # Utah.

--- a/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
@@ -39,6 +39,7 @@ class household_tax_before_refundable_credits(Variable):
         "ok_income_tax_before_refundable_credits",
         "pa_income_tax",  # PA has no refundable credits.
         "ri_income_tax_before_refundable_credits",
+        "sc_income_tax_before_refundable_credits",
         "wa_income_tax_before_refundable_credits",
         "flat_tax",
         "nyc_income_tax_before_refundable_credits",


### PR DESCRIPTION
Fixes #3783