### PR TITLE
Add safety catch in aca_ptc to return zero before 2025

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Add safety catch in aca_ptc to return zero before 2025 to prevent breaking 2024 microsim runs.

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
@@ -1,6 +1,17 @@
-- name: aca_ptc unit test 1
+- name: ACA PTC returns zero before 2025
   absolute_error_margin: 0.01
-  period: 2022
+  period: 2024
+  input:
+    is_aca_ptc_eligible: true
+    slcsp: 1_200
+    aca_magi: 25_000
+    aca_required_contribution_percentage: 0.04
+  output:
+    aca_ptc: 0
+
+- name: ACA PTC calculated for 2025
+  absolute_error_margin: 0.01
+  period: 2025
   input:
     is_aca_ptc_eligible: true
     slcsp: 1_200
@@ -9,24 +20,24 @@
   output:
     aca_ptc: 200  # 1200 - 0.04 * 25000 = 200
 
-- name: aca_ptc unit test 2
+- name: ACA PTC floors at zero when contribution exceeds plan cost
   absolute_error_margin: 0.01
-  period: 2022
+  period: 2025
   input:
     is_aca_ptc_eligible: true
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.05
   output:
-    aca_ptc: 0  # 1200 - 0.05 * 25000 = -50
+    aca_ptc: 0  # 1200 - 0.05 * 25000 = -50, floored to 0
 
-- name: aca_ptc unit test 1
+- name: ACA PTC zero when not eligible
   absolute_error_margin: 0.01
-  period: 2022
+  period: 2025
   input:
     is_aca_ptc_eligible: false
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
   output:
-    aca_ptc: 0  # 1200 - 0.04 * 25000 = 200
+    aca_ptc: 0

--- a/policyengine_us/variables/gov/aca/ptc/aca_ptc.py
+++ b/policyengine_us/variables/gov/aca/ptc/aca_ptc.py
@@ -11,6 +11,9 @@ class aca_ptc(Variable):
     defined_for = "is_aca_ptc_eligible"
 
     def formula(tax_unit, period, parameters):
+        return 0
+
+    def formula_2025(tax_unit, period, parameters):
         plan_cost = tax_unit("slcsp", period)
         income = tax_unit("aca_magi", period)
         applicable_figure = tax_unit(


### PR DESCRIPTION
## Summary

Uses dated formula pattern so `aca_ptc` returns 0 before 2025 to prevent breaking 2024 microsim runs. The actual calculation logic is now in `formula_2025`.

Supersedes #7032 (had merge conflicts).

Closes #6137

## Test plan

- [x] Added test verifying aca_ptc returns 0 for 2024
- [x] Updated existing tests to use 2025 period

🤖 Generated with [Claude Code](https://claude.com/claude-code)