### PR TITLE
fix(il): Add veteran eligibility to IL TANF immigration status check

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - IL TANF now correctly recognizes veterans as eligible regardless of immigration status per 89 Ill. Admin. Code 112.10.

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dhs/tanf/eligibility/il_tanf_immigration_status_eligible_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dhs/tanf/eligibility/il_tanf_immigration_status_eligible_person.yaml
@@ -22,10 +22,32 @@
   output:
     il_tanf_immigration_status_eligible_person: true
 
-- name: Eligible HONORABLY_DISCHARGED_VETERAN
+# Per 89 Ill. Admin. Code 112.10, honorably discharged veterans are eligible
+# regardless of immigration status. Veteran status is tracked separately
+# from immigration status via the is_veteran variable.
+- name: Eligible veteran (non-citizen LPR who is a veteran)
   period: 2023
   input:
-    immigration_status: HONORABLY_DISCHARGED_VETERAN
+    immigration_status: LEGAL_PERMANENT_RESIDENT
+    is_veteran: true
     state_code: IL
   output:
     il_tanf_immigration_status_eligible_person: true
+
+- name: Eligible veteran (undocumented person who is a veteran)
+  period: 2023
+  input:
+    immigration_status: UNDOCUMENTED
+    is_veteran: true
+    state_code: IL
+  output:
+    il_tanf_immigration_status_eligible_person: true
+
+- name: Not eligible (undocumented non-veteran)
+  period: 2023
+  input:
+    immigration_status: UNDOCUMENTED
+    is_veteran: false
+    state_code: IL
+  output:
+    il_tanf_immigration_status_eligible_person: false

--- a/policyengine_us/variables/gov/states/il/dhs/tanf/eligibility/il_tanf_immigration_status_eligible_person.py
+++ b/policyengine_us/variables/gov/states/il/dhs/tanf/eligibility/il_tanf_immigration_status_eligible_person.py
@@ -20,5 +20,9 @@ class il_tanf_immigration_status_eligible_person(Variable):
         is_citizen = (
             immigration_status == immigration_status.possible_values.CITIZEN
         )
+        # Per 89 Ill. Admin. Code 112.10, honorably discharged veterans
+        # (and their spouses/dependents) are eligible regardless of
+        # immigration status.
+        is_veteran = person("is_veteran", period.this_year)
 
-        return has_qualifying_status | is_citizen
+        return has_qualifying_status | is_citizen | is_veteran


### PR DESCRIPTION
## Summary

Per [89 Ill. Admin. Code 112.10](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.10), honorably discharged veterans are eligible for TANF regardless of their immigration status. 

Previously, the test incorrectly used `HONORABLY_DISCHARGED_VETERAN` as an `immigration_status` enum value, which is invalid—veteran status is orthogonal to immigration status.

## Changes

- Adds `is_veteran` check to the IL TANF immigration status eligibility formula
- Updates tests to use the proper `is_veteran` boolean variable
- Adds test cases demonstrating that veterans are eligible regardless of immigration status (including undocumented veterans)

## Test plan

- [x] Local tests pass: `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/il/dhs/tanf/eligibility/il_tanf_immigration_status_eligible_person.yaml -c policyengine_us`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)