### PR TITLE
State tax reforms produce no impact in microsimulation

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Bug causing State taxes to not have effects in microsimulations.

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -59,9 +59,12 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
         self.parameters = propagate_parameter_metadata(self.parameters)
         self.add_abolition_parameters()
 
-        reform = create_structural_reforms_from_parameters(
+        structural_reform = create_structural_reforms_from_parameters(
             self.parameters, year_start
         )
+        if reform is None:
+            reform = ()
+        reform = (reform, structural_reform)
 
         self.parameters = backdate_parameters(
             self.parameters, first_instant="2020-01-01"
@@ -71,7 +74,7 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
             parameter.modified = False
 
         if reform is not None:
-            reform.apply(self)
+            self.apply_reform_set(reform)
 
         self.add_variables(*create_50_state_variables())
 


### PR DESCRIPTION
Fixes #4538

TL;DR: parameters were being marked as unmodified (therefore caching overrides) even though the parametric reforms were being applied.