### PR TITLE
Adjust the Kentucky pension income exclusion to not count pension twice

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Adjust the Kentucky pension income exclusion to not count pension twice.

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/integration.yaml
@@ -1,242 +1,242 @@
-# - name: Tax unit files separately
-#   period: 2022
-#   # High error margin because of rounding in the tax tables
-#   absolute_error_margin: 2
-#   input:
-#     people:
-#       person1:
-#         adjusted_gross_income_person: 20_000
-#         ky_additions: 1_000
-#         ky_subtractions: 2_000
-#         is_tax_unit_head: true
-#       person2:
-#         adjusted_gross_income_person: 25_000
-#         ky_additions: 2_000
-#         ky_subtractions: 1_000
-#         is_tax_unit_spouse: true
-#     tax_units:
-#       tax_unit:
-#         members: [person1, person2]
-#         filing_status: SEPARATE
-#         ky_non_refundable_credits: 100
-#     households:
-#       household:
-#         members: [person1, person2]
-#         state_code: KY 
-#   output:
-#     ky_agi: [19_000, 26_000]
-#     ky_standard_deduction_indiv: [2_770, 2_770]
-#     ky_itemized_deductions_indiv: [0, 0]
-#     ky_taxable_income_indiv: [16_230, 23_230]
-#     ky_files_separately: true
-#     ky_personal_tax_credits_indiv: [0, 0] 
-#     ky_income_tax_before_non_refundable_credits_unit: 1973
-#     ky_income_tax_before_refundable_credits: 1873
+- name: Tax unit files separately
+  period: 2022
+  # High error margin because of rounding in the tax tables
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        adjusted_gross_income_person: 20_000
+        ky_additions: 1_000
+        ky_subtractions: 2_000
+        is_tax_unit_head: true
+      person2:
+        adjusted_gross_income_person: 25_000
+        ky_additions: 2_000
+        ky_subtractions: 1_000
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SEPARATE
+        ky_non_refundable_credits: 100
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KY 
+  output:
+    ky_agi: [19_000, 26_000]
+    ky_standard_deduction_indiv: [2_770, 2_770]
+    ky_itemized_deductions_indiv: [0, 0]
+    ky_taxable_income_indiv: [16_230, 23_230]
+    ky_files_separately: true
+    ky_personal_tax_credits_indiv: [0, 0] 
+    ky_income_tax_before_non_refundable_credits_unit: 1973
+    ky_income_tax_before_refundable_credits: 1873
 
-# - name: Tax unit files jointly
-#   period: 2022
-#   # High error margin because of rounding in the tax tables
-#   absolute_error_margin: 2
-#   input:
-#     people:
-#       person1:
-#         adjusted_gross_income_person: 20_000
-#         ky_additions: 1_000
-#         ky_subtractions: 2_000
-#         is_tax_unit_head: true
-#       person2:
-#         adjusted_gross_income_person: 25_000
-#         ky_additions: 2_000
-#         ky_subtractions: 1_000
-#         is_tax_unit_spouse: true
-#     tax_units:
-#       tax_unit:
-#         members: [person1, person2]
-#         filing_status: JOINT
-#         ky_non_refundable_credits: 100
-#     households:
-#       household:
-#         members: [person1, person2]
-#         state_code: KY 
-#   output:
-#     ky_agi: [19_000, 26_000]
-#     #If filing a joint return, only one standard deduction is allowed.
-#     ky_standard_deduction_joint: [2770, 0]
-#     ky_itemized_deductions_joint: [0, 0] 
-#     ky_taxable_income_joint: [42_230, 0]
-#     ky_files_separately: true
-#     ky_personal_tax_credits_joint: [0, 0] 
-#     # take separate result to maximize benefit
-#     ky_income_tax_before_non_refundable_credits_unit: 1973 
-#     ky_income_tax_before_refundable_credits: 1873
+- name: Tax unit files jointly
+  period: 2022
+  # High error margin because of rounding in the tax tables
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        adjusted_gross_income_person: 20_000
+        ky_additions: 1_000
+        ky_subtractions: 2_000
+        is_tax_unit_head: true
+      person2:
+        adjusted_gross_income_person: 25_000
+        ky_additions: 2_000
+        ky_subtractions: 1_000
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        ky_non_refundable_credits: 100
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KY 
+  output:
+    ky_agi: [19_000, 26_000]
+    #If filing a joint return, only one standard deduction is allowed.
+    ky_standard_deduction_joint: [2770, 0]
+    ky_itemized_deductions_joint: [0, 0] 
+    ky_taxable_income_joint: [42_230, 0]
+    ky_files_separately: true
+    ky_personal_tax_credits_joint: [0, 0] 
+    # take separate result to maximize benefit
+    ky_income_tax_before_non_refundable_credits_unit: 1973 
+    ky_income_tax_before_refundable_credits: 1873
 
-# #new baseline integration test
-# - name: baseline integration test joint
-#   period: 2022
-#   # High error margin because of rounding in the tax tables
-#   absolute_error_margin: 2
-#   input:
-#     people:
-#       person1:
-#         adjusted_gross_income_person: 20_000
-#         age: 30
-#       person2:
-#         adjusted_gross_income_person: 25_000
-#         age: 31
-#     tax_units:
-#       tax_unit:
-#         members: [person1, person2]
-#         filing_status: JOINT
-#     households:
-#       household:
-#         members: [person1, person2]
-#         state_code: KY 
-#   output:
-#     ky_agi: [20_000, 25_000]
-#     # If filing a joint return, only one standard deduction is allowed.
-#     # default: older perpon is head
-#     ky_standard_deduction_joint: [0, 2_770]
-#     ky_itemized_deductions_joint: [0, 0] 
-#     ky_taxable_income_joint: [0, 42_230]
-#     ky_personal_tax_credits_joint: [0, 0] 
-#     #not 2111.5, becase ky_files_separately return true (we optimize)
-#     ky_income_tax_before_non_refundable_credits_unit: 1973 
-#     ky_income_tax_before_refundable_credits: 1973
+#new baseline integration test
+- name: baseline integration test joint
+  period: 2022
+  # High error margin because of rounding in the tax tables
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        adjusted_gross_income_person: 20_000
+        age: 30
+      person2:
+        adjusted_gross_income_person: 25_000
+        age: 31
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KY 
+  output:
+    ky_agi: [20_000, 25_000]
+    # If filing a joint return, only one standard deduction is allowed.
+    # default: older perpon is head
+    ky_standard_deduction_joint: [0, 2_770]
+    ky_itemized_deductions_joint: [0, 0] 
+    ky_taxable_income_joint: [0, 42_230]
+    ky_personal_tax_credits_joint: [0, 0] 
+    #not 2111.5, becase ky_files_separately return true (we optimize)
+    ky_income_tax_before_non_refundable_credits_unit: 1973 
+    ky_income_tax_before_refundable_credits: 1973
 
-# #new baseline integration test
-# - name: baseline integration test separate
-#   period: 2022
-#   # High error margin because of rounding in the tax tables
-#   absolute_error_margin: 2
-#   input:
-#     people:
-#       person1:
-#         adjusted_gross_income_person: 20_000
-#         age: 30
-#       person2:
-#         adjusted_gross_income_person: 25_000
-#         age: 31
-#     tax_units:
-#       tax_unit:
-#         members: [person1, person2]
-#         filing_status: SEPARATE
-#     households:
-#       household:
-#         members: [person1, person2]
-#         state_code: KY 
-#   output:
-#     ky_agi: [20_000, 25_000]
-#     ky_standard_deduction_indiv: [2_770, 2_770]
-#     ky_itemized_deductions_indiv: [0, 0] 
-#     ky_taxable_income_indiv: [17_230, 22_230]
-#     ky_personal_tax_credits_indiv: [0, 0] 
-#     ky_income_tax_before_non_refundable_credits_unit: 1973 
-#     ky_income_tax_before_refundable_credits: 1973
+#new baseline integration test
+- name: baseline integration test separate
+  period: 2022
+  # High error margin because of rounding in the tax tables
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        adjusted_gross_income_person: 20_000
+        age: 30
+      person2:
+        adjusted_gross_income_person: 25_000
+        age: 31
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SEPARATE
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KY 
+  output:
+    ky_agi: [20_000, 25_000]
+    ky_standard_deduction_indiv: [2_770, 2_770]
+    ky_itemized_deductions_indiv: [0, 0] 
+    ky_taxable_income_indiv: [17_230, 22_230]
+    ky_personal_tax_credits_indiv: [0, 0] 
+    ky_income_tax_before_non_refundable_credits_unit: 1973 
+    ky_income_tax_before_refundable_credits: 1973
 
-# - name: integration test for personal tax credit joint
-#   period: 2022
-#   # High error margin because of rounding in the tax tables
-#   absolute_error_margin: 2
-#   input:
-#     people:
-#       person1:
-#         adjusted_gross_income_person: 20_000
-#         is_blind: true
-#         age: 30
-#         is_tax_unit_head_or_spouse: true
-#       person2:
-#         adjusted_gross_income_person: 25_000
-#         is_blind: true
-#         age: 31
-#         is_tax_unit_head_or_spouse: true
-#       child:
-#         is_blind: true
-#         is_tax_unit_head_or_spouse: false
-#         age: 10
-#     tax_units:
-#       tax_unit:
-#         members: [person1, person2, child]
-#         filing_status: JOINT
-#     households:
-#       household:
-#         members: [person1, person2, child]
-#         state_code: KY 
-#   output:
-#     ky_agi: [20_000, 25_000, 0]
-#     # If filing a joint return, only one standard deduction is allowed.
-#     # default: older perpon is head
-#     ky_standard_deduction_joint: [0, 2_770, 0]
-#     ky_itemized_deductions_joint: [0, 0, 0] 
-#     ky_taxable_income_joint: [0, 42_230, 0]
-#     ky_personal_tax_credits_joint: [0, 80, 0] 
-#     ky_income_tax_before_non_refundable_credits_unit: 1973 
-#     ky_income_tax_before_refundable_credits: 1893
+- name: integration test for personal tax credit joint
+  period: 2022
+  # High error margin because of rounding in the tax tables
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        adjusted_gross_income_person: 20_000
+        is_blind: true
+        age: 30
+        is_tax_unit_head_or_spouse: true
+      person2:
+        adjusted_gross_income_person: 25_000
+        is_blind: true
+        age: 31
+        is_tax_unit_head_or_spouse: true
+      child:
+        is_blind: true
+        is_tax_unit_head_or_spouse: false
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [person1, person2, child]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2, child]
+        state_code: KY 
+  output:
+    ky_agi: [20_000, 25_000, 0]
+    # If filing a joint return, only one standard deduction is allowed.
+    # default: older perpon is head
+    ky_standard_deduction_joint: [0, 2_770, 0]
+    ky_itemized_deductions_joint: [0, 0, 0] 
+    ky_taxable_income_joint: [0, 42_230, 0]
+    ky_personal_tax_credits_joint: [0, 80, 0] 
+    ky_income_tax_before_non_refundable_credits_unit: 1973 
+    ky_income_tax_before_refundable_credits: 1893
 
-# - name: Tax unit with taxsimid 95730 in e21.its.csv and e21.ots.csv
-#   absolute_error_margin: 0.01
-#   period: 2021
-#   input:
-#     people:
-#       person1:
-#         age: 66
-#         employment_income: 15010
-#         taxable_interest_income: 5505.0
-#         ssi: 0  # not in TAXSIM35
-#         state_supplement: 0  # not in TAXSIM35
-#         wic: 0  # not in TAXSIM35
-#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-#       person2:
-#         age: 66
-#         employment_income: 1010
-#         taxable_interest_income: 5505.0
-#         ssi: 0  # not in TAXSIM35
-#         state_supplement: 0  # not in TAXSIM35
-#         wic: 0  # not in TAXSIM35
-#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-#       person3:
-#         age: 11
-#         ssi: 0  # not in TAXSIM35
-#         state_supplement: 0  # not in TAXSIM35
-#         wic: 0  # not in TAXSIM35
-#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-#       person4:
-#         age: 11
-#         ssi: 0  # not in TAXSIM35
-#         state_supplement: 0  # not in TAXSIM35
-#         wic: 0  # not in TAXSIM35
-#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-#       person5:
-#         age: 11
-#         ssi: 0  # not in TAXSIM35
-#         state_supplement: 0  # not in TAXSIM35
-#         wic: 0  # not in TAXSIM35
-#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-#     tax_units:
-#       tax_unit:
-#         members: [person1, person2, person3, person4, person5]
-#         premium_tax_credit: 0  # not in TAXSIM35
-#         local_income_tax: 0  # not in TAXSIM35
-#         state_sales_tax: 0  # not in TAXSIM35
-#         ca_use_tax: 0  # not in TAXSIM35
-#         il_use_tax: 0  # not in TAXSIM35
-#         nm_2021_income_rebate: 0  # not in TAXSIM35
-#         nm_additional_2021_income_rebate: 0  # not in TAXSIM35
-#         nm_supplemental_2021_income_rebate: 0  # not in TAXSIM35
-#         ny_supplemental_eitc: 0  # not in TAXSIM35
-#         ok_use_tax: 0  # not in TAXSIM35
-#         pa_use_tax: 0  # not in TAXSIM35
-#         vt_renter_credit: 0  # not in TAXSIM35
-#     spm_units:
-#       spm_unit:
-#         members: [person1, person2, person3, person4, person5]
-#         snap: 0  # not in TAXSIM35
-#         tanf: 0  # not in TAXSIM35
-#     households:
-#       household:
-#         members: [person1, person2, person3, person4, person5]
-#         state_fips: 21  # KY
-#   output:  # expected results from patched TAXSIM35 2024-03-04 version
-#     ky_income_tax: 100.25
+- name: Tax unit with taxsimid 95730 in e21.its.csv and e21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 66
+        employment_income: 15010
+        taxable_interest_income: 5505.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person2:
+        age: 66
+        employment_income: 1010
+        taxable_interest_income: 5505.0
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person3:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person4:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person5:
+        age: 11
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5]
+        premium_tax_credit: 0  # not in TAXSIM35
+        local_income_tax: 0  # not in TAXSIM35
+        state_sales_tax: 0  # not in TAXSIM35
+        ca_use_tax: 0  # not in TAXSIM35
+        il_use_tax: 0  # not in TAXSIM35
+        nm_2021_income_rebate: 0  # not in TAXSIM35
+        nm_additional_2021_income_rebate: 0  # not in TAXSIM35
+        nm_supplemental_2021_income_rebate: 0  # not in TAXSIM35
+        ny_supplemental_eitc: 0  # not in TAXSIM35
+        ok_use_tax: 0  # not in TAXSIM35
+        pa_use_tax: 0  # not in TAXSIM35
+        vt_renter_credit: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5]
+        snap: 0  # not in TAXSIM35
+        tanf: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5]
+        state_fips: 21  # KY
+  output:  # expected results from patched TAXSIM35 2024-03-04 version
+    ky_income_tax: 100.25
 
 - name: Tax unit with taxsimid 99980 in f21.its.csv and f21.ots.csv
   absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/integration.yaml
@@ -1,239 +1,268 @@
-- name: Tax unit files separately
-  period: 2022
-  # High error margin because of rounding in the tax tables
-  absolute_error_margin: 2
-  input:
-    people:
-      person1:
-        adjusted_gross_income_person: 20_000
-        ky_additions: 1_000
-        ky_subtractions: 2_000
-        is_tax_unit_head: true
-      person2:
-        adjusted_gross_income_person: 25_000
-        ky_additions: 2_000
-        ky_subtractions: 1_000
-        is_tax_unit_spouse: true
-    tax_units:
-      tax_unit:
-        members: [person1, person2]
-        filing_status: SEPARATE
-        ky_non_refundable_credits: 100
-    households:
-      household:
-        members: [person1, person2]
-        state_code: KY 
-  output:
-    ky_agi: [19_000, 26_000]
-    ky_standard_deduction_indiv: [2_770, 2_770]
-    ky_itemized_deductions_indiv: [0, 0]
-    ky_taxable_income_indiv: [16_230, 23_230]
-    ky_files_separately: true
-    ky_personal_tax_credits_indiv: [0, 0] 
-    ky_income_tax_before_non_refundable_credits_unit: 1973
-    ky_income_tax_before_refundable_credits: 1873
+# - name: Tax unit files separately
+#   period: 2022
+#   # High error margin because of rounding in the tax tables
+#   absolute_error_margin: 2
+#   input:
+#     people:
+#       person1:
+#         adjusted_gross_income_person: 20_000
+#         ky_additions: 1_000
+#         ky_subtractions: 2_000
+#         is_tax_unit_head: true
+#       person2:
+#         adjusted_gross_income_person: 25_000
+#         ky_additions: 2_000
+#         ky_subtractions: 1_000
+#         is_tax_unit_spouse: true
+#     tax_units:
+#       tax_unit:
+#         members: [person1, person2]
+#         filing_status: SEPARATE
+#         ky_non_refundable_credits: 100
+#     households:
+#       household:
+#         members: [person1, person2]
+#         state_code: KY 
+#   output:
+#     ky_agi: [19_000, 26_000]
+#     ky_standard_deduction_indiv: [2_770, 2_770]
+#     ky_itemized_deductions_indiv: [0, 0]
+#     ky_taxable_income_indiv: [16_230, 23_230]
+#     ky_files_separately: true
+#     ky_personal_tax_credits_indiv: [0, 0] 
+#     ky_income_tax_before_non_refundable_credits_unit: 1973
+#     ky_income_tax_before_refundable_credits: 1873
 
-- name: Tax unit files jointly
-  period: 2022
-  # High error margin because of rounding in the tax tables
-  absolute_error_margin: 2
-  input:
-    people:
-      person1:
-        adjusted_gross_income_person: 20_000
-        ky_additions: 1_000
-        ky_subtractions: 2_000
-        is_tax_unit_head: true
-      person2:
-        adjusted_gross_income_person: 25_000
-        ky_additions: 2_000
-        ky_subtractions: 1_000
-        is_tax_unit_spouse: true
-    tax_units:
-      tax_unit:
-        members: [person1, person2]
-        filing_status: JOINT
-        ky_non_refundable_credits: 100
-    households:
-      household:
-        members: [person1, person2]
-        state_code: KY 
-  output:
-    ky_agi: [19_000, 26_000]
-    #If filing a joint return, only one standard deduction is allowed.
-    ky_standard_deduction_joint: [2770, 0]
-    ky_itemized_deductions_joint: [0, 0] 
-    ky_taxable_income_joint: [42_230, 0]
-    ky_files_separately: true
-    ky_personal_tax_credits_joint: [0, 0] 
-    # take separate result to maximize benefit
-    ky_income_tax_before_non_refundable_credits_unit: 1973 
-    ky_income_tax_before_refundable_credits: 1873
+# - name: Tax unit files jointly
+#   period: 2022
+#   # High error margin because of rounding in the tax tables
+#   absolute_error_margin: 2
+#   input:
+#     people:
+#       person1:
+#         adjusted_gross_income_person: 20_000
+#         ky_additions: 1_000
+#         ky_subtractions: 2_000
+#         is_tax_unit_head: true
+#       person2:
+#         adjusted_gross_income_person: 25_000
+#         ky_additions: 2_000
+#         ky_subtractions: 1_000
+#         is_tax_unit_spouse: true
+#     tax_units:
+#       tax_unit:
+#         members: [person1, person2]
+#         filing_status: JOINT
+#         ky_non_refundable_credits: 100
+#     households:
+#       household:
+#         members: [person1, person2]
+#         state_code: KY 
+#   output:
+#     ky_agi: [19_000, 26_000]
+#     #If filing a joint return, only one standard deduction is allowed.
+#     ky_standard_deduction_joint: [2770, 0]
+#     ky_itemized_deductions_joint: [0, 0] 
+#     ky_taxable_income_joint: [42_230, 0]
+#     ky_files_separately: true
+#     ky_personal_tax_credits_joint: [0, 0] 
+#     # take separate result to maximize benefit
+#     ky_income_tax_before_non_refundable_credits_unit: 1973 
+#     ky_income_tax_before_refundable_credits: 1873
 
-#new baseline integration test
-- name: baseline integration test joint
-  period: 2022
-  # High error margin because of rounding in the tax tables
-  absolute_error_margin: 2
-  input:
-    people:
-      person1:
-        adjusted_gross_income_person: 20_000
-        age: 30
-      person2:
-        adjusted_gross_income_person: 25_000
-        age: 31
-    tax_units:
-      tax_unit:
-        members: [person1, person2]
-        filing_status: JOINT
-    households:
-      household:
-        members: [person1, person2]
-        state_code: KY 
-  output:
-    ky_agi: [20_000, 25_000]
-    # If filing a joint return, only one standard deduction is allowed.
-    # default: older perpon is head
-    ky_standard_deduction_joint: [0, 2_770]
-    ky_itemized_deductions_joint: [0, 0] 
-    ky_taxable_income_joint: [0, 42_230]
-    ky_personal_tax_credits_joint: [0, 0] 
-    #not 2111.5, becase ky_files_separately return true (we optimize)
-    ky_income_tax_before_non_refundable_credits_unit: 1973 
-    ky_income_tax_before_refundable_credits: 1973
+# #new baseline integration test
+# - name: baseline integration test joint
+#   period: 2022
+#   # High error margin because of rounding in the tax tables
+#   absolute_error_margin: 2
+#   input:
+#     people:
+#       person1:
+#         adjusted_gross_income_person: 20_000
+#         age: 30
+#       person2:
+#         adjusted_gross_income_person: 25_000
+#         age: 31
+#     tax_units:
+#       tax_unit:
+#         members: [person1, person2]
+#         filing_status: JOINT
+#     households:
+#       household:
+#         members: [person1, person2]
+#         state_code: KY 
+#   output:
+#     ky_agi: [20_000, 25_000]
+#     # If filing a joint return, only one standard deduction is allowed.
+#     # default: older perpon is head
+#     ky_standard_deduction_joint: [0, 2_770]
+#     ky_itemized_deductions_joint: [0, 0] 
+#     ky_taxable_income_joint: [0, 42_230]
+#     ky_personal_tax_credits_joint: [0, 0] 
+#     #not 2111.5, becase ky_files_separately return true (we optimize)
+#     ky_income_tax_before_non_refundable_credits_unit: 1973 
+#     ky_income_tax_before_refundable_credits: 1973
 
-#new baseline integration test
-- name: baseline integration test separate
-  period: 2022
-  # High error margin because of rounding in the tax tables
-  absolute_error_margin: 2
-  input:
-    people:
-      person1:
-        adjusted_gross_income_person: 20_000
-        age: 30
-      person2:
-        adjusted_gross_income_person: 25_000
-        age: 31
-    tax_units:
-      tax_unit:
-        members: [person1, person2]
-        filing_status: SEPARATE
-    households:
-      household:
-        members: [person1, person2]
-        state_code: KY 
-  output:
-    ky_agi: [20_000, 25_000]
-    ky_standard_deduction_indiv: [2_770, 2_770]
-    ky_itemized_deductions_indiv: [0, 0] 
-    ky_taxable_income_indiv: [17_230, 22_230]
-    ky_personal_tax_credits_indiv: [0, 0] 
-    ky_income_tax_before_non_refundable_credits_unit: 1973 
-    ky_income_tax_before_refundable_credits: 1973
+# #new baseline integration test
+# - name: baseline integration test separate
+#   period: 2022
+#   # High error margin because of rounding in the tax tables
+#   absolute_error_margin: 2
+#   input:
+#     people:
+#       person1:
+#         adjusted_gross_income_person: 20_000
+#         age: 30
+#       person2:
+#         adjusted_gross_income_person: 25_000
+#         age: 31
+#     tax_units:
+#       tax_unit:
+#         members: [person1, person2]
+#         filing_status: SEPARATE
+#     households:
+#       household:
+#         members: [person1, person2]
+#         state_code: KY 
+#   output:
+#     ky_agi: [20_000, 25_000]
+#     ky_standard_deduction_indiv: [2_770, 2_770]
+#     ky_itemized_deductions_indiv: [0, 0] 
+#     ky_taxable_income_indiv: [17_230, 22_230]
+#     ky_personal_tax_credits_indiv: [0, 0] 
+#     ky_income_tax_before_non_refundable_credits_unit: 1973 
+#     ky_income_tax_before_refundable_credits: 1973
 
-- name: integration test for personal tax credit joint
-  period: 2022
-  # High error margin because of rounding in the tax tables
-  absolute_error_margin: 2
-  input:
-    people:
-      person1:
-        adjusted_gross_income_person: 20_000
-        is_blind: true
-        age: 30
-        is_tax_unit_head_or_spouse: true
-      person2:
-        adjusted_gross_income_person: 25_000
-        is_blind: true
-        age: 31
-        is_tax_unit_head_or_spouse: true
-      child:
-        is_blind: true
-        is_tax_unit_head_or_spouse: false
-        age: 10
-    tax_units:
-      tax_unit:
-        members: [person1, person2, child]
-        filing_status: JOINT
-    households:
-      household:
-        members: [person1, person2, child]
-        state_code: KY 
-  output:
-    ky_agi: [20_000, 25_000, 0]
-    # If filing a joint return, only one standard deduction is allowed.
-    # default: older perpon is head
-    ky_standard_deduction_joint: [0, 2_770, 0]
-    ky_itemized_deductions_joint: [0, 0, 0] 
-    ky_taxable_income_joint: [0, 42_230, 0]
-    ky_personal_tax_credits_joint: [0, 80, 0] 
-    ky_income_tax_before_non_refundable_credits_unit: 1973 
-    ky_income_tax_before_refundable_credits: 1893
+# - name: integration test for personal tax credit joint
+#   period: 2022
+#   # High error margin because of rounding in the tax tables
+#   absolute_error_margin: 2
+#   input:
+#     people:
+#       person1:
+#         adjusted_gross_income_person: 20_000
+#         is_blind: true
+#         age: 30
+#         is_tax_unit_head_or_spouse: true
+#       person2:
+#         adjusted_gross_income_person: 25_000
+#         is_blind: true
+#         age: 31
+#         is_tax_unit_head_or_spouse: true
+#       child:
+#         is_blind: true
+#         is_tax_unit_head_or_spouse: false
+#         age: 10
+#     tax_units:
+#       tax_unit:
+#         members: [person1, person2, child]
+#         filing_status: JOINT
+#     households:
+#       household:
+#         members: [person1, person2, child]
+#         state_code: KY 
+#   output:
+#     ky_agi: [20_000, 25_000, 0]
+#     # If filing a joint return, only one standard deduction is allowed.
+#     # default: older perpon is head
+#     ky_standard_deduction_joint: [0, 2_770, 0]
+#     ky_itemized_deductions_joint: [0, 0, 0] 
+#     ky_taxable_income_joint: [0, 42_230, 0]
+#     ky_personal_tax_credits_joint: [0, 80, 0] 
+#     ky_income_tax_before_non_refundable_credits_unit: 1973 
+#     ky_income_tax_before_refundable_credits: 1893
 
-- name: Tax unit with taxsimid 95730 in e21.its.csv and e21.ots.csv
+# - name: Tax unit with taxsimid 95730 in e21.its.csv and e21.ots.csv
+#   absolute_error_margin: 0.01
+#   period: 2021
+#   input:
+#     people:
+#       person1:
+#         age: 66
+#         employment_income: 15010
+#         taxable_interest_income: 5505.0
+#         ssi: 0  # not in TAXSIM35
+#         state_supplement: 0  # not in TAXSIM35
+#         wic: 0  # not in TAXSIM35
+#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+#       person2:
+#         age: 66
+#         employment_income: 1010
+#         taxable_interest_income: 5505.0
+#         ssi: 0  # not in TAXSIM35
+#         state_supplement: 0  # not in TAXSIM35
+#         wic: 0  # not in TAXSIM35
+#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+#       person3:
+#         age: 11
+#         ssi: 0  # not in TAXSIM35
+#         state_supplement: 0  # not in TAXSIM35
+#         wic: 0  # not in TAXSIM35
+#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+#       person4:
+#         age: 11
+#         ssi: 0  # not in TAXSIM35
+#         state_supplement: 0  # not in TAXSIM35
+#         wic: 0  # not in TAXSIM35
+#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+#       person5:
+#         age: 11
+#         ssi: 0  # not in TAXSIM35
+#         state_supplement: 0  # not in TAXSIM35
+#         wic: 0  # not in TAXSIM35
+#         ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+#     tax_units:
+#       tax_unit:
+#         members: [person1, person2, person3, person4, person5]
+#         premium_tax_credit: 0  # not in TAXSIM35
+#         local_income_tax: 0  # not in TAXSIM35
+#         state_sales_tax: 0  # not in TAXSIM35
+#         ca_use_tax: 0  # not in TAXSIM35
+#         il_use_tax: 0  # not in TAXSIM35
+#         nm_2021_income_rebate: 0  # not in TAXSIM35
+#         nm_additional_2021_income_rebate: 0  # not in TAXSIM35
+#         nm_supplemental_2021_income_rebate: 0  # not in TAXSIM35
+#         ny_supplemental_eitc: 0  # not in TAXSIM35
+#         ok_use_tax: 0  # not in TAXSIM35
+#         pa_use_tax: 0  # not in TAXSIM35
+#         vt_renter_credit: 0  # not in TAXSIM35
+#     spm_units:
+#       spm_unit:
+#         members: [person1, person2, person3, person4, person5]
+#         snap: 0  # not in TAXSIM35
+#         tanf: 0  # not in TAXSIM35
+#     households:
+#       household:
+#         members: [person1, person2, person3, person4, person5]
+#         state_fips: 21  # KY
+#   output:  # expected results from patched TAXSIM35 2024-03-04 version
+#     ky_income_tax: 100.25
+
+- name: Tax unit with taxsimid 99980 in f21.its.csv and f21.ots.csv
   absolute_error_margin: 0.01
   period: 2021
   input:
     people:
       person1:
         age: 66
-        employment_income: 15010
-        taxable_interest_income: 5505.0
-        ssi: 0  # not in TAXSIM35
-        state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
-        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+        employment_income: 25010
+        taxable_interest_income: 11010
+        taxable_private_pension_income: 12000
+        social_security_retirement: 7000
       person2:
-        age: 66
-        employment_income: 1010
-        taxable_interest_income: 5505.0
-        ssi: 0  # not in TAXSIM35
-        state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
-        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-      person3:
-        age: 11
-        ssi: 0  # not in TAXSIM35
-        state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
-        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-      person4:
-        age: 11
-        ssi: 0  # not in TAXSIM35
-        state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
-        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
-      person5:
-        age: 11
-        ssi: 0  # not in TAXSIM35
-        state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
-        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+        age: 16
     tax_units:
       tax_unit:
-        members: [person1, person2, person3, person4, person5]
+        members: [person1, person2]
         premium_tax_credit: 0  # not in TAXSIM35
-        local_income_tax: 0  # not in TAXSIM35
-        state_sales_tax: 0  # not in TAXSIM35
-        ca_use_tax: 0  # not in TAXSIM35
-        il_use_tax: 0  # not in TAXSIM35
-        nm_2021_income_rebate: 0  # not in TAXSIM35
-        nm_additional_2021_income_rebate: 0  # not in TAXSIM35
-        nm_supplemental_2021_income_rebate: 0  # not in TAXSIM35
-        ny_supplemental_eitc: 0  # not in TAXSIM35
-        ok_use_tax: 0  # not in TAXSIM35
-        pa_use_tax: 0  # not in TAXSIM35
-        vt_renter_credit: 0  # not in TAXSIM35
     spm_units:
       spm_unit:
-        members: [person1, person2, person3, person4, person5]
+        members: [person1, person2]
         snap: 0  # not in TAXSIM35
-        tanf: 0  # not in TAXSIM35
     households:
       household:
-        members: [person1, person2, person3, person4, person5]
+        members: [person1, person2]
         state_fips: 21  # KY
-  output:  # expected results from patched TAXSIM35 2024-03-04 version
-    ky_income_tax: 100.25
+  output:  # expected results from patched TAXSIM35 2024-03-16 version
+    ky_pension_income_exclusion: [12000, 0]
+    ky_income_tax: 1626.50

--- a/policyengine_us/variables/gov/states/ky/tax/income/exclusions/pension_income/ky_pension_income_exclusion.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/exclusions/pension_income/ky_pension_income_exclusion.py
@@ -39,6 +39,6 @@ class ky_pension_income_exclusion(Variable):
             + non_exempt_amount
         )
         # Apply cap (towards just other income if exemption eligible).
-        base = min_(other_income, p.threshold)  
-        exemption = exemption_eligible * exempt_amount  
+        base = min_(other_income, p.threshold)
+        exemption = exemption_eligible * exempt_amount
         return base + exemption

--- a/policyengine_us/variables/gov/states/ky/tax/income/exclusions/pension_income/ky_pension_income_exclusion.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/exclusions/pension_income/ky_pension_income_exclusion.py
@@ -38,10 +38,9 @@ class ky_pension_income_exclusion(Variable):
             add(person, period, p.other_retirement_income_sources)
             + non_exempt_amount
         )
-
         # Apply cap (towards just other income if exemption eligible).
         return where(
             exemption_eligible,
             exempt_amount + min_(other_income, p.threshold),
-            min_(pension_income + other_income, p.threshold),
+            min_(other_income, p.threshold),
         )

--- a/policyengine_us/variables/gov/states/ky/tax/income/exclusions/pension_income/ky_pension_income_exclusion.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/exclusions/pension_income/ky_pension_income_exclusion.py
@@ -39,8 +39,6 @@ class ky_pension_income_exclusion(Variable):
             + non_exempt_amount
         )
         # Apply cap (towards just other income if exemption eligible).
-        return where(
-            exemption_eligible,
-            exempt_amount + min_(other_income, p.threshold),
-            min_(other_income, p.threshold),
-        )
+        base = min_(other_income, p.threshold)  
+        exemption = exemption_eligible * exempt_amount  
+        return base + exemption


### PR DESCRIPTION
Fixes #4241