### PR TITLE
Prefer ZCTA over FIPS for all microsim contexts

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - In microsim contexts, modified county to prefer ZCTA-based counties over FIPS-based counties in all cases, including when FIPS is defined.

--- a/policyengine_us/variables/household/demographic/geographic/county/county.py
+++ b/policyengine_us/variables/household/demographic/geographic/county/county.py
@@ -1,4 +1,5 @@
 from policyengine_us.model_api import *
+from policyengine_core.simulations import Simulation
 from policyengine_us.tools.geography.county_helpers import (
     map_county_string_to_enum,
 )
@@ -20,11 +21,12 @@ class county(Variable):
     definition_period = YEAR
 
     def formula(household, period, parameters):
+        simulation: Simulation = household.simulation
 
         # First look if county FIPS is provided; if so, map to county name
         county_fips: "pd.Series[str]" | None = household("county_fips", period)
 
-        if county_fips.all():
+        if not simulation.is_over_dataset and county_fips.all():
             COUNTY_FIPS_DATASET: "pd.DataFrame" = load_county_fips_dataset()
 
             # Decode FIPS codes


### PR DESCRIPTION
Fixes https://github.com/PolicyEngine/policyengine-api/issues/2553.

This code ensures that for all microsimulations, including those that specify county FIPS for all households, the county FIPS values are ignored and ZCTA-based regions are used instead. This prevents bugs around county FIPS encoding that are prevalent throughout the API due to type inferences made automatically by `pandas` around the creation of dataframes.

I am unsure on how to test these changes and would love guidance from @PavelMakarchuk on how to proceed.