### PR TITLE
Add scheduled weekly uv.lock update workflow

### DIFF
--- a/.github/workflows/weekly-uv-lock.yaml
+++ b/.github/workflows/weekly-uv-lock.yaml
@@ -1,0 +1,71 @@
+name: Weekly uv.lock Update
+
+on:
+  schedule:
+    # Every Wednesday at 5 PM EST (10 PM UTC)
+    - cron: "0 22 * * 3"
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+jobs:
+  update-lock:
+    name: Update uv.lock
+    runs-on: ubuntu-latest
+    if: github.repository == 'PolicyEngine/policyengine-us'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          token: ${{ secrets.POLICYENGINE_GITHUB }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Update lock file
+        run: uv lock --upgrade
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          commit-message: "Update uv.lock dependencies"
+          branch: bot/weekly-uv-lock-update
+          delete-branch: true
+          title: "chore: Weekly uv.lock update"
+          body: |
+            ## Summary
+
+            Automated weekly update of `uv.lock` dependencies.
+
+            Related to #7000
+
+            ## Changes
+
+            This PR updates the `uv.lock` file with the latest compatible dependency versions.
+
+            ## Review
+
+            - Review the lock file changes to ensure no unexpected dependency updates
+            - If unwanted, simply close this PR - master remains unchanged
+
+            ---
+            🤖 Generated automatically by GitHub Actions
+          labels: |
+            dependencies
+            automated

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Add scheduled GitHub Action workflow for weekly uv.lock updates


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically creates PRs to update `uv.lock` on a weekly schedule.

Related to #7000 (standing tracking issue - kept open for recurring PRs)

## Implementation

New file: `.github/workflows/weekly-uv-lock.yaml`

**Schedule:** Every Wednesday at 5 PM EST (10 PM UTC)

**Workflow steps:**
1. Checkout master branch
2. Install uv
3. Run `uv lock --upgrade`
4. If changes detected, create a PR to master using `peter-evans/create-pull-request`

**Features:**
- Never directly modifies master - all changes go through PR review
- Manual trigger available via `workflow_dispatch` for testing
- Auto-deletes the bot branch when PR is closed/merged
- Only runs on the main PolicyEngine repo (not forks)

## Why This Approach

- **Safe**: Master is never directly modified
- **Controllable**: You can close unwanted PRs with no impact
- **Traceable**: All dependency updates go through normal review process
- **Recurring**: Issue #7000 stays open as a tracking issue; weekly PRs reference it but don't close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)