### PR TITLE
Fix ma_state_supplement missing defined_for=StateCode.MA

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Add missing defined_for=StateCode.MA to ma_state_supplement, fixing bug where non-MA households received Massachusetts State Supplement.

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/dta/ssp/ma_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/dta/ssp/ma_state_supplement.yaml
@@ -1,6 +1,7 @@
 - name: Single person.
   period: 2022
   input:
+    state_code: MA
     is_ssi_aged_blind_disabled: true
     uncapped_ssi: -100
     ma_maximum_state_supplement: 300
@@ -11,6 +12,7 @@
 - name: Single person fails resource test.
   period: 2022
   input:
+    state_code: MA
     is_ssi_aged_blind_disabled: true
     uncapped_ssi: -100
     ma_maximum_state_supplement: 300

--- a/policyengine_us/variables/gov/states/ma/dta/ssp/ma_state_supplement.py
+++ b/policyengine_us/variables/gov/states/ma/dta/ssp/ma_state_supplement.py
@@ -6,6 +6,7 @@ class ma_state_supplement(Variable):
     entity = Person
     label = "Massachusetts State Supplement payment amount"
     definition_period = YEAR
+    defined_for = StateCode.MA
     exhaustive_parameter_dependencies = "gov.states.ma.dta.ssp"
     reference = (
         "https://www.law.cornell.edu/regulations/massachusetts/106-CMR-327-330"


### PR DESCRIPTION
## Summary

- Adds missing `defined_for = StateCode.MA` to `ma_state_supplement` variable
- Updates unit test to include `state_code: MA` input

This bug caused non-Massachusetts households to incorrectly receive Massachusetts State Supplement payments. The California State Supplement already had this restriction (`defined_for = StateCode.CA`), but the Massachusetts version was missing it.

## Test plan

- [x] Existing MA SSP unit tests pass with updated state_code input
- [x] Integration test passes
- [ ] Verify non-MA households no longer receive MA State Supplement in web app

🤖 Generated with [Claude Code](https://claude.com/claude-code)