### PR TITLE
Remove special character quotation marks in yaml file

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -9979,3 +9979,8 @@
     fixed:
     - Add CHIP eligibility to per capita CHIP variable.
   date: 2025-05-20 23:30:36
+- bump: patch
+  changes:
+    fixed:
+    - Removed special character breaking imports on Windows 
+  date: 2025-05-21 07:36:00

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -9979,8 +9979,3 @@
     fixed:
     - Add CHIP eligibility to per capita CHIP variable.
   date: 2025-05-20 23:30:36
-- bump: patch
-  changes:
-    fixed:
-    - Removed special character breaking imports on Windows 
-  date: 2025-05-21 07:36:00

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-    - Remove special characters causing imports to fail on Windows 
+    - Remove special characters causing imports to fail on Windows. 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Remove special characters causing imports to fail on Windows 

--- a/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
+++ b/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
@@ -1,4 +1,4 @@
-description: The US classifies as exempt from overtime individuals employed in a “bona fide executive, administrative, or professional capacity” and other generally exempt occupations if they have a weekly salary level of or above this value.
+description: The US classifies as exempt from overtime individuals employed in a "bona fide executive, administrative, or professional capacity" and other generally exempt occupations if they have a weekly salary level of or above this value.
 metadata:
   unit: currency-USD
   period: year


### PR DESCRIPTION
Fixes #6019 

Only two characters have been changed in a yaml file. Requesting @juaristi22 as reviewer as file was just checked in the last 24 hours.

(And it's a nice low risk initial contribution to policyengine-us)