### PR TITLE
Use default argument to numpy.select instead of dummy True condition

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Use default argument to numpy.select instead of dummy True condition for ~10% performance improvement.

--- a/policyengine_us/variables/contrib/taxsim/taxsim_state.py
+++ b/policyengine_us/variables/contrib/taxsim/taxsim_state.py
@@ -16,13 +16,7 @@ class taxsim_state(Variable):
                 state_code_str == "MA",
                 state_code_str == "NY",
                 state_code_str == "WA",
-                True,
             ],
-            [
-                21,
-                22,
-                33,
-                48,
-                0,
-            ],
+            [21, 22, 33, 48],
+            default=0,
         )

--- a/policyengine_us/variables/gov/hhs/ccdf/ccdf_duration_of_care.py
+++ b/policyengine_us/variables/gov/hhs/ccdf/ccdf_duration_of_care.py
@@ -27,12 +27,11 @@ class ccdf_duration_of_care(Variable):
                 hours_per_week >= 30,
                 hours_per_day >= 6,
                 hours_per_day >= 3,
-                True,
             ],
             [
                 CCDFDurationOfCare.WEEKLY,
                 CCDFDurationOfCare.DAILY,
                 CCDFDurationOfCare.PART_DAY,
-                CCDFDurationOfCare.HOURLY,
             ],
+            default=CCDFDurationOfCare.HOURLY,
         )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
@@ -53,7 +53,7 @@ class medicaid_category(Variable):
             [
                 person(variable, period)
                 for variable in variable_to_category.keys()
-            ]
-            + [True],
-            list(variable_to_category.values()) + [MedicaidCategory.NONE],
+            ],
+            list(variable_to_category.values()),
+            default=MedicaidCategory.NONE,
         )

--- a/policyengine_us/variables/gov/irs/credits/elderly_and_disabled/section_22_income.py
+++ b/policyengine_us/variables/gov/irs/credits/elderly_and_disabled/section_22_income.py
@@ -27,14 +27,13 @@ class section_22_income(Variable):
                 num_qualifying_individuals == 1,
                 num_qualifying_individuals == 2,
                 filing_status == filing_status.possible_values.SEPARATE,
-                True,
             ],
             [
                 elderly_disabled.amount.one_qualified,
                 elderly_disabled.amount.two_qualified,
                 elderly_disabled.amount.separate,
-                0,
             ],
+            default=0,
         )
 
         # Limitations on under-65s

--- a/policyengine_us/variables/gov/usda/school_meals/school_meal_tier.py
+++ b/policyengine_us/variables/gov/usda/school_meals/school_meal_tier.py
@@ -27,7 +27,7 @@ class school_meal_tier(Variable):
             [
                 (fpg_ratio <= p_income_limit.FREE) | categorical_eligibility,
                 fpg_ratio <= p_income_limit.REDUCED,
-                True,
             ],
-            [SchoolMealTier.FREE, SchoolMealTier.REDUCED, SchoolMealTier.PAID],
+            [SchoolMealTier.FREE, SchoolMealTier.REDUCED],
+            default=SchoolMealTier.PAID,
         )

--- a/policyengine_us/variables/gov/usda/wic/wic_category.py
+++ b/policyengine_us/variables/gov/usda/wic/wic_category.py
@@ -28,15 +28,19 @@ class wic_category(Variable):
         # Categorize mothers based on the minimum age of children in the SPM unit.
         min_age_family = person.family.min(age)
         return select(
-            *zip(
-                (pregnant, WICCategory.PREGNANT),
-                (
-                    mother & breastfeeding & (min_age_family < 1),
-                    WICCategory.BREASTFEEDING,
-                ),
-                (mother & (min_age_family < 0.5), WICCategory.POSTPARTUM),
-                (age < 1, WICCategory.INFANT),
-                (age < 5, WICCategory.CHILD),
-                (True, WICCategory.NONE),
-            )
+            [
+                pregnant,
+                mother & breastfeeding & (min_age_family < 1),
+                mother & (min_age_family < 0.5),
+                age < 1,
+                age < 5,
+            ],
+            [
+                WICCategory.PREGNANT,
+                WICCategory.BREASTFEEDING,
+                WICCategory.POSTPARTUM,
+                WICCategory.INFANT,
+                WICCategory.CHILD,
+            ],
+            default=WICCategory.NONE,
         )

--- a/policyengine_us/variables/household/demographic/person/postpartum/count_days_postpartum.py
+++ b/policyengine_us/variables/household/demographic/person/postpartum/count_days_postpartum.py
@@ -12,14 +12,7 @@ class count_days_postpartum(Variable):
         under_60_days = person("under_60_days_postpartum", period)
         under_12_months = person("under_12_months_postpartum", period)
         return select(
-            [
-                under_60_days,
-                under_12_months,
-                True,
-            ],
-            [
-                0,
-                60,
-                np.inf,
-            ],
+            [under_60_days, under_12_months],
+            [0, 60],
+            default=np.inf,
         )

--- a/policyengine_us/variables/household/demographic/person/race.py
+++ b/policyengine_us/variables/household/demographic/person/race.py
@@ -25,12 +25,11 @@ class race(Variable):
                 hispanic,
                 (cps_race == 1) & ~hispanic,
                 (cps_race == 2) & ~hispanic,
-                True,
             ],
             [
                 Race.HISPANIC,
                 Race.WHITE,
                 Race.BLACK,
-                Race.OTHER,
             ],
+            default=Race.OTHER,
         )

--- a/policyengine_us/variables/household/income/person/fsla_overtime_occupation_exemption_category.py
+++ b/policyengine_us/variables/household/income/person/fsla_overtime_occupation_exemption_category.py
@@ -28,7 +28,6 @@ class fsla_overtime_occupation_exemption_category(Variable):
                 person("is_executive_administrative_professional", period),
                 person("is_farmer_fisher", period),
                 person("is_computer_scientist", period),
-                True,  # Default case
             ],
             [
                 OvertimeExemptionCategory.MILITARY,
@@ -36,6 +35,6 @@ class fsla_overtime_occupation_exemption_category(Variable):
                 OvertimeExemptionCategory.EXECUTIVE_ADMINISTRATIVE,
                 OvertimeExemptionCategory.FARMER_FISHER,
                 OvertimeExemptionCategory.COMPUTER_SCIENTIST,
-                OvertimeExemptionCategory.NONE,
             ],
+            default=OvertimeExemptionCategory.NONE,
         )


### PR DESCRIPTION
## Summary

Replace patterns where `True` is used as a fallback condition in `select` statements with the explicit `default` parameter. This provides ~10% performance improvement for select operations according to [time tests](https://colab.research.google.com/drive/11dJtJSLPxskoEow0QEsiMI7xaCyYOQrw#scrollTo=RnWjLYrWxTr5).

**Before:**
```python
return select(
    [under_60_days, under_12_months, True],
    [0, 60, np.inf],
)
```

**After:**
```python
return select(
    [under_60_days, under_12_months],
    [0, 60],
    default=np.inf,
)
```

## Changes

Updated 9 files to use the `default` parameter:
- `count_days_postpartum.py` - postpartum days calculation
- `ccdf_duration_of_care.py` - childcare duration categorization
- `school_meal_tier.py` - school meal tier determination
- `section_22_income.py` - elderly/disabled credit income
- `race.py` - race categorization
- `medicaid_category.py` - Medicaid category selection
- `taxsim_state.py` - TAXSIM state code mapping
- `wic_category.py` - WIC demographic category
- `fsla_overtime_occupation_exemption_category.py` - FSLA overtime exemption

## Test plan

- [x] All existing tests pass (ran school meals, medicaid, CCDF, WIC, elderly/disabled tests)
- [x] Manual verification with test simulations
- [x] No functional changes - only refactoring select statements

Fixes #1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)