### PR TITLE
Remove erroneous variable overwrite in household tax classes

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,6 +1,6 @@
 - bump: patch
   changes:
     changed:
-    - Refactored household_refundable_tax_credits and
+    - Refactored household_refundable_tax_credits and household_tax_before_refundable_credits to remove erroneous variable overwrite.
        household_tax_before_refundable_credits to remove
        erroneous variable overwrite

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    changed:
+    - Refactored household_refundable_tax_credits and
+    household_tax_before_refundable_credits to remove
+    erroneous variable overwrite

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,5 +2,5 @@
   changes:
     changed:
     - Refactored household_refundable_tax_credits and
-    household_tax_before_refundable_credits to remove
-    erroneous variable overwrite
+       household_tax_before_refundable_credits to remove
+       erroneous variable overwrite

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,6 +1,6 @@
 - bump: patch
   changes:
-    changed:
+    fixed:
     - Refactored household_refundable_tax_credits and household_tax_before_refundable_credits to remove erroneous variable overwrite.
        household_tax_before_refundable_credits to remove
        erroneous variable overwrite

--- a/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
+++ b/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
@@ -10,9 +10,7 @@ class household_refundable_tax_credits(Variable):
 
     def formula(household, period, parameters):
         params = parameters(period)
-        added_components = add(
-            household, period, params.gov.household_refundable_credits
-        )
+        added_components = params.gov.household_refundable_credits
         p = params.gov.contrib.ubi_center.flat_tax
         if p.abolish_federal_income_tax:
             added_components = [
@@ -24,4 +22,4 @@ class household_refundable_tax_credits(Variable):
             added_components = [
                 "income_tax_refundable_credits",  # Federal.
             ]
-        return added_components
+        return add(household, period, added_components)

--- a/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
+++ b/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
@@ -9,7 +9,7 @@ class household_refundable_tax_credits(Variable):
     unit = USD
 
     def formula(household, period, parameters):
-        params = parameters(period)
+        p = parameters(period)
         added_components = params.gov.household_refundable_credits
         p = params.gov.contrib.ubi_center.flat_tax
         if p.abolish_federal_income_tax:

--- a/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
+++ b/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
@@ -10,14 +10,14 @@ class household_refundable_tax_credits(Variable):
 
     def formula(household, period, parameters):
         p = parameters(period)
-        added_components = params.gov.household_refundable_credits
+        added_components = p.gov.household_refundable_credits
         if p.gov.contrib.ubi_center.flat_tax.abolish_federal_income_tax:
             added_components = [
                 c
                 for c in added_components
                 if c != "income_tax_refundable_credits"
             ]
-        if params.simulation.reported_state_income_tax:
+        if p.simulation.reported_state_income_tax:
             added_components = [
                 "income_tax_refundable_credits",  # Federal.
             ]

--- a/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
+++ b/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
@@ -11,7 +11,6 @@ class household_refundable_tax_credits(Variable):
     def formula(household, period, parameters):
         p = parameters(period)
         added_components = params.gov.household_refundable_credits
-        p = params.gov.contrib.ubi_center.flat_tax
         if p.abolish_federal_income_tax:
             added_components = [
                 c

--- a/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
+++ b/policyengine_us/variables/household/income/household/household_refundable_tax_credits.py
@@ -11,7 +11,7 @@ class household_refundable_tax_credits(Variable):
     def formula(household, period, parameters):
         p = parameters(period)
         added_components = params.gov.household_refundable_credits
-        if p.abolish_federal_income_tax:
+        if p.gov.contrib.ubi_center.flat_tax.abolish_federal_income_tax:
             added_components = [
                 c
                 for c in added_components

--- a/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
@@ -10,7 +10,7 @@ class household_tax_before_refundable_credits(Variable):
     definition_period = YEAR
 
     def formula(household, period, parameters):
-        params = parameters(period)
+        p = parameters(period)
         added_components = params.gov.household_tax_before_refundable_credits
         flat_tax = params.gov.contrib.ubi_center.flat_tax
         if params.simulation.reported_state_income_tax:

--- a/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
@@ -11,9 +11,9 @@ class household_tax_before_refundable_credits(Variable):
 
     def formula(household, period, parameters):
         p = parameters(period)
-        added_components = params.gov.household_tax_before_refundable_credits
-        flat_tax = params.gov.contrib.ubi_center.flat_tax
-        if params.simulation.reported_state_income_tax:
+        added_components = p.gov.household_tax_before_refundable_credits
+        flat_tax = p.gov.contrib.ubi_center.flat_tax
+        if p.simulation.reported_state_income_tax:
             added_components = [
                 "employee_payroll_tax",
                 "self_employment_tax",

--- a/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/household/income/household/household_tax_before_refundable_credits.py
@@ -10,14 +10,10 @@ class household_tax_before_refundable_credits(Variable):
     definition_period = YEAR
 
     def formula(household, period, parameters):
-        p = parameters(period)
-        added_components = add(
-            household,
-            period,
-            p.gov.household_tax_before_refundable_credits,
-        )
-        flat_tax = p.gov.contrib.ubi_center.flat_tax
-        if p.simulation.reported_state_income_tax:
+        params = parameters(period)
+        added_components = params.gov.household_tax_before_refundable_credits
+        flat_tax = params.gov.contrib.ubi_center.flat_tax
+        if params.simulation.reported_state_income_tax:
             added_components = [
                 "employee_payroll_tax",
                 "self_employment_tax",
@@ -35,4 +31,4 @@ class household_tax_before_refundable_credits(Variable):
                 for c in added_components
                 if c != "income_tax_before_refundable_credits"
             ]
-        return added_components
+        return add(household, period, added_components)


### PR DESCRIPTION
Fixes #3814. This repairs an error in both `household_tax_before_refundable_credits.py` and `household_refundable_tax_credits.py` that calls the `add` function early on in the class, then at times overwrites its output with an array of parameters, by instead enqueuing the call at the end of the class, within the return statement, akin to what the classes did prior to `policyengine-us` v.0.648.0.