### PR TITLE
Fix invalid filing_status enum values in test files

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix invalid filing_status enum values in test files (lowercase 'single', numeric '0', typos 'WIDWO' and 'HEAD_OF_HOUSE_HOLD').

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/federal_deduction/co_federal_deduction_addback.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/federal_deduction/co_federal_deduction_addback.yaml
@@ -203,7 +203,7 @@
   input:
     state_code: CO
     co_federal_deduction_addback_required: true
-    filing_status: HEAD_OF_HOUSE_HOLD
+    filing_status: HEAD_OF_HOUSEHOLD
     itemized_taxable_income_deductions: 40_000
   output:
     co_federal_deduction_addback: 10_000
@@ -304,7 +304,7 @@
   input:
     state_code: CO
     co_federal_deduction_addback_required: true
-    filing_status: HEAD_OF_HOUSE_HOLD
+    filing_status: HEAD_OF_HOUSEHOLD
     taxable_income_deductions: 32_000
   output:
     co_federal_deduction_addback: 20_000

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/mo_pension_and_ss_or_ssd_deduction_section_b.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/mo_pension_and_ss_or_ssd_deduction_section_b.yaml
@@ -4,7 +4,7 @@
   input:
     mo_adjusted_gross_income: 0
     tax_unit_taxable_social_security: 0
-    filing_status: 0
+    filing_status: SINGLE
     taxable_private_pension_income: 0
     state_code: MO
   output:

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/mo_pension_and_ss_or_ssd_deduction_section_c.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/mo_pension_and_ss_or_ssd_deduction_section_c.yaml
@@ -4,7 +4,7 @@
   input:
     mo_adjusted_gross_income: 0
     taxable_social_security: 0
-    filing_status: 0
+    filing_status: SINGLE
     state_code: MO
   output:
     mo_pension_and_ss_or_ssd_deduction_section_c: 0.0

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_itemized_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_itemized_deductions.yaml
@@ -13,7 +13,7 @@
 - name: Real estate taxes and mortgage capped 
   period: 2022
   input:
-    filing_status: WIDWO
+    filing_status: SURVIVING_SPOUSE
     mortgage_interest: 11_000
     real_estate_taxes: 11_000
     charitable_deduction: 0
@@ -25,7 +25,7 @@
 - name: Real estate taxes and mortgage capped with medical and charitable
   period: 2022
   input:
-    filing_status: WIDWO
+    filing_status: SURVIVING_SPOUSE
     mortgage_interest: 11_000
     real_estate_taxes: 11_000
     charitable_deduction: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit_max.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit_max.yaml
@@ -4,7 +4,7 @@
     taxable_social_security: 5_000
     ut_total_income: 20_000
     tax_exempt_interest_income: 500
-    filing_status: single
+    filing_status: SINGLE
     state_code: UT
   output:
     ut_ss_benefits_credit_max: 242.50
@@ -15,7 +15,7 @@
     taxable_social_security: 5_000
     ut_total_income: 30_000
     tax_exempt_interest_income: 500
-    filing_status: single
+    filing_status: SINGLE
     state_code: UT
   output:
     ut_ss_benefits_credit_max: 242.50
@@ -26,7 +26,7 @@
     taxable_social_security: 5_000
     ut_total_income: 25_000
     tax_exempt_interest_income: 500
-    filing_status: single
+    filing_status: SINGLE
     state_code: UT
   output:
     ut_ss_benefits_credit_max: 242.50
@@ -37,7 +37,7 @@
     taxable_social_security: 0
     ut_total_income: 20_000
     tax_exempt_interest_income: 500
-    filing_status: single
+    filing_status: SINGLE
     state_code: UT
   output:
     ut_ss_benefits_credit_max: 0  # no taxable social security income
@@ -48,7 +48,7 @@
     taxable_social_security: 100_000
     ut_total_income: 20_000
     tax_exempt_interest_income: 20_000
-    filing_status: single
+    filing_status: SINGLE
     state_code: UT
   output:
     ut_ss_benefits_credit_max: 4_700  


### PR DESCRIPTION
## Summary

Fixes invalid `filing_status` enum values in test files that were silently converted to `SINGLE` (index 0) due to a bug in policyengine-core (see [#410](https://github.com/PolicyEngine/policyengine-core/issues/410)).

## Changes

| File | Invalid Value | Corrected To |
|------|---------------|--------------|
| Utah SS benefits credit tests | `single` (lowercase) | `SINGLE` |
| Missouri pension deduction section B | `0` (numeric) | `SINGLE` |
| Missouri pension deduction section C | `0` (numeric) | `SINGLE` |
| Colorado federal deduction addback | `HEAD_OF_HOUSE_HOLD` (typo) | `HEAD_OF_HOUSEHOLD` |
| North Carolina itemized deductions | `WIDWO` (typo) | `SURVIVING_SPOUSE` |

## Context

These invalid values didn't cause test failures because `numpy.select()` in `Enum.encode()` returns 0 (the default) when no condition matches, silently converting invalid values to the first enum value.

[PolicyEngine/policyengine-core#411](https://github.com/PolicyEngine/policyengine-core/pull/411) adds validation to raise clear errors for invalid enum values. This PR should be merged first to prevent test failures when that fix is released.

## Test Plan

- [x] Verified no remaining invalid `filing_status` values in test files
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)