### PR TITLE
Fix Social Security taxation formula parameter issue

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Social Security taxation formula now uses a separate parameter for combined income calculation instead of incorrectly reusing the base taxation rate

--- a/policyengine_us/parameters/gov/irs/social_security/taxability/combined_income_ss_fraction.yaml
+++ b/policyengine_us/parameters/gov/irs/social_security/taxability/combined_income_ss_fraction.yaml
@@ -1,4 +1,4 @@
-description: Fraction of Social Security benefits included in combined income for determining taxability
+description: The United States includes this fraction of Social Security benefits for determining taxability.
 values:
   1984-01-01: 0.5
 

--- a/policyengine_us/parameters/gov/irs/social_security/taxability/combined_income_ss_fraction.yaml
+++ b/policyengine_us/parameters/gov/irs/social_security/taxability/combined_income_ss_fraction.yaml
@@ -1,0 +1,14 @@
+description: Fraction of Social Security benefits included in combined income for determining taxability
+values:
+  1984-01-01: 0.5
+
+metadata:
+  unit: /1
+  period: year
+  label: Social Security fraction for combined income calculation
+  reference:
+  - title: 26 U.S. Code § 86(b)(1)
+    href: https://www.law.cornell.edu/uscode/text/26/86#b_1
+  - title: IRS Publication 915 - Social Security and Equivalent Railroad Retirement Benefits
+    href: https://www.irs.gov/publications/p915
+ 

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/test_ss_combined_income_fix.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/test_ss_combined_income_fix.yaml
@@ -1,0 +1,21 @@
+- name: Test combined income calculation uses separate parameter
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 67
+        social_security: 20_000
+        employment_income: 30_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    # Combined income should be 30_000 + 0.5 * 20_000 = 40_000
+    # (using the default 0.5 fraction from the new parameter)
+    tax_unit_combined_income_for_social_security_taxability: 40_000

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/tax_unit_combined_income_for_social_security_taxability.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/tax_unit_combined_income_for_social_security_taxability.py
@@ -16,11 +16,10 @@ class tax_unit_combined_income_for_social_security_taxability(Variable):
         p = parameters(period).gov.irs.social_security.taxability
         gross_ss = tax_unit("tax_unit_social_security", period)
 
-        # The legislation directs the usage an income definition that is
+        # The legislation directs the usage of an income definition that is
         # a particularly modified AGI, plus half of gross Social Security
-        # payments. We assume that the 'half' here is the same underlying
-        # parameter as the lower taxability marginal rate (also 50% in the
-        # baseline), and that they would be mechanically the same parameter.
+        # payments. Per IRC Section 86(b)(1), this fraction is always 0.5
+        # regardless of the taxation rates applied to the benefits.
 
-        ss_fraction = p.rate.base * gross_ss
+        ss_fraction = p.combined_income_ss_fraction * gross_ss
         return tax_unit("taxable_ss_magi", period) + ss_fraction

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/tax_unit_ss_combined_income_excess.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/tax_unit_ss_combined_income_excess.py
@@ -14,11 +14,10 @@ class tax_unit_ss_combined_income_excess(Variable):
             period
         ).gov.irs.social_security.taxability.threshold.base
 
-        # The legislation directs the usage an income definition that is
+        # The legislation directs the usage of an income definition that is
         # a particularly modified AGI, plus half of gross Social Security
-        # payments. We assume that the 'half' here is the same underlying
-        # parameter as the lower taxability marginal rate (also 50% in the
-        # baseline), and that they would be mechanically the same parameter.
+        # payments. Per IRC Section 86(b)(1), this fraction is always 0.5
+        # and is handled by the combined_income_ss_fraction parameter.
 
         combined_income = tax_unit(
             "tax_unit_combined_income_for_social_security_taxability", period

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/tax_unit_taxable_social_security.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/social_security/tax_unit_taxable_social_security.py
@@ -14,11 +14,10 @@ class tax_unit_taxable_social_security(Variable):
         p = parameters(period).gov.irs.social_security.taxability
         gross_ss = tax_unit("tax_unit_social_security", period)
 
-        # The legislation directs the usage an income definition that is
+        # The legislation directs the usage of an income definition that is
         # a particularly modified AGI, plus half of gross Social Security
-        # payments. We assume that the 'half' here is the same underlying
-        # parameter as the lower taxability marginal rate (also 50% in the
-        # baseline), and that they would be mechanically the same parameter.
+        # payments. Per IRC Section 86(b)(1), this fraction is always 0.5
+        # and is handled by the combined_income_ss_fraction parameter.
 
         combined_income = tax_unit(
             "tax_unit_combined_income_for_social_security_taxability", period


### PR DESCRIPTION
## Summary
- Fixes bug where the `rate.base` parameter was incorrectly used for both the combined income calculation and the taxation rate
- Introduces new parameter `combined_income_ss_fraction` that is fixed at 0.5 per IRC Section 86(b)(1)
- Ensures that policy analysis modifications to taxation rates don't affect the combined income calculation

## Problem
The Social Security taxation formula had a bug where the `rate.base` parameter was used for two different purposes:
1. To determine what fraction of Social Security benefits to add to MAGI for the combined income test
2. As the actual taxation rate for the first tier of benefits

This caused incorrect results when modifying parameters for policy analysis. For example, when setting base rate to 0.85 and thresholds to 0, only 81.8% of benefits were taxed instead of the expected 85%.

## Solution
Created a new parameter `combined_income_ss_fraction` that:
- Defaults to 0.5 (50%) to match current law
- Is used specifically for the combined income calculation
- Separates this from the `rate.base` parameter which now only controls the taxation rate

## Changes
- Added new parameter file `combined_income_ss_fraction.yaml`
- Updated `tax_unit_combined_income_for_social_security_taxability.py` to use the new parameter
- Updated comments in related files to clarify the separation
- Added test to verify the fix works correctly

## Testing
- Added test case to verify combined income calculation uses the fixed 0.5 fraction
- All existing tests continue to pass

Fixes #6516

🤖 Generated with [Claude Code](https://claude.ai/code)