### PR TITLE
Eliminate randomness in baseline tax results across model runsUse same zip_code seed across runs.

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Randomness in baseline tax results across model runs.

--- a/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
+++ b/policyengine_us/variables/household/demographic/geographic/zip_code/zip_code.py
@@ -36,6 +36,7 @@ class zip_code(Variable):
                     .sample(
                         count_households_in_state,
                         weights="population",
+                        random_state=192837465,
                         replace=True,
                     )
                     .zip_code


### PR DESCRIPTION
Fixes issue #3579.   Replaces pull request #4052.