### PR TITLE
Remove uv.lock freshness check, add weekly update workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,24 +15,6 @@ jobs:
         uses: "lgeiger/black-action@master"
         with:
           args: ". -l 79 --check"
-  check-lock-freshness:
-    name: Check uv.lock freshness
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.13
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-      - name: Check lock file is up-to-date
-        run: |
-          uv lock --upgrade
-          git diff --exit-code uv.lock || {
-            echo "::error::uv.lock is outdated. Run 'uv lock --upgrade' and commit the changes."
-            exit 1
-          }
   check-version:
     name: Check version
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-uv-lock.yaml
+++ b/.github/workflows/weekly-uv-lock.yaml
@@ -1,0 +1,71 @@
+name: Weekly uv.lock Update
+
+on:
+  schedule:
+    # Every Wednesday at 5 PM EST (10 PM UTC)
+    - cron: "0 22 * * 3"
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+jobs:
+  update-lock:
+    name: Update uv.lock
+    runs-on: ubuntu-latest
+    if: github.repository == 'PolicyEngine/policyengine-us'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          token: ${{ secrets.POLICYENGINE_GITHUB }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Update lock file
+        run: uv lock --upgrade
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          commit-message: "Update uv.lock dependencies"
+          branch: bot/weekly-uv-lock-update
+          delete-branch: true
+          title: "chore: Weekly uv.lock update"
+          body: |
+            ## Summary
+
+            Automated weekly update of `uv.lock` dependencies.
+
+            Related to #7000
+
+            ## Changes
+
+            This PR updates the `uv.lock` file with the latest compatible dependency versions.
+
+            ## Review
+
+            - Review the lock file changes to ensure no unexpected dependency updates
+            - If unwanted, simply close this PR - master remains unchanged
+
+            ---
+            Generated automatically by GitHub Actions
+          labels: |
+            dependencies
+            automated

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    removed:
+      - Remove uv.lock freshness check from PR CI workflow.
+    added:
+      - Add scheduled GitHub Action workflow for weekly uv.lock updates.


### PR DESCRIPTION
## Summary

Closes #7034

Remove the strict `uv.lock` freshness check from PR CI and replace it with a weekly scheduled workflow.

## Changes

- **Removed**: `check-lock-freshness` job from `.github/workflows/pr.yaml`
- **Added**: `.github/workflows/weekly-uv-lock.yaml` - runs every Wednesday at 5 PM EST to update dependencies automatically

## Reason

The current check is too strict. A weekly scheduled script will keep the lock file up to date instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)