### PR TITLE
Update `policyengine-core`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update policyengine-core to 3.6.5

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         ),
     ],
     install_requires=[
-        "policyengine-core>=3.6.4",
+        "policyengine-core>=3.6.5",
         "microdf-python",
         "tqdm",
     ],


### PR DESCRIPTION
Fixes #5022.

Updates `policyengine-core` to use `>=3.6.5` to ensure that the update at https://github.com/PolicyEngine/policyengine-core/pull/269 is captured.