### PR TITLE
Update pinned versions of policyengine-core and policyengine-us-data

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - Upgraded minimum policyengine-core version
+    - Allowed more flexibility in policyengine-us-data version

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,9 @@ setup(
         ),
     ],
     install_requires=[
-        "policyengine-core>=3.10.0",
-        "policyengine-us-data==1.13.0",
+        "policyengine-core>=3.14.1",
+        # Removing the > portion of the below will cause circular dep issues in -us-data
+        "policyengine-us-data>=1.13.0",
         "microdf-python>=0.4.3",
         "tqdm",
     ],


### PR DESCRIPTION
Fixes #5379. See the original issue for more details as to why this is necessary.

Following approval and merging of this issue, I should be able to rework https://github.com/PolicyEngine/policyengine-us-data/pull/130 to allow for the use of Hugging Face dataset downloads.