### PR TITLE
Make the EZ save program household level and use pre-subsidy electricity expenses.

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Make the EZ save program household level and use pre-subsidy electricity expenses.

--- a/policyengine_us/parameters/household/expense/utilities/subsidies.yaml
+++ b/policyengine_us/parameters/household/expense/utilities/subsidies.yaml
@@ -3,6 +3,7 @@ values:
   0000-01-01:
     - ca_care
     - ca_fera
+    - ca_la_ez_save
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/la/dwp/ez_save/ca_la_ez_save.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/la/dwp/ez_save/ca_la_ez_save.yaml
@@ -1,7 +1,7 @@
 - name: Eligible person, large utility expenses
   period: 2022
   input:
-    electricity_expense: 1_000
+    pre_subsidy_electricity_expense: 1_000
     ca_la_ez_save_eligible: true
   output:
     ca_la_ez_save: 98.04
@@ -9,7 +9,7 @@
 - name: Eligible person, program capped at utility expenses
   period: 2022
   input:
-    electricity_expense: 10
+    pre_subsidy_electricity_expense: 10
     ca_la_ez_save_eligible: true
   output:
     ca_la_ez_save: 10

--- a/policyengine_us/variables/gov/local/ca/la/dwp/ez_save/ca_la_ez_save.py
+++ b/policyengine_us/variables/gov/local/ca/la/dwp/ez_save/ca_la_ez_save.py
@@ -3,13 +3,15 @@ from policyengine_us.model_api import *
 
 class ca_la_ez_save(Variable):
     value_type = float
-    entity = SPMUnit
+    entity = Household
     definition_period = YEAR
     label = "Los Angeles County EZ Save program"
     defined_for = "ca_la_ez_save_eligible"
 
-    def formula(spm_unit, period, parameters):
-        electricity_expense = spm_unit("electricity_expense", period)
+    def formula(household, period, parameters):
+        electricity_expense = add(
+            household, period, ["pre_subsidy_electricity_expense"]
+        )
         p = parameters(period).gov.local.ca.la.dwp.ez_save
         uncapped_amount = p.amount * MONTHS_IN_YEAR
         return min_(electricity_expense, uncapped_amount)


### PR DESCRIPTION
Fixes #4140