### PR TITLE
Add self-hosted GCP runner for CI/CD workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 jobs:
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Check formatting
@@ -13,7 +13,7 @@ jobs:
           args: ". -l 79 --check"
   check-version:
     name: Check version
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,7 +34,7 @@ jobs:
         run: make changelog
   Quick-Feedback:
     name: Quick Feedback (Selective Tests + Coverage)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
         run: uv build
   YAML-NonStructural:
     name: Full Suite - Non-Structural YAML
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
           uv run make test-yaml-no-structural
   Structural-and-Python:
     name: Full Suite - Structural YAML & Python
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 jobs:
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: |
       (github.repository == 'PolicyEngine/policyengine-us')
       && (github.event.head_commit.message == 'Update PolicyEngine US')
@@ -19,7 +19,7 @@ jobs:
     if: |
       (github.repository == 'PolicyEngine/policyengine-us')
       && !(github.event.head_commit.message == 'Update PolicyEngine US')
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +50,7 @@ jobs:
           fetch: false
   YAML-NonStructural:
     name: Non-Structural YAML Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: |
       (github.repository == 'PolicyEngine/policyengine-us')
       && (github.event.head_commit.message == 'Update PolicyEngine US')
@@ -76,7 +76,7 @@ jobs:
           uv run make test-yaml-no-structural
   Structural-and-Python:
     name: Structural YAML & Python Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: |
       (github.repository == 'PolicyEngine/policyengine-us')
       && (github.event.head_commit.message == 'Update PolicyEngine US')
@@ -107,7 +107,7 @@ jobs:
           echo "Running Python-based tests..."
           uv run make test-other
   Publish:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: |
       (github.repository == 'PolicyEngine/policyengine-us')
       && (github.event.head_commit.message == 'Update PolicyEngine US')
@@ -135,7 +135,7 @@ jobs:
     if: |
       (github.repository == 'PolicyEngine/policyengine-us')
       && (github.event.head_commit.message == 'Update PolicyEngine US')
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
     steps:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - GitHub Actions workflows now use self-hosted GCP runner for improved performance and resource availability


### PR DESCRIPTION
## Summary
- Migrates all GitHub Actions workflows from `ubuntu-latest` to self-hosted GCP runner
- Improves performance and resource availability for CI/CD jobs
- Uses n2-standard-16 spot instance (64GB RAM, 32GB swap) in `policyengine-research` GCP project

## Changes
- Updated `.github/workflows/pr.yaml` - all 5 jobs now use `runs-on: self-hosted`
  - Lint
  - check-version
  - Quick-Feedback
  - YAML-NonStructural
  - Structural-and-Python
- Updated `.github/workflows/push.yaml` - all 6 jobs now use `runs-on: self-hosted`
  - Lint
  - versioning
  - YAML-NonStructural
  - Structural-and-Python
  - Publish
  - Deploy
- Added changelog entry documenting infrastructure change

## Test plan
- [ ] Verify self-hosted runner is online and registered in GitHub Actions
- [ ] Push this PR and confirm workflows pick up jobs on self-hosted runner
- [ ] Monitor all CI jobs complete successfully on self-hosted environment
- [ ] Verify GCP service account authentication still works
- [ ] Confirm PyPI publish and deployment steps work correctly

## Infrastructure notes
Runner VM is managed via:
- VM name: `pe-us-runner`
- Start/stop: `gcloud compute instances start/stop pe-us-runner --zone=us-central1-a`
- Cost: ~$180/month running, ~$8/month stopped
- Setup documented in `~/devl/code-snippets/gcp/github-runners/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)