### PR TITLE
Correct meets_school_meal_categorical_eligibility for vectorized inputs

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    fixed:
+    - Corrected meets_school_meal_categorical_eligilibity to properly calculate eligibility for vectorized inputs.
+    added:
+    - Test for meets_school_meal_categorical_eligibility with vectorized inputs.

--- a/policyengine_us/tests/policy/baseline/gov/usda/school_meals/meets_school_meal_categorical_eligibility.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/school_meals/meets_school_meal_categorical_eligibility.yaml
@@ -81,3 +81,12 @@
       is_head_start_eligible: false
   output:
       meets_school_meal_categorical_eligibility: false
+
+- name: Vectorized operations
+  period: 2024
+  input:
+      snap: [1, 0, 0, 0, 0, 0, 0, 0]
+      fdpir: [0, 1, 1, 0, 0, 0, 0, 0]
+      is_homeless: [False, False, True, True, False, False, False, False]
+  output:
+      meets_school_meal_categorical_eligibility: [True, True, True, True, False, False, False, False]

--- a/policyengine_us/variables/gov/usda/school_meals/meets_school_meal_categorical_eligibility.py
+++ b/policyengine_us/variables/gov/usda/school_meals/meets_school_meal_categorical_eligibility.py
@@ -12,4 +12,4 @@ class meets_school_meal_categorical_eligibility(Variable):
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.usda.school_meals
         programs = add(spm_unit, period, p.categorical_eligibility)
-        return np.any(programs)
+        return programs > 0

--- a/policyengine_us/variables/gov/usda/school_meals/meets_school_meal_categorical_eligibility.py
+++ b/policyengine_us/variables/gov/usda/school_meals/meets_school_meal_categorical_eligibility.py
@@ -8,8 +8,4 @@ class meets_school_meal_categorical_eligibility(Variable):
     documentation = "Whether this SPM unit is eligible for free school meal via participation in other programs"
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/cfr/text/7/245.2"
-
-    def formula(spm_unit, period, parameters):
-        p = parameters(period).gov.usda.school_meals
-        programs = add(spm_unit, period, p.categorical_eligibility)
-        return programs > 0
+    adds = "gov.usda.school_meals.categorical_eligibility"


### PR DESCRIPTION
Fixes #5317 

See the write-up in #5317 that explains how this bug functions. This PR changes how we evaluate whether or not someone is categorically eligible for free school meals, checking whether the total value they receive from eligible programs is greater than 0. This is supported for Booleans (since True is cast to 1) and supported by an added test.