### PR TITLE
Fixed loss.py docstring

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+      - Inaccurate docstring in loss.py

--- a/policyengine_us/data/datasets/cps/enhanced_cps/loss.py
+++ b/policyengine_us/data/datasets/cps/enhanced_cps/loss.py
@@ -19,12 +19,12 @@ def generate_model_variables(
         no_weight_adjustment (bool, optional): Whether to skip the weight adjustment. Defaults to False.
 
     Returns:
-        household_weights (torch.Tensor): The household weights.
-        weight_adjustment (torch.Tensor): The weight adjustment.
+        household_weights (np.ndarray): The household weights.
+        weight_adjustment (np.ndarray): The weight adjustment.
         values_df (pd.DataFrame): A 2D array of values to transform household weights into statistical predictions.
         targets (dict): A dictionary of names and target values for the statistical predictions.
-        targets_array (dict): A 1D array of target values for the statistical predictions.
-        equivalisation_factors_array (dict): A 1D array of equivalisation factors for the statistical predictions to normalise the targets.
+        targets_array (np.ndarray): A 1D array of target values for the statistical predictions.
+        equivalisation_factors_array (np.ndarray): A 1D array of equivalisation factors for the statistical predictions to normalise the targets.
     """
     simulation = Microsimulation(dataset=dataset)
     simulation.default_calculation_period = time_period


### PR DESCRIPTION
I replaced some of the data types specified in the loss.py docstring with the data types that my testing returned.

My one reservation is that I'm not sure if the bug is with the docstring, or with the returned data types. I fixed the docstring because that was easier, but if you want me to rewrite PolicyEngine US so that it returns Torch tensors, I can do that as well.