### PR TITLE
Rent Relief Credit needs to use un-reduced income for calculating the excess

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Use un-reduced income for calculating the excess of the rent relief credit.

--- a/policyengine_us/reforms/harris/rent_relief_act/rent_relief_tax_credit.py
+++ b/policyengine_us/reforms/harris/rent_relief_act/rent_relief_tax_credit.py
@@ -33,10 +33,12 @@ def create_rent_relief_tax_credit() -> Reform:
             rent_cap = safmr * p.safmr_share_rent_cap
             capped_rent = min_(rent, rent_cap)
             gross_income_fraction = (
-                p.rent_income_share_threshold * applicable_gross_income
+                p.rent_income_share_threshold * gross_income
             )
             rent_excess = max_(capped_rent - gross_income_fraction, 0)
-            applicable_percentage = p.applicable_percentage.calc(gross_income)
+            applicable_percentage = p.applicable_percentage.calc(
+                applicable_gross_income
+            )
             amount_if_rent_not_subsidized = applicable_percentage * rent_excess
             housing_assistance = tax_unit.spm_unit(
                 "housing_assistance", period

--- a/policyengine_us/reforms/harris/rent_relief_act/rent_relief_tax_credit.py
+++ b/policyengine_us/reforms/harris/rent_relief_act/rent_relief_tax_credit.py
@@ -18,26 +18,28 @@ def create_rent_relief_tax_credit() -> Reform:
                 period
             ).gov.contrib.harris.rent_relief_act.rent_relief_credit
             safmr = tax_unit.household("small_area_fair_market_rent", period)
-            safmr_used_for_hcv = tax_unit.household(
-                "safmr_used_for_hcv", period
-            )
+
             gross_income = add(tax_unit, period, ["irs_gross_income"])
             # Reduce the income (equivalent to raising thresholds) for households
             # in high income areas, as defined by using SAFMR for HCV.
-            high_income_reduction = (
-                safmr_used_for_hcv * p.high_income_area_threshold_increase
-            )
-            applicable_gross_income = max_(
-                gross_income - high_income_reduction, 0
-            )
+
             rent_cap = safmr * p.safmr_share_rent_cap
             capped_rent = min_(rent, rent_cap)
             gross_income_fraction = (
                 p.rent_income_share_threshold * gross_income
             )
             rent_excess = max_(capped_rent - gross_income_fraction, 0)
+            safmr_used_for_hcv = tax_unit.household(
+                "safmr_used_for_hcv", period
+            )
+            high_income_reduction = (
+                safmr_used_for_hcv * p.high_income_area_threshold_increase
+            )
+            applicable_gross_income = max_(
+                gross_income - high_income_reduction, 0
+            )
             applicable_percentage = p.applicable_percentage.calc(
-                applicable_gross_income
+                applicable_gross_income, right=True
             )
             amount_if_rent_not_subsidized = applicable_percentage * rent_excess
             housing_assistance = tax_unit.spm_unit(

--- a/policyengine_us/tests/policy/contrib/harris/rent_relief_act/rent_relief_tax_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/harris/rent_relief_act/rent_relief_tax_credit.yaml
@@ -74,32 +74,6 @@
   output:
     rent_relief_tax_credit: 0
 
-- name: Credit partially reduced, safmr used for HCV
-  period: 2019
-  reforms: policyengine_us.reforms.harris.rent_relief_act.rent_relief_tax_credit.rent_relief_tax_credit
-  input:
-    gov.contrib.harris.rent_relief_act.rent_relief_credit.in_effect: true
-    people:
-      person1:
-        irs_gross_income: 55_000
-        rent: 26_500
-      person2:
-        irs_gross_income: 0
-    tax_units:
-      tax_unit:
-        members: [person1, person2]
-        eitc: 0
-    spm_units:
-      spm_unit:
-        members: [person1, person2]
-        housing_assistance: 0
-    households:
-      household:
-        members: [person1, person2]
-        small_area_fair_market_rent: 25_000
-        safmr_used_for_hcv: true
-  output:
-    rent_relief_tax_credit: 8_000
 
 - name: Credit partially reduced, safmr not used for HCV
   period: 2019
@@ -183,3 +157,30 @@
         safmr_used_for_hcv: false
   output:
     rent_relief_tax_credit: 0
+
+- name: Credit partially reduced, safmr used for HCV
+  period: 2019
+  reforms: policyengine_us.reforms.harris.rent_relief_act.rent_relief_tax_credit.rent_relief_tax_credit
+  input:
+    gov.contrib.harris.rent_relief_act.rent_relief_credit.in_effect: true
+    people:
+      person1:
+        irs_gross_income: 55_000
+        rent: 26_500
+      person2:
+        irs_gross_income: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        eitc: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        housing_assistance: 0
+    households:
+      household:
+        members: [person1, person2]
+        small_area_fair_market_rent: 25_000
+        safmr_used_for_hcv: true
+  output:
+    rent_relief_tax_credit: 6_375

--- a/policyengine_us/tests/policy/contrib/harris/rent_relief_act/rent_relief_tax_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/harris/rent_relief_act/rent_relief_tax_credit.yaml
@@ -61,7 +61,6 @@
       tax_unit:
         members: [person1, person2]
         rents: 40_000
-        eitc: 0
     spm_units:
       spm_unit:
         members: [person1, person2]
@@ -89,7 +88,6 @@
     tax_units:
       tax_unit:
         members: [person1, person2]
-        eitc: 0
     spm_units:
       spm_unit:
         members: [person1, person2]
@@ -117,7 +115,6 @@
     tax_units:
       tax_unit:
         members: [person1, person2]
-        eitc: 0
     spm_units:
       spm_unit:
         members: [person1, person2]
@@ -145,7 +142,6 @@
     tax_units:
       tax_unit:
         members: [person1, person2]
-        eitc: 0
     spm_units:
       spm_unit:
         members: [person1, person2]
@@ -172,7 +168,6 @@
     tax_units:
       tax_unit:
         members: [person1, person2]
-        eitc: 0
     spm_units:
       spm_unit:
         members: [person1, person2]
@@ -199,7 +194,6 @@
     tax_units:
       tax_unit:
         members: [person1, person2]
-        eitc: 0
     spm_units:
       spm_unit:
         members: [person1, person2]

--- a/policyengine_us/tests/policy/contrib/harris/rent_relief_act/rent_relief_tax_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/harris/rent_relief_act/rent_relief_tax_credit.yaml
@@ -75,7 +75,7 @@
     rent_relief_tax_credit: 0
 
 
-- name: Credit partially reduced, safmr not used for HCV
+- name: Credit partially reduced, SAFMR not used for HCV 
   period: 2019
   reforms: policyengine_us.reforms.harris.rent_relief_act.rent_relief_tax_credit.rent_relief_tax_credit
   input:
@@ -102,7 +102,7 @@
   output:
     rent_relief_tax_credit: 4_250
 
-- name: Householf received subsidized rent
+- name: Household received subsidized rent 
   period: 2019
   absolute_error_margin: 1
   reforms: policyengine_us.reforms.harris.rent_relief_act.rent_relief_tax_credit.rent_relief_tax_credit
@@ -184,3 +184,30 @@
         safmr_used_for_hcv: true
   output:
     rent_relief_tax_credit: 6_375
+
+- name: 50k in a SAMFR-for-HCV area
+  period: 2019
+  reforms: policyengine_us.reforms.harris.rent_relief_act.rent_relief_tax_credit.rent_relief_tax_credit
+  input:
+    gov.contrib.harris.rent_relief_act.rent_relief_credit.in_effect: true
+    people:
+      person1:
+        irs_gross_income: 50_000
+        rent: 26_500
+      person2:
+        irs_gross_income: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        eitc: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        housing_assistance: 0
+    households:
+      household:
+        members: [person1, person2]
+        small_area_fair_market_rent: 25_000
+        safmr_used_for_hcv: true
+  output:
+    rent_relief_tax_credit: 10_000


### PR DESCRIPTION
Fixes #4898