### PR TITLE
NY S04487 Supplemental Empire State Child Tax Credit for Newborns

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - NY Senate Bill S04487 Supplemental Empire State Child Tax Credit for Newborns reform.

--- a/policyengine_us/parameters/gov/contrib/states/ny/s04487/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ny/s04487/amount.yaml
@@ -1,0 +1,12 @@
+description: The supplemental credit amount per qualifying newborn under the Supplemental Empire State Child Tax Credit for Newborns.
+metadata:
+  unit: currency-USD
+  period: year
+  label: NY S04487 newborn credit amount
+  reference:
+    - title: NY Senate Bill 2025-S04487
+      href: https://www.nysenate.gov/legislation/bills/2025/S4487
+    - title: NY Tax Law Section 606 - Credits Against Tax
+      href: https://www.nysenate.gov/legislation/laws/TAX/606
+values:
+  2026-01-01: 1_000

--- a/policyengine_us/parameters/gov/contrib/states/ny/s04487/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ny/s04487/in_effect.yaml
@@ -1,0 +1,10 @@
+description: The New York Supplemental Empire State Child Tax Credit for Newborns (Senate Bill S04487) applies if this is true.
+metadata:
+  unit: bool
+  period: year
+  label: NY S04487 Supplemental Empire State Child Tax Credit for Newborns in effect
+  reference:
+    - title: NY Senate Bill 2025-S04487
+      href: https://www.nysenate.gov/legislation/bills/2025/S4487
+values:
+  0000-01-01: false

--- a/policyengine_us/parameters/gov/contrib/states/ny/s04487/max_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ny/s04487/max_age.yaml
@@ -1,0 +1,10 @@
+description: The maximum age for a child to qualify as a newborn under the Supplemental Empire State Child Tax Credit for Newborns. Children born in the current or previous tax year are eligible, meaning age 0 or 1.
+metadata:
+  unit: year
+  period: year
+  label: NY S04487 newborn maximum age
+  reference:
+    - title: NY Senate Bill 2025-S04487
+      href: https://www.nysenate.gov/legislation/bills/2025/S4487
+values:
+  2026-01-01: 1

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -21,6 +21,7 @@ from .biden.budget_2025 import create_capital_gains_tax_increase_reform
 from .eitc import create_halve_joint_eitc_phase_out_rate_reform
 from .states.ny.wftc import create_ny_working_families_tax_credit_reform
 from .states.sc.h3492 import create_sc_h3492_eitc_refundable_reform
+from .states.ny.s04487 import create_ny_s04487_newborn_credit_reform
 from .harris.lift.middle_class_tax_credit import (
     create_middle_class_tax_credit_reform,
 )
@@ -182,6 +183,9 @@ def create_structural_reforms_from_parameters(parameters, period):
     sc_h3492_eitc_refundable = create_sc_h3492_eitc_refundable_reform(
         parameters, period
     )
+    ny_s04487_newborn_credit = create_ny_s04487_newborn_credit_reform(
+        parameters, period
+    )
 
     middle_class_tax_credit = create_middle_class_tax_credit_reform(
         parameters, period
@@ -328,6 +332,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         halve_joint_eitc_phase_out_rate,
         ny_wftc,
         sc_h3492_eitc_refundable,
+        ny_s04487_newborn_credit,
         middle_class_tax_credit,
         rent_relief_tax_credit,
         end_child_poverty_act,

--- a/policyengine_us/reforms/states/ny/s04487/__init__.py
+++ b/policyengine_us/reforms/states/ny/s04487/__init__.py
@@ -1,0 +1,3 @@
+from .ny_s04487_newborn_credit import (
+    create_ny_s04487_newborn_credit_reform,
+)

--- a/policyengine_us/reforms/states/ny/s04487/ny_s04487_newborn_credit.py
+++ b/policyengine_us/reforms/states/ny/s04487/ny_s04487_newborn_credit.py
@@ -1,0 +1,102 @@
+from policyengine_us.model_api import *
+
+
+def create_ny_s04487_newborn_credit() -> Reform:
+    """
+    NY Senate Bill S04487 - Supplemental Empire State Child Tax Credit for Newborns
+
+    Establishes a $1,000 supplemental credit for newborns (children born in
+    the current or previous tax year who have not been previously claimed).
+
+    Reference: https://www.nysenate.gov/legislation/bills/2025/S4487
+    """
+
+    class ny_s04487_qualifying_newborn(Variable):
+        value_type = bool
+        entity = Person
+        label = "Qualifies as newborn for NY S04487 credit"
+        definition_period = YEAR
+        reference = "https://www.nysenate.gov/legislation/bills/2025/S4487"
+        defined_for = StateCode.NY
+
+        def formula(person, period, parameters):
+            p = parameters(period).gov.contrib.states.ny.s04487
+            in_effect = p.in_effect
+            # Child must be age 0 or 1 (born in current or previous tax year)
+            age = person("age", period)
+            age_eligible = age <= p.max_age
+            # Must be a dependent
+            is_dependent = person("is_tax_unit_dependent", period)
+            return in_effect & age_eligible & is_dependent
+
+    class ny_s04487_newborn_count(Variable):
+        value_type = int
+        entity = TaxUnit
+        label = "Number of qualifying newborns for NY S04487 credit"
+        definition_period = YEAR
+        reference = "https://www.nysenate.gov/legislation/bills/2025/S4487"
+        defined_for = StateCode.NY
+
+        def formula(tax_unit, period, parameters):
+            person = tax_unit.members
+            qualifying = person("ny_s04487_qualifying_newborn", period)
+            return tax_unit.sum(qualifying)
+
+    class ny_s04487_newborn_credit(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "NY S04487 supplemental newborn credit"
+        unit = USD
+        definition_period = YEAR
+        reference = "https://www.nysenate.gov/legislation/bills/2025/S4487"
+        defined_for = StateCode.NY
+
+        def formula(tax_unit, period, parameters):
+            p = parameters(period).gov.contrib.states.ny.s04487
+            in_effect = p.in_effect
+            newborn_count = tax_unit("ny_s04487_newborn_count", period)
+            credit_per_newborn = p.amount
+            return where(in_effect, newborn_count * credit_per_newborn, 0)
+
+    class ny_refundable_credits(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "NY refundable credits"
+        unit = USD
+        definition_period = YEAR
+        defined_for = StateCode.NY
+
+        def formula(tax_unit, period, parameters):
+            p = parameters(period).gov.states.ny.tax.income.credits
+            standard_credits = add(tax_unit, period, p.refundable)
+            # Add newborn credit from S04487
+            newborn_credit = tax_unit("ny_s04487_newborn_credit", period)
+            return standard_credits + newborn_credit
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(ny_s04487_qualifying_newborn)
+            self.update_variable(ny_s04487_newborn_count)
+            self.update_variable(ny_s04487_newborn_credit)
+            self.update_variable(ny_refundable_credits)
+
+    return reform
+
+
+def create_ny_s04487_newborn_credit_reform(
+    parameters, period, bypass: bool = False
+):
+    if bypass:
+        return create_ny_s04487_newborn_credit()
+
+    p = parameters(period).gov.contrib.states.ny.s04487
+
+    if p.in_effect:
+        return create_ny_s04487_newborn_credit()
+    else:
+        return None
+
+
+ny_s04487_newborn_credit = create_ny_s04487_newborn_credit_reform(
+    None, None, bypass=True
+)

--- a/policyengine_us/tests/policy/contrib/states/ny/s04487/ny_s04487_newborn_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ny/s04487/ny_s04487_newborn_credit.yaml
@@ -1,0 +1,171 @@
+# NY S04487 Supplemental Empire State Child Tax Credit for Newborns Tests
+# Tests the $1,000 supplemental credit for newborns (age 0-1)
+
+# Basic eligibility tests
+- name: Newborn credit - one newborn age 0 gets $1,000
+  period: 2026
+  reforms: policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit.ny_s04487_newborn_credit
+  input:
+    gov.contrib.states.ny.s04487.in_effect: true
+    people:
+      parent:
+        age: 30
+        is_tax_unit_head: true
+      child:
+        age: 0
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NY
+  output:
+    ny_s04487_qualifying_newborn: [false, true]
+    ny_s04487_newborn_count: 1
+    ny_s04487_newborn_credit: 1_000
+
+- name: Newborn credit - one child age 1 gets $1,000
+  period: 2026
+  reforms: policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit.ny_s04487_newborn_credit
+  input:
+    gov.contrib.states.ny.s04487.in_effect: true
+    people:
+      parent:
+        age: 30
+        is_tax_unit_head: true
+      child:
+        age: 1
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NY
+  output:
+    ny_s04487_qualifying_newborn: [false, true]
+    ny_s04487_newborn_count: 1
+    ny_s04487_newborn_credit: 1_000
+
+- name: Newborn credit - two newborns (twins) get $2,000
+  period: 2026
+  reforms: policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit.ny_s04487_newborn_credit
+  input:
+    gov.contrib.states.ny.s04487.in_effect: true
+    people:
+      parent:
+        age: 30
+        is_tax_unit_head: true
+      child1:
+        age: 0
+        is_tax_unit_dependent: true
+      child2:
+        age: 0
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child1, child2]
+    households:
+      household:
+        members: [parent, child1, child2]
+        state_code: NY
+  output:
+    ny_s04487_qualifying_newborn: [false, true, true]
+    ny_s04487_newborn_count: 2
+    ny_s04487_newborn_credit: 2_000
+
+- name: Newborn credit - child age 2 not eligible
+  period: 2026
+  reforms: policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit.ny_s04487_newborn_credit
+  input:
+    gov.contrib.states.ny.s04487.in_effect: true
+    people:
+      parent:
+        age: 30
+        is_tax_unit_head: true
+      child:
+        age: 2
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NY
+  output:
+    ny_s04487_qualifying_newborn: [false, false]
+    ny_s04487_newborn_count: 0
+    ny_s04487_newborn_credit: 0
+
+- name: Newborn credit - mixed ages, only newborn qualifies
+  period: 2026
+  reforms: policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit.ny_s04487_newborn_credit
+  input:
+    gov.contrib.states.ny.s04487.in_effect: true
+    people:
+      parent:
+        age: 35
+        is_tax_unit_head: true
+      child1:
+        age: 5
+        is_tax_unit_dependent: true
+      child2:
+        age: 0
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child1, child2]
+    households:
+      household:
+        members: [parent, child1, child2]
+        state_code: NY
+  output:
+    ny_s04487_qualifying_newborn: [false, false, true]
+    ny_s04487_newborn_count: 1
+    ny_s04487_newborn_credit: 1_000
+
+- name: Newborn credit - reform not in effect
+  period: 2026
+  reforms: policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit.ny_s04487_newborn_credit
+  input:
+    gov.contrib.states.ny.s04487.in_effect: false
+    people:
+      parent:
+        age: 30
+        is_tax_unit_head: true
+      child:
+        age: 0
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NY
+  output:
+    ny_s04487_newborn_credit: 0
+
+- name: Newborn credit - no children
+  period: 2026
+  reforms: policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit.ny_s04487_newborn_credit
+  input:
+    gov.contrib.states.ny.s04487.in_effect: true
+    people:
+      person:
+        age: 30
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code: NY
+  output:
+    ny_s04487_newborn_count: 0
+    ny_s04487_newborn_credit: 0


### PR DESCRIPTION
## Summary
- Implements NY Senate Bill S04487 which establishes a $1,000 supplemental credit for newborns
- Newborns defined as children age 0-1 (born in current or previous tax year)
- No income limits
- Effective April 1, 2026

Closes part of #7181 (Policy 4)

## References
- [NY Senate Bill 2025-S04487](https://www.nysenate.gov/legislation/bills/2025/S4487)
- [NY Tax Law Section 606](https://www.nysenate.gov/legislation/laws/TAX/606)

## Test plan
- [x] 7 YAML tests passing
- [x] Tests cover age 0, age 1, age 2 (not eligible), twins, mixed ages
- [x] Tests verify $1,000 per qualifying newborn
- [x] Code formatted with Black

🤖 Generated with [Claude Code](https://claude.com/claude-code)