### PR TITLE
Vermont tax parameters include unnecessary breakdown

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+    - Unnecessary parameters in VT's parameter tree.

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/fair_market_rent.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/fair_market_rent.yaml
@@ -4,7 +4,6 @@ metadata:
   period: month
   breakdown: 
     - list(range(1,9))
-    - county
   label: Vermont fair market rent amount 
   reference: 
     # The values are derived from the renter credit computation tables which represent 10% of the 

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/fifty_percent.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/fifty_percent.yaml
@@ -4,7 +4,6 @@ metadata:
   period: year
   breakdown: 
     - list(range(1,8))
-    - county
   label: Vermont partial renter credit income limit  
   reference:
      # The table is derived from the official Vermont government website. The legal code refers to area median income.

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/thirty_percent.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/thirty_percent.yaml
@@ -3,8 +3,7 @@ metadata:
   unit: currency-USD 
   period: year
   breakdown: 
-    - list(range(1,8))
-    - county
+    - list(range(1,8))    
   label: Vermont full renter credit income limit
   reference:
      # The table is derived from the official Vermont government website. The legal code refers to area median income.


### PR DESCRIPTION
Fixes #5102

I think this should still work because we're never passing in non-VT counties into this formula. Or if that isn't true, we should change the code so it is with a defined-for attribute.
