### PR TITLE
Fix Head Start and Early Head Start variable metadata

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Fix Head Start and Early Head Start variable metadata (add unit=USD, simplify labels)

--- a/policyengine_us/variables/gov/hhs/head_start/early_head_start.py
+++ b/policyengine_us/variables/gov/hhs/head_start/early_head_start.py
@@ -4,7 +4,8 @@ from policyengine_us.model_api import *
 class early_head_start(Variable):
     value_type = float
     entity = Person
-    label = "Amount of Early Head Start benefit"
+    label = "Early Head Start"
+    unit = USD
     definition_period = YEAR
     defined_for = "is_early_head_start_eligible"
     reference = "https://headstart.gov/program-data/article/head-start-program-facts-fiscal-year-2022"

--- a/policyengine_us/variables/gov/hhs/head_start/head_start.py
+++ b/policyengine_us/variables/gov/hhs/head_start/head_start.py
@@ -4,7 +4,8 @@ from policyengine_us.model_api import *
 class head_start(Variable):
     value_type = float
     entity = Person
-    label = "Amount of Head Start benefit"
+    label = "Head Start"
+    unit = USD
     definition_period = YEAR
     defined_for = "is_head_start_eligible"
     reference = "https://headstart.gov/program-data/article/head-start-program-facts-fiscal-year-2022"


### PR DESCRIPTION
## Summary
- Add `unit = USD` to both `head_start` and `early_head_start` variables
- Simplify labels from "Amount of X benefit" to just program name
- Aligns with naming conventions used for other benefit variables (SNAP, TANF, CHIP)

## Background
Both Head Start programs were missing the unit metadata and had verbose labels that didn't match the pattern used elsewhere in the codebase.

## Open Question: Takeup Modeling
Currently, these variables calculate a per-child benefit (state spending ÷ state enrollment) and apply it to ALL eligible children. In reality, Head Start and Early Head Start are capacity-constrained programs with limited enrollment slots.

Selection is based on a priority system (not lottery) considering:
- Family income level
- Homelessness, foster care status
- Child age and disability status
- Family risk factors

Should we implement takeup variables similar to SNAP? The challenge is that:
1. Takeup rates would vary significantly by state and demographics
2. The enrollment numbers already represent actual participation
3. Unlike SNAP, this isn't a "don't claim despite eligible" situation - it's "can't access due to capacity"

## Test plan
- [x] Verify code changes are correct
- [x] Confirm labels and units match conventions
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)