### PR TITLE
Adjust the Los Angeles income types to exclude basic income.

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Adjust the Los Angeles income types to exclude basic income.

--- a/policyengine_us/parameters/gov/local/ca/la/dwp/ez_save/income_sources.yaml
+++ b/policyengine_us/parameters/gov/local/ca/la/dwp/ez_save/income_sources.yaml
@@ -13,5 +13,8 @@ values:
     - self_employment_income
     - child_support_received
     - alimony_income
-    - household_benefits # Assuming all government benefits are included
+    - social_security
+    - ssi
+    - tanf
+    - snap
     - pension_income


### PR DESCRIPTION
Fixes #4546