### PR TITLE
Document time-specific input format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,85 @@
 
 PolicyEngine US is a microsimulation model of the US state and federal tax and benefit system.
 
+## Installation
+
 To install, run `pip install policyengine-us`.
+
+## Usage
+
+### Quick Start
+
+```python
+from policyengine_us import Simulation
+
+# Create a simulation
+sim = Simulation(
+    situation={
+        "people": {
+            "person": {
+                "age": 30,
+                "employment_income": 50_000,
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "state_name": "CA",
+            }
+        }
+    }
+)
+
+# Calculate values
+income_tax = sim.calculate("income_tax")
+snap_benefits = sim.calculate("snap")
+```
+
+### ⚠️ Important: Time-Specific Inputs
+
+When calculating for specific years, you **must** use the time-specific format:
+
+```python
+# ❌ Wrong for year-specific calculations
+"age": 30
+
+# ✅ Correct for year-specific calculations  
+"age": {"2025": 30}
+```
+
+Example:
+```python
+sim = Simulation(
+    situation={
+        "people": {
+            "person": {
+                "age": {"2025": 30},
+                "employment_income": {"2025": 50_000},
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "state_name": {"2025": "CA"},
+            }
+        }
+    }
+)
+
+# Calculate for 2025
+snap_2025 = sim.calculate("snap", 2025)
+```
+
+## Documentation
+
+For detailed documentation, including:
+- Complete usage guide
+- Examples for families, state-specific programs, and multi-year calculations
+- Full list of available variables and entities
+- Troubleshooting guide
+
+Visit **[policyengine.github.io/policyengine-us](https://policyengine.github.io/policyengine-us/)**
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    added:
+    - Documentation for time-specific input format in README and new Getting Started guide
+    - Clear examples showing the difference between simple and time-specific formats
+    - Warning about incorrect calculations when using wrong format for specific years

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -63,6 +63,7 @@ parts:
       - file: validation/taxsim
   - caption: Usage
     chapters:
+      - file: usage/getting_started
       - file: usage/speed
   - caption: Examples
     chapters:

--- a/docs/usage/getting_started.md
+++ b/docs/usage/getting_started.md
@@ -1,0 +1,141 @@
+# Getting Started
+
+This guide helps you get started with PolicyEngine US for microsimulation analysis.
+
+## Installation
+
+```bash
+pip install policyengine-us
+```
+
+## Basic Usage
+
+The simplest simulation involves creating a single person household:
+
+```python
+from policyengine_us import Simulation
+
+# Create a simulation
+sim = Simulation(
+    situation={
+        "people": {
+            "person": {
+                "age": 30,
+                "employment_income": 50_000,
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "state_name": "CA",
+            }
+        }
+    }
+)
+
+# Calculate values
+income_tax = sim.calculate("income_tax")
+snap_benefits = sim.calculate("snap")
+```
+
+## Time-Specific Inputs
+
+When calculating values for specific years (past or future), you must use the time-specific input format.
+
+### ⚠️ Critical Difference
+
+**Simple format** (only for current year):
+```python
+"age": 30,
+"employment_income": 50_000,
+```
+
+**Time-specific format** (required for specific years):
+```python
+"age": {"2025": 30},
+"employment_income": {"2025": 50_000},
+```
+
+### Example: Calculating 2025 Benefits
+
+```python
+sim = Simulation(
+    situation={
+        "people": {
+            "person": {
+                "age": {"2025": 30},
+                "employment_income": {"2025": 50_000},
+                "pre_subsidy_rent": {"2025": 24_000},
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["person"],
+                "state_name": {"2025": "CA"},
+            }
+        }
+    }
+)
+
+# Calculate for 2025
+snap_2025 = sim.calculate("snap", 2025)
+
+# Calculate for specific month
+snap_jan_2025 = sim.calculate("snap", "2025-01")
+```
+
+## Entity Structure
+
+PolicyEngine US models four types of entities:
+
+1. **People**: Individual persons
+2. **Tax Units**: Groups that file taxes together
+3. **SPM Units**: Supplemental Poverty Measure units (for poverty calculations)
+4. **Households**: Physical households
+
+### Family Example
+
+```python
+sim = Simulation(
+    situation={
+        "people": {
+            "parent": {
+                "age": {"2025": 35},
+                "employment_income": {"2025": 60_000},
+            },
+            "child": {
+                "age": {"2025": 10},
+            }
+        },
+        "tax_units": {
+            "tax_unit": {
+                "members": ["parent", "child"],
+            }
+        },
+        "spm_units": {
+            "spm_unit": {
+                "members": ["parent", "child"],
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["parent", "child"],
+                "state_name": {"2025": "NY"},
+            }
+        }
+    }
+)
+```
+
+## Common Pitfalls
+
+1. **Using simple format for specific years**: This will give incorrect results
+2. **Missing entities**: Always include all required entity types
+3. **Forgetting state_name**: Required for state-specific calculations
+4. **Wrong variable names**: Variable names are case-sensitive
+
+## Next Steps
+
+- Explore specific benefit programs in the documentation
+- See the [examples](../examples) directory for more complex scenarios
+- Check state-specific documentation for your state


### PR DESCRIPTION
## Summary

This PR adds documentation for the time-specific input format that's required when calculating benefits for specific years.

## Problem

As discovered in #6354, users were getting incorrect calculations when using the simple format for year-specific calculations instead of the required dictionary format.

## Changes

1. **Updated README.md**:
   - Added clear warning about time-specific inputs
   - Included examples showing both formats
   - Simplified overall structure and pointed to detailed docs

2. **Created Getting Started guide** (docs/usage/getting_started.md):
   - Comprehensive explanation of time-specific inputs
   - Examples for single person and family scenarios
   - Common pitfalls section
   - Entity structure explanation

3. **Updated documentation TOC** to include the new Getting Started guide

## Impact

This documentation will help users avoid the confusion that led to incorrect SNAP calculations (e.g., getting $206/month instead of the correct $249/month for 2025).

Fixes #6354