### PR TITLE
QBID variables and updated formulas

### DIFF
--- a/policyengine_us/parameters/gov/irs/deductions/qbi/income_definition.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/qbi/income_definition.yaml
@@ -2,9 +2,13 @@ description: Income sources that count as qualified business income.
 values:
   2018-01-01:
     - self_employment_income
-    - partnership_s_corp_income
-    - farm_income
-    - farm_rent_income
+    - partnership_income
+    - s_corp_income
+    - farm_rental_income
+    - farm_operations_income
+    - rental_income
+    - estate_income
+
 metadata:
   unit: list
   label: Qualified business income sources

--- a/policyengine_us/variables/input/income.py
+++ b/policyengine_us/variables/input/income.py
@@ -72,6 +72,76 @@ class farm_income(Variable):
     entity = Person
     label = "farm income"
     unit = USD
-    documentation = "Income from agricultural businesses. Do not include this income in self-employment income."
+    documentation = "Income averaging for farmers and fishermen. Schedule J. Seperate from QBI and self-employment income."
     definition_period = YEAR
     uprating = "calibration.gov.irs.soi.farm_income"
+
+
+class farm_operations_income(Variable):
+    value_type = float
+    entity = Person
+    label = "farm income"
+    unit = USD
+    documentation = "Income from active farming operations. Schedule F. Do not include this income in self-employment income."
+    definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.farm_income"  # TODO: update
+
+
+class farm_rental_income(Variable):
+    value_type = float
+    entity = Person
+    label = "farm income"
+    unit = USD
+    documentation = "Schedule E farm rental income."
+    definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.farm_income"  # TODO: update
+
+
+class s_corp_income(Variable):
+    value_type = float
+    entity = Person
+    label = "S Corp Income"
+    unit = USD
+    documentation = "S Corporation active passthrough income. Schedule E. Do not include this income in self-employment income."
+    definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.self_employment_income"  # TODO: Update
+
+
+class partnership_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Partnership Income"
+    unit = USD
+    documentation = "S Corporation active passthrough income. Schedule E. Do not include this income in self-employment income."
+    definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.self_employment_income"  # TODO: Update
+
+
+class reit_dividend_income(Variable):
+    value_type = float
+    entity = Person
+    label = "REIT Dividend Income"
+    unit = USD
+    documentation = "REIT Dividend Income. Included in QBID."
+    definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.self_employment_income"  # TODO: Update
+
+
+class ptp_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Publically Traded Partnership Income"
+    unit = USD
+    documentation = "Publically Traded Partnership Income. Included in QBID."
+    definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.self_employment_income"  # TODO: Update
+
+
+class bdc_dividend_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Business Development Company Dividend Income"
+    unit = USD
+    documentation = " Business Development Company Dividend Income. Included in QBID."
+    definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.self_employment_income"  # TODO: Update


### PR DESCRIPTION
This is a draft. I need to do the following:

- put s_corp_income and partnership_income back into  partnership_s_corp_income
- Change the new farm_rental_income back to farm_rent_income, because it already exists.
- Decide if the QBID passive vehicles are going to be included (REIT, PTPs, Dividends). If so:
     * Fix the uprating logic
     * Simulated them more appropriately
     * Add them to the qbid_amount.py files (normal and reconcilliation)
- Try to understand why the new phase out is so different revenue-wise

