### PR TITLE
Add partnership_se_income to SE tax base

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - partnership_se_income variable for general partners' SE income from Schedule K-1 Box 14, now included in taxable_self_employment_income per 26 USC 1402(a).

--- a/policyengine_us/tests/policy/baseline/gov/irs/self_employment/taxable_self_employment_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/self_employment/taxable_self_employment_income.yaml
@@ -24,14 +24,24 @@
   output:
     taxable_self_employment_income: 0
 
-- name: S-corp and partnership income is not subject to SE tax per 26 USC 1402.
+- name: S-corp and general partnership distributions not subject to SE tax.
   period: 2024
   input:
     self_employment_income: 50_000
     partnership_s_corp_income: 100_000
   output:
     # Only the $50k self-employment income is subject to SE tax.
-    # The $100k partnership/S-corp income passes through for income tax
-    # but is not self-employment income.
+    # The $100k partnership/S-corp distributions pass through for income tax
+    # but are not self-employment income (S-corp never, partnership only via K-1 Box 14).
     # 50_000 * (1 - 0.5 * 0.153) = 50_000 * 0.9235 = 46_175
     taxable_self_employment_income: 46_175
+
+- name: Partnership SE income from K-1 Box 14 is subject to SE tax.
+  period: 2024
+  input:
+    self_employment_income: 50_000
+    partnership_se_income: 30_000
+  output:
+    # Both Schedule C ($50k) and K-1 Box 14 ($30k) are subject to SE tax.
+    # 80_000 * (1 - 0.5 * 0.153) = 80_000 * 0.9235 = 73_880
+    taxable_self_employment_income: 73_880

--- a/policyengine_us/variables/gov/irs/tax/self_employment/taxable_self_employment_income.py
+++ b/policyengine_us/variables/gov/irs/tax/self_employment/taxable_self_employment_income.py
@@ -10,11 +10,15 @@ class taxable_self_employment_income(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/26/1402#a"
 
     def formula(person, period, parameters):
-        # Per 26 USC 1402(a), SE income includes Schedule C and Schedule F income.
-        # S-corp distributions and partnership income are excluded here.
+        # Per 26 USC 1402(a), SE income includes:
+        # - Schedule C net profit (self_employment_income)
+        # - Schedule F net profit (farm_income)
+        # - General partners' distributive share (partnership_se_income from K-1 Box 14)
+        # S-corp distributions are NOT subject to SE tax.
         SEI_SOURCES = [
             "self_employment_income",
             "farm_income",
+            "partnership_se_income",
         ]
         gross_sei = add(person, period, SEI_SOURCES)
         p = parameters(period).gov.irs

--- a/policyengine_us/variables/household/income/person/self_employment/partnership_se_income.py
+++ b/policyengine_us/variables/household/income/person/self_employment/partnership_se_income.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class partnership_se_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Partnership self-employment income"
+    definition_period = YEAR
+    documentation = "Partnership income subject to self-employment tax from Schedule K-1 Box 14. Only general partners' distributive share of trade/business income is included per 26 USC 1402(a)(13)."
+    unit = USD
+    reference = "https://www.law.cornell.edu/uscode/text/26/1402#a_13"


### PR DESCRIPTION
## Summary
- Add `partnership_se_income` variable for general partners' distributive share from Schedule K-1 Box 14
- Include it in `taxable_self_employment_income` per [26 USC 1402(a)](https://www.law.cornell.edu/uscode/text/26/1402#a)
- Remove `s_corp_self_employment_income` (S-corp distributions are NOT subject to SE tax)

## SE tax base now correctly includes:
- ✅ Schedule C net profit (`self_employment_income`)
- ✅ Schedule F net profit (`farm_income`)
- ✅ General partners' K-1 Box 14 income (`partnership_se_income`)
- ❌ S-corp distributions (correctly excluded)
- ❌ Limited partners' distributions (correctly excluded via K-1 Box 14 data)

## Dependencies
- Requires PolicyEngine/policyengine-us-data#481 for the `partnership_se_income` data source

## Test plan
- [x] SE tax tests pass (10 tests)
- [ ] CI passes

Fixes #5273
Closes #7238

🤖 Generated with [Claude Code](https://claude.ai/code)