### PR TITLE
Remove non-existent labels from weekly uv.lock workflow

### DIFF
--- a/.github/workflows/weekly-uv-lock.yaml
+++ b/.github/workflows/weekly-uv-lock.yaml
@@ -82,6 +82,4 @@ jobs:
           ---
           Generated automatically by GitHub Actions
           EOF
-          )" \
-            --label "dependencies" \
-            --label "automated"
+          )"

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Remove non-existent labels from weekly uv.lock workflow PR creation.


### PR DESCRIPTION
## Summary

Fixes the weekly uv.lock workflow which was failing because it tried to add labels (`dependencies`, `automated`) that don't exist in the repository.

Related to #7000

## Changes

- Removed `--label` flags from `gh pr create` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)