### PR TITLE
Add 2020 Washington state income tax rules

### DIFF
--- a/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/wa_2020_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/wa_2020_integration.yaml
@@ -1,0 +1,93 @@
+- name: Washington has no income tax in 2020 - single person
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code_str: WA
+  output:
+    wa_income_tax: 0
+    wa_income_tax_before_refundable_credits: 0
+    wa_capital_gains_tax: 0
+
+- name: Washington has no income tax in 2020 - married couple with high income
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 150_000
+      person2:
+        age: 38
+        employment_income: 100_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code_str: WA
+  output:
+    wa_income_tax: 0
+    wa_income_tax_before_refundable_credits: 0
+    wa_capital_gains_tax: 0
+
+- name: Washington has no income tax in 2020 - high capital gains
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 55
+        employment_income: 50_000
+        long_term_capital_gains: 500_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code_str: WA
+  output:
+    wa_income_tax: 0
+    wa_income_tax_before_refundable_credits: 0
+    wa_capital_gains_tax: 0
+
+- name: Washington has no income tax in 2020 - family with children
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    people:
+      parent1:
+        age: 35
+        employment_income: 45_000
+      parent2:
+        age: 33
+        employment_income: 35_000
+      child1:
+        age: 10
+      child2:
+        age: 7
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child1, child2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [parent1, parent2, child1, child2]
+        state_code_str: WA
+  output:
+    wa_income_tax: 0
+    wa_income_tax_before_refundable_credits: 0
+    wa_capital_gains_tax: 0
+    wa_working_families_tax_credit: 0  # Not in effect in 2020


### PR DESCRIPTION
## Summary
This PR adds support for 2020 Washington state income tax rules to PolicyEngine US.

## Background
Washington state has no individual income tax. This has been confirmed through research of official sources:

### Primary Sources
1. **Washington Department of Revenue - Income Tax Page**
   - URL: https://dor.wa.gov/taxes-rates/income-tax
   - Statement: "Washington state does not have a personal or corporate income tax."
   - Residents do not need to file state income tax returns

2. **Tax Foundation - 2020 State Individual Income Tax Rates and Brackets**
   - URL: https://taxfoundation.org/data/all/state/state-individual-income-tax-rates-and-brackets-for-2020/
   - Confirms Washington is among the states with no individual income tax

### Key Facts
- Washington has no personal income tax (confirmed for 2020 and 2021)
- No state income tax return filing requirement for residents
- State revenue comes from:
  - Sales tax (base rate 6.5%, combined average 9.452%)
  - Business & Occupation (B&O) tax
  - Property tax
  - Other excise taxes
- Federal income taxes still apply to Washington residents

## Implementation
The existing PolicyEngine implementation already correctly handles Washington's lack of income tax in 2020. The `in_effect` parameter in `policyengine_us/parameters/gov/states/wa/tax/income/in_effect.yaml` is set to `false` before 2022, which means all Washington income tax calculations return 0 for 2020.

## Changes
- Added integration tests to verify Washington has no state income tax in 2020
- Tests cover various scenarios: single filers, married couples, high earners, capital gains, and families with children

## Testing
All tests pass, confirming that:
- `wa_income_tax` returns 0 for all 2020 scenarios
- `wa_income_tax_before_refundable_credits` returns 0
- `wa_capital_gains_tax` returns 0 (not in effect until 2022)
- `wa_working_families_tax_credit` returns 0 (not in effect until 2022)

Fixes #6307