### PR TITLE
feat: Implement Rep. Tlaib's Income Security Package (2025)

### DIFF
--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/baby_bonus_act/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/baby_bonus_act/amount.yaml
@@ -1,0 +1,13 @@
+description: Baby bonus payment amount provided to qualifying pregnant persons or eligible parents with a qualifying child
+metadata:
+  unit: currency-USD
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Baby bonus amount
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 1
+values:
+  2025-01-01: 2_000

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/baby_bonus_act/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/baby_bonus_act/in_effect.yaml
@@ -1,0 +1,10 @@
+description: The Baby Bonus Act is in effect when this is true
+metadata:
+  unit: bool
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Baby Bonus Act in effect
+values:
+  0000-01-01: false
+  2025-01-01: true
+  2025-12-31: false

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/baby_bonus_act/max_child_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/baby_bonus_act/max_child_age.yaml
@@ -1,0 +1,10 @@
+description: Maximum age of qualifying child for baby bonus eligibility
+# Note: The Baby Bonus Act does not technically limit the benefit to children under 1
+# since it could be claimed later, however this is how PolicyEngine models this program
+metadata:
+  unit: year
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Maximum child age for baby bonus
+values:
+  2025-01-01: 1

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/amount.yaml
@@ -1,0 +1,13 @@
+description: BOOST Act monthly payment amount
+metadata:
+  unit: currency-USD
+  period: month
+  # reference: placeholder - bill not yet introduced
+  label: BOOST Act monthly amount
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 1
+values:
+  2025-01-01: 250

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/in_effect.yaml
@@ -1,0 +1,10 @@
+description: BOOST Act is in effect
+metadata:
+  unit: bool
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: BOOST Act in effect
+values:
+  0000-01-01: false
+  2025-01-01: true
+  2025-12-31: false

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/max_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/max_age.yaml
@@ -1,0 +1,8 @@
+description: Maximum age for BOOST Act eligibility
+metadata:
+  unit: year
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: BOOST Act maximum age
+values:
+  2025-01-01: 67

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/min_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/min_age.yaml
@@ -1,0 +1,8 @@
+description: Minimum age for BOOST Act eligibility
+metadata:
+  unit: year
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: BOOST Act minimum age
+values:
+  2025-01-01: 19

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/tax/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/tax/rate.yaml
@@ -1,0 +1,8 @@
+description: BOOST Act supplemental tax rate on income above threshold
+metadata:
+  unit: /1
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: BOOST Act tax rate
+values:
+  2025-01-01: 0.025

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/tax/threshold.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/boost_act/tax/threshold.yaml
@@ -1,0 +1,24 @@
+description: AGI threshold above which BOOST Act supplemental tax applies
+metadata:
+  unit: currency-USD
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: BOOST Act tax threshold
+  propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 1
+  breakdown:
+    - filing_status
+JOINT:
+  2025-01-01: 60_000
+SINGLE:
+  2025-01-01: 30_000
+SEPARATE:
+  2025-01-01: 30_000
+HEAD_OF_HOUSEHOLD:
+  2025-01-01: 30_000
+SURVIVING_SPOUSE:
+  2025-01-01: 60_000

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/adult_dependent_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/adult_dependent_credit/amount.yaml
@@ -1,0 +1,9 @@
+description: Adult dependent credit amount per qualifying dependent
+metadata:
+  unit: currency-USD
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Adult dependent credit amount
+  uprating: gov.irs.uprating
+values:
+  2025-01-01: 700

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/adult_dependent_credit/min_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/adult_dependent_credit/min_age.yaml
@@ -1,0 +1,8 @@
+description: Minimum age for adult dependent credit eligibility
+metadata:
+  unit: year
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Adult dependent minimum age
+values:
+  2025-01-01: 18

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/child_benefit/age_limit.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/child_benefit/age_limit.yaml
@@ -1,0 +1,8 @@
+description: Maximum age for child assistance payment eligibility
+metadata:
+  unit: year
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Child benefit age limit
+values:
+  2025-01-01: 19

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/child_benefit/amount_per_month.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/child_benefit/amount_per_month.yaml
@@ -1,0 +1,14 @@
+description: Monthly child benefit amount under End Child Poverty Act
+# Calculated as (poverty guideline - current average monthly child benefit) / 12
+metadata:
+  unit: currency-USD
+  period: month
+  # reference: placeholder - bill not yet introduced
+  label: ECPA child benefit monthly amount
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 1
+values:
+  2025-01-01: 393

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/amount.yaml
@@ -1,0 +1,20 @@
+description: Filer credit amount by filing status
+metadata:
+  unit: currency-USD
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Filer credit amount
+  propagate_metadata_to_children: true
+  uprating: gov.irs.uprating
+  breakdown:
+    - filing_status
+JOINT:
+  2025-01-01: 1_400
+SINGLE:
+  2025-01-01: 700
+SEPARATE:
+  2025-01-01: 700
+HEAD_OF_HOUSEHOLD:
+  2025-01-01: 700
+SURVIVING_SPOUSE:
+  2025-01-01: 700

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/eligibility/min_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/eligibility/min_age.yaml
@@ -1,0 +1,8 @@
+description: Minimum age for filer credit eligibility
+metadata:
+  unit: year
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Filer credit minimum age
+values:
+  2025-01-01: 19

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/phase_out/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/phase_out/rate.yaml
@@ -1,0 +1,8 @@
+description: Filer credit phase-out rate
+metadata:
+  unit: /1
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Filer credit phase-out rate
+values:
+  2025-01-01: 0.05

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/phase_out/start.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/filer_credit/phase_out/start.yaml
@@ -1,0 +1,20 @@
+description: AGI threshold where filer credit phase-out begins
+metadata:
+  unit: currency-USD
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: Filer credit phase-out start
+  propagate_metadata_to_children: true
+  uprating: gov.irs.uprating
+  breakdown:
+    - filing_status
+JOINT:
+  2025-01-01: 40_000
+SINGLE:
+  2025-01-01: 20_000
+SEPARATE:
+  2025-01-01: 20_000
+HEAD_OF_HOUSEHOLD:
+  2025-01-01: 20_000
+SURVIVING_SPOUSE:
+  2025-01-01: 40_000

--- a/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/congress/tlaib/income_security_package/end_child_poverty_act/in_effect.yaml
@@ -1,0 +1,10 @@
+description: The End Child Poverty Act is in effect when this is true
+metadata:
+  unit: bool
+  period: year
+  # reference: placeholder - bill not yet introduced
+  label: End Child Poverty Act in effect
+values:
+  0000-01-01: false
+  2025-01-01: true
+  2025-12-31: false

--- a/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/baby_bonus_act/baby_bonus.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/baby_bonus_act/baby_bonus.yaml
@@ -1,0 +1,63 @@
+- name: Baby under 1 receives bonus
+  period: 2025
+  input:
+    people:
+      child:
+        age: 0
+  output:
+    baby_bonus:
+      2025: 2_000
+
+- name: Child exactly 1 year old does not receive bonus
+  period: 2025
+  input:
+    people:
+      child:
+        age: 1
+  output:
+    baby_bonus:
+      2025: 0
+
+- name: Child over 1 does not receive bonus
+  period: 2025
+  input:
+    people:
+      child:
+        age: 5
+  output:
+    baby_bonus:
+      2025: 0
+
+- name: Multiple children under 1 each receive bonus
+  period: 2025
+  input:
+    people:
+      twin1:
+        age: 0
+      twin2:
+        age: 0
+      parent:
+        age: 30
+  output:
+    baby_bonus:
+      2025: [2_000, 2_000, 0]
+
+- name: No bonus in 2024
+  period: 2024
+  input:
+    people:
+      child:
+        age: 0
+  output:
+    baby_bonus:
+      2024: 0
+
+- name: No bonus after 2025
+  period: 2026
+  input:
+    people:
+      child:
+        age: 0
+  output:
+    baby_bonus:
+      2026: 0

--- a/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/boost_act/boost_payment.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/boost_act/boost_payment.yaml
@@ -1,0 +1,87 @@
+- name: Adult age 19-67 receives full payment
+  period: 2025
+  input:
+    people:
+      adult:
+        age: 30
+  output:
+    boost_payment:
+      2025: 3_000  # 250 * 12
+
+- name: Adult exactly 19 is eligible
+  period: 2025
+  input:
+    people:
+      young_adult:
+        age: 19
+  output:
+    boost_payment:
+      2025: 3_000
+
+- name: Adult exactly 67 is eligible
+  period: 2025
+  input:
+    people:
+      older_adult:
+        age: 67
+  output:
+    boost_payment:
+      2025: 3_000
+
+- name: Child under 19 not eligible
+  period: 2025
+  input:
+    people:
+      child:
+        age: 18
+  output:
+    boost_payment:
+      2025: 0
+
+- name: Adult over 67 not eligible
+  period: 2025
+  input:
+    people:
+      senior:
+        age: 68
+  output:
+    boost_payment:
+      2025: 0
+
+- name: Multiple eligible adults each receive payment
+  period: 2025
+  input:
+    people:
+      adult1:
+        age: 25
+      adult2:
+        age: 35
+      adult3:
+        age: 45
+      child:
+        age: 10
+      senior:
+        age: 70
+  output:
+    boost_payment:
+      2025: [3_000, 3_000, 3_000, 0, 0]
+
+- name: No payment in 2024
+  period: 2024
+  input:
+    people:
+      adult:
+        age: 30
+  output:
+    boost_payment:
+      2024: 0
+
+- name: No payment after 2025
+  period: 2026
+  input:
+    people:
+      adult:
+        age: 30
+  output:
+    boost_payment:
+      2026: 0

--- a/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/boost_act/boost_tax.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/boost_act/boost_tax.yaml
@@ -1,0 +1,125 @@
+- name: Single filer below threshold owes no tax
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 30
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 25_000
+  output:
+    boost_tax:
+      2025: 0
+
+- name: Single filer above threshold owes tax
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 40_000  # 10,000 above 30,000 threshold
+  output:
+    boost_tax:
+      2025: 250  # 10,000 * 0.025
+
+- name: Joint filers below threshold owe no tax
+  period: 2025
+  input:
+    people:
+      head:
+        age: 40
+      spouse:
+        age: 38
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+        adjusted_gross_income: 50_000
+  output:
+    boost_tax:
+      2025: 0
+
+- name: Joint filers above threshold owe tax
+  period: 2025
+  input:
+    people:
+      head:
+        age: 45
+      spouse:
+        age: 43
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+        adjusted_gross_income: 100_000  # 40,000 above 60,000 threshold
+  output:
+    boost_tax:
+      2025: 1_000  # 40,000 * 0.025
+
+- name: Head of household above threshold owes tax
+  period: 2025
+  input:
+    people:
+      head:
+        age: 35
+      child:
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+        adjusted_gross_income: 50_000  # 20,000 above 30,000 threshold
+  output:
+    boost_tax:
+      2025: 500  # 20,000 * 0.025
+
+- name: High income single filer owes substantial tax
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 50
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 130_000  # 100,000 above 30,000 threshold
+  output:
+    boost_tax:
+      2025: 2_500  # 100,000 * 0.025
+
+- name: No tax in 2024
+  period: 2024
+  input:
+    people:
+      filer:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 50_000
+  output:
+    boost_tax:
+      2024: 0
+
+- name: No tax after 2025
+  period: 2026
+  input:
+    people:
+      filer:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 50_000
+  output:
+    boost_tax:
+      2026: 0

--- a/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_adult_dependent_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_adult_dependent_credit.yaml
@@ -1,0 +1,69 @@
+- name: Adult dependent 18 or over receives credit
+  period: 2025
+  input:
+    people:
+      dependent:
+        age: 20
+        is_tax_unit_dependent: true
+      parent:
+        age: 45
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [parent, dependent]
+  output:
+    ecpa_adult_dependent_credit:
+      2025: [700, 0]
+
+- name: Non-dependent adult does not receive credit
+  period: 2025
+  input:
+    people:
+      adult:
+        age: 25
+        is_tax_unit_dependent: false
+  output:
+    ecpa_adult_dependent_credit:
+      2025: 0
+
+- name: Child under 18 does not receive adult dependent credit
+  period: 2025
+  input:
+    people:
+      child:
+        age: 16
+        is_tax_unit_dependent: true
+  output:
+    ecpa_adult_dependent_credit:
+      2025: 0
+
+- name: Multiple adult dependents each receive credit
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 50
+        is_tax_unit_head: true
+      dependent1:
+        age: 18
+        is_tax_unit_dependent: true
+      dependent2:
+        age: 22
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, dependent1, dependent2]
+  output:
+    ecpa_adult_dependent_credit:
+      2025: [0, 700, 700]
+
+- name: No credit in 2024
+  period: 2024
+  input:
+    people:
+      dependent:
+        age: 20
+        is_tax_unit_dependent: true
+  output:
+    ecpa_adult_dependent_credit:
+      2024: 0

--- a/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_child_benefit.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_child_benefit.yaml
@@ -1,0 +1,65 @@
+- name: Child under 19 receives full benefit
+  period: 2025
+  input:
+    people:
+      child:
+        age: 10
+  output:
+    ecpa_child_benefit:
+      2025: 4_716  # 393 * 12
+
+- name: Child exactly 18 receives benefit
+  period: 2025
+  input:
+    people:
+      child:
+        age: 18
+  output:
+    ecpa_child_benefit:
+      2025: 4_716
+
+- name: Adult 19 or over does not receive child benefit
+  period: 2025
+  input:
+    people:
+      adult:
+        age: 19
+  output:
+    ecpa_child_benefit:
+      2025: 0
+
+- name: Multiple children each receive benefit
+  period: 2025
+  input:
+    people:
+      child1:
+        age: 5
+      child2:
+        age: 10
+      child3:
+        age: 15
+      parent:
+        age: 40
+  output:
+    ecpa_child_benefit:
+      2025: [4_716, 4_716, 4_716, 0]
+
+- name: No benefit in 2024
+  period: 2024
+  input:
+    people:
+      child:
+        age: 10
+  output:
+    ecpa_child_benefit:
+      2024: 0
+
+- name: No benefit after 2025
+  period: 2026
+  input:
+    people:
+      child:
+        age: 10
+  output:
+    ecpa_child_benefit:
+      2026: 0

--- a/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_filer_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_filer_credit.yaml
@@ -1,0 +1,123 @@
+- name: Single filer age 19-64 receives full credit
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 30
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 15_000
+  output:
+    ecpa_filer_credit:
+      2025: 700
+
+- name: Joint filers receive higher credit
+  period: 2025
+  input:
+    people:
+      head:
+        age: 35
+      spouse:
+        age: 33
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+        adjusted_gross_income: 30_000
+  output:
+    ecpa_filer_credit:
+      2025: 1_400
+
+- name: Credit phases out above threshold for single filer
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 24_000  # 4,000 above 20,000 threshold
+  output:
+    ecpa_filer_credit:
+      2025: 500  # 700 - (4,000 * 0.05)
+
+- name: Credit phases out for joint filers
+  period: 2025
+  input:
+    people:
+      head:
+        age: 40
+      spouse:
+        age: 38
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+        adjusted_gross_income: 50_000  # 10,000 above 40,000 threshold
+  output:
+    ecpa_filer_credit:
+      2025: 900  # 1,400 - (10,000 * 0.05)
+
+- name: Credit fully phases out at high income
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 45
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 50_000  # 30,000 above threshold
+  output:
+    ecpa_filer_credit:
+      2025: 0  # 700 - (30,000 * 0.05) = -800, max to 0
+
+- name: Filer under 19 not eligible
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 18
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 10_000
+  output:
+    ecpa_filer_credit:
+      2025: 0
+
+- name: Filer 65 or over not eligible
+  period: 2025
+  input:
+    people:
+      filer:
+        age: 65
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 10_000
+  output:
+    ecpa_filer_credit:
+      2025: 0
+
+- name: No credit in 2024
+  period: 2024
+  input:
+    people:
+      filer:
+        age: 30
+    tax_units:
+      tax_unit:
+        members: [filer]
+        filing_status: SINGLE
+        adjusted_gross_income: 15_000
+  output:
+    ecpa_filer_credit:
+      2024: 0

--- a/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/integration.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/tlaib/income_security/integration.yaml
@@ -1,0 +1,138 @@
+- name: Family with baby, children, and adults receives all benefits
+  period: 2025
+  input:
+    people:
+      baby:
+        age: 0
+      child1:
+        age: 5
+      child2:
+        age: 10
+      adult_head:
+        age: 35
+      adult_spouse:
+        age: 33
+      adult_dependent:
+        age: 20
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [adult_head, adult_spouse, baby, child1, child2, adult_dependent]
+        filing_status: JOINT
+        adjusted_gross_income: 45_000  # 5,000 above phase-out start
+  output:
+    # Baby Bonus
+    baby_bonus:
+      2025: [2_000, 0, 0, 0, 0, 0]  # Only baby gets bonus
+    # ECPA Child Benefit  
+    ecpa_child_benefit:
+      2025: [4_716, 4_716, 4_716, 0, 0, 0]  # All children under 19
+    # ECPA Adult Dependent Credit
+    ecpa_adult_dependent_credit:
+      2025: [0, 0, 0, 0, 0, 700]  # Only adult dependent
+    # BOOST Payment
+    boost_payment:
+      2025: [0, 0, 0, 3_000, 3_000, 3_000]  # Adults 19-67
+    # ECPA Filer Credit (at tax unit level)
+    ecpa_filer_credit:
+      2025: 1_150  # 1,400 - (5,000 * 0.05)
+    # BOOST Tax (at tax unit level)
+    boost_tax:
+      2025: 0  # Below 60,000 threshold for joint
+
+- name: Single parent with high income
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 40
+      child:
+        age: 8
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+        adjusted_gross_income: 80_000
+  output:
+    # No baby bonus (child too old)
+    baby_bonus:
+      2025: [0, 0]
+    # Child benefit
+    ecpa_child_benefit:
+      2025: [0, 4_716]
+    # BOOST payment for parent
+    boost_payment:
+      2025: [3_000, 0]
+    # ECPA filer credit fully phased out
+    ecpa_filer_credit:
+      2025: 0  # 700 - (60,000 * 0.05) = -2,300, max to 0
+    # BOOST tax on high income
+    boost_tax:
+      2025: 1_250  # (80,000 - 30,000) * 0.025
+
+- name: Senior couple with adult dependent
+  period: 2025
+  input:
+    people:
+      senior1:
+        age: 68
+      senior2:
+        age: 70
+      adult_dependent:
+        age: 40
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [senior1, senior2, adult_dependent]
+        filing_status: JOINT
+        adjusted_gross_income: 35_000
+  output:
+    # No baby bonus
+    baby_bonus:
+      2025: [0, 0, 0]
+    # No child benefit (all adults)
+    ecpa_child_benefit:
+      2025: [0, 0, 0]
+    # Adult dependent credit
+    ecpa_adult_dependent_credit:
+      2025: [0, 0, 700]
+    # BOOST payment only for adult dependent (seniors too old)
+    boost_payment:
+      2025: [0, 0, 3_000]
+    # No filer credit (seniors over 64)
+    ecpa_filer_credit:
+      2025: 0
+    # No BOOST tax (below threshold)
+    boost_tax:
+      2025: 0
+
+- name: Young adult living alone
+  period: 2025
+  input:
+    people:
+      young_adult:
+        age: 19
+    tax_units:
+      tax_unit:
+        members: [young_adult]
+        filing_status: SINGLE
+        adjusted_gross_income: 12_000
+  output:
+    # No baby bonus
+    baby_bonus:
+      2025: 0
+    # No child benefit (19 or over)
+    ecpa_child_benefit:
+      2025: 0
+    # Not a dependent
+    ecpa_adult_dependent_credit:
+      2025: 0
+    # Gets BOOST payment
+    boost_payment:
+      2025: 3_000
+    # Gets filer credit
+    ecpa_filer_credit:
+      2025: 700  # No phase-out
+    # No BOOST tax (below threshold)
+    boost_tax:
+      2025: 0

--- a/policyengine_us/variables/contrib/congress/tlaib/income_security/baby_bonus_act/baby_bonus.py
+++ b/policyengine_us/variables/contrib/congress/tlaib/income_security/baby_bonus_act/baby_bonus.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class baby_bonus(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "Baby Bonus Act payment"
+    unit = USD
+    documentation = "One-time payment for children under 1 year old under the Baby Bonus Act"
+    reference = "placeholder - bill not yet introduced"
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.contrib.congress.tlaib.income_security_package.baby_bonus_act
+
+        if not p.in_effect:
+            return person("age", period) * 0
+
+        age = person("age", period)
+        max_age = p.max_child_age
+        is_eligible_child = age < max_age
+
+        amount = p.amount
+
+        return is_eligible_child * amount

--- a/policyengine_us/variables/contrib/congress/tlaib/income_security/boost_act/boost_payment.py
+++ b/policyengine_us/variables/contrib/congress/tlaib/income_security/boost_act/boost_payment.py
@@ -1,0 +1,30 @@
+from policyengine_us.model_api import *
+
+
+class boost_payment(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "BOOST Act payment"
+    unit = USD
+    documentation = "Monthly payments under the BOOST Act for eligible adults"
+    reference = "placeholder - bill not yet introduced"
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.contrib.congress.tlaib.income_security_package.boost_act
+
+        if not p.in_effect:
+            return person("age", period) * 0
+
+        age = person("age", period)
+        min_age = p.min_age
+        max_age = p.max_age
+
+        is_eligible = (age >= min_age) & (age <= max_age)
+
+        monthly_amount = p.amount
+        annual_amount = monthly_amount * MONTHS_IN_YEAR
+
+        return is_eligible * annual_amount

--- a/policyengine_us/variables/contrib/congress/tlaib/income_security/boost_act/boost_tax.py
+++ b/policyengine_us/variables/contrib/congress/tlaib/income_security/boost_act/boost_tax.py
@@ -1,0 +1,30 @@
+from policyengine_us.model_api import *
+
+
+class boost_tax(Variable):
+    value_type = float
+    entity = TaxUnit
+    definition_period = YEAR
+    label = "BOOST Act supplemental tax"
+    unit = USD
+    documentation = "Supplemental tax on AGI to fund the BOOST Act"
+    reference = "placeholder - bill not yet introduced"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.contrib.congress.tlaib.income_security_package.boost_act
+
+        if not p.in_effect:
+            return tax_unit("adjusted_gross_income", period) * 0
+
+        agi = tax_unit("adjusted_gross_income", period)
+        filing_status = tax_unit("filing_status", period)
+
+        threshold = p.tax.threshold[filing_status]
+        rate = p.tax.rate
+
+        excess_agi = max_(agi - threshold, 0)
+        tax = excess_agi * rate
+
+        return tax

--- a/policyengine_us/variables/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_adult_dependent_credit.py
+++ b/policyengine_us/variables/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_adult_dependent_credit.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class ecpa_adult_dependent_credit(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "End Child Poverty Act adult dependent credit"
+    unit = USD
+    documentation = (
+        "Credit for adult dependents under the End Child Poverty Act"
+    )
+    reference = "placeholder - bill not yet introduced"
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.contrib.congress.tlaib.income_security_package.end_child_poverty_act
+
+        if not p.in_effect:
+            return person("age", period) * 0
+
+        age = person("age", period)
+        min_age = p.adult_dependent_credit.min_age
+        is_dependent = person("is_tax_unit_dependent", period)
+
+        is_eligible = (age >= min_age) & is_dependent
+
+        amount = p.adult_dependent_credit.amount
+
+        return is_eligible * amount

--- a/policyengine_us/variables/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_child_benefit.py
+++ b/policyengine_us/variables/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_child_benefit.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class ecpa_child_benefit(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "End Child Poverty Act child benefit"
+    unit = USD
+    documentation = "Universal child benefit under the End Child Poverty Act"
+    reference = "placeholder - bill not yet introduced"
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.contrib.congress.tlaib.income_security_package.end_child_poverty_act
+
+        if not p.in_effect:
+            return person("age", period) * 0
+
+        age = person("age", period)
+        age_limit = p.child_benefit.age_limit
+        is_eligible = age < age_limit
+
+        monthly_amount = p.child_benefit.amount_per_month
+        annual_amount = monthly_amount * MONTHS_IN_YEAR
+
+        return is_eligible * annual_amount

--- a/policyengine_us/variables/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_filer_credit.py
+++ b/policyengine_us/variables/contrib/congress/tlaib/income_security/end_child_poverty_act/ecpa_filer_credit.py
@@ -1,0 +1,48 @@
+from policyengine_us.model_api import *
+
+
+class ecpa_filer_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    definition_period = YEAR
+    label = "End Child Poverty Act filer credit"
+    unit = USD
+    documentation = (
+        "Filer credit under the End Child Poverty Act for eligible tax filers"
+    )
+    reference = "placeholder - bill not yet introduced"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.contrib.congress.tlaib.income_security_package.end_child_poverty_act
+
+        if not p.in_effect:
+            return tax_unit("adjusted_gross_income", period) * 0
+
+        person = tax_unit.members
+        age = person("age", period)
+        min_age = p.filer_credit.eligibility.min_age
+
+        is_head = person("is_tax_unit_head", period)
+        is_spouse = person("is_tax_unit_spouse", period)
+        is_filer = is_head | is_spouse
+
+        is_eligible_age = (age >= min_age) & (age < 65)
+        is_eligible_filer = is_filer & is_eligible_age
+
+        has_eligible_filer = tax_unit.any(is_eligible_filer)
+
+        filing_status = tax_unit("filing_status", period)
+        amount = p.filer_credit.amount[filing_status]
+
+        agi = tax_unit("adjusted_gross_income", period)
+        phase_out_start = p.filer_credit.phase_out.start[filing_status]
+        phase_out_rate = p.filer_credit.phase_out.rate
+
+        excess_agi = max_(agi - phase_out_start, 0)
+        phase_out = excess_agi * phase_out_rate
+
+        credit = max_(amount - phase_out, 0)
+
+        return has_eligible_filer * credit


### PR DESCRIPTION
## Summary

This PR implements Rep. Tlaib's comprehensive Income Security Package consisting of three major benefit programs targeted for 2025.

## Programs Implemented

### 1. Baby Bonus Act
- One-time $2,000 payment for children under 1 year old
- Inflation-adjusted benefit amounts with downwards rounding
- Note: Modeled as age < 1 restriction per PolicyEngine conventions

### 2. End Child Poverty Act (ECPA)
- **Universal child benefit**: $393/month for children under 19
- **Adult dependent credit**: $700 for dependents 18+
- **Filer credit**: $700 (single) / $1,400 (joint) for ages 19-64
- **Phase-out**: 5% rate above AGI thresholds ($20k single / $40k joint)
- All benefits include inflation adjustment

### 3. BOOST Act
- **Monthly payment**: $250 for adults ages 19-67
- **Supplemental tax**: 2.5% on AGI above thresholds
- **Income thresholds**: $30k (single) / $60k (joint)
- Inflation-adjusted amounts and thresholds

## Implementation Details

- All programs active only during 2025
- Parameters stored under `gov.contrib.congress.tlaib.income_security_package`
- Follows PolicyEngine modeling conventions and code style
- Uses standard inflation adjustment with `gov.irs.uprating`

## Testing

- ✅ 45 comprehensive tests covering all programs
- ✅ Integration tests verifying programs work together
- ✅ Edge cases for age limits, phase-outs, and income thresholds
- ✅ All tests passing

## Related Issues

Closes #6470

🤖 Generated with [Claude Code](https://claude.ai/code)