### PR TITLE
Add phase-out logic to CRFB Social Security nonrefundable credit

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Add phase-out logic to CRFB Social Security nonrefundable credit based on AGI thresholds (6% rate above $150k joint, $75k other).

--- a/policyengine_us/parameters/gov/contrib/crfb/ss_credit/phase_out/applies.yaml
+++ b/policyengine_us/parameters/gov/contrib/crfb/ss_credit/phase_out/applies.yaml
@@ -1,0 +1,8 @@
+description: The Committee for a Responsible Federal Budget's proposed replacement of the additional senior deduction with a nonrefundable credit which is phased out if this is true.
+metadata:
+  unit: bool
+  period: year
+  label: CRFB Social Security nonrefundable credit phase out applies
+
+values:
+  0000-01-01: false

--- a/policyengine_us/parameters/gov/contrib/crfb/ss_credit/phase_out/rate/joint.yaml
+++ b/policyengine_us/parameters/gov/contrib/crfb/ss_credit/phase_out/rate/joint.yaml
@@ -1,0 +1,17 @@
+description: The Committee for a Responsible Federal Budget proposes to replace the additional senior deduction with a nonrefundable credit which is phased out at this rate for joint filers.
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-USD
+  rate_unit: /1
+  period: year
+  label: CRFB Social Security nonrefundable credit joint filers phase out rate
+
+brackets:
+  - threshold:
+      0000-01-01: 0
+    rate:
+      0000-01-01: 0
+  - threshold:
+      0000-01-01: 150_000
+    rate:
+      0000-01-01: 0.06

--- a/policyengine_us/parameters/gov/contrib/crfb/ss_credit/phase_out/rate/other.yaml
+++ b/policyengine_us/parameters/gov/contrib/crfb/ss_credit/phase_out/rate/other.yaml
@@ -1,0 +1,18 @@
+description: The Committee for a Responsible Federal Budget proposes to replace the additional senior deduction with a nonrefundable credit which is phased out at this rate for non-joint filers.
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-USD
+  rate_unit: /1
+  period: year
+  label: CRFB Social Security nonrefundable credit other filers phase out rate
+
+
+brackets:
+  - threshold:
+      0000-01-01: 0
+    rate:
+      0000-01-01: 0
+  - threshold:
+      0000-01-01: 75_000
+    rate:
+      0000-01-01: 0.06

--- a/policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml
@@ -86,3 +86,62 @@
     taxable_social_security: 4_250
     ss_credit: 425
     income_tax_non_refundable_credits: 425
+
+# Phase-out edge case tests
+- name: Phase-out disabled - high income single gets full credit
+  period: 2026
+  reforms: policyengine_us.reforms.crfb.non_refundable_ss_credit.non_refundable_ss_credit_reform_object
+  input:
+    gov.contrib.crfb.ss_credit.in_effect: true
+    gov.contrib.crfb.ss_credit.phase_out.applies: false
+    taxable_social_security: 30_000
+    taxable_income: 1_000_000
+    adjusted_gross_income: 500_000
+    filing_status: SINGLE
+  output:
+    # With phase_out.applies = false, no phase-out occurs regardless of AGI
+    ss_credit: 600
+
+- name: Phase-out enabled - single below threshold gets full credit
+  period: 2026
+  reforms: policyengine_us.reforms.crfb.non_refundable_ss_credit.non_refundable_ss_credit_reform_object
+  input:
+    gov.contrib.crfb.ss_credit.in_effect: true
+    gov.contrib.crfb.ss_credit.phase_out.applies: true
+    taxable_social_security: 30_000
+    taxable_income: 1_000_000
+    adjusted_gross_income: 70_000
+    filing_status: SINGLE
+  output:
+    # AGI of 70k is below 75k threshold, so no phase-out
+    ss_credit: 600
+
+- name: Phase-out enabled - single partial phase-out
+  period: 2026
+  reforms: policyengine_us.reforms.crfb.non_refundable_ss_credit.non_refundable_ss_credit_reform_object
+  input:
+    gov.contrib.crfb.ss_credit.in_effect: true
+    gov.contrib.crfb.ss_credit.phase_out.applies: true
+    taxable_social_security: 30_000
+    taxable_income: 1_000_000
+    adjusted_gross_income: 80_000
+    filing_status: SINGLE
+  output:
+    # Phase out = 6% * (80k - 75k) = $300
+    # Credit = 600 - 300 = 300
+    ss_credit: 300
+
+- name: Phase-out enabled - joint full phase-out
+  period: 2026
+  reforms: policyengine_us.reforms.crfb.non_refundable_ss_credit.non_refundable_ss_credit_reform_object
+  input:
+    gov.contrib.crfb.ss_credit.in_effect: true
+    gov.contrib.crfb.ss_credit.phase_out.applies: true
+    taxable_social_security: 30_000
+    taxable_income: 1_000_000
+    adjusted_gross_income: 165_000
+    filing_status: JOINT
+  output:
+    # Phase out = 6% * (165k - 150k) = $900
+    # Credit = max(0, 600 - 900) = 0
+    ss_credit: 0


### PR DESCRIPTION
## Summary
- Add income-based phase-out to the CRFB Social Security nonrefundable credit reform
- Phase-out is controlled by `gov.contrib.crfb.ss_credit.phase_out.applies` parameter

## Changes
- **Joint filers**: 6% phase-out rate for AGI above $150,000
- **Other filers**: 6% phase-out rate for AGI above $75,000

## Test plan
- [x] Test phase-out disabled (high income gets full credit)
- [x] Test below threshold (full credit when AGI under threshold)
- [x] Test partial phase-out (reduced credit)
- [x] Test full phase-out (credit reduced to $0)

Closes #7088

🤖 Generated with [Claude Code](https://claude.com/claude-code)