### PR TITLE
Disabled the cdcc cap increase in 2021 for the `id_household_and_dependent_care_expense_deduction`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Disabled the cdcc cap increase in 2021 for the id_household_and_dependent_care_expense_deduction.

--- a/policyengine_us/parameters/gov/irs/credits/cdcc/max.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/cdcc/max.yaml
@@ -1,7 +1,6 @@
 description: Maximum child and dependent care expenses per dependent.
 metadata:
   unit: currency-USD
-  name: cdcc_max_expense
   label: Maximum care expenses per dependent for CDCC.
   period: year
   reference:

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/household_and_dependent_care/id_cdcc_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/household_and_dependent_care/id_cdcc_limit.yaml
@@ -1,0 +1,15 @@
+- name: Federal cdcc limit is applied in 2022
+  period: 2022
+  input:
+    capped_count_cdcc_eligible: 1
+    state_code: ID
+  output:
+    id_cdcc_limit: 3_000
+
+- name: Federal cdcc limit is not applied in 2021
+  period: 2021
+  input:
+    capped_count_cdcc_eligible: 1
+    state_code: ID
+  output:
+    id_cdcc_limit: 3_000

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/household_and_dependent_care/id_household_and_dependent_care_expense_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/household_and_dependent_care/id_household_and_dependent_care_expense_deduction.yaml
@@ -2,7 +2,7 @@
   period: 2022
   input:
     tax_unit_childcare_expenses: 13_000
-    cdcc_limit: 6_000
+    id_cdcc_limit: 6_000
     min_head_spouse_earned: 4_000
     state_code: ID
   output:
@@ -12,7 +12,7 @@
   period: 2023
   input:
     tax_unit_childcare_expenses: 13_000
-    cdcc_limit: 6_000
+    id_cdcc_limit: 6_000
     min_head_spouse_earned: 14_000    
     state_code: ID
   output:
@@ -71,3 +71,30 @@
         state_code: ID
   output:
     id_household_and_dependent_care_expense_deduction: 12_000
+
+- name: In 2021 the federal limit is not applied
+  period: 2021
+  input:
+    people:
+      person1: 
+        earned_income: 14_000
+        age: 40
+      person2:
+        earned_income: 18_000
+        age: 40
+      person3:
+        age: 10
+      person4:
+        age: 10
+      person5:
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5]
+        tax_unit_childcare_expenses: 17_000
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5]
+        state_code: ID
+  output:
+    id_household_and_dependent_care_expense_deduction: 6_000

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/integration.yaml
@@ -1,0 +1,26 @@
+- name: Tax unit with taxsimid 99980 in g21.its.csv and g21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 46
+        employment_income: 134_010
+        taxable_interest_income: 5_505
+        rent: 17_000
+      person2:
+        age: 46
+        employment_income: 24_010
+        taxable_interest_income: 5_505
+      person3:
+        age: 11
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        tax_unit_childcare_expenses: 10_000
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_fips: 16  # ID
+  output:  # expected results from patched TAXSIM35 2024-02-15 version
+    id_income_tax: 8_179.59

--- a/policyengine_us/variables/gov/states/id/tax/income/subtractions/household_and_dependent_care/id_cdcc_limit.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/subtractions/household_and_dependent_care/id_cdcc_limit.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class id_cdcc_limit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Federal CDCC-relevant care expense limit for Idaho tax purposes"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.ID
+
+    def formula(tax_unit, period, parameters):
+        if period.start.year == 2021:
+            instant_str = f"2022-01-01"
+        else:
+            instant_str = period
+        p = parameters(instant_str).gov.irs.credits.cdcc
+        capped_count_cdcc_eligible = tax_unit(
+            "capped_count_cdcc_eligible", period
+        )
+        return p.max * capped_count_cdcc_eligible

--- a/policyengine_us/variables/gov/states/id/tax/income/subtractions/household_and_dependent_care/id_cdcc_limit.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/subtractions/household_and_dependent_care/id_cdcc_limit.py
@@ -7,11 +7,12 @@ class id_cdcc_limit(Variable):
     label = "Federal CDCC-relevant care expense limit for Idaho tax purposes"
     unit = USD
     definition_period = YEAR
+    reference = "https://tax.idaho.gov/governance/statutes/irc/"
     defined_for = StateCode.ID
 
     def formula(tax_unit, period, parameters):
         if period.start.year == 2021:
-            instant_str = f"2022-01-01"
+            instant_str = f"2020-01-01"
         else:
             instant_str = period
         p = parameters(instant_str).gov.irs.credits.cdcc

--- a/policyengine_us/variables/gov/states/id/tax/income/subtractions/household_and_dependent_care/id_household_and_dependent_care_expense_deduction.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/subtractions/household_and_dependent_care/id_household_and_dependent_care_expense_deduction.py
@@ -15,7 +15,7 @@ class id_household_and_dependent_care_expense_deduction(Variable):
         ).gov.states.id.tax.income.deductions.dependent_care_expenses
         expenses = tax_unit("tax_unit_childcare_expenses", period)
         # In 2023 Idaho implemented an increased cap independent of the number of children
-        limit = max_(tax_unit("cdcc_limit", period), p.cap)
+        limit = max_(tax_unit("id_cdcc_limit", period), p.cap)
         eligible_capped_expenses = min_(expenses, limit)
         # cap further to the lowest earnings between the taxpayer and spouse
         return min_(


### PR DESCRIPTION
Fixes #3937