### PR TITLE
Fix `ny_ctc_pre_2024.py` formula

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - Adjusted New York CTC calculations pre 2025.

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc.yaml
@@ -42,25 +42,6 @@
   output:
     ny_ctc: 100
 
-- name: Parent of four-year old child with no income gets minimum credit, $100 per child
-  period: 2022
-  input:
-    people:
-      parent:
-        age: 30
-      child:
-        age: 4
-    tax_units:
-      tax_unit:
-        members: [parent, child]
-        ctc: 0
-    households:
-      household:
-        members: [parent, child]
-        state_code: NY
-  output:
-    ny_ctc: 100
-
 - name: Simpler calculation if not set to pre-TCJA.
   period: 2022
   input:
@@ -323,7 +304,7 @@
         members: [parent, child]
         state_code: NY
   output:
-    ny_ctc: 100  # Original rule: $100 minimum per child
+    ny_ctc: 100
 
 - name: 2025 - Updated CTC disabled vs enabled comparison (young child)
   period: 2025
@@ -344,4 +325,4 @@
         members: [parent, child]
         state_code: NY
   output:
-    ny_ctc: 100  # Original rule: $100 minimum (not $1,000 from updated rules)
+    ny_ctc: 330

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc_pre_2024.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc_pre_2024.yaml
@@ -1,0 +1,99 @@
+- name: Case 1, taxsim_record_225838_2024.yaml.
+  absolute_error_margin: 0.2
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 0.0
+        taxable_interest_income: 24_248.203
+        is_tax_unit_head: true
+      person2:
+        age: 41
+        employment_income: 0.0
+        taxable_interest_income: 24_248.203
+        is_tax_unit_spouse: true
+      person3:
+        age: 10
+        employment_income: 0
+        is_tax_unit_dependent: true
+        is_tax_unit_head: false
+        is_tax_unit_spouse: false
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        premium_tax_credit: 0
+        local_income_tax: 0
+        state_sales_tax: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_fips: 36
+  output:
+    ny_ctc: 330
+    ny_ctc_pre_2024: 330
+   # ny_ctc: 0
+
+- name: Case 2, parent of four-year old child with no income gets minimum credit, $100 per child.
+  period: 2022
+  input:
+    people:
+      parent:
+        age: 30
+      child:
+        age: 4
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NY
+  output:
+    ny_ctc: 100
+    ny_ctc_pre_2024: 100
+
+- name: Case 3, parent of four-year old child with some earned income.
+  period: 2022
+  input:
+    people:
+      parent:
+        age: 30
+        employment_income: 25_000
+      child:
+        age: 4
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NY
+  output:
+    ny_ctc: 330
+    ny_ctc_pre_2024: 330
+
+- name: Case 4, parent of four-year old child with some earned income.
+  period: 2022
+  input:
+    people:
+      parent:
+        age: 30
+        taxable_interest_income: 50_000
+      child:
+        age: 4
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NY
+  output:
+    ny_ctc: 330
+    ny_ctc_pre_2024: 330

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_ctc_pre_2024.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_ctc_pre_2024.py
@@ -55,9 +55,21 @@ class ny_ctc_pre_2024(Variable):
                 period,
                 maximum_ctc * meets_ny_minimum_age,
             )
+            # Get maximum federal CTC from pre-TCJA rules
             max_federal_ctc = pre_tcja_ctc.tax_unit("ctc", period)
-            ctc_phase_in = pre_tcja_ctc.tax_unit("ctc_phase_in", period)
-            federal_ctc = min_(max_federal_ctc, ctc_phase_in)
+
+            # Limit by actual tax liability (for non-refundable portion)
+            limiting_tax = pre_tcja_ctc.tax_unit(
+                "ctc_limiting_tax_liability", period
+            )
+            non_refundable_ctc = min_(max_federal_ctc, limiting_tax)
+
+            # Get refundable portion (requires earned income)
+            refundable_ctc = pre_tcja_ctc.tax_unit("refundable_ctc", period)
+
+            # Total federal CTC they can actually claim
+            federal_ctc = non_refundable_ctc + refundable_ctc
+
             qualifies_for_federal_ctc = pre_tcja_ctc.person(
                 "ctc_qualifying_child", period
             )


### PR DESCRIPTION
Fixes #6510

  **What was broken:**
  Families with investment income (like interest or dividends) were only getting $100 NY Child Tax Credit when they should get $330.

  **Why it was broken:**
  The formula was checking if families had wages/earned income. If they didn't have wages, it gave them $0 federal CTC, even though they could claim the credit using their tax liability from investment income.

  **What I fixed:**
  Removed the earned income restriction for the non-refundable portion of the federal CTC. The credit now properly considers tax liability from all income sources, not just wages.

  **The fix:**
  ```python
  # Before: Incorrectly required earned income
  federal_ctc = min_(max_federal_ctc, ctc_phase_in)  # Wrong - zeros out if no wages

  # After: Correctly uses tax liability
  non_refundable_ctc = min_(max_federal_ctc, limiting_tax)  # Uses actual tax liability
  refundable_ctc = ...  # Still requires earned income
  federal_ctc = non_refundable_ctc + refundable_ctc

  Test results:
  - ✅ Family with $48k interest income: Now gets $330 (was incorrectly $100)
  - ✅ Family with $0 income: Still gets $100 minimum (working correctly)

  Who this helps:
  - Retirees living on interest/dividends
  - Families with investment income
  - Anyone with non-wage income who qualifies for the child tax credit