### PR TITLE
Fix SC H.3492 reform to use 5-year in_effect check pattern

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Update SC H.3492 reform to use 5-year in_effect check pattern consistent with other contributed reforms.

--- a/policyengine_us/reforms/states/sc/h3492/sc_h3492_eitc_refundable.py
+++ b/policyengine_us/reforms/states/sc/h3492/sc_h3492_eitc_refundable.py
@@ -1,4 +1,5 @@
 from policyengine_us.model_api import *
+from policyengine_core.periods import period as period_
 
 
 def create_sc_h3492_eitc_refundable() -> Reform:
@@ -150,9 +151,18 @@ def create_sc_h3492_eitc_refundable_reform(
     if bypass:
         return create_sc_h3492_eitc_refundable()
 
-    p = parameters(period).gov.contrib.states.sc.h3492
+    p = parameters.gov.contrib.states.sc.h3492
 
-    if p.in_effect:
+    reform_active = False
+    current_period = period_(period)
+
+    for i in range(5):
+        if p(current_period).in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
         return create_sc_h3492_eitc_refundable()
     else:
         return None


### PR DESCRIPTION
## Summary

Update the SC H.3492 partially refundable EITC reform to use the 5-year `in_effect` check pattern consistent with other contributed reforms (e.g., Utah refundable EITC).

## Changes

- Added import for `period as period_` from `policyengine_core.periods`
- Updated `create_sc_h3492_eitc_refundable_reform` to:
  - Access parameters without calling with period first: `parameters.gov.contrib...`
  - Loop through 5 years checking if `in_effect` is true
  - Use `p(current_period).in_effect` to access the parameter value

## Before

```python
def create_sc_h3492_eitc_refundable_reform(parameters, period, bypass: bool = False):
    if bypass:
        return create_sc_h3492_eitc_refundable()

    p = parameters(period).gov.contrib.states.sc.h3492

    if p.in_effect:
        return create_sc_h3492_eitc_refundable()
    else:
        return None
```

## After

```python
def create_sc_h3492_eitc_refundable_reform(parameters, period, bypass: bool = False):
    if bypass:
        return create_sc_h3492_eitc_refundable()

    p = parameters.gov.contrib.states.sc.h3492

    reform_active = False
    current_period = period_(period)

    for i in range(5):
        if p(current_period).in_effect:
            reform_active = True
            break
        current_period = current_period.offset(1, "year")

    if reform_active:
        return create_sc_h3492_eitc_refundable()
    else:
        return None
```

## Test plan

- [x] All 6 existing SC H.3492 tests pass

Closes #7231

🤖 Generated with [Claude Code](https://claude.com/claude-code)