### PR TITLE
Add `head_start` and `early_head_start` variables to `household_benefits` parameter list

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Add head_start and early_head_start variables to household_benefits parameter.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-    - Add head_start and early_head_start variables to household_benefits parameter.
+    - Add head_start and early_head_start variables to household_state_benefits parameter.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-    - Add head_start and early_head_start variables to household_state_benefits parameter.
+    - Add head_start and early_head_start variables to household_benefits parameter.

--- a/policyengine_us/parameters/gov/household/household_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_benefits.yaml
@@ -12,6 +12,8 @@ values:
     - high_efficiency_electric_home_rebate
     - residential_efficiency_electrification_rebate
     - unemployment_compensation
+    - head_start
+    - early_head_start
     # Contributed.
     - basic_income
     - spm_unit_capped_housing_subsidy

--- a/policyengine_us/parameters/gov/household/household_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_benefits.yaml
@@ -12,8 +12,6 @@ values:
     - high_efficiency_electric_home_rebate
     - residential_efficiency_electrification_rebate
     - unemployment_compensation
-    - head_start
-    - early_head_start
     # Contributed.
     - basic_income
     - spm_unit_capped_housing_subsidy

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -2,6 +2,8 @@ description: The government counts these sources as benefits paid by state agenc
 values:
   2023-01-01:
     - state_supplement
+    - head_start
+    - early_head_start
     - co_state_supplement
     # State child care subsidies.
     - ca_child_care_subsidies

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -2,8 +2,6 @@ description: The government counts these sources as benefits paid by state agenc
 values:
   2023-01-01:
     - state_supplement
-    - head_start
-    - early_head_start
     - co_state_supplement
     # State child care subsidies.
     - ca_child_care_subsidies


### PR DESCRIPTION
Fixes #4918