### PR TITLE
Allocate the Montana dependent exemptions optimally if the filing status is married filing separately

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Allocate the Montana dependent exemptions optimally if the filing status is married filing separately.

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/exemptions/mt_dependent_exemptions_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/exemptions/mt_dependent_exemptions_person.yaml
@@ -19,7 +19,7 @@
         members: [person1, person3, person4]
         state_code: MT
   output:
-    mt_dependent_exemptions: [0, 0, 1]
+    mt_dependent_exemptions_person: [0, 0, 2_580]
 
 - name: Two dependents in 2022 - two eligible
   period: 2022
@@ -40,7 +40,7 @@
         members: [person1, person3, person4]
         state_code: MT
   output:
-    mt_dependent_exemptions: [0, 1, 1]
+    mt_dependent_exemptions_person: [0, 2_710, 2_710]
 
 - name: Two dependents in 2022 - two eligible, one disabled
   period: 2022
@@ -62,7 +62,7 @@
         members: [person1, person3, person4]
         state_code: MT
   output:
-    mt_dependent_exemptions: [0, 1, 2]
+    mt_dependent_exemptions_person: [0, 2_710, 5_420]
 
 - name: Two dependents in 2022 - no eligible
   period: 2022
@@ -84,4 +84,4 @@
         members: [person1, person3, person4]
         state_code: MT
   output:
-    mt_dependent_exemptions: [0, 0, 0]
+    mt_dependent_exemptions_person: [0, 0, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_indiv.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_indiv.yaml
@@ -4,10 +4,9 @@
     is_tax_unit_head: true
     is_blind: false
     state_code: MT
-    mt_dependent_exemptions: 2
     mt_aged_exemption_eligible_person: true
   output: 
-    mt_exemptions_indiv: 10_840
+    mt_personal_exemptions_indiv: 5_420
 
 - name: No exemptions for the dependent 
   period: 2023
@@ -16,12 +15,11 @@
     is_blind: false
     is_tax_unit_head_or_spouse: false
     state_code: MT
-    mt_dependent_exemptions: 2
     mt_aged_exemption_eligible_person: false
   output: 
-    mt_exemptions_indiv: 0
+    mt_personal_exemptions_indiv: 0
 
-- name: The exemptions are allocated to the head
+- name: No dependent exemptions are not allocated under the personal exemptions
   period: 2022
   input:
     people:
@@ -32,10 +30,10 @@
         is_tax_unit_spouse: true
         mt_aged_exemption_eligible_person: true
       person3:
-        mt_dependent_exemptions: true
+        mt_dependent_exemptions_person: true
     households:
       household:
         members: [person1, person2, person3]
         state_code: MT
   output:
-    mt_exemptions_indiv: [8_130, 5_420, 0]
+    mt_personal_exemptions_indiv: [5_420, 5_420, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_joint.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_joint.yaml
@@ -4,16 +4,16 @@
     people:
       person3:
         is_tax_unit_head: true
-        mt_exemptions_indiv: 1_000
+        mt_personal_exemptions_indiv: 1_000
       person4:
         is_tax_unit_head: false
-        mt_exemptions_indiv: 3_000
+        mt_personal_exemptions_indiv: 3_000
     households:
       household:
         members: [person3, person4]
         state_code: MT
   output:
-    mt_exemptions_joint: [4_000, 0]
+    mt_personal_exemptions_joint: [4_000, 0]
 
 - name: The exemptions are allocated to the head, even if the head does not recieve an exemption amount
   period: 2022
@@ -21,13 +21,13 @@
     people:
       person1:
         is_tax_unit_head: true
-        mt_exemptions_indiv: 0
+        mt_personal_exemptions_indiv: 0
       person2:
         is_tax_unit_head: false
-        mt_exemptions_indiv: 3_000
+        mt_personal_exemptions_indiv: 3_000
     households:
       household:
         members: [person1, person2]
         state_code: MT
   output:
-    mt_exemptions_joint: [3_000, 0]
+    mt_personal_exemptions_joint: [3_000, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
@@ -20,8 +20,9 @@
       household:
         state_code: MT
   output:
-    mt_exemptions_indiv: [5_420, 2_710, 0]
-    mt_exemptions_joint: [8_130, 0, 0]
+    mt_personal_exemptions_indiv: [2710, 2_710, 0]
+    mt_dependent_exemptions_person: [0, 0, 2_710]
+    mt_personal_exemptions_joint: [5420, 0, 0]
     mt_agi: [10_000, 19_000, 0]
     mt_standard_deduction_indiv: [2_260, 3_800, 0]
     mt_standard_deduction_joint: [5_800, 0, 0]
@@ -60,4 +61,42 @@
   output:  # expected results from patched TAXSIM35 2024-02-05 version
     mt_agi: [18_515, 151_515, 0, 0, 0, 0]
     mt_itemized_deductions_indiv: [10_000, 0, 0, 0, 0, 0]
-    mt_exemptions_indiv: [12_900, 2_580, 0, 0, 0, 0]
+    mt_personal_exemptions_indiv: [2_580, 2_580, 0, 0, 0, 0]
+    mt_dependent_exemptions_person: [0, 0, 2_580, 2_580, 2_580, 2_580]
+
+- name: Tax unit with taxsimid 34790 in e21.its.csv and e21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 33
+        employment_income: 7_010
+        taxable_interest_income: 5_505
+      person2:
+        age: 33
+        employment_income: 136_010
+        taxable_interest_income: 5_505
+      person3:
+        age: 16
+      person4:
+        age: 16
+      person5:
+        age: 16
+      person6:
+        age: 16
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        premium_tax_credit: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5, person6]
+        state_fips: 30  # MT
+  output:  # expected results from patched TAXSIM35 2024-03-09 version
+    mt_income_tax: 7_812.64

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/mt_taxable_income_indiv.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/mt_taxable_income_indiv.yaml
@@ -4,7 +4,7 @@
     mt_agi: 6_000
     mt_standard_deduction_indiv: 2_000
     mt_itemized_deductions_indiv: 3_000
-    mt_exemptions_indiv: 2_710
+    mt_personal_exemptions_indiv: 2_710
     state_code: MT
   output: 
     mt_taxable_income_indiv: 290
@@ -15,7 +15,7 @@
     mt_agi: 5_000
     mt_standard_deduction_indiv: 2_000
     mt_itemized_deductions_indiv: 3_000
-    mt_exemptions_indiv: 2_710
+    mt_personal_exemptions_indiv: 2_710
     state_code: MT
   output: 
     mt_taxable_income_indiv: 0
@@ -26,7 +26,7 @@
     mt_agi: 5_000
     mt_standard_deduction_indiv: 3_000
     mt_itemized_deductions_indiv: 2_000
-    mt_exemptions_indiv: 2_710
+    mt_personal_exemptions_indiv: 2_710
     state_code: MT
   output: 
     mt_taxable_income_indiv: 0
@@ -37,7 +37,7 @@
     mt_agi: 7_000
     mt_standard_deduction_indiv: 3_000
     mt_itemized_deductions_indiv: 2_000
-    mt_exemptions_indiv: 2_710
+    mt_personal_exemptions_indiv: 2_710
     state_code: MT
   output: 
     mt_taxable_income_indiv: 1_290
@@ -51,13 +51,13 @@
         mt_agi: 10_000
         mt_standard_deduction_indiv: 5_000
         mt_itemized_deductions_indiv: 0
-        mt_exemptions_indiv: 4_000
+        mt_personal_exemptions_indiv: 4_000
       person2:
         is_tax_unit_spouse: true
         mt_agi: 12_000
         mt_standard_deduction_indiv: 15_000
         mt_itemized_deductions_indiv: 0
-        mt_exemptions_indiv: 2_000
+        mt_personal_exemptions_indiv: 2_000
     tax_units:
       tax_unit:
         members: [person1, person2]
@@ -78,13 +78,13 @@
         mt_agi: 10_000
         mt_standard_deduction_indiv: 1_000
         mt_itemized_deductions_indiv: 5_000
-        mt_exemptions_indiv: 3_000
+        mt_personal_exemptions_indiv: 3_000
       person2:
         is_tax_unit_spouse: true
         mt_agi: 12_000
         mt_standard_deduction_indiv: 2_000
         mt_itemized_deductions_indiv: 3_000
-        mt_exemptions_indiv: 3_000
+        mt_personal_exemptions_indiv: 3_000
     tax_units:
       tax_unit:
         members: [person1, person2]
@@ -105,13 +105,13 @@
         mt_agi: 20_000
         mt_standard_deduction_indiv: 1_000
         mt_itemized_deductions_indiv: 5_000
-        mt_exemptions_indiv: 4_000
+        mt_personal_exemptions_indiv: 4_000
       person2:
         is_tax_unit_spouse: true
         mt_agi: 20_000
         mt_standard_deduction_indiv: 2_000
         mt_itemized_deductions_indiv: 3_000
-        mt_exemptions_indiv: 2_000
+        mt_personal_exemptions_indiv: 2_000
       person3:
         mt_agi: 0
     tax_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/mt_taxable_income_joint.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/mt_taxable_income_joint.yaml
@@ -7,13 +7,13 @@
         mt_agi: 10_000
         mt_standard_deduction_joint: 3_000
         mt_itemized_deductions_joint: 1_000
-        mt_exemptions_joint: 500
+        mt_personal_exemptions_joint: 500
       person2:
         is_tax_unit_head: false
         mt_agi: 5_000
         mt_standard_deduction_joint: 100
         mt_itemized_deductions_joint: 1_000
-        mt_exemptions_joint: 3_000
+        mt_personal_exemptions_joint: 3_000
     tax_units:
       tax_unit:
         members: [person1, person2]
@@ -33,13 +33,13 @@
         mt_agi: 10_000
         mt_standard_deduction_joint: 0
         mt_itemized_deductions_joint: 1_000
-        mt_exemptions_joint: 500
+        mt_personal_exemptions_joint: 500
       person2:
         is_tax_unit_head: false
         mt_agi: 5_000
         mt_standard_deduction_joint: 100
         mt_itemized_deductions_joint: 1_000
-        mt_exemptions_joint: 3_000
+        mt_personal_exemptions_joint: 3_000
     tax_units:
       tax_unit:
         members: [person1, person2]

--- a/policyengine_us/variables/gov/states/mt/tax/income/deductions/mt_tax_unit_deductions_exemptions_indiv.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/deductions/mt_tax_unit_deductions_exemptions_indiv.py
@@ -12,8 +12,12 @@ class mt_tax_unit_deductions_exemptions_indiv(Variable):
         standard_deduction = add(
             tax_unit, period, ["mt_standard_deduction_indiv"]
         )
+        dependent_exemptions = add(
+            tax_unit, period, ["mt_dependent_exemptions_person"]
+        )
         itemized_deductions = add(
             tax_unit, period, ["mt_itemized_deductions_indiv"]
         )
         itemizes = tax_unit("mt_tax_unit_itemizes", period)
-        return where(itemizes, itemized_deductions, standard_deduction)
+        deductions = where(itemizes, itemized_deductions, standard_deduction)
+        return deductions + dependent_exemptions

--- a/policyengine_us/variables/gov/states/mt/tax/income/exemptions/mt_dependent_exemptions_person.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/exemptions/mt_dependent_exemptions_person.py
@@ -1,10 +1,10 @@
 from policyengine_us.model_api import *
 
 
-class mt_dependent_exemptions(Variable):
+class mt_dependent_exemptions_person(Variable):
     value_type = int
     entity = Person
-    label = "Montana number of dependent exemption for each dependent"
+    label = "Montana dependent exemption for each dependent"
     unit = USD
     definition_period = YEAR
     reference = "https://regulations.justia.com/states/montana/department-42/chapter-42-15/subchapter-42-15-4/rule-42-15-403/"
@@ -15,4 +15,7 @@ class mt_dependent_exemptions(Variable):
         qualifying_child = person("is_child_dependent", period)
         # Disabled dependents get an additional exemption.
         disabled = person("is_disabled", period)
-        return qualifying_child * (1 + disabled)
+        p = parameters(period).gov.states.mt.tax.income.exemptions
+
+        eligible_dependent = qualifying_child * (1 + disabled)
+        return eligible_dependent * p.amount

--- a/policyengine_us/variables/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_indiv.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_indiv.py
@@ -1,7 +1,7 @@
 from policyengine_us.model_api import *
 
 
-class mt_exemptions_indiv(Variable):
+class mt_personal_exemptions_indiv(Variable):
     value_type = float
     entity = Person
     label = "Montana exemptions when married couples file separately"
@@ -15,15 +15,10 @@ class mt_exemptions_indiv(Variable):
         blind_head_or_spouse = blind * head_or_spouse
         # Allocate the dependent exemption to the head
         head = person("is_tax_unit_head", period)
-        dependent_exemption = person("mt_dependent_exemptions", period)
-        total_dependent_exemption = (
-            person.tax_unit.sum(dependent_exemption) * head
-        )
         aged_exemption = person("mt_aged_exemption_eligible_person", period)
         exemption_count = (
             head_or_spouse.astype(int)
             + blind_head_or_spouse.astype(int)
-            + total_dependent_exemption.astype(int)
             + aged_exemption.astype(int)
         )
         p = parameters(period).gov.states.mt.tax.income.exemptions

--- a/policyengine_us/variables/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_joint.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/exemptions/mt_personal_exemptions_joint.py
@@ -1,7 +1,7 @@
 from policyengine_us.model_api import *
 
 
-class mt_exemptions_joint(Variable):
+class mt_personal_exemptions_joint(Variable):
     value_type = float
     entity = Person
     label = "Montana exemptions when married couple files jointly"
@@ -12,6 +12,7 @@ class mt_exemptions_joint(Variable):
     def formula(person, period, parameters):
         # Allocate the exemptions to the head
         head = person("is_tax_unit_head", period)
-        exemptions = add(person.tax_unit, period, ["mt_exemptions_indiv"])
-        p = parameters(period).gov.states.mt.tax.income.exemptions
+        exemptions = add(
+            person.tax_unit, period, ["mt_personal_exemptions_indiv"]
+        )
         return exemptions * head

--- a/policyengine_us/variables/gov/states/mt/tax/income/mt_taxable_income_indiv.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/mt_taxable_income_indiv.py
@@ -15,7 +15,7 @@ class mt_taxable_income_indiv(Variable):
 
     def formula(person, period, parameters):
         mt_agi = person("mt_agi", period)
-        exemptions = person("mt_exemptions_indiv", period)
+        exemptions = person("mt_personal_exemptions_indiv", period)
         reduced_agi = max_(mt_agi - exemptions, 0)
         deductions_and_exemptions = person.tax_unit(
             "mt_tax_unit_deductions_exemptions_indiv", period

--- a/policyengine_us/variables/gov/states/mt/tax/income/mt_taxable_income_joint.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/mt_taxable_income_joint.py
@@ -25,5 +25,10 @@ class mt_taxable_income_joint(Variable):
         )
         # Tax units can claim the larger of the itemized or standard deductions
         deductions = max_(itemized_deductions, standard_deduction)
-        exemptions = add(person.tax_unit, period, ["mt_exemptions_joint"])
+        exemptions = add(
+            person.tax_unit,
+            period,
+            ["mt_personal_exemptions_joint", "mt_dependent_exemptions_person"],
+        )
+
         return max_(0, total_agi - deductions - exemptions)


### PR DESCRIPTION
Fixes #4227