### PR TITLE
Fix medicaid_category precedence for pregnant people

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Medicaid category precedence now follows covered.yaml order (pregnant/parent before expansion adult)

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.yaml
@@ -74,6 +74,8 @@
     medicaid_cost_if_enrolled: 7_054
 
 - name: Multiple people in recent expansion state
+  # person1 (age 25 with child) is categorized as PARENT (NON_EXPANSION_ADULT)
+  # not EXPANSION_ADULT because parent takes precedence per covered.yaml
   period: 2024
   absolute_error_margin: 0.1
   input:
@@ -87,5 +89,5 @@
         employment_income: 0
       person2:
         age: 2
-  output: 
-    medicaid_cost_if_enrolled: [7_054, 2_867.7]
+  output:
+    medicaid_cost_if_enrolled: [4_631.1, 2_867.8]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
@@ -1,0 +1,55 @@
+# Test: Pregnant person in Medicaid expansion state
+# Expected: Should be assigned NON_EXPANSION_ADULT, not EXPANSION_ADULT
+# Reasoning: Pregnancy Medicaid should take precedence over expansion adult
+# per the parameter file covered.yaml which lists is_pregnant_for_medicaid first
+
+- name: Pregnant person in expansion state gets pregnancy Medicaid (not expansion)
+  period: 2024
+  input:
+    households:
+      household:
+        state_code: CA  # California has Medicaid expansion
+        members: [person]
+    people:
+      person:
+        age: 30
+        is_pregnant: true
+        is_pregnant_for_medicaid: true
+        is_medicaid_eligible: true
+  output:
+    medicaid_category: PREGNANT
+    medicaid_group: NON_EXPANSION_ADULT
+
+- name: Non-pregnant adult in expansion state gets expansion Medicaid
+  period: 2024
+  input:
+    households:
+      household:
+        state_code: CA  # California has Medicaid expansion
+        members: [person]
+    people:
+      person:
+        age: 30
+        is_pregnant: false
+        is_adult_for_medicaid: true
+        is_medicaid_eligible: true
+  output:
+    medicaid_category: ADULT
+    medicaid_group: EXPANSION_ADULT
+
+- name: Pregnant person in non-expansion state still gets pregnancy Medicaid
+  period: 2024
+  input:
+    households:
+      household:
+        state_code: TX  # Texas does not have Medicaid expansion
+        members: [person]
+    people:
+      person:
+        age: 30
+        is_pregnant: true
+        is_pregnant_for_medicaid: true
+        is_medicaid_eligible: true
+  output:
+    medicaid_category: PREGNANT
+    medicaid_group: NON_EXPANSION_ADULT

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
@@ -11,7 +11,7 @@ class MedicaidCategory(Enum):
     PARENT = "Parent"
     PREGNANT = "Pregnant"
     SSI_RECIPIENT = "SSI recipient"
-    SENIOR_OR_DISABLED = " Senior or disabled"
+    SENIOR_OR_DISABLED = "Senior or disabled"
     NONE = "None"
 
 
@@ -40,20 +40,15 @@ class medicaid_category(Variable):
             is_optional_senior_or_disabled_for_medicaid=MedicaidCategory.SENIOR_OR_DISABLED,
         )
 
-        # Ensure parametric reforms to the list of categories prevent those
-        # categories from being selected.
-
-        variable_to_category = {
-            name: category
-            for name, category in variable_to_category.items()
-            if name in categories
-        }
+        # Iterate in the order defined by the parameter file (covered.yaml)
+        # to ensure correct precedence (e.g., pregnant before expansion adult)
+        ordered_variables = [
+            name for name in categories if name in variable_to_category
+        ]
 
         return select(
-            [
-                person(variable, period)
-                for variable in variable_to_category.keys()
-            ]
+            [person(variable, period) for variable in ordered_variables]
             + [True],
-            list(variable_to_category.values()) + [MedicaidCategory.NONE],
+            [variable_to_category[variable] for variable in ordered_variables]
+            + [MedicaidCategory.NONE],
         )


### PR DESCRIPTION
The medicaid_category variable now iterates in the order defined by covered.yaml parameter file instead of Python dict insertion order. This ensures pregnant people are correctly categorized as PREGNANT instead of ADULT in Medicaid expansion states.

Fixes #7127


