### PR TITLE
test: Attempt to load from core updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         ),
     ],
     install_requires=[
-        "policyengine-core>=3.8.1",
+        "policyengine-core @ git+https://github.com/anth-volk/policyengine-core.git@fix/varying-fail",
         "policyengine-us-data==1.11.0",
         "microdf-python",
         "tqdm",


### PR DESCRIPTION
This is a test PR and will be deleted. This is open to test whether or not https://github.com/PolicyEngine/policyengine-core/pull/294 passes all current `-us` tests in advance of merging in `-core`.