### PR TITLE
Adjust the Arkansas files separately formula to rely on ar_income_tax_before_non_refundable_credits comparison

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixes:
+    - Adjust the Arkansas files separately formula to rely on ar_income_tax_before_non_refundable_credits comparisons.

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/ar_files_separately.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/ar_files_separately.yaml
@@ -3,11 +3,11 @@
   input:
     people:
       person1:
-        ar_taxable_income_indiv: 1_000
-        ar_taxable_income_joint: 100
+        ar_income_tax_before_non_refundable_credits_indiv: 1_000
+        ar_income_tax_before_non_refundable_credits_joint: 100
       person2:
-        ar_taxable_income_indiv: 100
-        ar_taxable_income_joint: 500
+        ar_income_tax_before_non_refundable_credits_indiv: 100
+        ar_income_tax_before_non_refundable_credits_joint: 500
     households:
       household:
         members: [person1, person2]
@@ -20,11 +20,11 @@
   input:
     people:
       person1:
-        ar_taxable_income_indiv: 0
-        ar_taxable_income_joint: 100
+        ar_income_tax_before_non_refundable_credits_indiv: 0
+        ar_income_tax_before_non_refundable_credits_joint: 100
       person2:
-        ar_taxable_income_indiv: 100
-        ar_taxable_income_joint: 500
+        ar_income_tax_before_non_refundable_credits_indiv: 100
+        ar_income_tax_before_non_refundable_credits_joint: 500
     households:
       household:
         members: [person1, person2]

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/integration.yaml
@@ -111,3 +111,51 @@
     ar_taxable_income_indiv: [168_820, 0]
     ar_income_tax_before_non_refundable_credits_indiv: [9_710.38, 0]
     ar_income_tax: 9_625.88
+
+- name: Tax unit with taxsimid 98028 in e21.its.csv and e21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 77010
+        taxable_interest_income: 5505.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person2:
+        age: 40
+        employment_income: 20010
+        taxable_interest_income: 5505.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+        state_sales_tax: 0  # not in TAXSIM35
+        ca_use_tax: 0  # not in TAXSIM35
+        il_use_tax: 0  # not in TAXSIM35
+        nm_2021_income_rebate: 0  # not in TAXSIM35
+        nm_additional_2021_income_rebate: 0  # not in TAXSIM35
+        nm_supplemental_2021_income_rebate: 0  # not in TAXSIM35
+        ny_supplemental_eitc: 0  # not in TAXSIM35
+        ok_use_tax: 0  # not in TAXSIM35
+        pa_use_tax: 0  # not in TAXSIM35
+        vt_renter_credit: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 5  # AR
+  output:  # expected results from patched TAXSIM35 2024-02-09 version
+    ar_income_tax: 4427.88

--- a/policyengine_us/variables/gov/states/ar/tax/income/ar_files_separately.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/ar_files_separately.py
@@ -11,6 +11,14 @@ class ar_files_separately(Variable):
     defined_for = StateCode.AR
 
     def formula(tax_unit, period, parameters):
-        itax_indiv = add(tax_unit, period, ["ar_taxable_income_indiv"])
-        itax_joint = add(tax_unit, period, ["ar_taxable_income_joint"])
+        itax_indiv = add(
+            tax_unit,
+            period,
+            ["ar_income_tax_before_non_refundable_credits_indiv"],
+        )
+        itax_joint = add(
+            tax_unit,
+            period,
+            ["ar_income_tax_before_non_refundable_credits_joint"],
+        )
         return itax_indiv < itax_joint


### PR DESCRIPTION
Fixes #3843