### PR TITLE
Typo in NY WFTC EITC match parameter name

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fiex:
+    - Typo in New York working families tax credit match.

--- a/policyengine_us/parameters/gov/contrib/states/ny/wftc/eitc/match.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ny/wftc/eitc/match.yaml
@@ -2,7 +2,7 @@ description: New York matches this fraction of the Earned Income Tax Credit unde
 metadata:
   unit: /1
   period: year
-  label: New York Working Working Families Tax Credit EITC match
+  label: New York Working Families Tax Credit EITC match
   reference: 
     - title: New York Senate Bill S277B Subs. 1 (9)
       href: https://www.nysenate.gov/legislation/bills/2023/S277/amendment/B


### PR DESCRIPTION
Fixes #4897