### PR TITLE
Add missing label metadata to bracket/scale parameters

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Added missing label metadata to bracket/scale parameters that had no labels.

--- a/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/amount.yaml
@@ -13,6 +13,7 @@ brackets:
     rate:
       2009-01-01: 0
 metadata:
+  label: American Opportunity Credit marginal rate schedule
   type: marginal_rate
   rate_unit: /1
   threshold_unit: currency-USD

--- a/policyengine_us/parameters/gov/irs/credits/eitc/phase_out/joint_bonus.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/eitc/phase_out/joint_bonus.yaml
@@ -1,5 +1,6 @@
 description: Extra earned income credit phase-out start AGI for married filing jointly.
 metadata:
+  label: EITC joint filer bonus phase-out start
   rate_unit: currency-USD
   propagate_metadata_to_children: true
   threshold_unit: child

--- a/policyengine_us/parameters/gov/irs/credits/premium_tax_credit/eligibility.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/premium_tax_credit/eligibility.yaml
@@ -13,6 +13,7 @@ brackets:
     amount:
       2015-01-01: false
 metadata:
+  label: Premium Tax Credit eligibility thresholds
   type: single_amount
   threshold_unit: /1
   reference:

--- a/policyengine_us/parameters/gov/irs/credits/premium_tax_credit/phase_out/ending_rate.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/premium_tax_credit/phase_out/ending_rate.yaml
@@ -45,6 +45,7 @@ brackets:
       2021-01-01: 0.085
       2023-01-01: 0
 metadata:
+  label: Premium Tax Credit phase-out ending rate
   type: single_amount
   rate_unit: /1
   threshold_unit: currency-USD

--- a/policyengine_us/parameters/gov/irs/credits/premium_tax_credit/phase_out/starting_rate.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/premium_tax_credit/phase_out/starting_rate.yaml
@@ -45,6 +45,7 @@ brackets:
       2021-01-01: 0.085
       2023-01-01: 0
 metadata:
+  label: Premium Tax Credit phase-out starting rate
   type: single_amount
   rate_unit: /1
   threshold_unit: currency-USD

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/fraction_elderly.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/fraction_elderly.yaml
@@ -1,5 +1,6 @@
 description: DC property tax credit offset is this AGI-specific fraction of US AGI for elderly.
 metadata:
+  label: DC property tax credit offset fraction (elderly)
   type: single_amount
   threshold_period: year
   threshold_unit: currency-USD  # federal AGI

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/fraction_nonelderly.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/ptc/fraction_nonelderly.yaml
@@ -1,5 +1,6 @@
 description: DC property tax credit offset is this AGI-specific fraction of US AGI for non-elderly.
 metadata:
+  label: DC property tax credit offset fraction (non-elderly)
   type: single_amount
   threshold_period: year
   threshold_unit: currency-USD  # federal AGI

--- a/policyengine_us/parameters/gov/states/dc/tax/income/rates.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/rates.yaml
@@ -1,5 +1,6 @@
 description: DC uses these income tax brackets and rates for all filing units.
 metadata:
+  label: DC income tax rates
   type: marginal_rate
   threshold_period: year
   threshold_unit: currency-USD  # non-negative DC taxable income


### PR DESCRIPTION
## Summary

Adds `label` metadata to 8 ParameterScale parameters that had no labels. This enables automatic label generation for their 68 bracket child parameters (e.g., `[0].rate`, `[1].threshold`) in the PolicyEngine API.

## Parameters updated

| Scale Parameter | Label Added |
|----------------|-------------|
| `gov.irs.credits.education.american_opportunity_credit.amount` | American Opportunity Credit marginal rate schedule |
| `gov.irs.credits.eitc.phase_out.joint_bonus` | EITC joint filer bonus phase-out start |
| `gov.irs.credits.premium_tax_credit.eligibility` | Premium Tax Credit eligibility thresholds |
| `gov.irs.credits.premium_tax_credit.phase_out.ending_rate` | Premium Tax Credit phase-out ending rate |
| `gov.irs.credits.premium_tax_credit.phase_out.starting_rate` | Premium Tax Credit phase-out starting rate |
| `gov.states.dc.tax.income.credits.ptc.fraction_elderly` | DC property tax credit offset fraction (elderly) |
| `gov.states.dc.tax.income.credits.ptc.fraction_nonelderly` | DC property tax credit offset fraction (non-elderly) |
| `gov.states.dc.tax.income.rates` | DC income tax rates |

## Test plan

- [ ] Verify parameter labels are correctly generated in the API for bracket children
- [ ] Confirm no breaking changes to existing functionality

Fixes #7115

🤖 Generated with [Claude Code](https://claude.com/claude-code)