### PR TITLE
Bug: RI personal exemptions fail to phase out at high incomes in PR #6643 reform

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Rhode Island exemption reform now correctly applies baseline phase-out to personal exemptions at high incomes

--- a/policyengine_us/tests/policy/contrib/states/ri/exemption_reform_test.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ri/exemption_reform_test.yaml
@@ -86,3 +86,32 @@
     # Dependent exemption after phaseout: 5_100 - 1_000 = 4_100
     # Final: 5_050 (personal) + 4_100 (dependent) = 9_150
     ri_exemptions: 9_150
+
+- name: RI exemption reform - high income personal exemption baseline phaseout
+  period: 2024
+  reforms: policyengine_us.reforms.states.ri.exemption.ri_exemption_reform.ri_exemption_reform
+  input:
+    gov.contrib.states.ri.dependent_exemption.in_effect: true
+    gov.contrib.states.ri.dependent_exemption.amount: 0
+    people:
+      parent:
+        age: 40
+        employment_income: 300_000
+    tax_units:
+      tax_unit:
+        members: [parent]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [parent]
+        state_name: RI
+  output:
+    # At AGI of $300,000, personal exemption should be fully phased out
+    # Baseline phaseout: starts at $246,450, rate 0.2 per $7,050 increment
+    # Excess AGI: $300,000 - $246,450 = $53,550
+    # Increments: ceil($53,550 / $7,050) = 8
+    # Reduction rate: min(0.2 * 8, 1) = min(1.6, 1) = 1 (100%)
+    # Personal exemption: $5,050 * (1 - 1) = $0
+    # Dependent exemption: $0 (set to $0 in reform)
+    # Final: $0 + $0 = $0
+    ri_exemptions: 0


### PR DESCRIPTION
Fixes #6733