### PR TITLE
Memory Fix Option B

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,10 +53,15 @@ jobs:
       - name: Turn off default branching
         shell: bash
         run: ./update_itemization.sh
-      - name: Run selective tests
+      - name: Run comprehensive tests (TEMPORARY - full test suite for memory fix testing)
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_BASE_REF: ${{ github.base_ref }}
-        run: uv run python policyengine_us/tests/run_selective_tests.py --verbose --debug
+          PYTHONUNBUFFERED: 1
+        run: |
+          echo "Running full test suite with memory optimization..."
+          echo "After merge, this will revert to selective testing"
+          echo ""
+          uv run make test-yaml-no-structural
+          uv run make test-yaml-structural
+          uv run make test-other
       - name: Build package
         run: uv build

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,9 @@ test:
 	coverage run -a --branch -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/ -c policyengine_us
 	coverage xml -i
 test-yaml-structural:
-	coverage run -a --branch --data-file=.coverage.contrib -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib -c policyengine_us 
+	python policyengine_us/tests/test_contrib_batched.py
 test-yaml-no-structural:
-	coverage run -a --branch --data-file=.coverage.baseline -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline -c policyengine_us
-	coverage run -a --branch --data-file=.coverage.reform -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/reform -c policyengine_us
+	python policyengine_us/tests/test_baseline_batched.py
 test-other:
 	pytest policyengine_us/tests/ --maxfail=0
 coverage:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+      - Memory exhaustion errors in GitHub Actions with two-batch test runners
+      - Test hanging issues with early termination on completion

--- a/policyengine_us/tests/test_baseline_batched.py
+++ b/policyengine_us/tests/test_baseline_batched.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+"""
+Run baseline tests in two batches with memory cleanup.
+Batch 1: All state tests (gov/states)
+Batch 2: Everything else in baseline
+"""
+
+import subprocess
+import sys
+import os
+import gc
+import time
+from pathlib import Path
+
+
+def run_batch_isolated(test_dirs, batch_name, timeout_seconds):
+    """
+    Run a batch of test directories in an isolated subprocess.
+    Shows real-time output while also capturing it for analysis.
+    """
+    # Use the current Python executable (works with uv run, conda, etc.)
+    python_exe = sys.executable
+
+    # Convert to list of directory strings
+    test_dirs_list = [str(d) for d in test_dirs]
+
+    try:
+        start_time = time.time()
+
+        # Run all directories in one command
+        cmd = (
+            [
+                python_exe,
+                "-m",
+                "policyengine_core.scripts.policyengine_command",
+                "test",
+            ]
+            + test_dirs_list
+            + ["-c", "policyengine_us"]
+        )
+
+        print(f"    Running {batch_name}...")
+        print("    " + "-" * 60)
+
+        # Use Popen to show real-time output while capturing
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            universal_newlines=True,
+        )
+
+        output_lines = []
+        passed_count = 0
+        failed_count = 0
+        current_test = None
+
+        # Read output line by line and display it
+        for line in iter(process.stdout.readline, ""):
+            if not line:
+                break
+            output_lines.append(line)
+
+            # Show which test file is being run
+            if ".yaml" in line and ("test" in line or "Testing" in line):
+                # Extract test file name
+                import re
+
+                match = re.search(r"(policyengine_us/tests/.*?\.yaml)", line)
+                if match and match.group(1) != current_test:
+                    current_test = match.group(1)
+                    # Show just the file name being tested
+                    short_name = current_test.split("/")[-1]
+                    print(f"    Testing {short_name}...")
+
+            # Only show the final summary lines
+            if "passed" in line and "==" in line:
+                print(f"    {line}", end="")
+
+            # Extract test counts from output
+            if " passed" in line and "==" in line:
+                import re
+
+                match = re.search(r"(\d+) passed", line)
+                if match:
+                    passed_count = int(match.group(1))
+            if " failed" in line and "==" in line:
+                import re
+
+                match = re.search(r"(\d+) failed", line)
+                if match:
+                    failed_count = int(match.group(1))
+
+            # If we see the pytest summary, tests are done - kill process
+            if "====" in line and ("passed" in line or "failed" in line):
+                print("    Tests completed, terminating process...")
+                process.terminate()
+                break
+
+        # Wait for process to complete (with timeout)
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            raise
+
+        elapsed = time.time() - start_time
+        output = "".join(output_lines)
+
+        print("    " + "-" * 60)
+        print(
+            f"    Completed in {elapsed:.1f}s: {passed_count} passed, {failed_count} failed"
+        )
+
+        return {
+            "batch_name": batch_name,
+            "passed": passed_count,
+            "failed": failed_count,
+            "elapsed": elapsed,
+            "status": "passed" if process.returncode == 0 else "failed",
+            "stdout": output,
+            "stderr": "",
+        }
+
+    except subprocess.TimeoutExpired:
+        print(f"    Timeout after {timeout_seconds}s")
+        return {
+            "batch_name": batch_name,
+            "passed": 0,
+            "failed": 0,
+            "elapsed": timeout_seconds,
+            "status": "timeout",
+        }
+    except Exception as e:
+        print(f"    Error: {str(e)[:100]}")
+        return {
+            "batch_name": batch_name,
+            "passed": 0,
+            "failed": 0,
+            "elapsed": 0,
+            "status": "error",
+        }
+
+
+def main():
+    """
+    Run baseline tests in two batches:
+    1. All state tests (gov/states)
+    2. Everything else in baseline
+    """
+    print("PolicyEngine Baseline Test Runner - Two Batch Strategy", flush=True)
+    print("=" * 80, flush=True)
+    print("Batch 1: All state tests (gov/states)", flush=True)
+    print("Batch 2: Everything else in baseline", flush=True)
+    print("=" * 80, flush=True)
+
+    baseline_path = Path("policyengine_us/tests/policy/baseline")
+
+    # Define the two batches
+    states_path = baseline_path / "gov" / "states"
+
+    # Batch 1: All states
+    print("\n[Batch 1/2] Running all state tests")
+    print(f"  Directory: {states_path}")
+
+    batch1_results = run_batch_isolated(
+        [states_path], "State tests", timeout_seconds=1800  # 30 minutes
+    )
+
+    # Clean up memory after batch 1
+    gc.collect()
+
+    # Batch 2: Everything else (collect all other directories)
+    print("\n[Batch 2/2] Running all other baseline tests and reform tests")
+
+    # Find all test directories except gov/states
+    other_dirs = []
+
+    # Check for yaml files directly in baseline folder
+    baseline_yamls = list(baseline_path.glob("*.yaml"))
+    if baseline_yamls:
+        other_dirs.append(str(baseline_path))
+
+    # Add all top-level directories in baseline except those we already ran
+    for item in baseline_path.iterdir():
+        if item.is_dir():
+            if item.name == "gov":
+                # Add gov subdirectories except states
+                gov_path = baseline_path / "gov"
+                for gov_item in gov_path.iterdir():
+                    if gov_item.is_dir() and gov_item.name != "states":
+                        other_dirs.append(str(gov_item))
+                # Also add any yaml files directly in gov/
+                gov_yamls = list(gov_path.glob("*.yaml"))
+                if gov_yamls and str(gov_path) not in other_dirs:
+                    # Run the gov directory itself to catch direct yaml files
+                    other_dirs.append(str(gov_path))
+            else:
+                # Add non-gov directories
+                other_dirs.append(str(item))
+
+    # Add reform tests directory
+    reform_path = Path("policyengine_us/tests/policy/reform")
+    if reform_path.exists():
+        other_dirs.append(str(reform_path))
+
+    if not other_dirs:
+        print("  No other directories found")
+        batch2_results = {
+            "batch_name": "Other tests",
+            "passed": 0,
+            "failed": 0,
+            "elapsed": 0,
+            "status": "passed",
+        }
+    else:
+        print(
+            f"  Directories: {', '.join([Path(d).name for d in other_dirs])}"
+        )
+        batch2_results = run_batch_isolated(
+            other_dirs,
+            "Other baseline tests",
+            timeout_seconds=1800,  # 30 minutes
+        )
+
+    # Clean up memory after batch 2
+    gc.collect()
+
+    # Collect all failed tests
+    all_failed_tests = []
+
+    # Extract failed tests from batch 1
+    if batch1_results["status"] == "failed" and batch1_results.get("stdout"):
+        import re
+
+        failed_tests = re.findall(
+            r"FAILED (.*\.yaml.*?) -", batch1_results["stdout"]
+        )
+        all_failed_tests.extend(failed_tests)
+
+    # Extract failed tests from batch 2
+    if batch2_results["status"] == "failed" and batch2_results.get("stdout"):
+        import re
+
+        failed_tests = re.findall(
+            r"FAILED (.*\.yaml.*?) -", batch2_results["stdout"]
+        )
+        all_failed_tests.extend(failed_tests)
+
+    # Final summary
+    print("\n" + "=" * 80)
+    print("FINAL TEST SUMMARY")
+    print("=" * 80)
+
+    total_passed = batch1_results["passed"] + batch2_results["passed"]
+    total_failed = batch1_results["failed"] + batch2_results["failed"]
+
+    print(f"✓ Passed: {total_passed} tests")
+    print(f"✗ Failed: {total_failed} tests")
+
+    # Show all failed tests at the end
+    if all_failed_tests:
+        print(f"\n❌ FAILED TEST FILES ({len(all_failed_tests)} total):")
+        for test in all_failed_tests:
+            print(f"  - {test}")
+
+    # Return success if all tests passed
+    return len(all_failed_tests) == 0
+
+
+if __name__ == "__main__":
+    if not os.path.exists("policyengine_us"):
+        print("Error: Must run from PolicyEngine US root directory")
+        sys.exit(1)
+
+    success = main()
+    sys.exit(0 if success else 1)

--- a/policyengine_us/tests/test_contrib_batched.py
+++ b/policyengine_us/tests/test_contrib_batched.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+"""
+Run contrib tests in two batches with memory cleanup.
+Batch 1: First half of contrib tests
+Batch 2: Second half of contrib tests
+"""
+
+import subprocess
+import sys
+import os
+import gc
+import time
+from pathlib import Path
+
+
+def run_batch_isolated(test_files, batch_name, timeout_seconds):
+    """
+    Run a batch of test files in an isolated subprocess.
+    Shows real-time output while also capturing it for analysis.
+    """
+    python_exe = sys.executable
+
+    try:
+        start_time = time.time()
+
+        cmd = (
+            [
+                python_exe,
+                "-m",
+                "policyengine_core.scripts.policyengine_command",
+                "test",
+            ]
+            + test_files
+            + ["-c", "policyengine_us"]
+        )
+
+        print(f"    Running {batch_name} ({len(test_files)} test files)...")
+        print("    " + "-" * 60)
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            universal_newlines=True,
+        )
+
+        output_lines = []
+        passed_count = 0
+        failed_count = 0
+        current_test = None
+
+        for line in iter(process.stdout.readline, ""):
+            if not line:
+                break
+            output_lines.append(line)
+
+            # Show which test file is being run
+            if ".yaml" in line and ("test" in line or "Testing" in line):
+                # Extract test file name
+                import re
+
+                match = re.search(r"(policyengine_us/tests/.*?\.yaml)", line)
+                if match and match.group(1) != current_test:
+                    current_test = match.group(1)
+                    # Show just the file name being tested
+                    short_name = current_test.split("/")[-1]
+                    print(f"    Testing {short_name}...")
+
+            # Only show the final summary lines
+            if "passed" in line and "==" in line:
+                print(f"    {line}", end="")
+
+            if " passed" in line and "==" in line:
+                import re
+
+                match = re.search(r"(\d+) passed", line)
+                if match:
+                    passed_count = int(match.group(1))
+            if " failed" in line and "==" in line:
+                import re
+
+                match = re.search(r"(\d+) failed", line)
+                if match:
+                    failed_count = int(match.group(1))
+
+            # If we see the pytest summary, tests are done - kill process
+            if "====" in line and ("passed" in line or "failed" in line):
+                print("    Tests completed, terminating process...")
+                process.terminate()
+                break
+
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            raise
+
+        elapsed = time.time() - start_time
+        output = "".join(output_lines)
+
+        print("    " + "-" * 60)
+        print(
+            f"    Completed in {elapsed:.1f}s: {passed_count} passed, {failed_count} failed"
+        )
+
+        return {
+            "batch_name": batch_name,
+            "passed": passed_count,
+            "failed": failed_count,
+            "elapsed": elapsed,
+            "status": "passed" if process.returncode == 0 else "failed",
+            "stdout": output,
+            "stderr": "",
+        }
+
+    except subprocess.TimeoutExpired:
+        print(f"    Timeout after {timeout_seconds}s")
+        process.kill()
+        return {
+            "batch_name": batch_name,
+            "passed": 0,
+            "failed": 0,
+            "elapsed": timeout_seconds,
+            "status": "timeout",
+        }
+    except Exception as e:
+        print(f"    Error: {str(e)[:100]}")
+        return {
+            "batch_name": batch_name,
+            "passed": 0,
+            "failed": 0,
+            "elapsed": 0,
+            "status": "error",
+        }
+
+
+def main():
+    """
+    Run contrib tests in two batches:
+    1. First half of test files
+    2. Second half of test files
+    """
+    print("PolicyEngine Contrib Test Runner - Two Batch Strategy", flush=True)
+    print("=" * 80, flush=True)
+    print("Batch 1: First half of contrib tests", flush=True)
+    print("Batch 2: Second half of contrib tests", flush=True)
+    print("=" * 80, flush=True)
+
+    contrib_path = Path("policyengine_us/tests/policy/contrib")
+
+    # Group all test files by folder
+    folder_files = {}
+    for yaml_file in contrib_path.rglob("*.yaml"):
+        parts = str(yaml_file).split("/")
+        if len(parts) > 5:  # Has a subfolder under contrib
+            folder_name = parts[4]
+        else:  # Files directly in contrib folder
+            folder_name = "_root"  # Special name for files in contrib root
+
+        if folder_name not in folder_files:
+            folder_files[folder_name] = []
+        folder_files[folder_name].append(str(yaml_file))
+
+    if not folder_files:
+        print("No contrib test files found")
+        sys.exit(0)
+
+    # Sort folders and files within each folder
+    sorted_folders = sorted(folder_files.keys())
+    for folder in sorted_folders:
+        folder_files[folder].sort()
+
+    # Show folder breakdown
+    total_files = sum(len(files) for files in folder_files.values())
+    print(
+        f"\nFound {total_files} test files in {len(sorted_folders)} folders:"
+    )
+    for folder in sorted_folders:
+        if folder == "_root":
+            print(f"  (root contrib): {len(folder_files[folder])} files")
+        else:
+            print(f"  {folder}: {len(folder_files[folder])} files")
+
+    # Split folders into two batches (keeping all files from same folder together)
+    midpoint = len(sorted_folders) // 2
+    batch1_folders = sorted_folders[:midpoint]
+    batch2_folders = sorted_folders[midpoint:]
+
+    # Collect all files for each batch
+    batch1_files = []
+    for folder in batch1_folders:
+        batch1_files.extend(folder_files[folder])
+
+    batch2_files = []
+    for folder in batch2_folders:
+        batch2_files.extend(folder_files[folder])
+
+    print(
+        f"\n[Batch 1/2] Running {len(batch1_files)} test files from folders:"
+    )
+    print(f"  {', '.join(batch1_folders)}")
+    batch1_results = run_batch_isolated(
+        batch1_files, "Batch 1", timeout_seconds=1800  # 30 minutes
+    )
+
+    gc.collect()
+
+    print(
+        f"\n[Batch 2/2] Running {len(batch2_files)} test files from folders:"
+    )
+    print(f"  {', '.join(batch2_folders)}")
+    batch2_results = run_batch_isolated(
+        batch2_files, "Batch 2", timeout_seconds=1800  # 30 minutes
+    )
+
+    # Clean up memory after batch 2
+    gc.collect()
+
+    all_failed_tests = []
+
+    if batch1_results["status"] == "failed" and batch1_results.get("stdout"):
+        import re
+
+        failed_tests = re.findall(
+            r"FAILED (.*\.yaml.*?) -", batch1_results["stdout"]
+        )
+        all_failed_tests.extend(failed_tests)
+
+    if batch2_results["status"] == "failed" and batch2_results.get("stdout"):
+        import re
+
+        failed_tests = re.findall(
+            r"FAILED (.*\.yaml.*?) -", batch2_results["stdout"]
+        )
+        all_failed_tests.extend(failed_tests)
+
+    print("\n" + "=" * 80)
+    print("FINAL TEST SUMMARY")
+    print("=" * 80)
+
+    total_passed = batch1_results["passed"] + batch2_results["passed"]
+    total_failed = batch1_results["failed"] + batch2_results["failed"]
+
+    print(f"✓ Passed: {total_passed} tests")
+    print(f"✗ Failed: {total_failed} tests")
+
+    if all_failed_tests:
+        print(f"\n❌ FAILED TEST FILES ({len(all_failed_tests)} total):")
+        for test in all_failed_tests:
+            print(f"  - {test}")
+
+    return len(all_failed_tests) == 0
+
+
+if __name__ == "__main__":
+    if not os.path.exists("policyengine_us"):
+        print("Error: Must run from PolicyEngine US root directory")
+        sys.exit(1)
+
+    success = main()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
Fixes memory exhaustion errors in GitHub Actions by implementing two-batch test runners.

## Problem
- Tests failing with 'Killed: 9' errors due to memory exhaustion  
- policyengine-core test command hanging after completion

## Solution: Two-Batch Test Runners

### test_baseline_batched.py
- **Batch 1**: All state tests (gov/states)
- **Batch 2**: Everything else including reform tests

### test_contrib_batched.py
- Tests grouped by folder (all files from same folder stay together)
- **Batch 1**: First half of folders
- **Batch 2**: Second half of folders

## Key Features
- Memory cleanup between batches with gc.collect()
- Early termination when pytest summary detected (fixes hanging)
- Handles root-level test files properly
- 30-minute timeout protection per batch
- Shows test progress in real-time
- Collects and displays all failed tests at the end

## Testing
```bash
make test-yaml-no-structural  # Runs baseline + reform in 2 batches
make test-yaml-structural     # Runs contrib in 2 batches
```

This is the 'Option B' approach from PR #6441 adapted for the current codebase.