### PR TITLE
Remove `qualified_business_income_deduction_person` from the list of Ohio deductions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixes:
+    - Remove qualified_business_income_deduction_person from the list of Ohio dedductions.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixes:
-    - Remove qualified_business_income_deduction_person from the list of Ohio dedductions.
+    - Remove qualified_business_income_deduction_person from the list of Ohio deductions.

--- a/policyengine_us/parameters/gov/states/oh/tax/income/deductions/deductions.yaml
+++ b/policyengine_us/parameters/gov/states/oh/tax/income/deductions/deductions.yaml
@@ -3,7 +3,6 @@ values:
   2021-01-01:
     - oh_section_179_expense_add_back
     - taxable_social_security
-  #   above_the_line_deductions" #only need line 8z
     - oh_uniformed_services_retirement_income_deduction
     - oh_529_plan_deduction_person
     - pell_grant
@@ -17,8 +16,8 @@ metadata:
   label: Ohio adjusted gross income deductions
   reference:
     - title: Ohio 2021 Instructions for Filing Original and Amended
-      href: https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf
+      href: https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=16
     - title: Ohio 2022 Tax Form 
-      href: https://tax.ohio.gov/static/forms/ohio_individual/individual/2022/it1040-sd100-instruction-booklet.pdf#page=14
+      href: https://tax.ohio.gov/static/forms/ohio_individual/individual/2022/it1040-sd100-instruction-booklet.pdf#page=16
     - title: Ohio Revised Code, Title 57 Taxation, Chapter 5747 Income Tax, Section 5747.01
       href: https://law.justia.com/codes/ohio/2022/title-57/chapter-5747/section-5747-01/

--- a/policyengine_us/parameters/gov/states/oh/tax/income/deductions/deductions.yaml
+++ b/policyengine_us/parameters/gov/states/oh/tax/income/deductions/deductions.yaml
@@ -2,9 +2,8 @@ description: Ohio deducts these sources from the federal adjusted gross income.
 values:
   2021-01-01:
     - oh_section_179_expense_add_back
-    - qualified_business_income_deduction_person
     - taxable_social_security
-  # - above_the_line_deductions" #only need line 8z
+  #   above_the_line_deductions" #only need line 8z
     - oh_uniformed_services_retirement_income_deduction
     - oh_529_plan_deduction_person
     - pell_grant

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/integration.yaml
@@ -49,3 +49,42 @@
     oh_senior_citizen_credit: 50
     oh_exemption_credit: 100
     oh_income_tax: 314.32
+
+- name: Tax unit with taxsimid 94803 in j21.its.csv and j21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 48
+        employment_income: 152_010
+        qualified_dividend_income: 4_005
+        taxable_interest_income: 5_505
+        short_term_capital_gains: 3_505
+        long_term_capital_gains: 3_005
+        rental_income: 4_005
+        rent: 17_000
+        self_employment_income: 160_010
+        business_is_qualified: true
+        business_is_sstb: false
+        w2_wages_from_qualified_business: 100e6
+      person2:
+        age: 48
+        employment_income: 53_010
+        qualified_dividend_income: 4_005
+        taxable_interest_income: 5_505
+        short_term_capital_gains: 3_505
+        long_term_capital_gains: 3_005
+        rental_income: 4_005
+      person3:
+        age: 11
+      person4:
+        age: 11
+      person5:
+        age: 11
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5]
+        state_fips: 39  # OH
+  output:  # expected results from patched TAXSIM35 2024-02-21 version
+    oh_income_tax: 13_756.36

--- a/policyengine_us/variables/gov/states/oh/tax/income/oh_modifed_agi.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/oh_modifed_agi.py
@@ -8,9 +8,11 @@ class oh_modified_agi(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://codes.ohio.gov/ohio-revised-code/section-5747.71",
         "https://tax.ohio.gov/static/forms/ohio_individual/individual/2022/it1040-sd100-instruction-booklet.pdf#page=31",
     )
     defined_for = StateCode.OH
 
-    adds = ["oh_agi", "qualified_business_income_deduction"]
+    adds = ["oh_agi"]
+
+
+# Additionally adds the Ohio Business income deduction


### PR DESCRIPTION
Fixes #4068