### PR TITLE
Add qualified business income adjustments

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,11 @@
-- bump: patch
+- bump: minor
   changes:
+    added:
+      - estate_income_would_be_qualified
+      - farm_operations_income_would_be_qualified
+      - farm_rent_income_would_be_qualified
+      - partnership_s_corp_income_would_be_qualified
+      - rental_income_would_be_qualified
+      - self_employment_income_would_be_qualified
     changed:
-      - Add detailed tax code references with subsection anchors for qualified business income deduction parameters
+      - qualified_business_income

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
@@ -13,6 +13,12 @@ class qualified_business_income(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.irs.deductions.qbi
-        gross_qbi = add(person, period, p.income_definition)
+        gross_qbi = sum(
+            [
+                person(var, period)
+                * person(var + "_would_be_qualified", period)
+                for var in p.income_definition
+            ]
+        )
         qbi_deductions = add(person, period, p.deduction_definition)
         return max_(0, gross_qbi - qbi_deductions)

--- a/policyengine_us/variables/household/income/person/estate/estate_income_would_be_qualified.py
+++ b/policyengine_us/variables/household/income/person/estate/estate_income_would_be_qualified.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class estate_income_would_be_qualified(Variable):
+    value_type = bool
+    entity = Person
+    label = "Estate income would be qualified"
+    documentation = "Whether income from estates would be considered qualified business income."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/199A#c_3_A"
+    default_value = True

--- a/policyengine_us/variables/household/income/person/farm/farm_operations_income_would_be_qualified.py
+++ b/policyengine_us/variables/household/income/person/farm/farm_operations_income_would_be_qualified.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class farm_operations_income_would_be_qualified(Variable):
+    value_type = bool
+    entity = Person
+    label = "Farm operations income would be qualified"
+    documentation = "Whether farm operations income would be considered qualified business income."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/199A#c_3_A"
+    default_value = True

--- a/policyengine_us/variables/household/income/person/farm/farm_rent_income_would_be_qualified.py
+++ b/policyengine_us/variables/household/income/person/farm/farm_rent_income_would_be_qualified.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class farm_rent_income_would_be_qualified(Variable):
+    value_type = bool
+    entity = Person
+    label = "Farm rent income would be qualified"
+    documentation = "Whether farm rental income would be considered qualified business income."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/199A#c_3_A"
+    default_value = True

--- a/policyengine_us/variables/household/income/person/misc/rental_income_would_be_qualified.py
+++ b/policyengine_us/variables/household/income/person/misc/rental_income_would_be_qualified.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class rental_income_would_be_qualified(Variable):
+    value_type = bool
+    entity = Person
+    label = "Rental income would be qualified"
+    documentation = "Whether rental income would be considered qualified business income."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/199A#c_3_A"
+    default_value = True

--- a/policyengine_us/variables/household/income/person/self_employment/partnership_s_corp_income_would_be_qualified.py
+++ b/policyengine_us/variables/household/income/person/self_employment/partnership_s_corp_income_would_be_qualified.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class partnership_s_corp_income_would_be_qualified(Variable):
+    value_type = bool
+    entity = Person
+    label = "Partnership and S-corp income would be qualified"
+    documentation = "Whether income from partnerships and S corporations would be considered qualified business income."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/199A#c_3_A"
+    default_value = True

--- a/policyengine_us/variables/household/income/person/self_employment/self_employment_income_would_be_qualified.py
+++ b/policyengine_us/variables/household/income/person/self_employment/self_employment_income_would_be_qualified.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class self_employment_income_would_be_qualified(Variable):
+    value_type = bool
+    entity = Person
+    label = "Self-employment income would be qualified"
+    documentation = "Whether self-employment income would be considered qualified business income."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/199A#c_3_A"
+    default_value = True


### PR DESCRIPTION
## Summary
- add `_would_be_qualified` flags for estate, farm, rental, partnership and self-employment income
- compute `qualified_business_income` using these flags
- note new variables and change in changelog

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*