### PR TITLE
Modifying Arkansas Income Tax Thresholds for the Low-Income Tax Table

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+bump: minor
+  changes:
+    changed:
+      - Corrected income tax thresholds for low-income Arkansas tax tables

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: policyengine-us
+name: ar-policyengine-us
 dependencies:
   - python=3.9
   - hdf5

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: ar-policyengine-us
+name: policyengine-us
 dependencies:
   - python=3.9
   - hdf5

--- a/policyengine_us/parameters/gov/states/ar/tax/income/rates/main/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/rates/main/rate.yaml
@@ -47,7 +47,6 @@ brackets:
         2021-01-01: 4_800
         2022-01-01: 5_100
         2023-01-01: 5_300
-        2024-01-01: 5_500
       metadata:
         uprating: gov.irs.uprating
         rounding:
@@ -65,7 +64,6 @@ brackets:
         2021-01-01: 9_500
         2022-01-01: 10_300
         2023-01-01: 10_600
-        2024-01-01: 10_900
       metadata:
         uprating: gov.irs.uprating
         rounding:
@@ -84,7 +82,6 @@ brackets:
         2021-01-01: 14_300
         2022-01-01: 14_700
         2023-01-01: 15_100
-        2024-01-01: 15_600
       metadata:
         uprating: gov.irs.uprating
         rounding:
@@ -103,7 +100,6 @@ brackets:
         2021-01-01: 23_600
         2022-01-01: 24_300
         2023-01-01: 25_000
-        2024-01-01: 25_700
       metadata:
         uprating: gov.irs.uprating
         rounding:

--- a/policyengine_us/parameters/gov/states/ar/tax/income/rates/main/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/rates/main/rate.yaml
@@ -24,7 +24,7 @@ metadata:
     href: https://www.dfa.arkansas.gov/wp-content/uploads/TaxBrackets_2023.pdf#page=1
   - title: 2024 Indexed Tax Brackets
     href: https://www.dfa.arkansas.gov/wp-content/uploads/2024_TaxBrackets.pdf#page=1
-  - title: Bill to reduce the 2024 income tax HB1001 
+  - title: Bill signed into law to reduce the 2024 income tax HB1001 
     href: https://www.arkleg.state.ar.us/Home/FTPDocument?path=%2FBills%2F2024S2%2FPublic%2FHB1001.pdf#page=2
 
 brackets:


### PR DESCRIPTION
This pull request modifies the Arkansas income tax thresholds in rate.yaml to reflect the most recent thresholds for taxpayers earning under $89,600.