### PR TITLE
Move Social Security wage base to gov.ssa.social_security

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+      - Moved Social Security contribution and benefit base (wage cap) from gov.irs.payroll.social_security.cap to gov.ssa.social_security.contribution_and_benefit_base to reflect its statutory location in the Social Security Act (42 U.S.C. § 430).

--- a/policyengine_us/parameters/gov/ssa/nawi.yaml
+++ b/policyengine_us/parameters/gov/ssa/nawi.yaml
@@ -73,9 +73,8 @@ values:
   2021-01-01: 60_575.07 # NAWI(Y-2) for CBB(2023)
   2022-01-01: 63_795.13 # NAWI(Y-2) for CBB(2024)
   2023-01-01: 66_621.80 # NAWI(Y-2) for CBB(2025)
-  # Back out NAWI from CBO's forecast of the payroll tax cap, in
-  # parameters/gov/irs/payroll/social_security/cap.yaml
-  # Back out NAWI from CBO's forecast of the payroll tax cap.
+  # Back out NAWI from CBO's forecast of the contribution and benefit base, in
+  # parameters/gov/ssa/social_security/contribution_and_benefit_base.yaml
   # The formula to derive NAWI(Y-2) from CBB(Y) is:
   # NAWI(Y-2) approx = CBB(Y) * (NAWI_1992 / CBB_1994)
   # where NAWI_1992 = 22_935.42 and CBB_1994 = 60_600.

--- a/policyengine_us/parameters/gov/ssa/social_security/contribution_and_benefit_base.yaml
+++ b/policyengine_us/parameters/gov/ssa/social_security/contribution_and_benefit_base.yaml
@@ -1,4 +1,4 @@
-description: Individual earnings below this amount are subjected to Social Security (OASDI) payroll tax. This parameter is indexed by the rate of growth in average wages, not by the price inflation rate.
+description: The contribution and benefit base (commonly called the Social Security wage base) is the maximum amount of earnings subject to Social Security tax. This applies to both FICA (payroll) and SECA (self-employment) taxes. Defined in the Social Security Act and indexed by the national average wage index.
 values:
   1937-01-01: 3_000
   1951-01-01: 3_600
@@ -72,7 +72,7 @@ values:
 metadata:
   unit: currency-USD
   period: year
-  label: Social Security earnings cap
+  label: Social Security contribution and benefit base
   uprating: gov.ssa.nawi
   reference:
     - title: 42 U.S.C. § 430(b)
@@ -81,7 +81,10 @@ metadata:
       # (b)(2) indexes based on the national average wage index relative to 1992
     - title: 26 U.S.C. § 3121(a)(1)
       href: https://www.law.cornell.edu/uscode/text/26/3121#a_1
-      # Defines wages for FICA tax purposes as amounts from the benefit base.
+      # Defines wages for FICA tax purposes as amounts up to the contribution and benefit base.
+    - title: 26 U.S.C. § 1402(b)(1)
+      href: https://www.law.cornell.edu/uscode/text/26/1402#b_1
+      # Defines self-employment income for SECA tax purposes as amounts up to the contribution and benefit base.
     - title: Contribution And Benefit Base
       href: https://www.ssa.gov/oact/cola/cbb.html
     - title: CBO Tax Parameters and Effective Marginal Tax Rates | Jan 2025

--- a/policyengine_us/reforms/cbo/payroll/increase_taxable_earnings_for_social_security.py
+++ b/policyengine_us/reforms/cbo/payroll/increase_taxable_earnings_for_social_security.py
@@ -12,7 +12,9 @@ def create_increase_taxable_earnings_for_social_security() -> Reform:
         def formula(person, period, parameters):
             earnings = person("payroll_tax_gross_wages", period)
             p = parameters(period).gov
-            base_taxable = min_(earnings, p.irs.payroll.social_security.cap)
+            base_taxable = min_(
+                earnings, p.ssa.social_security.contribution_and_benefit_base
+            )
             secondary_taxable = max_(
                 0,
                 earnings - p.contrib.cbo.payroll.secondary_earnings_threshold,

--- a/policyengine_us/variables/gov/irs/tax/payroll/social_security/taxable_earnings_for_social_security.py
+++ b/policyengine_us/variables/gov/irs/tax/payroll/social_security/taxable_earnings_for_social_security.py
@@ -9,5 +9,7 @@ class taxable_earnings_for_social_security(Variable):
     unit = USD
 
     def formula(person, period, parameters):
-        p = parameters(period).gov.irs.payroll.social_security
-        return min_(p.cap, person("payroll_tax_gross_wages", period))
+        ss_wage_base = parameters(
+            period
+        ).gov.ssa.social_security.contribution_and_benefit_base
+        return min_(ss_wage_base, person("payroll_tax_gross_wages", period))

--- a/policyengine_us/variables/gov/irs/tax/self_employment/social_security_taxable_self_employment_income.py
+++ b/policyengine_us/variables/gov/irs/tax/self_employment/social_security_taxable_self_employment_income.py
@@ -10,10 +10,12 @@ class social_security_taxable_self_employment_income(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/26/1402#b"
 
     def formula(person, period, parameters):
-        p = parameters(period).gov.irs.payroll.social_security
+        ss_wage_base = parameters(
+            period
+        ).gov.ssa.social_security.contribution_and_benefit_base
         # This will not be negative, since
-        # taxable_earnings_for_social_security is capped at the cap.
-        cap_minus_earnings = p.cap - person(
+        # taxable_earnings_for_social_security is capped at the wage base.
+        cap_minus_earnings = ss_wage_base - person(
             "taxable_earnings_for_social_security", period
         )
         # Deduct SS payroll taxable wages and salaries.


### PR DESCRIPTION
## Summary
Moves the Social Security contribution and benefit base (wage cap) from `gov.irs.payroll.social_security.cap` to `gov.ssa.social_security.contribution_and_benefit_base` to reflect its statutory location.

## Rationale
The wage base is defined in the **Social Security Act** (42 U.S.C. § 430), not the Internal Revenue Code. Both FICA and SECA reference this single SSA-defined value:

- **42 U.S.C. § 430** (SSA) - Defines the "contribution and benefit base"
- **26 U.S.C. § 3121(a)(1)** (IRC/FICA) - References the SSA-defined base for payroll taxes
- **26 U.S.C. § 1402(b)(1)** (IRC/SECA) - References the same base for self-employment taxes

Having it under `irs/payroll/` was misleading since:
1. It's not an IRS-defined parameter
2. It's not payroll-specific (applies equally to self-employment)

## Changes

| Before | After |
|--------|-------|
| `gov.irs.payroll.social_security.cap` | `gov.ssa.social_security.contribution_and_benefit_base` |

### Files updated
- New: `parameters/gov/ssa/social_security/contribution_and_benefit_base.yaml`
- Deleted: `parameters/gov/irs/payroll/social_security/cap.yaml`
- Updated: `taxable_earnings_for_social_security.py` (payroll)
- Updated: `social_security_taxable_self_employment_income.py` (self-employment)
- Updated: `increase_taxable_earnings_for_social_security.py` (CBO reform)
- Updated: `nawi.yaml` (comment reference)

## Test plan
- [x] All references updated to new parameter path
- [x] No functional changes - same values, just reorganized

Fixes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)