### PR TITLE
Add household_fpg variable

### DIFF
--- a/policyengine_us/tests/policy/baseline/gov/hhs/household_fpg.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/household_fpg.yaml
@@ -1,0 +1,39 @@
+- name: Single person household in contiguous states
+  period: 2024
+  input:
+    household_size: 1
+    state_code: CA
+  output:
+    household_fpg: 15_060
+
+- name: Family of 4 in contiguous states
+  period: 2024
+  input:
+    household_size: 4
+    state_code: NY
+  output:
+    household_fpg: 31_200
+
+- name: Family of 2 in Alaska
+  period: 2024
+  input:
+    household_size: 2
+    state_code: AK
+  output:
+    household_fpg: 25_480
+
+- name: Family of 3 in Hawaii
+  period: 2024
+  input:
+    household_size: 3
+    state_code: HI
+  output:
+    household_fpg: 31_470
+
+- name: Large family of 8 in contiguous states
+  period: 2024
+  input:
+    household_size: 8
+    state_code: TX
+  output:
+    household_fpg: 53_000

--- a/policyengine_us/variables/gov/hhs/household_fpg.py
+++ b/policyengine_us/variables/gov/hhs/household_fpg.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+from policyengine_us.variables.gov.hhs.tax_unit_fpg import fpg
+
+
+class household_fpg(Variable):
+    value_type = float
+    entity = Household
+    label = "Household's federal poverty guideline"
+    definition_period = YEAR
+    unit = USD
+
+    def formula(household, period, parameters):
+        n = household("household_size", period)
+        state_group = household("state_group_str", period)
+        return fpg(n, state_group, period, parameters)


### PR DESCRIPTION
## Summary
This PR adds a household-level federal poverty guideline (FPG) variable that complements the existing tax_unit_fpg variable.

## Changes
- Added household_fpg variable in policyengine_us/variables/gov/hhs/household_fpg.py
- Added comprehensive tests for various household sizes and states (including Alaska and Hawaii)
- Reuses the existing fpg() function from tax_unit_fpg.py to ensure consistency

## Motivation
Many poverty-related analyses and programs operate at the household level rather than the tax unit level. This variable enables:
- Household-level poverty calculations
- Analysis of programs that use household FPG thresholds
- Consistency with household-level benefit programs

## Testing
- Added 5 test cases covering various household sizes (1-8 people) and states (including special cases for Alaska and Hawaii)
- Tests verify correct FPG calculations for 2024

Related to PolicyEngine/analysis-notebooks#76 - California AEI rebate base analysis