### PR TITLE
Adjust the NY Empire State Child Credit to take into account the full ctc amount

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Adjust the NY Empire State Child Credit to take into account the full ctc amount.

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
@@ -40,7 +40,7 @@
         members: [parent, child]
         state_code: NY
   output:
-    ny_ctc: 100
+    ny_ctc: 330
 
 - name: Parent of four-year old child with no income gets minimum credit
   period: 2022
@@ -59,7 +59,7 @@
         members: [parent, child]
         state_code: NY
   output:
-    ny_ctc: 100
+    ny_ctc: 330
 
 - name: Simpler calculation if not set to pre-TCJA.
   period: 2022

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/integration.yaml
@@ -1,0 +1,71 @@
+- name: Tax unit with taxsimid 92522 in e21.its.csv and e21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 67
+        employment_income: 23010
+        taxable_interest_income: 5505.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person2:
+        age: 67
+        employment_income: 2010
+        taxable_interest_income: 5505.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person3:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person4:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person5:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person6:
+        age: 16
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+        state_sales_tax: 0  # not in TAXSIM35
+        ca_use_tax: 0  # not in TAXSIM35
+        il_use_tax: 0  # not in TAXSIM35
+        nm_2021_income_rebate: 0  # not in TAXSIM35
+        nm_additional_2021_income_rebate: 0  # not in TAXSIM35
+        nm_supplemental_2021_income_rebate: 0  # not in TAXSIM35
+        ny_supplemental_eitc: 0  # not in TAXSIM35
+        ok_use_tax: 0  # not in TAXSIM35
+        pa_use_tax: 0  # not in TAXSIM35
+        vt_renter_credit: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5, person6]
+        state_fips: 36  # NY
+  output:  # expected results from patched TAXSIM35 2024-02-15 version
+    ny_income_tax: -680.80

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_ctc.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_ctc.py
@@ -52,7 +52,7 @@ class ny_ctc(Variable):
                 period,
                 maximum_ctc * meets_ny_minimum_age,
             )
-            federal_ctc = pre_tcja_ctc.tax_unit("ctc_value", period)
+            federal_ctc = pre_tcja_ctc.tax_unit("ctc", period)
             qualifies_for_federal_ctc = pre_tcja_ctc.person(
                 "ctc_qualifying_child", period
             )


### PR DESCRIPTION
Fixes #3995