### PR TITLE
Remove the mistakenly added tax-dependent limit from the NC SCCA program

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Remove the mistakenly added tax-dependent limit from the NC SCCA program as it is not required. 

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/ncdhhs/scca/nc_scca_child_age_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/ncdhhs/scca/nc_scca_child_age_eligible.yaml
@@ -2,7 +2,6 @@
   period: 2024
   input:
     is_disabled: false
-    is_tax_unit_dependent: true
     age: 12
     state_code: NC
   output:
@@ -12,7 +11,6 @@
   period: 2024
   input:
     is_disabled: false
-    is_tax_unit_dependent: true
     age: 13
     state_code: NC
   output:
@@ -22,7 +20,6 @@
   period: 2024
   input:
     is_disabled: true
-    is_tax_unit_dependent: true
     age: 16
     state_code: NC
   output:
@@ -32,7 +29,6 @@
   period: 2024
   input:
     is_disabled: true
-    is_tax_unit_dependent: true
     age: 17
     state_code: NC
   output:
@@ -42,7 +38,6 @@
   period: 2024
   input:
     is_disabled: true
-    is_tax_unit_dependent: true
     age: 18
     state_code: NC
   output:

--- a/policyengine_us/variables/gov/states/nc/ncdhhs/scca/nc_scca_child_age_eligible.py
+++ b/policyengine_us/variables/gov/states/nc/ncdhhs/scca/nc_scca_child_age_eligible.py
@@ -20,4 +20,4 @@ class nc_scca_child_age_eligible(Variable):
 
         age_eligible = age < age_limit
 
-        return age_eligible & person("is_tax_unit_dependent", period)
+        return age_eligible

--- a/policyengine_us/variables/gov/states/nc/ncdhhs/scca/nc_scca_child_age_eligible.py
+++ b/policyengine_us/variables/gov/states/nc/ncdhhs/scca/nc_scca_child_age_eligible.py
@@ -18,6 +18,4 @@ class nc_scca_child_age_eligible(Variable):
         # Apply appropriate age limit based on disability status
         age_limit = where(is_disabled, p.disabled, p.non_disabled)
 
-        age_eligible = age < age_limit
-
-        return age_eligible
+        return age < age_limit


### PR DESCRIPTION
Fixes #5738 

