### PR TITLE
Fix abolitions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Moved loading of abolitions parameters earlier in initialization process

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -48,6 +48,7 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
     def __init__(self, reform=None):
         super().__init__(entities, reform=reform)
         self.load_parameters(COUNTRY_DIR / "parameters")
+        self.add_abolition_parameters()
         if reform:
             self.apply_reform_set(reform)
         self.parameters = set_irs_uprating_parameter(self.parameters)
@@ -58,7 +59,6 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
         self.parameters = interpolate_parameters(self.parameters)
         self.parameters = uprate_parameters(self.parameters)
         self.parameters = propagate_parameter_metadata(self.parameters)
-        self.add_abolition_parameters()
         add_default_uprating(self)
 
         structural_reform = create_structural_reforms_from_parameters(

--- a/policyengine_us/tests/policy/baseline/gov/abolitions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/abolitions.yaml
@@ -1,0 +1,9 @@
+- name: Abolish adjusted gross income
+  period: 2024
+  input:
+    gov.abolitions.adjusted_gross_income: true
+    filing_status: SINGLE
+    taxable_self_employment_income: 1_000
+    irs_employment_income: 10_000
+  output:
+    adjusted_gross_income: 0


### PR DESCRIPTION
Fixes #5161.

Previously, the abolitions folder was correctly added to the US model, but when activating an abolition parameter, the application would crash. This PR moves up the adding of the abolitions parameters such that they're added before the application of a reform. This also adds a basic test for abolishing the `adjusted_gross_income` variable, but more can be added if desired.