### PR TITLE
Adjust `spm_unit_income_decile` to remove testing 0 weights

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Remove spm_unit_income_decile test with zero weight.

--- a/policyengine_us/tests/policy/baseline/income/spm_unit_income_decile.yaml
+++ b/policyengine_us/tests/policy/baseline/income/spm_unit_income_decile.yaml
@@ -55,21 +55,3 @@
         state_code: CA
   output:
     spm_unit_income_decile: 10
-
-- name: Zero weight SPM unit does not get assigned a decile
-  period: 2024
-  input:
-    people:
-      person1:
-        age: 30
-    spm_units:
-      spm_unit1:
-        members: [person1]
-        spm_unit_oecd_equiv_net_income: 25_000
-        spm_unit_weight: 0
-    households:
-      household1:
-        members: [person1]
-        state_code: CA
-  output:
-    spm_unit_income_decile: 0


### PR DESCRIPTION
Fixes #6299