### PR TITLE
Remove the SNAP child support deduction from the net income computation if applied to gross income

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Remove the SNAP child support deduction from the net income computation if applied to gross income.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_child_support_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_child_support_deduction.yaml
@@ -1,0 +1,15 @@
+- name: 0 out if gross income deduction is present
+  period: 2022
+  input:
+    child_support_expense: 500
+    snap_child_support_gross_income_deduction: 500
+  output:
+    snap_child_support_deduction: 0
+
+- name: Otherwise, full deduction
+  period: 2022
+  input:
+    child_support_expense: 500
+    snap_child_support_gross_income_deduction: 0
+  output:
+    snap_child_support_deduction: 500

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_net_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_net_income.yaml
@@ -54,3 +54,33 @@
         state_group: CONTIGUOUS_US
   output:
     snap_net_income: 428.5 * 12
+
+- name: SNAP child support deduction integration test
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person_1:
+        age: 30
+        child_support_expense: 500
+      person_2:
+        age: 10
+    spm_units:
+      spm_unit:
+        snap_earned_income: 2_000
+        snap_unearned_income: 0
+        members: [person_1, person_2]
+        snap_standard_deduction: 0
+        snap_earned_income_deduction: 0
+        snap_excess_medical_expense_deduction: 0
+        snap_excess_shelter_expense_deduction: 0
+        snap_dependent_care_deduction: 0
+    households:
+      household:
+        state_code: DC
+  output:
+    snap_child_support_gross_income_deduction: 500
+    snap_gross_income: 1_500
+    snap_child_support_deduction: 0
+    snap_deductions: 0
+    snap_net_income: 1_500

--- a/policyengine_us/variables/gov/usda/snap/income/deductions/snap_child_support_deduction.py
+++ b/policyengine_us/variables/gov/usda/snap/income/deductions/snap_child_support_deduction.py
@@ -12,4 +12,11 @@ class snap_child_support_deduction(Variable):
     definition_period = MONTH
     reference = "https://www.law.cornell.edu/uscode/text/7/2014#e_4"
 
-    adds = ["child_support_expense"]
+    # Excluding deduction for child support, which is applies to the gross income
+    # calculation
+    def formula(spm_unit, period, parameters):
+        child_support = add(spm_unit, period, ["child_support_expense"])
+        gross_income_deduction = spm_unit(
+            "snap_child_support_gross_income_deduction", period
+        )
+        return max_(child_support - gross_income_deduction, 0)


### PR DESCRIPTION
Fixes #5369