### PR TITLE
Uprate MOOP by CMS projections and remove OTC expenses from IRS and SNAP MOOP definitions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    removed:
+      - Over-the-counter expenses from MOOP definition for IRS and SNAP.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,5 @@
   changes:
     removed:
       - Over-the-counter expenses from MOOP definition for IRS and SNAP.
+    changed:
+      - Uprate medical expense categories by CMS MOOP per capita projections.

--- a/policyengine_us/parameters/calibration/gov/hhs/cms/moop_per_capita.yaml
+++ b/policyengine_us/parameters/calibration/gov/hhs/cms/moop_per_capita.yaml
@@ -1,0 +1,35 @@
+description: The Centers for Medicare and Medicaid Services (CMS) projects these per-capita out-of-pocket health payments.
+metadata:
+  unit: currency-USD
+  label: Per-capita MOOP
+  reference:
+  # Data underlying figures:
+  # https://www.cms.gov/files/zip/nhe-projections-tables.zip
+  # Table03 National Health Expenditures by Sources of Funds
+  # Retrieved 2025-02-17.
+  - title: NHE Projections
+    href: https://www.cms.gov/data-research/statistics-trends-and-reports/national-health-expenditure-data/projected
+values:
+  # Historical.
+  2016-01-01: 1_130
+  2017-01-01: 1_139
+  2018-01-01: 1_181
+  2019-01-01: 1_227
+  2020-01-01: 1_210
+  2021-01-01: 1_341
+  2022-01-01: 1_425
+  # Projections.
+  2023-01-01: 1_528
+  2024-01-01: 1_619
+  2025-01-01: 1_669
+  2026-01-01: 1_720
+  2027-01-01: 1_786
+  2028-01-01: 1_851
+  2029-01-01: 1_917
+  2030-01-01: 1_985
+  2031-01-01: 2_057
+  2032-01-01: 2_131
+  # Applying the same growth rate as 2031-2032.
+  2033-01-01: 2_208 # 2_131 * (2_131 / 2_057)
+  2034-01-01: 2_287 # 2_131 * (2_131 / 2_057)^2
+  2035-01-01: 2_369 # 2_131 * (2_131 / 2_057)^3

--- a/policyengine_us/variables/household/expense/health/ambulance_expense.py
+++ b/policyengine_us/variables/household/expense/health/ambulance_expense.py
@@ -7,3 +7,4 @@ class ambulance_expense(Variable):
     label = "Ambulance expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/er_visit_expense.py
+++ b/policyengine_us/variables/household/expense/health/er_visit_expense.py
@@ -7,3 +7,4 @@ class er_visit_expense(Variable):
     label = "Emergency room visit expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/health_insurance_premiums_without_medicare_part_b.py
+++ b/policyengine_us/variables/household/expense/health/health_insurance_premiums_without_medicare_part_b.py
@@ -7,4 +7,4 @@ class health_insurance_premiums_without_medicare_part_b(Variable):
     label = "Health insurance premiums without Medicare Part B premiums"
     unit = USD
     definition_period = YEAR
-    uprating = "gov.bls.cpi.cpi_u"
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/health_savings_account_contributions.py
+++ b/policyengine_us/variables/household/expense/health/health_savings_account_contributions.py
@@ -9,3 +9,4 @@ class health_savings_account_payroll_contributions(Variable):
     label = "Health Savings Account payroll contributions"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/imaging_expense.py
+++ b/policyengine_us/variables/household/expense/health/imaging_expense.py
@@ -7,3 +7,4 @@ class imaging_expense(Variable):
     label = "Imaging expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/inpatient_expense.py
+++ b/policyengine_us/variables/household/expense/health/inpatient_expense.py
@@ -7,3 +7,4 @@ class inpatient_expense(Variable):
     label = "Inpatient expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/lab_expense.py
+++ b/policyengine_us/variables/household/expense/health/lab_expense.py
@@ -7,3 +7,4 @@ class lab_expense(Variable):
     label = "Lab expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/long_term_health_insurance_premiums.py
+++ b/policyengine_us/variables/household/expense/health/long_term_health_insurance_premiums.py
@@ -7,3 +7,4 @@ class long_term_health_insurance_premiums(Variable):
     label = "Long-term health insurance premiums"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/medical_out_of_pocket_expenses.py
+++ b/policyengine_us/variables/household/expense/health/medical_out_of_pocket_expenses.py
@@ -9,6 +9,9 @@ class medical_out_of_pocket_expenses(Variable):
     definition_period = YEAR
     adds = [
         "health_insurance_premiums",
-        "over_the_counter_health_expenses",
         "other_medical_expenses",
+        # Note: Excludes over_the_counter_health_expenses
+        # as IRS does not include them in the itemized deduction, and
+        # USDA only includes doctor-approved over-the-counter medications
+        # in their medical out-of-pocket expenses definition for SNAP.
     ]

--- a/policyengine_us/variables/household/expense/health/medicare_part_b_premiums.py
+++ b/policyengine_us/variables/household/expense/health/medicare_part_b_premiums.py
@@ -7,4 +7,4 @@ class medicare_part_b_premiums(Variable):
     label = "Medicare Part B premiums"
     definition_period = YEAR
     unit = USD
-    uprating = "gov.bls.cpi.cpi_u"
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/other_medical_expenses.py
+++ b/policyengine_us/variables/household/expense/health/other_medical_expenses.py
@@ -7,4 +7,4 @@ class other_medical_expenses(Variable):
     label = "Other medical expenses"
     unit = USD
     definition_period = YEAR
-    uprating = "gov.bls.cpi.cpi_u"
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/outpatient_expense.py
+++ b/policyengine_us/variables/household/expense/health/outpatient_expense.py
@@ -7,3 +7,4 @@ class outpatient_expense(Variable):
     label = "Outpatient expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/over_the_counter_health_expenses.py
+++ b/policyengine_us/variables/household/expense/health/over_the_counter_health_expenses.py
@@ -7,4 +7,4 @@ class over_the_counter_health_expenses(Variable):
     label = "Over the counter health expenses"
     unit = USD
     definition_period = YEAR
-    uprating = "gov.bls.cpi.cpi_u"
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/physician_services_expense.py
+++ b/policyengine_us/variables/household/expense/health/physician_services_expense.py
@@ -7,3 +7,4 @@ class physician_services_expense(Variable):
     label = "Physician services expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/prescription_expense.py
+++ b/policyengine_us/variables/household/expense/health/prescription_expense.py
@@ -7,3 +7,4 @@ class prescription_expense(Variable):
     label = "Prescription expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"

--- a/policyengine_us/variables/household/expense/health/self_employed_health_insurance_premiums.py
+++ b/policyengine_us/variables/household/expense/health/self_employed_health_insurance_premiums.py
@@ -8,8 +8,5 @@ class self_employed_health_insurance_premiums(Variable):
     unit = USD
     documentation = "Health insurance premiums for plans covering individuals who are not covered by any employer-sponsored health insurance."
     definition_period = YEAR
-
-    def formula(person, period, parameters):
-        is_self_employed = person("is_self_employed", period)
-        health_insurance_premiums = person("health_insurance_premiums", period)
-        return is_self_employed * health_insurance_premiums
+    defined_for = "is_self_employed"
+    adds = ["health_insurance_premiums"]

--- a/policyengine_us/variables/household/expense/health/urgent_care_expense.py
+++ b/policyengine_us/variables/household/expense/health/urgent_care_expense.py
@@ -7,3 +7,4 @@ class urgent_care_expense(Variable):
     label = "Urgent care expenses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.hhs.cms.moop_per_capita"


### PR DESCRIPTION
Fix #5597
Fix #5595

Also adds MOOP/capita uprating to other medical expense categories, even though we don't have them in microdata for completeness.