### PR TITLE
Add AMT regression test from issue #1279

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Regression test for AMT calculation against TAXSIM35 (issue #1279).

--- a/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/alternative_minimum_tax/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/alternative_minimum_tax/integration.yaml
@@ -1,0 +1,26 @@
+# Integration test from GitHub issue #1279
+# Validates AMT calculation against TAXSIM35
+- name: Issue 1279 - Joint filers with employment income and capital gains
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 55
+        employment_income: 177_000
+        long_term_capital_gains: 100_000
+      person2:
+        age: 58
+        employment_income: 176_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    # TAXSIM35 and USI-Tax-Analyzer both produce zero AMT for this case
+    alternative_minimum_tax: 0
+    # Expected income tax from TAXSIM35
+    income_tax: 85_538

--- a/uv.lock
+++ b/uv.lock
@@ -1244,7 +1244,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.432.2"
+version = "1.441.0"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Adds regression test validating AMT calculation against TAXSIM35
- The bug reported in #1279 (AMT overcalculated by ~$11k for joint filers with employment income and capital gains) appears to be fixed
- Test confirms `alternative_minimum_tax: 0` and `income_tax: 85,538` matching TAXSIM35

Closes #1279

## Test plan
- [x] Test passes locally with expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)