### PR TITLE
Add taxable unemployment compensation to the list of California subtractions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Add taxable unemployment compensation to the list of California subtractions.

--- a/policyengine_us/parameters/gov/states/ca/tax/income/agi/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/agi/subtractions.yaml
@@ -2,6 +2,7 @@ description: List of California AGI subtractions.
 values:
   2021-01-01:
     - taxable_social_security
+    - taxable_unemployment_compensation
 
 metadata:
   reference:

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/integration.yaml
@@ -59,3 +59,53 @@
         state_fips: 6
   output:
     ca_income_tax: 791_292
+
+- name: 0-CA.yaml
+  absolute_error_margin: 2
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 0.0
+        ssi: 0
+        wic: 0
+        head_start: 0
+        early_head_start: 0
+        commodity_supplemental_food_program: 0
+        unemployment_compensation: 5440.0
+        qualified_dividend_income: 4.3401766
+        long_term_capital_gains: 27410.084
+        taxable_interest_income: 113.7181
+        is_tax_unit_head: true
+      person2:
+        age: 40
+        employment_income: 0.0
+        ssi: 0
+        wic: 0
+        head_start: 0
+        early_head_start: 0
+        commodity_supplemental_food_program: 0
+        qualified_dividend_income: 4.3401766
+        long_term_capital_gains: 27410.084
+        taxable_interest_income: 113.7181
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0
+        local_income_tax: 0
+        state_sales_tax: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0
+        tanf: 0
+        free_school_meals: 0
+        reduced_price_school_meals: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 6
+  output:
+    ca_income_tax: 371


### PR DESCRIPTION
Fixes #6716