### PR TITLE
Split AMT exemption into separate variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Split AMT exemption calculation into separate `amt_exemption` variable from `amt_income_less_exemptions`.

--- a/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/alternative_minimum_tax/exemption/amt_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/alternative_minimum_tax/exemption/amt_exemption.yaml
@@ -1,0 +1,68 @@
+- name: No phase-out, no kiddie tax
+  period: 2022
+  input:
+    amt_income: 200_000
+    amt_kiddie_tax_applies: false
+    filer_adjusted_earnings: 400_000
+    filing_status: SINGLE
+  output:
+    # Base exemption for SINGLE in 2022 is 75,900
+    # income_excess = max(0, 200,000 - 539,900) = 0
+    # No phase-out, full exemption of 75,900
+    amt_exemption: 75_900
+
+- name: No phase-out, kiddie tax applies with low earnings
+  period: 2022
+  input:
+    amt_income: 200_000
+    amt_kiddie_tax_applies: true
+    filer_adjusted_earnings: 10_000
+    filing_status: SINGLE
+  output:
+    # Base exemption for SINGLE in 2022 is 75,900
+    # reduced_exemption = 75,900 (no phase-out)
+    # exemption_cap = 10,000 + 8,200 (child amount) = 18,200
+    # amt_exemption = min(75,900, 18,200) = 18,200
+    amt_exemption: 18_200
+
+- name: Full phase-out at high income
+  period: 2022
+  input:
+    amt_income: 1_000_000
+    amt_kiddie_tax_applies: false
+    filer_adjusted_earnings: 400_000
+    filing_status: SINGLE
+  output:
+    # Base exemption for SINGLE in 2022 is 75,900
+    # income_excess = max(0, 1,000,000 - 539,900) = 460,100
+    # exemption_phase_out = 0.25 * 460,100 = 115,025
+    # reduced_exemption = max(0, 75,900 - 115,025) = 0
+    amt_exemption: 0
+
+- name: Partial phase-out
+  period: 2022
+  input:
+    amt_income: 600_000
+    amt_kiddie_tax_applies: false
+    filer_adjusted_earnings: 400_000
+    filing_status: SINGLE
+  output:
+    # Base exemption for SINGLE in 2022 is 75,900
+    # income_excess = max(0, 600,000 - 539,900) = 60,100
+    # exemption_phase_out = 0.25 * 60,100 = 15,025
+    # reduced_exemption = max(0, 75,900 - 15,025) = 60,875
+    amt_exemption: 60_875
+
+- name: Joint filers, no phase-out
+  period: 2022
+  input:
+    amt_income: 500_000
+    amt_kiddie_tax_applies: false
+    filer_adjusted_earnings: 400_000
+    filing_status: JOINT
+  output:
+    # Base exemption for JOINT in 2022 is 118,100
+    # Phase-out starts at 1,079,800
+    # income_excess = max(0, 500,000 - 1,079,800) = 0
+    # Full exemption of 118,100
+    amt_exemption: 118_100

--- a/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax/exemption/amt_exemption.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax/exemption/amt_exemption.py
@@ -1,0 +1,47 @@
+from policyengine_us.model_api import *
+
+
+class amt_exemption(Variable):
+    value_type = float
+    entity = TaxUnit
+    definition_period = YEAR
+    label = "Alternative Minimum Tax exemption"
+    unit = USD
+    documentation = (
+        "AMT exemption amount after phase-out and kiddie tax adjustments. "
+        "Form 6251, Line 5."
+    )
+    reference = [
+        "https://www.law.cornell.edu/uscode/text/26/55#d",  # 26 U.S.C. § 55(d)
+        "https://www.irs.gov/instructions/i6251",
+    ]
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.irs.income.amt
+        phase_out = p.exemption.phase_out
+        filing_status = tax_unit("filing_status", period)
+        amt_income = tax_unit("amt_income", period)
+
+        # Base exemption amount based on filing status
+        base_exemption_amount = p.exemption.amount[filing_status]
+
+        # Phase-out at higher income levels
+        income_excess = max_(0, amt_income - phase_out.start[filing_status])
+        exemption_phase_out = phase_out.rate * income_excess
+        reduced_exemption_amount = max_(
+            0,
+            base_exemption_amount - exemption_phase_out,
+        )
+
+        # A reduced exemption amount is applied to kiddie tax filers
+        kiddie_tax_applies = tax_unit("amt_kiddie_tax_applies", period)
+        adj_earnings = tax_unit("filer_adjusted_earnings", period)
+        child_amount = p.exemption.child.amount
+
+        exemption_cap = where(
+            kiddie_tax_applies,
+            adj_earnings + child_amount,
+            np.inf,
+        )
+
+        return min_(reduced_exemption_amount, exemption_cap)

--- a/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax/income/amt_income_less_exemptions.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax/income/amt_income_less_exemptions.py
@@ -17,28 +17,10 @@ class amt_income_less_exemptions(Variable):
         taxable_income = tax_unit("taxable_income", period)
         kiddie_tax_applies = tax_unit("amt_kiddie_tax_applies", period)
         applied_income = where(kiddie_tax_applies, taxable_income, amt_income)
-        # Form 6251, Part II top
-        p = parameters(period).gov.irs.income.amt
-        phase_out = p.exemption.phase_out
-        filing_status = tax_unit("filing_status", period)
-        # Line 5 the exemption amount is based on filing status and
-        # is phased-out at higher income
-        base_exemption_amount = p.exemption.amount[filing_status]
-        income_excess = max_(0, amt_income - phase_out.start[filing_status])
-        exemption_phase_out = phase_out.rate * income_excess
-        reduced_exemption_amount = max_(
-            0,
-            (base_exemption_amount - exemption_phase_out),
-        )
-        # A reduced exemption amount is applied to kiddie tax filers
-        adj_earnings = tax_unit("filer_adjusted_earnings", period)
-        child_amount = p.exemption.child.amount
 
-        exemption_cap = where(
-            kiddie_tax_applies,
-            adj_earnings + child_amount,
-            np.inf,
-        )
-        capped_exemption_amount = min_(reduced_exemption_amount, exemption_cap)
+        # Form 6251, Part II top
+        # Line 5
+        amt_exemption = tax_unit("amt_exemption", period)
+
         # Line 6
-        return max_(0, applied_income - capped_exemption_amount)
+        return max_(0, applied_income - amt_exemption)


### PR DESCRIPTION
## Summary
- Extracts the AMT exemption calculation from `amt_income_less_exemptions` into a new `amt_exemption` variable
- Improves code modularity following the "one variable per file" pattern
- Adds comprehensive unit tests for the new variable

Closes #6040

## Test plan
- [x] All 48 AMT tests pass
- [x] New `amt_exemption.yaml` tests cover: no phase-out, kiddie tax cap, full phase-out, partial phase-out, joint filers

🤖 Generated with [Claude Code](https://claude.com/claude-code)