### PR TITLE
Fix uprating for QBI incomes

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -9,3 +9,9 @@
       - self_employment_income_would_be_qualified
     changed:
       - qualified_business_income
+
+- bump: patch
+  changes:
+    fixed:
+      - corrected uprating for QBI dividend income variables
+      - documented uprating for farm_operations_income

--- a/policyengine_us/variables/household/income/person/dividends/qualified_bdc_income.py
+++ b/policyengine_us/variables/household/income/person/dividends/qualified_bdc_income.py
@@ -9,4 +9,5 @@ class qualified_bdc_income(Variable):
     documentation = "Business Development Company Dividend Income. Part of the QBID calculation."
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/uscode/text/26/1#h_11"
-    uprating = "calibration.gov.irs.soi.self_employment_income"  # TODO: Update
+    # Uprate using the same series as other dividend income.
+    uprating = "calibration.gov.irs.soi.qualified_dividend_income"

--- a/policyengine_us/variables/household/income/person/dividends/qualified_reit_and_ptp_income.py
+++ b/policyengine_us/variables/household/income/person/dividends/qualified_reit_and_ptp_income.py
@@ -8,4 +8,5 @@ class qualified_reit_and_ptp_income(Variable):
     unit = USD
     documentation = "REIT and Publically Traded Partnership Income. Part of the QBID calclulation."
     definition_period = YEAR
-    uprating = "calibration.gov.irs.soi.self_employment_income"  # TODO: Update
+    # Uprate using the same series as other dividend income.
+    uprating = "calibration.gov.irs.soi.qualified_dividend_income"

--- a/policyengine_us/variables/household/income/person/farm/farm_rent_income.py
+++ b/policyengine_us/variables/household/income/person/farm/farm_rent_income.py
@@ -17,7 +17,5 @@ class farm_operations_income(Variable):
     unit = USD
     documentation = "Income from active farming operations. Schedule F. Do not include this income in self-employment income."
     definition_period = YEAR
-    uprating = "calibration.gov.irs.soi.farm_income"  # TODO: update
-
-
-
+    # Uprate farm operations income using SOI farm income series.
+    uprating = "calibration.gov.irs.soi.farm_income"


### PR DESCRIPTION
## Summary
- fix uprating references for BDC dividend and REIT/PTP income
- document uprating for farm operations income
- note these updates in the changelog

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*