### PR TITLE
Backdating Illinois TANF

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update Illinois TANF parameter historical dates to reflect actual policy enactment dates.

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/age_threshold/minor_child.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/age_threshold/minor_child.yaml
@@ -1,6 +1,6 @@
 description: Illinois limits the Temporary Assistance for Needy Families program to applicants with children younger than this age.
 values:
-  2021-01-01: 18
+  1997-07-01: 18
   
 metadata:
   unit: year

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/age_threshold/student_dependent.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/age_threshold/student_dependent.yaml
@@ -1,6 +1,6 @@
 description: Illinois provides the Temporary Assistance for Needy Families program to applicants with student dependent of this age or younger.
 values:
-  2021-01-01: 18
+  1997-07-01: 18
   
 metadata:
   unit: year

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/income/disregard/rate.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/income/disregard/rate.yaml
@@ -1,7 +1,7 @@
 description: Illinois excludes this share of earnings from the Temporary Assistance for Needy Families program countable income, when computing the benefit value.
 
 values:
-  2020-10-01: 0.75
+  2010-07-01: 0.75
 
 metadata:
   unit: /1

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/income/initial_employment_deduction/rate.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/income/initial_employment_deduction/rate.yaml
@@ -1,7 +1,7 @@
 description: Illinois applies this percentage of federal poverty level under the Temporary Assistance for Needy Families program countable income, when computing the initial employment deduction.
 
 values:
-  2020-10-01: 0.5
+  2010-07-01: 0.5
 
 metadata:
   unit: /1

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/income/sources/earned.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/income/sources/earned.yaml
@@ -1,6 +1,6 @@
 description: Illinois counts these income sources as earned income under the Temporary Assistance for Needy Families program.
 values:
-  2020-01-01:
+  1997-07-01:
     - employment_income
     - self_employment_income
     - rental_income

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/income/sources/unearned.yaml
@@ -1,6 +1,6 @@
 description: Illinois counts these income sources as unearned income under the Temporary Assistance for Needy Families program.
 values:
-  2020-01-01:
+  1997-07-01:
     - social_security
     - disability_benefits
     - workers_compensation

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/payment_level/child_only_rate.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/payment_level/child_only_rate.yaml
@@ -1,7 +1,7 @@
 description: Illinois applies this percentage of payment level as child only payment level under the Temporary Assistance for Needy Families program.
 
 values:
-  2020-10-01: 0.75
+  2018-10-01: 0.75
 
 metadata:
   unit: /1

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/payment_level/parent_only_rate.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/payment_level/parent_only_rate.yaml
@@ -1,7 +1,7 @@
 description: Illinois applies this percentage of payment level as parent only payment level under the Temporary Assistance for Needy Families program.
 
 values:
-  2020-10-01: 0.25
+  2018-10-01: 0.25
 
 metadata:
   unit: /1

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/payment_level/rate.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/payment_level/rate.yaml
@@ -1,7 +1,7 @@
 description: Illinois applies this percentage of federal poverty level as payment level under the Temporary Assistance for Needy Families program.
 
 values:
-  2020-10-01: 0.3
+  2018-10-01: 0.3
   2023-10-01: 0.35
 
 metadata:
@@ -11,5 +11,7 @@ metadata:
   reference:
     - title: Ill. Admin. Code tit. 89, § 112.251 - Payment Levels
       href: https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.251
-    - title: MR 23.30 TANF Payment Level Increase/IED Levels
+    - title: COIN Act (SB3115/HB5135) - MR 18.17 Increase in TANF Payment Levels (October 2018 - 30% FPL)
+      href: https://www.dhs.state.il.us/page.aspx?item=112906
+    - title: MR 23.30 TANF Payment Level Increase/IED Levels (October 2023 - 35% FPL)
       href: https://www.dhs.state.il.us/page.aspx?item=149890


### PR DESCRIPTION
## Summary

Fixes #7258

Updates Illinois TANF parameter files with correct historical effective dates based on regulatory research.

## Parameter Date Updates

| Parameter | Previous Date | Corrected Date | Source |
|-----------|---------------|----------------|--------|
| Payment level rate (30% FPL) | 2020-10-01 | 2018-10-01 | [MR 18.17](https://www.dhs.state.il.us/page.aspx?item=112906) |
| Earned income disregard (75%) | 2020-10-01 | 2010-07-01 | [89 Ill. Admin. Code § 112.141](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.141) |
| Initial employment deduction | 2020-10-01 | 2010-07-01 | [89 Ill. Admin. Code § 112.141](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.141) |
| Child-only rate (75%) | 2020-10-01 | 2018-10-01 | [MR 18.17](https://www.dhs.state.il.us/page.aspx?item=112906) |
| Parent-only rate (25%) | 2020-10-01 | 2018-10-01 | [MR 18.17](https://www.dhs.state.il.us/page.aspx?item=112906) |
| Minor child age threshold | 2021-01-01 | 1997-07-01 | [89 Ill. Admin. Code § 112.30](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.30) |
| Student dependent age threshold | 2021-01-01 | 1997-07-01 | [89 Ill. Admin. Code § 112.30](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.30) |
| Earned income sources | 2020-01-01 | 1997-07-01 | [89 Ill. Admin. Code § 112.130](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.130) |
| Unearned income sources | 2020-01-01 | 1997-07-01 | [89 Ill. Admin. Code § 112.100](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.100) |

## Regulatory Authority

- [89 Ill. Admin. Code tit. 89, Part 112](https://www.law.cornell.edu/regulations/illinois/title-89/part-112) - TANF program rules
- [305 ILCS 5/12-4.11](https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=030500050K12-4.11) - Grant amounts statute
- [Ill. Admin. Code tit. 89, § 112.251](https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-112.251) - Payment Levels

## Key Historical Dates

| Date | Event | Source |
|------|-------|--------|
| July 1, 1997 | Illinois TANF program implementation (replaced AFDC) | Federal PRWORA |
| July 1, 2010 | 75% earned income disregard established | [34 Ill. Reg. 10085](https://www.cyberdriveillinois.com/departments/index/register/register_volume34_issue28.pdf) |
| October 1, 2018 | 30% FPL payment level, county groups eliminated, 75% child-only rate | [MR 18.17](https://www.dhs.state.il.us/page.aspx?item=112906) |
| October 1, 2023 | Payment level increased to 35% FPL | [MR 23.30](https://www.dhs.state.il.us/page.aspx?item=149890) |

---

## Background: October 2018 TANF Reform (COIN Act)

The Creating Opportunity for Illinoisans in Need (COIN) Act (SB3115/HB5135) enacted major reforms to Illinois TANF effective October 1, 2018:

**Before October 2018:**
- Payment levels varied by **3 county groups**:
  - Group I (Cook County): Higher payment amounts
  - Group II (Collar counties): Middle payment amounts  
  - Group III (Downstate): Lower payment amounts
- Payment levels were fixed dollar amounts, not tied to FPL

**After October 2018:**
- County-based variation **eliminated** - uniform statewide rates
- Payment levels set as **percentage of Federal Poverty Level**
- October 2018: 30% FPL
- October 2023: 35% FPL (per [MR 23.30](https://www.dhs.state.il.us/page.aspx?item=149890))
- Child-only grants: 75% of regular grants
- Parent-only portion: 25% of regular grants

**Source:** [SB3115](https://www.ilga.gov/legislation/BillStatus.asp?DocNum=3115&GAID=14&GA=100&DocTypeID=SB&LegID=110065&SessionID=91) (305 ILCS 5/12-4.11)

> **TODO:** Pre-October 2018 county group payment levels are not yet implemented.