### PR TITLE
Move Medicaid parameters to CSVs

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Medicaid national parameters run off a CSV, cutting runtime by ~8%.

--- a/policyengine_us/parameters/__init__.py
+++ b/policyengine_us/parameters/__init__.py
@@ -1,4 +1,1 @@
-from pathlib import Path
-from policyengine_core.parameters import ParameterNode
 
-default_parameters = ParameterNode(directory_path=Path(__file__).parent)

--- a/policyengine_us/parameters/gov/hhs/medicaid/geography/__init__.py
+++ b/policyengine_us/parameters/gov/hhs/medicaid/geography/__init__.py
@@ -1,0 +1,9 @@
+import pandas as pd
+from pathlib import Path
+
+FOLDER = Path(__file__).parent
+
+medicaid_rating_areas = pd.read_csv(FOLDER / "medicaid_rating_areas.csv")
+second_lowest_silver_plan_cost = pd.read_csv(
+    FOLDER / "second_lowest_silver_plan_cost.csv"
+)

--- a/policyengine_us/variables/household/demographic/geographic/slspc.py
+++ b/policyengine_us/variables/household/demographic/geographic/slspc.py
@@ -3,6 +3,9 @@ from policyengine_core.parameters.operations import (
     homogenize_parameter_structures,
 )
 from policyengine_core.simulations import Simulation
+from policyengine_us.parameters.gov.hhs.medicaid.geography import (
+    second_lowest_silver_plan_cost as slspc_data,
+)
 
 
 class second_lowest_silver_plan_cost(Variable):
@@ -11,7 +14,6 @@ class second_lowest_silver_plan_cost(Variable):
     label = "Second-lowest silver plan cost"
     unit = USD
     definition_period = YEAR
-    defined_for = "is_ptc_eligible"
     hidden_input = True
 
     def formula(tax_unit, period, parameters):
@@ -23,31 +25,11 @@ class second_lowest_silver_plan_cost(Variable):
             # If the user has provided a value for the second-lowest silver plan
             # cost, use that.
             return simulation.calculate("reported_slspc", period)
-        parameter_tree = tax_unit.simulation.tax_benefit_system.parameters
-        if not hasattr(parameter_tree.gov.hhs.medicaid, "geography"):
-            medicaid_parameters = ParameterNode(
-                directory_path=REPO
-                / "params_on_demand"
-                / "gov"
-                / "hhs"
-                / "medicaid"
-                / "geography"
-            )
-            medicaid_parameters = homogenize_parameter_structures(
-                medicaid_parameters,
-                tax_unit.simulation.tax_benefit_system.variables,
-            )
-            parameter_tree.gov.hhs.medicaid.add_child(
-                "geography", medicaid_parameters
-            )
         person = tax_unit.members
         household = person.household
         area = household("medicaid_rating_area", period)
         state = household("state_code_str", period)
         age = person("age", period)
-        slspc = parameter_tree.gov.hhs.medicaid.geography.second_lowest_silver_plan_cost(
-            period
-        )
         age_code = select(
             [
                 age < 21,
@@ -61,9 +43,20 @@ class second_lowest_silver_plan_cost(Variable):
             ],
         )
         eligible = person.tax_unit("is_ptc_eligible", period)
-        per_person_cost = index_(
-            into=slspc,
-            indices=[state, area, age_code],
-            where=eligible,
+        per_person_cost = np.zeros_like(age)
+        lookup_df = pd.DataFrame(
+            {
+                "state": state,
+                "rating_area": area,
+                "age": age_code,
+            }
         )
+        merged = pd.merge(
+            lookup_df[eligible],
+            slspc_data,
+            how="left",
+            on=["state", "rating_area", "age"],
+        ).value.values
+        per_person_cost = np.zeros_like(age)
+        per_person_cost[eligible] = merged
         return tax_unit.sum(per_person_cost)


### PR DESCRIPTION
Fixes #5100

From initial checks it seems like this cuts the SLSPC variable computation time from 3.3s to 0.6s (taking total disposable income runtime down around 8%.

