### PR TITLE
Add the `wv_homestead_excess_property_tax_credit` to the state income tree

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Add the wv_homestead_excess_property_tax_credit to the state income tree.

--- a/policyengine_us/parameters/gov/states/wv/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/wv/tax/income/credits/non_refundable.yaml
@@ -3,5 +3,6 @@ values:
   2022-01-01:
   - wv_low_income_family_tax_credit
 metadata:
-  unit: program
+  unit: list
+  period: year
   label: West Virginia non-refundable tax credits

--- a/policyengine_us/parameters/gov/states/wv/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/wv/tax/income/credits/refundable.yaml
@@ -2,6 +2,8 @@ description: West Virginia allows these refundable tax credits.
 values:
   2020-01-01:
   - wv_sctc
+  - wv_homestead_excess_property_tax_credit
 metadata:
-  unit: program
+  unit: list
+  period: year
   label: West Virginia refundable tax credits

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/integration.yaml
@@ -1,0 +1,38 @@
+- name: Tax unit with taxsimid 99997 in k21.its.csv and k21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 72
+        employment_income: 8_010
+        qualified_dividend_income: 4_010
+        taxable_interest_income: 11_010
+        short_term_capital_gains: 3_010
+        long_term_capital_gains: 1_010
+        rental_income: 3_010
+        taxable_private_pension_income: 9_000
+        social_security_retirement: 1_000
+        real_estate_taxes: 8_000
+        mortgage_interest: 3_000
+        self_employment_income: 38_010
+        business_is_qualified: true
+        business_is_sstb: true
+        w2_wages_from_qualified_business: 100e6
+      person2:
+        age: 11
+      person3:
+        age: 11
+      person4:
+        age: 16
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        tax_unit_itemizes: False
+        state_income_tax: 2729.08
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_fips: 54  # WV
+  output:  # expected results from patched TAXSIM35 2024-02-18 version
+    wv_income_tax: 1_729.08


### PR DESCRIPTION
Fixes #3942