### PR TITLE
Update tables

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     changed:
-    - Updated version of tables
+    - Updated version of tables.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Updated version of tables

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "requests",
         "scipy==1.10.1",
         "synthimpute",
-        "tables==3.8.0",
+        "tables==3.9.2",
         "tabulate",
         "tqdm",
     ],


### PR DESCRIPTION
Fixes #4273

PR updates `tables` to allow some external contributors who had install issues with `tables==3.8.0` to contribute. I haven't run into the error messages mentioned in the issue, which was opened in March.