### PR TITLE
Backdate New Hampshire interest and dividends tax to 2020

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - New Hampshire interest and dividends tax parameters and exemptions for 2020

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/base.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/base.yaml
@@ -19,12 +19,12 @@ metadata:
     - title: 2021 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/forms/2022/documents/dp-10-2021-print.pdf#page=3
 SINGLE: 
-  2021-01-01: 2_400
+  2020-01-01: 2_400
 JOINT:
-  2021-01-01: 4_800
+  2020-01-01: 4_800
 SEPARATE:
-  2021-01-01: 2_400
+  2020-01-01: 2_400
 HEAD_OF_HOUSEHOLD: 
-  2021-01-01: 2_400
+  2020-01-01: 2_400
 SURVIVING_SPOUSE:
-  2021-01-01: 2_400
+  2020-01-01: 2_400

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/blind_addition.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/blind_addition.yaml
@@ -16,4 +16,4 @@ metadata:
     - title: 2021 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/forms/2022/documents/dp-10-2021-print.pdf#page=3
 values:
-  2021-01-01: 1_200
+  2020-01-01: 1_200

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/disabled_addition.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/disabled_addition.yaml
@@ -16,4 +16,4 @@ metadata:
     - title: 2021 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/forms/2022/documents/dp-10-2021-print.pdf#page=3
 values:
-  2021-01-01: 1_200
+  2020-01-01: 1_200

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/old_age_addition.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/old_age_addition.yaml
@@ -16,4 +16,4 @@ metadata:
     - title: 2021 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/forms/2022/documents/dp-10-2021-print.pdf#page=3
 values:
-  2021-01-01: 1_200
+  2020-01-01: 1_200

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/disability_age_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/disability_age_threshold.yaml
@@ -14,4 +14,4 @@ metadata:
     - title: 2024 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-2024.pdf#page=3
 values:
-  2021-01-01: 65
+  2020-01-01: 65

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/old_age_eligibility.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/old_age_eligibility.yaml
@@ -14,4 +14,4 @@ metadata:
     - title: 2024 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-2024.pdf#page=3
 values:
-  2021-01-01: 65
+  2020-01-01: 65

--- a/policyengine_us/parameters/gov/states/nh/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/rate.yaml
@@ -1,6 +1,6 @@
 description: New Hampshire taxes interest and dividends at this rate.
 values:
-  2021-01-01: 0.05
+  2020-01-01: 0.05
   2023-01-01: 0.04
   2024-01-01: 0.03
 

--- a/policyengine_us/tests/policy/baseline/gov/states/nh/tax/income/integration_2020.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nh/tax/income/integration_2020.yaml
@@ -1,0 +1,126 @@
+- name: Single filer with interest income in 2020
+  period: 2020
+  input:
+    people:
+      person1:
+        age: 45
+        interest_income: 5_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NH
+  output:
+    nh_base_exemption: 2_400
+    nh_taxable_income: 2_600  # 5,000 - 2,400
+    nh_income_tax_before_refundable_credits: 130  # 2,600 * 0.05
+
+- name: Joint filers with dividends in 2020
+  period: 2020
+  input:
+    people:
+      person1:
+        age: 50
+        dividend_income: 8_000
+      person2:
+        age: 48
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NH
+  output:
+    nh_base_exemption: 4_800
+    nh_taxable_income: 3_200  # 8,000 - 4,800
+    nh_income_tax_before_refundable_credits: 160  # 3,200 * 0.05
+
+- name: Single senior with old age exemption in 2020
+  period: 2020
+  input:
+    people:
+      person1:
+        age: 70
+        interest_income: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NH
+  output:
+    nh_base_exemption: 2_400
+    nh_old_age_exemption: 1_200
+    nh_taxable_income: 2_400  # 6,000 - 2,400 - 1,200
+    nh_income_tax_before_refundable_credits: 120  # 2,400 * 0.05
+
+- name: Blind filer with additional exemption in 2020
+  period: 2020
+  input:
+    people:
+      person1:
+        age: 40
+        interest_income: 4_000
+        is_blind: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NH
+  output:
+    nh_base_exemption: 2_400
+    nh_blind_exemption: 1_200
+    nh_taxable_income: 400  # 4,000 - 2,400 - 1,200
+    nh_income_tax_before_refundable_credits: 20  # 400 * 0.05
+
+- name: Disabled filer under 65 with exemption in 2020
+  period: 2020
+  input:
+    people:
+      person1:
+        age: 55
+        interest_income: 5_500
+        is_disabled: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NH
+  output:
+    nh_base_exemption: 2_400
+    nh_disabled_exemption: 1_200
+    nh_taxable_income: 1_900  # 5,500 - 2,400 - 1,200
+    nh_income_tax_before_refundable_credits: 95  # 1,900 * 0.05
+
+- name: No tax due to low income in 2020
+  period: 2020
+  input:
+    people:
+      person1:
+        age: 30
+        interest_income: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NH
+  output:
+    nh_base_exemption: 2_400
+    nh_taxable_income: -400  # 2,000 - 2,400 = -400
+    nh_income_tax_before_refundable_credits: 0  # Tax is 0 on negative income

--- a/policyengine_us/tests/policy/baseline/gov/states/nh/tax/income/nh_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nh/tax/income/nh_income_tax_before_refundable_credits.yaml
@@ -1,3 +1,11 @@
+- name: 2020 rate
+  period: 2020
+  input:
+    state_code: NH
+    nh_taxable_income: 2_000
+  output:
+    nh_income_tax_before_refundable_credits: 100
+
 - name: 2023 rate 
   period: 2023
   input:


### PR DESCRIPTION
## Summary
This PR backdates New Hampshire's interest and dividends tax parameters to include tax year 2020.

## Context
- New Hampshire only taxes interest and dividend income (not wages)
- The tax rate was 5% in 2020, unchanged from 1977-2022
- Exemption amounts have remained constant throughout the tax's history
- Currently, the earliest year in the parameters is 2021

## Changes
- Added 2020-01-01 entries to all NH tax parameter files:
  - Tax rate: 5%
  - Base exemptions: ,400 (single) / ,800 (joint)
  - Additional exemptions: ,200 (age 65+, blind, or disabled)
  - Age thresholds: 65 for both old age and disability exemptions
- Added comprehensive integration tests for 2020 calculations
- All existing tests continue to pass

## Test Plan
✅ Added new integration test file with 6 test cases for 2020
✅ Verified all 53 existing NH tests still pass
✅ Tests cover various scenarios including exemptions and negative taxable income

Fixes #6301