### PR TITLE
Break up tests and update `-us-data` version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,10 +45,20 @@ jobs:
           python-version: 3.12
       - name: Install package
         run: make install
-      - name: Run tests
-        run: make test
+      - name: Run non-structural YAML tests
+        run: make test-yaml-no-structural
         env:
           POVERTYTRACKER_RAW_URL: ${{ secrets.POVERTYTRACKER_RAW_URL }}
+      - name: Run structural YAML tests
+        run: make test-yaml-structural
+        env:
+          POVERTYTRACKER_RAW_URL: ${{ secrets.POVERTYTRACKER_RAW_URL }}
+      - name: Run Python-based tests
+        run: make test-other
+        env:
+          POVERTYTRACKER_RAW_URL: ${{ secrets.POVERTYTRACKER_RAW_URL }}
+      - name: Produce combined coverage repository
+        run: make coverage
       - uses: codecov/codecov-action@v4
       - name: Build package
         run: make

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -60,10 +60,20 @@ jobs:
           python-version: 3.12
       - name: Install package
         run: make install
-      - name: Run tests
-        run: make test
+      - name: Run non-structural YAML tests
+        run: make test-yaml-no-structural
         env:
           POVERTYTRACKER_RAW_URL: ${{ secrets.POVERTYTRACKER_RAW_URL }}
+      - name: Run structural YAML tests
+        run: make test-yaml-structural
+        env:
+          POVERTYTRACKER_RAW_URL: ${{ secrets.POVERTYTRACKER_RAW_URL }}
+      - name: Run Python-based tests
+        run: make test-other
+        env:
+          POVERTYTRACKER_RAW_URL: ${{ secrets.POVERTYTRACKER_RAW_URL }}
+      - name: Produce combined coverage repository
+        run: make coverage
       - uses: codecov/codecov-action@v4
       - name: Test documentation builds
         if: matrix.os == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ venv/
 **/_build
 **/.ipynb_checkpoints
 .coverage
+.coverage.*
 **/*.xml
 taxcalc_output
 .vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ test:
 	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/ -c policyengine_us
 	coverage xml -i
 test-yaml-structural:
-	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib -c policyengine_us 
+	coverage run -a --branch --data-file=.coverage.contrib -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib -c policyengine_us 
 test-yaml-no-structural:
-	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline -c policyengine_us
-	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/reform -c policyengine_us
+	coverage run -a --branch --data-file=.coverage.baseline -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline -c policyengine_us
+	coverage run -a --branch --data-file=.coverage.reform -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/reform -c policyengine_us
 test-other:
 	pytest policyengine_us/tests/ --maxfail=0
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ test:
 test-yaml-structural:
 	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib -c policyengine_us 
 test-yaml-no-structural:
-	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy --ignore policyengine_us/tests/policy/contrib -c policyengine_us
+	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline -c policyengine_us
+	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/reform -c policyengine_us
 test-other:
 	pytest policyengine_us/tests/ --maxfail=0
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,15 @@ test:
 	pytest policyengine_us/tests/ --maxfail=0
 	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/ -c policyengine_us
 	coverage xml -i
+test-yaml-structural:
+	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib -c policyengine_us 
+test-yaml-no-structural:
+	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy --ignore policyengine_us/tests/policy/contrib -c policyengine_us
+test-other:
+	pytest policyengine_us/tests/ --maxfail=0
+coverage:
+	coverage combine
+	coverage xml -i
 documentation:
 	jb clean docs
 	jb build docs

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    added:
+    - Loading of policyengine-us-data from PyPI
+    fixed:
+    - Divided tests within GitHub Actions to avoid resource issues

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     install_requires=[
         "policyengine-core>=3.6.5",
-        "policyengine-us-data @ git+https://git@github.com/PolicyEngine/policyengine-us-data.git",
+        "policyengine-us-data>=1.1.0",
         "microdf-python",
         "tqdm",
     ],


### PR DESCRIPTION
Fixes #5039.
Fixes #5061.

To avoid running out of resources when running GitHub Actions, this PR divides up the test runs into three portions, creating three new `make` recipes to accommodate this. It also runs `coverage` separately, where relevant, and combines the resulting datasets. Finally, it sets the required version of `-us-data` to a PyPI-compatible version.

Note that pushing would render #5051 moot.