### PR TITLE
Fix NY CTC pre-2024 parameter freeze expiration

### DIFF
--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_ctc_pre_2024.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_ctc_pre_2024.py
@@ -38,7 +38,7 @@ class ny_ctc_pre_2024(Variable):
                 if isinstance(ctc_parameter, Parameter):
                     ctc_parameter.update(
                         start=instant("2017-01-01"),
-                        stop=instant("2026-01-01"),
+                        stop=instant("2035-01-01"),
                         value=ctc_parameter("2017-01-01"),
                     )
             # Delete all arrays from pre-TCJA CTC branch.


### PR DESCRIPTION
## Summary
Fixes #6612

The pre-TCJA parameter override in `ny_ctc_pre_2024.py` had a stop date of 2026-01-01, causing it to expire and use actual (inflated) 2027 federal CTC values instead of frozen 2017 values. This made the baseline pre-2024 NY CTC jump from ~$600M to ~$1,900M in 2027+.

## Changes
- Changed `stop=instant("2026-01-01")` to `stop=instant("2035-01-01")` in `ny_ctc_pre_2024.py` line 41
- This matches the fix previously applied to `ny_ctc_pre_2024_eligible.py` line 44

## Impact
**Before:**
- 2025-2026: Pre-2024 NY CTC baseline ~$600M (correct)
- 2027+: Pre-2024 NY CTC baseline ~$1,900M (incorrect - 3x inflation due to parameter freeze expiration)

**After:**
- 2025-2035: Pre-2024 NY CTC baseline remains frozen at ~$600M (correct)

## Test Plan
- [ ] Verify 2027 baseline pre-2024 NY CTC is ~$600M (not ~$1,900M)
- [ ] Verify enhanced CTC comparison shows correct budget impact (costs money, not saves money) in 2027
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)