### PR TITLE
Hide program takeup parameters from web UI by setting economy: false

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,9 @@
 - When using `defined_for`, ensure it's tested in microsimulation context
 - Be careful with chained comparisons in formulas - they work with scalars but fail with arrays
 - Prefer explicit vectorized comparison operators joined with `&` and `|`
+- Program takeup is assigned during microdata construction, not simulation time
+  - Changes to takeup parameters (SNAP, EITC, etc.) have no effect in the web app
+  - These parameters should include `economy: false` in their metadata
 
 ## Parameter Validation Best Practices
 - Cross-check parameter values against authoritative external sources (gov websites, calculators)

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,4 +2,3 @@
   changes:
     fixed:
     - Hide program takeup parameters from the web UI by setting economy: false in their metadata
-  date: 2025-02-24 00:00:00

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Hide program takeup parameters from the web UI by setting economy: false in their metadata
+  date: 2025-02-24 00:00:00

--- a/policyengine_us/parameters/gov/irs/credits/eitc/takeup.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/eitc/takeup.yaml
@@ -18,6 +18,7 @@ metadata:
   type: single_amount
   threshold_unit: child
   economy: false
+  household: false
   reference:
     - title: National Taxpayer Advocate Special Report to Congress 2020 | IRS
       href: https://www.taxpayeradvocate.irs.gov/wp-content/uploads/2020/08/JRC20_Volume3.pdf#page=62

--- a/policyengine_us/parameters/gov/irs/credits/eitc/takeup.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/eitc/takeup.yaml
@@ -17,6 +17,7 @@ metadata:
   amount_unit: /1
   type: single_amount
   threshold_unit: child
+  economy: false
   reference:
     - title: National Taxpayer Advocate Special Report to Congress 2020 | IRS
       href: https://www.taxpayeradvocate.irs.gov/wp-content/uploads/2020/08/JRC20_Volume3.pdf#page=62

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/takeup.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/takeup.yaml
@@ -3,6 +3,7 @@ metadata:
   unit: /1
   label: DC property tax credit takeup rate
   period: year
+  economy: false
   reference:
     - title: District of Columbia Tax Expenditure Report, 2024
       href: https://ora-cfo.dc.gov/sites/default/files/dc/sites/ora-cfo/publication/attachments/2024%20Tax%20Expenditure%20Report.pdf#page=234

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/takeup.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/takeup.yaml
@@ -4,6 +4,7 @@ metadata:
   label: DC property tax credit takeup rate
   period: year
   economy: false
+  household: false
   reference:
     - title: District of Columbia Tax Expenditure Report, 2024
       href: https://ora-cfo.dc.gov/sites/default/files/dc/sites/ora-cfo/publication/attachments/2024%20Tax%20Expenditure%20Report.pdf#page=234

--- a/policyengine_us/parameters/gov/usda/snap/takeup_rate.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/takeup_rate.yaml
@@ -4,6 +4,7 @@ values:
 metadata:
   label: SNAP takeup rate
   unit: /1
+  economy: false
   reference:
     - title: USDA
       href: https://www.fns.usda.gov/usamap

--- a/policyengine_us/parameters/gov/usda/snap/takeup_rate.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/takeup_rate.yaml
@@ -5,6 +5,7 @@ metadata:
   label: SNAP takeup rate
   unit: /1
   economy: false
+  household: false
   reference:
     - title: USDA
       href: https://www.fns.usda.gov/usamap

--- a/policyengine_us/parameters/gov/usda/wic/takeup.yaml
+++ b/policyengine_us/parameters/gov/usda/wic/takeup.yaml
@@ -4,6 +4,7 @@ metadata:
   breakdown:
   - wic_category
   label: WIC takeup rate
+  economy: false
   reference:
   - title: WIC Eligibility and Coverage Rates - 2018
     href: https://www.fns.usda.gov/wic/eligibility-and-coverage-rates-2018

--- a/policyengine_us/parameters/gov/usda/wic/takeup.yaml
+++ b/policyengine_us/parameters/gov/usda/wic/takeup.yaml
@@ -5,6 +5,7 @@ metadata:
   - wic_category
   label: WIC takeup rate
   economy: false
+  household: false
   reference:
   - title: WIC Eligibility and Coverage Rates - 2018
     href: https://www.fns.usda.gov/wic/eligibility-and-coverage-rates-2018


### PR DESCRIPTION
These parameters don't have any effect in the web UI since takeup is assigned during microdata construction, not simulation time. Setting economy: false prevents confusion by hiding them from users.

Fixes #5638