### PR TITLE
Update Iowa SNAP self-employment deduction effective date

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Update Iowa SNAP self-employment deduction effective date from 2021-10-01 to 2012-08-01 based on USDA FNS State Options Report research.

--- a/policyengine_us/parameters/gov/usda/snap/income/deductions/self_employment/rate.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/income/deductions/self_employment/rate.yaml
@@ -26,7 +26,8 @@ GU:
 HI:
   2021-10-01: 0
 IA:
-  2021-10-01: 0.4
+  # First appears in 10th State Options Report (August 2012); not in 9th (June 2011)
+  2012-08-01: 0.4
 ID:
   2021-10-01: 0.5
 IL:
@@ -120,3 +121,9 @@ metadata:
       href: https://assets-global.website-files.com/63345e33f3c909d27d0e558b/634eb3c77156ee846ee68852_streamlining-snap-gig-economy.pdf
     - title: Delaware DEPARTMENT OF health and social services,  Division of Social Services
       href: https://regulations.delaware.gov/register/august2005/proposed/9%20DE%20Reg%20168%2008-01-05.htm
+    - title: USDA FNS SNAP State Options Report (10th Edition, August 2012), p. 16
+      href: https://www.fns.usda.gov/sites/default/files/snap/10-State_Options.pdf#page=16
+      # Iowa first appears with 40% in 10th edition; not in 9th (June 2011)
+    - title: Iowa HHS Employees' Manual Title 7 Chapter I - SNAP Specific Households
+      href: https://hhs.iowa.gov/media/4001/download
+      # Iowa 40% deduction per 7 CFR 273.11(b), 441 IAC 65.29(1)


### PR DESCRIPTION
## Summary
- Updates Iowa's SNAP self-employment deduction effective date from 2021-10-01 to 2012-08-01
- Based on research of USDA FNS State Options Reports:
  - **9th Edition (June 2011)**: Iowa NOT listed (only 18 states had simplified method)
  - **10th Edition (August 2012)**: Iowa listed with 40% rate
- Added references to FNS State Options Report and Iowa HHS Employees' Manual
- Iowa policy is codified at 7 CFR 273.11(b), 441 IAC 65.29(1)

## Test plan
- [x] Existing Iowa SNAP self-employment tests pass
- [x] Tests use 2025 period which is after the new 2012-08-01 effective date

🤖 Generated with [Claude Code](https://claude.com/claude-code)