### PR TITLE
Remove the child tax rebate from the list of 2023 rhode island refundable credits

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Remove the child tax rebate from the list of 2023 rhode island refundable credits.

--- a/policyengine_us/parameters/gov/states/ri/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/credits/refundable.yaml
@@ -7,6 +7,9 @@ values:
     - ri_eitc
     - ri_property_tax_credit
     - ri_child_tax_rebate
+  2023-01-01:
+    - ri_eitc
+    - ri_property_tax_credit
 
 metadata:
   reference:

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/integration.yaml
@@ -1,0 +1,21 @@
+- name: Joint filers with 81k of income each and one dependent
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 81_000
+      person2: 
+        age: 19
+        employment_income: 81_000
+      person3:
+        age: 8
+    tax_units:
+      tax_units:
+        members: [person1, person2, person3]
+    households:
+      households:
+        state_code: RI
+  output:
+    ri_income_tax: 5_338


### PR DESCRIPTION
Fixes #5329