### PR TITLE
Use gross income instead of taxable income in the Kansas zero tax computation

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Use gross income instead of taxable income in the Kansas zero tax computation.

--- a/policyengine_us/parameters/gov/states/ks/tax/income/rates/zero_tax_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ks/tax/income/rates/zero_tax_threshold.yaml
@@ -14,6 +14,7 @@ metadata:
     href: https://www.ksrevenue.gov/pdf/ip23.pdf#page=32
   - title: 2024 Form K-40 instructions
     href: https://www.ksrevenue.gov/pdf/ip24.pdf#page=3
+  # The minimum filing requirement only appears in the tax forms, not in the legal code
   - title: Kansas 2022 Statute | Article 32 | §79-32,110_(e)
     href: http://www.kslegislature.org/li/b2023_24/statute/079_000_0000_chapter/079_032_0000_article/079_032_0110_section/079_032_0110_k/
 

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_income_tax_before_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_income_tax_before_credits.yaml
@@ -3,6 +3,7 @@
   input:
     filing_status: SINGLE
     ks_taxable_income: 100_000
+    ks_agi: 100_000
     state_code: KS
   output:  # from filling out 2021 Tax Computation Worksheet
     ks_income_tax_before_credits: 0.057 * 100_000 - 457.50
@@ -12,6 +13,7 @@
   input:
     filing_status: JOINT
     ks_taxable_income: 100_000
+    ks_agi: 100_000
     state_code: KS
   output:  # from filling out 2022 Tax Computation Worksheet
     ks_income_tax_before_credits: 0.057 * 100_000 - 915
@@ -21,6 +23,43 @@
   input:
     filing_status: JOINT
     ks_taxable_income: 4_900
+    ks_agi: 4_900
     state_code: KS
   output:  # from filling out 2021 Tax Computation Worksheet
     ks_income_tax_before_credits: 0
+
+- name: 492-KS.yaml
+  absolute_error_margin: 2
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 25051
+        ssi: 0
+        wic: 0
+        deductible_mortgage_interest: 0
+      person2:
+        age: 40
+        employment_income: 25051
+        ssi: 0
+        wic: 0
+        deductible_mortgage_interest: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_childcare_expenses: 0
+        premium_tax_credit: 0
+        local_income_tax: 0
+        state_sales_tax: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 20
+  output:
+    ks_income_tax: 1_223

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_income_tax_before_credits.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_income_tax_before_credits.py
@@ -23,4 +23,5 @@ class ks_income_tax_before_credits(Variable):
             p.other.calc(taxable_income),
         )
         zero_tax_taxinc = p.zero_tax_threshold[filing_status]
-        return where(taxable_income <= zero_tax_taxinc, 0, tax)
+        agi = tax_unit("ks_agi", period)
+        return where(agi <= zero_tax_taxinc, 0, tax)


### PR DESCRIPTION
Fixes #6163