### PR TITLE
Cap the NY household credit amount which reduces the NY EITC at income tax before credits

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixes:
+    - Cap the NY household credit amount which reduces the NY EITC at state tax before credits.

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_eitc.yaml
@@ -16,3 +16,14 @@
     ny_household_credit: 10
   output:
     ny_eitc: 20
+
+- name: Household credit does not apply when tax is 0
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    state_code: NY
+    eitc: 100
+    ny_household_credit: 10
+    nj_main_income_tax: 0
+  output:
+    ny_eitc: 30

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_eitc.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_eitc.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class ny_eitc(Variable):
     value_type = float
     entity = TaxUnit
-    label = "NY EITC"
+    label = "New York EITC"
     unit = USD
     definition_period = YEAR
     reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (d)
@@ -14,5 +14,7 @@ class ny_eitc(Variable):
         federal_eitc = tax_unit("eitc", period)
         p = parameters(period).gov.states.ny.tax.income.credits
         tentative_nys_eitc = federal_eitc * p.eitc.match
+        income_tax_before_credits = tax_unit("nj_main_income_tax", period)
         household_credit = tax_unit("ny_household_credit", period)
-        return max_(0, tentative_nys_eitc - household_credit)
+        capped_household_credit = min_(income_tax_before_credits, household_credit)
+        return max_(0, tentative_nys_eitc - capped_household_credit)


### PR DESCRIPTION
Fixes #5919