### PR TITLE
Include the self employment deduction to the list of Michigan additions and remove the self employment income from the list of household resources

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -3,3 +3,4 @@
     fixed:
     - Include the self employment deduction to the list of Michigan additions.
     - Remove the self employment income from the list of household resources.
+    - Subtract the above the line deductions from the household resources.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Include the self employment deduction to the list of Michigan additions.
+    - Remove the self employment income from the list of household resources.

--- a/policyengine_us/parameters/gov/states/mi/tax/income/additions.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/additions.yaml
@@ -1,7 +1,8 @@
 description: Michigan adds these sources to federal adjusted gross income when computing taxable income.  
 values:
-  2017-01-01: []
-# Current Michigan additions are not included in the model.
+  2017-01-01: 
+    - self_employment_tax_ald
+
 metadata:
   unit: list  
   label: Michigan taxable income addition sources  

--- a/policyengine_us/parameters/gov/states/mi/tax/income/household_resources.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/household_resources.yaml
@@ -2,7 +2,6 @@ description: Michigan accounts for the following income sources as the household
 values:
   2021-01-01:
     - irs_employment_income
-    - self_employment_income
     - strike_benefits
     - dividend_income
     - interest_income

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/integration.yaml
@@ -52,3 +52,53 @@
         state_fips: 26  # MI
   output:  # expected results from patched TAXSIM35 2024-03-06 version
     mi_income_tax: 2178.13
+
+- name: Tax unit with taxsimid 50656 in j21.its.csv and j21.ots.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 59
+        employment_income: 2010
+        qualified_dividend_income: 1005.0
+        taxable_interest_income: 5505.0
+        short_term_capital_gains: 3005.0
+        long_term_capital_gains: 505.0
+        rental_income: 2005.0
+        taxable_private_pension_income: 3500.0
+        rent: 24000
+        self_employment_income: 10010
+        business_is_qualified: true
+        business_is_sstb: true
+        w2_wages_from_qualified_business: 100e6
+        ssi: 0  # not in TAXSIM35
+        state_supplement: 0  # not in TAXSIM35
+        wic: 0  # not in TAXSIM35
+        ma_covid_19_essential_employee_premium_pay_program: 0  # not in TAXSIM35
+      person2:
+        age: 59
+        employment_income: 9010
+        qualified_dividend_income: 1005
+        taxable_interest_income: 5505
+        short_term_capital_gains: 3005
+        long_term_capital_gains: 505
+        rental_income: 2005.0
+        taxable_private_pension_income: 3500
+      person3:
+        age: 16
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        premium_tax_credit: 0  # not in TAXSIM35
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        snap: 0  # not in TAXSIM35
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_fips: 26  # MI
+  output:  # expected results from patched TAXSIM35 2024-03-09 version
+    mi_taxable_income: 37_380
+    mi_income_tax: 88.65

--- a/policyengine_us/variables/gov/states/mi/tax/income/mi_household_resources.py
+++ b/policyengine_us/variables/gov/states/mi/tax/income/mi_household_resources.py
@@ -10,4 +10,4 @@ class mi_household_resources(Variable):
     defined_for = StateCode.MI
     reference = "https://law.justia.com/codes/michigan/2022/chapter-206/statute-act-281-of-1967/division-281-1967-1/division-281-1967-1-9/section-206-508/"
     adds = "gov.states.mi.tax.income.household_resources"
-    subtracts = ["health_insurance_premiums"]
+    subtracts = ["health_insurance_premiums", "above_the_line_deductions"]


### PR DESCRIPTION
Fixes #4243