### PR TITLE
Backdating Texas TANF

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Backdate Texas TANF program.

--- a/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/additional_person.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/additional_person.yaml
@@ -1,6 +1,6 @@
 description: Texas adds this amount to the budgetary needs for each person beyond 15 in the certified group under the Temporary Assistance for Needy Families program.
 values:
-  2023-10-01: 173
+  1994-03-01: 173
 
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/caretaker_with_second_parent.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/caretaker_with_second_parent.yaml
@@ -7,7 +7,7 @@ metadata:
   amount_unit: currency-USD
   period: month
   reference:
-    - title: Texas Works Handbook C-110, TANF (2023-10-01)
+    - title: Texas Works Handbook C-110, TANF (1994-03-01)
       href: https://web.archive.org/web/20240911175553/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
     - title: Texas Works Handbook C-110, TANF (2024-10-01)
       href: https://web.archive.org/web/20250308063323/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
@@ -20,62 +20,62 @@ metadata:
 
 brackets:
   - threshold:
-      2023-10-01: 0
+      1994-03-01: 0
     amount:
-      2023-10-01: 0
+      1994-03-01: 0
   - threshold:
-      2023-10-01: 2
+      1994-03-01: 2
     amount:
-      2023-10-01: 498
+      1994-03-01: 498
   - threshold:
-      2023-10-01: 3
+      1994-03-01: 3
     amount:
-      2023-10-01: 824
+      1994-03-01: 824
   - threshold:
-      2023-10-01: 4
+      1994-03-01: 4
     amount:
-      2023-10-01: 925
+      1994-03-01: 925
   - threshold:
-      2023-10-01: 5
+      1994-03-01: 5
     amount:
-      2023-10-01: 1_073
+      1994-03-01: 1_073
   - threshold:
-      2023-10-01: 6
+      1994-03-01: 6
     amount:
-      2023-10-01: 1_176
+      1994-03-01: 1_176
   - threshold:
-      2023-10-01: 7
+      1994-03-01: 7
     amount:
-      2023-10-01: 1_319
+      1994-03-01: 1_319
   - threshold:
-      2023-10-01: 8
+      1994-03-01: 8
     amount:
-      2023-10-01: 1_422
+      1994-03-01: 1_422
   - threshold:
-      2023-10-01: 9
+      1994-03-01: 9
     amount:
-      2023-10-01: 1_595
+      1994-03-01: 1_595
   - threshold:
-      2023-10-01: 10
+      1994-03-01: 10
     amount:
-      2023-10-01: 1_698
+      1994-03-01: 1_698
   - threshold:
-      2023-10-01: 11
+      1994-03-01: 11
     amount:
-      2023-10-01: 1_871
+      1994-03-01: 1_871
   - threshold:
-      2023-10-01: 12
+      1994-03-01: 12
     amount:
-      2023-10-01: 1_975
+      1994-03-01: 1_975
   - threshold:
-      2023-10-01: 13
+      1994-03-01: 13
     amount:
-      2023-10-01: 2_147
+      1994-03-01: 2_147
   - threshold:
-      2023-10-01: 14
+      1994-03-01: 14
     amount:
-      2023-10-01: 2_251
+      1994-03-01: 2_251
   - threshold:
-      2023-10-01: 15
+      1994-03-01: 15
     amount:
-      2023-10-01: 2_423
+      1994-03-01: 2_423

--- a/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/caretaker_without_second_parent.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/caretaker_without_second_parent.yaml
@@ -7,7 +7,7 @@ metadata:
   amount_unit: currency-USD
   period: month
   reference:
-    - title: Texas Works Handbook C-110, TANF (2023-10-01)
+    - title: Texas Works Handbook C-110, TANF (1994-03-01)
       href: https://web.archive.org/web/20240911175553/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
     - title: Texas Works Handbook C-110, TANF (2024-10-01)
       href: https://web.archive.org/web/20250308063323/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
@@ -20,66 +20,66 @@ metadata:
 
 brackets:
   - threshold:
-      2023-10-01: 0
+      1994-03-01: 0
     amount:
-      2023-10-01: 0
+      1994-03-01: 0
   - threshold:
-      2023-10-01: 1
+      1994-03-01: 1
     amount:
-      2023-10-01: 313
+      1994-03-01: 313
   - threshold:
-      2023-10-01: 2
+      1994-03-01: 2
     amount:
-      2023-10-01: 650
+      1994-03-01: 650
   - threshold:
-      2023-10-01: 3
+      1994-03-01: 3
     amount:
-      2023-10-01: 751
+      1994-03-01: 751
   - threshold:
-      2023-10-01: 4
+      1994-03-01: 4
     amount:
-      2023-10-01: 903
+      1994-03-01: 903
   - threshold:
-      2023-10-01: 5
+      1994-03-01: 5
     amount:
-      2023-10-01: 1_003
+      1994-03-01: 1_003
   - threshold:
-      2023-10-01: 6
+      1994-03-01: 6
     amount:
-      2023-10-01: 1_153
+      1994-03-01: 1_153
   - threshold:
-      2023-10-01: 7
+      1994-03-01: 7
     amount:
-      2023-10-01: 1_252
+      1994-03-01: 1_252
   - threshold:
-      2023-10-01: 8
+      1994-03-01: 8
     amount:
-      2023-10-01: 1_425
+      1994-03-01: 1_425
   - threshold:
-      2023-10-01: 9
+      1994-03-01: 9
     amount:
-      2023-10-01: 1_528
+      1994-03-01: 1_528
   - threshold:
-      2023-10-01: 10
+      1994-03-01: 10
     amount:
-      2023-10-01: 1_701
+      1994-03-01: 1_701
   - threshold:
-      2023-10-01: 11
+      1994-03-01: 11
     amount:
-      2023-10-01: 1_804
+      1994-03-01: 1_804
   - threshold:
-      2023-10-01: 12
+      1994-03-01: 12
     amount:
-      2023-10-01: 1_977
+      1994-03-01: 1_977
   - threshold:
-      2023-10-01: 13
+      1994-03-01: 13
     amount:
-      2023-10-01: 2_080
+      1994-03-01: 2_080
   - threshold:
-      2023-10-01: 14
+      1994-03-01: 14
     amount:
-      2023-10-01: 2_253
+      1994-03-01: 2_253
   - threshold:
-      2023-10-01: 15
+      1994-03-01: 15
     amount:
-      2023-10-01: 2_356
+      1994-03-01: 2_356

--- a/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/non_caretaker.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/budgetary_needs/non_caretaker.yaml
@@ -7,7 +7,7 @@ metadata:
   amount_unit: currency-USD
   period: month
   reference:
-    - title: Texas Works Handbook C-110, TANF (2023-10-01)
+    - title: Texas Works Handbook C-110, TANF (1994-03-01)
       href: https://web.archive.org/web/20240911175553/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
     - title: Texas Works Handbook C-110, TANF (2024-10-01)
       href: https://web.archive.org/web/20250308063323/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
@@ -20,66 +20,66 @@ metadata:
 
 brackets:
   - threshold:
-      2023-10-01: 0
+      1994-03-01: 0
     amount:
-      2023-10-01: 0
+      1994-03-01: 0
   - threshold:
-      2023-10-01: 1
+      1994-03-01: 1
     amount:
-      2023-10-01: 256
+      1994-03-01: 256
   - threshold:
-      2023-10-01: 2
+      1994-03-01: 2
     amount:
-      2023-10-01: 369
+      1994-03-01: 369
   - threshold:
-      2023-10-01: 3
+      1994-03-01: 3
     amount:
-      2023-10-01: 518
+      1994-03-01: 518
   - threshold:
-      2023-10-01: 4
+      1994-03-01: 4
     amount:
-      2023-10-01: 617
+      1994-03-01: 617
   - threshold:
-      2023-10-01: 5
+      1994-03-01: 5
     amount:
-      2023-10-01: 793
+      1994-03-01: 793
   - threshold:
-      2023-10-01: 6
+      1994-03-01: 6
     amount:
-      2023-10-01: 856
+      1994-03-01: 856
   - threshold:
-      2023-10-01: 7
+      1994-03-01: 7
     amount:
-      2023-10-01: 1_068
+      1994-03-01: 1_068
   - threshold:
-      2023-10-01: 8
+      1994-03-01: 8
     amount:
-      2023-10-01: 1_173
+      1994-03-01: 1_173
   - threshold:
-      2023-10-01: 9
+      1994-03-01: 9
     amount:
-      2023-10-01: 1_346
+      1994-03-01: 1_346
   - threshold:
-      2023-10-01: 10
+      1994-03-01: 10
     amount:
-      2023-10-01: 1_450
+      1994-03-01: 1_450
   - threshold:
-      2023-10-01: 11
+      1994-03-01: 11
     amount:
-      2023-10-01: 1_623
+      1994-03-01: 1_623
   - threshold:
-      2023-10-01: 12
+      1994-03-01: 12
     amount:
-      2023-10-01: 1_726
+      1994-03-01: 1_726
   - threshold:
-      2023-10-01: 13
+      1994-03-01: 13
     amount:
-      2023-10-01: 1_899
+      1994-03-01: 1_899
   - threshold:
-      2023-10-01: 14
+      1994-03-01: 14
     amount:
-      2023-10-01: 2_003
+      1994-03-01: 2_003
   - threshold:
-      2023-10-01: 15
+      1994-03-01: 15
     amount:
-      2023-10-01: 2_174
+      1994-03-01: 2_174

--- a/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/recognizable_needs/additional_person.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/needs_standard/recognizable_needs/additional_person.yaml
@@ -1,6 +1,6 @@
 description: Texas adds this amount to the recognizable needs for each person beyond 15 in the certified group under the Temporary Assistance for Needy Families program.
 values:
-  2023-10-01: 43
+  1994-03-01: 43
 
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/additional_person.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/additional_person.yaml
@@ -1,9 +1,14 @@
 description: Texas adds this amount to the maximum grant for each person beyond 15 in the certified group under the Temporary Assistance for Needy Families program.
 values:
+  2017-10-01: 67
+  2018-10-01: 68
+  2019-10-01: 70
   2023-10-01: 81
   2024-10-01: 85
   2025-10-01: 88
 
+  # 2017-2018 values calculated using rate = (17% × monthly FPL for size 3) ÷ budgetary needs for size 3. 
+  # Rate: 38.48% (2017), 39.15% (2018). Applied uniformly to all family types/sizes. Original bulletins unavailable. 
 metadata:
   unit: currency-USD
   period: month
@@ -11,9 +16,11 @@ metadata:
   reference:
     - title: Texas Works Handbook C-110, TANF (2023-10-01)
       href: https://web.archive.org/web/20240911175553/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
-    - title: Texas Works Handbook C-110, TANF (2024-10-01)
-      href: https://web.archive.org/web/20250308063323/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
+    - title: Texas TANF Maximum Grant Amounts (2024-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/mepd-and-twh-Bulletin-24-12.pdf#page=2
     - title: Texas Works Handbook C-110, TANF (Current)
       href: https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
     - title: 1 Tex. Admin. Code § 372.1505 (a) - Calculating Benefits
       href: https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-1505
+    - title: Texas TANF Maximum Grant Amounts (2019-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/laws-regulations/handbooks/twh/bulletin2020/19-08.pdf#page=6

--- a/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/caretaker_with_second_parent.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/caretaker_with_second_parent.yaml
@@ -8,98 +8,145 @@ metadata:
   reference:
     - title: Texas Works Handbook C-110, TANF (2023-10-01)
       href: https://web.archive.org/web/20240911175553/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
-    - title: Texas Works Handbook C-110, TANF (2024-10-01)
-      href: https://web.archive.org/web/20250308063323/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
+    - title: Texas TANF Maximum Grant Amounts (2024-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/mepd-and-twh-Bulletin-24-12.pdf#page=2
     - title: Texas Works Handbook C-110, TANF (Current)
       href: https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
     - title: 1 Tex. Admin. Code § 372.1505 (a) - Calculating Benefits
       href: https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-1505
+    - title: Texas TANF Maximum Grant Amounts (2019-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/laws-regulations/handbooks/twh/bulletin2020/19-08.pdf#page=6
+
+  # 2017-2018 values calculated using rate = (17% × monthly FPL for size 3) ÷ budgetary needs for size 3. 
+  # Rate: 38.48% (2017), 39.15% (2018). Applied uniformly to all family types/sizes. Original bulletins unavailable. 
 brackets:
   - threshold:
-      2023-10-01: 0
+      2017-10-01: 0
     amount:
-      2023-10-01: 0
+      2017-10-01: 0
   - threshold:
-      2023-10-01: 2
+      2017-10-01: 2
     amount:
+      2017-10-01: 192
+      2018-10-01: 195
+      2019-10-01: 200
       2023-10-01: 216
       2024-10-01: 245
       2025-10-01: 253
   - threshold:
-      2023-10-01: 3
+      2017-10-01: 3
     amount:
+      2017-10-01: 317
+      2018-10-01: 323
+      2019-10-01: 332
       2023-10-01: 386
       2024-10-01: 405
       2025-10-01: 418
   - threshold:
-      2023-10-01: 4
+      2017-10-01: 4
     amount:
+      2017-10-01: 356
+      2018-10-01: 362
+      2019-10-01: 372
       2023-10-01: 434
       2024-10-01: 455
       2025-10-01: 470
   - threshold:
-      2023-10-01: 5
+      2017-10-01: 5
     amount:
+      2017-10-01: 413
+      2018-10-01: 420
+      2019-10-01: 432
       2023-10-01: 503
       2024-10-01: 528
       2025-10-01: 545
   - threshold:
-      2023-10-01: 6
+      2017-10-01: 6
     amount:
+      2017-10-01: 453
+      2018-10-01: 460
+      2019-10-01: 473
       2023-10-01: 552
       2024-10-01: 578
       2025-10-01: 597
   - threshold:
-      2023-10-01: 7
+      2017-10-01: 7
     amount:
+      2017-10-01: 508
+      2018-10-01: 516
+      2019-10-01: 531
       2023-10-01: 619
       2024-10-01: 649
       2025-10-01: 670
   - threshold:
-      2023-10-01: 8
+      2017-10-01: 8
     amount:
+      2017-10-01: 547
+      2018-10-01: 557
+      2019-10-01: 572
       2023-10-01: 667
       2024-10-01: 699
       2025-10-01: 722
   - threshold:
-      2023-10-01: 9
+      2017-10-01: 9
     amount:
+      2017-10-01: 614
+      2018-10-01: 624
+      2019-10-01: 642
       2023-10-01: 748
       2024-10-01: 785
       2025-10-01: 810
   - threshold:
-      2023-10-01: 10
+      2017-10-01: 10
     amount:
+      2017-10-01: 653
+      2018-10-01: 665
+      2019-10-01: 683
       2023-10-01: 796
       2024-10-01: 835
       2025-10-01: 862
   - threshold:
-      2023-10-01: 11
+      2017-10-01: 11
     amount:
+      2017-10-01: 720
+      2018-10-01: 733
+      2019-10-01: 753
       2023-10-01: 877
       2024-10-01: 920
       2025-10-01: 950
   - threshold:
-      2023-10-01: 12
+      2017-10-01: 12
     amount:
+      2017-10-01: 760
+      2018-10-01: 773
+      2019-10-01: 795
       2023-10-01: 926
       2024-10-01: 972
       2025-10-01: 1_003
   - threshold:
-      2023-10-01: 13
+      2017-10-01: 13
     amount:
+      2017-10-01: 826
+      2018-10-01: 841
+      2019-10-01: 864
       2023-10-01: 1_007
       2024-10-01: 1_056
       2025-10-01: 1_090
   - threshold:
-      2023-10-01: 14
+      2017-10-01: 14
     amount:
+      2017-10-01: 866
+      2018-10-01: 881
+      2019-10-01: 906
       2023-10-01: 1_056
       2024-10-01: 1_107
       2025-10-01: 1_143
   - threshold:
-      2023-10-01: 15
+      2017-10-01: 15
     amount:
+      2017-10-01: 932
+      2018-10-01: 949
+      2019-10-01: 975
       2023-10-01: 1_136
       2024-10-01: 1_192
       2025-10-01: 1_230

--- a/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/caretaker_without_second_parent.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/caretaker_without_second_parent.yaml
@@ -8,105 +8,154 @@ metadata:
   reference:
     - title: Texas Works Handbook C-110, TANF (2023-10-01)
       href: https://web.archive.org/web/20240911175553/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
-    - title: Texas Works Handbook C-110, TANF (2024-10-01)
-      href: https://web.archive.org/web/20250308063323/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
+    - title: Texas TANF Maximum Grant Amounts (2024-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/mepd-and-twh-Bulletin-24-12.pdf#page=2
     - title: Texas Works Handbook C-110, TANF (Current)
       href: https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
     - title: 1 Tex. Admin. Code § 372.1505 (a) - Calculating Benefits
       href: https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-1505
+    - title: Texas TANF Maximum Grant Amounts (2019-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/laws-regulations/handbooks/twh/bulletin2020/19-08.pdf#page=6
+
+  # 2017-2018 values calculated using rate = (17% × monthly FPL for size 3) ÷ budgetary needs for size 3. 
+  # Rate: 38.48% (2017), 39.15% (2018). Applied uniformly to all family types/sizes. Original bulletins unavailable. 
 brackets:
   - threshold:
-      2023-10-01: 0
+      2017-10-01: 0
     amount:
-      2023-10-01: 0
+      2017-10-01: 0
   - threshold:
-      2023-10-01: 1
+      2017-10-01: 1
     amount:
+      2017-10-01: 120
+      2018-10-01: 123
+      2019-10-01: 126
       2023-10-01: 147
       2024-10-01: 154
       2025-10-01: 159
   - threshold:
-      2023-10-01: 2
+      2017-10-01: 2
     amount:
+      2017-10-01: 250
+      2018-10-01: 254
+      2019-10-01: 262
       2023-10-01: 305
       2024-10-01: 320
       2025-10-01: 331
   - threshold:
-      2023-10-01: 3
+      2017-10-01: 3
     amount:
+      2017-10-01: 289
+      2018-10-01: 294
+      2019-10-01: 303
       2023-10-01: 353
       2024-10-01: 370
       2025-10-01: 382
   - threshold:
-      2023-10-01: 4
+      2017-10-01: 4
     amount:
+      2017-10-01: 347
+      2018-10-01: 354
+      2019-10-01: 364
       2023-10-01: 424
       2024-10-01: 445
       2025-10-01: 459
   - threshold:
-      2023-10-01: 5
+      2017-10-01: 5
     amount:
+      2017-10-01: 386
+      2018-10-01: 393
+      2019-10-01: 404
       2023-10-01: 471
       2024-10-01: 494
       2025-10-01: 510
   - threshold:
-      2023-10-01: 6
-      2024-10-01: 6
+      2017-10-01: 6
     amount:
+      2017-10-01: 444
+      2018-10-01: 451
+      2019-10-01: 464
       2023-10-01: 541
       2024-10-01: 568
       2025-10-01: 586
   - threshold:
-      2023-10-01: 7
+      2017-10-01: 7
     amount:
+      2017-10-01: 482
+      2018-10-01: 490
+      2019-10-01: 504
       2023-10-01: 588
       2024-10-01: 616
       2025-10-01: 636
   - threshold:
-      2023-10-01: 8
+      2017-10-01: 8
     amount:
+      2017-10-01: 548
+      2018-10-01: 558
+      2019-10-01: 574
       2023-10-01: 669
       2024-10-01: 701
       2025-10-01: 724
   - threshold:
-      2023-10-01: 9
+      2017-10-01: 9
     amount:
+      2017-10-01: 588
+      2018-10-01: 598
+      2019-10-01: 615
       2023-10-01: 717
       2024-10-01: 752
       2025-10-01: 776
   - threshold:
-      2023-10-01: 10
+      2017-10-01: 10
     amount:
+      2017-10-01: 655
+      2018-10-01: 666
+      2019-10-01: 685
       2023-10-01: 798
       2024-10-01: 837
       2025-10-01: 864
   - threshold:
-      2023-10-01: 11
+      2017-10-01: 11
     amount:
+      2017-10-01: 694
+      2018-10-01: 706
+      2019-10-01: 726
       2023-10-01: 847
       2024-10-01: 888
       2025-10-01: 916
   - threshold:
-      2023-10-01: 12
+      2017-10-01: 12
     amount:
+      2017-10-01: 761
+      2018-10-01: 774
+      2019-10-01: 796
       2023-10-01: 928
       2024-10-01: 973
       2025-10-01: 1_004
   - threshold:
-      2023-10-01: 13
+      2017-10-01: 13
     amount:
+      2017-10-01: 800
+      2018-10-01: 814
+      2019-10-01: 837
       2023-10-01: 976
       2024-10-01: 1_024
       2025-10-01: 1_057
   - threshold:
-      2023-10-01: 14
+      2017-10-01: 14
     amount:
+      2017-10-01: 867
+      2018-10-01: 882
+      2019-10-01: 907
       2023-10-01: 1_057
       2024-10-01: 1_109
       2025-10-01: 1_144
   - threshold:
-      2023-10-01: 15
+      2017-10-01: 15
     amount:
+      2017-10-01: 907
+      2018-10-01: 922
+      2019-10-01: 949
       2023-10-01: 1_105
       2024-10-01: 1_159
       2025-10-01: 1_197

--- a/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/non_caretaker.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/payment_standard/non_caretaker.yaml
@@ -8,104 +8,154 @@ metadata:
   reference:
     - title: Texas Works Handbook C-110, TANF (2023-10-01)
       href: https://web.archive.org/web/20240911175553/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
-    - title: Texas Works Handbook C-110, TANF (2024-10-01)
-      href: https://web.archive.org/web/20250308063323/https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
+    - title: Texas TANF Maximum Grant Amounts (2024-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/mepd-and-twh-Bulletin-24-12.pdf#page=2
     - title: Texas Works Handbook C-110, TANF (Current)
       href: https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf
     - title: 1 Tex. Admin. Code § 372.1505 (a) - Calculating Benefits
       href: https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-1505
+    - title: Texas TANF Maximum Grant Amounts (2019-10-01)
+      href: https://www.hhs.texas.gov/sites/default/files/documents/laws-regulations/handbooks/twh/bulletin2020/19-08.pdf#page=6
+
+  # 2017-2018 values calculated using rate = (17% × monthly FPL for size 3) ÷ budgetary needs for size 3. 
+  # Rate: 38.48% (2017), 39.15% (2018). Applied uniformly to all family types/sizes. Original bulletins unavailable. 
 brackets:
   - threshold:
-      2023-10-01: 0
+      2017-10-01: 0
     amount:
-      2023-10-01: 0
+      2017-10-01: 0
   - threshold:
-      2023-10-01: 1
+      2017-10-01: 1
     amount:
+      2017-10-01: 99
+      2018-10-01: 100
+      2019-10-01: 104
       2023-10-01: 121
       2024-10-01: 126
       2025-10-01: 130
   - threshold:
-      2023-10-01: 2
+      2017-10-01: 2
     amount:
+      2017-10-01: 142
+      2018-10-01: 144
+      2019-10-01: 149
       2023-10-01: 174
       2024-10-01: 182
       2025-10-01: 188
   - threshold:
-      2023-10-01: 3
+      2017-10-01: 3
     amount:
+      2017-10-01: 199
+      2018-10-01: 203
+      2019-10-01: 209
       2023-10-01: 243
       2024-10-01: 255
       2025-10-01: 263
   - threshold:
-      2023-10-01: 4
+      2017-10-01: 4
     amount:
+      2017-10-01: 237
+      2018-10-01: 242
+      2019-10-01: 249
       2023-10-01: 290
       2024-10-01: 304
       2025-10-01: 314
   - threshold:
-      2023-10-01: 5
+      2017-10-01: 5
     amount:
+      2017-10-01: 305
+      2018-10-01: 310
+      2019-10-01: 320
       2023-10-01: 372
       2024-10-01: 391
       2025-10-01: 403
   - threshold:
-      2023-10-01: 6
+      2017-10-01: 6
     amount:
+      2017-10-01: 329
+      2018-10-01: 335
+      2019-10-01: 345
       2023-10-01: 402
       2024-10-01: 422
       2025-10-01: 435
   - threshold:
-      2023-10-01: 7
+      2017-10-01: 7
     amount:
+      2017-10-01: 411
+      2018-10-01: 418
+      2019-10-01: 430
       2023-10-01: 501
       2024-10-01: 526
       2025-10-01: 543
   - threshold:
-      2023-10-01: 8
+      2017-10-01: 8
     amount:
+      2017-10-01: 451
+      2018-10-01: 459
+      2019-10-01: 473
       2023-10-01: 551
       2024-10-01: 577
       2025-10-01: 596
   - threshold:
-      2023-10-01: 9
+      2017-10-01: 9
     amount:
+      2017-10-01: 518
+      2018-10-01: 527
+      2019-10-01: 542
       2023-10-01: 632
       2024-10-01: 663
       2025-10-01: 684
   - threshold:
-      2023-10-01: 10
+      2017-10-01: 10
     amount:
+      2017-10-01: 558
+      2018-10-01: 568
+      2019-10-01: 584
       2023-10-01: 681
       2024-10-01: 714
       2025-10-01: 737
   - threshold:
-      2023-10-01: 11
+      2017-10-01: 11
     amount:
+      2017-10-01: 625
+      2018-10-01: 635
+      2019-10-01: 654
       2023-10-01: 762
       2024-10-01: 799
       2025-10-01: 824
   - threshold:
-      2023-10-01: 12
+      2017-10-01: 12
     amount:
+      2017-10-01: 664
+      2018-10-01: 676
+      2019-10-01: 695
       2023-10-01: 810
       2024-10-01: 850
       2025-10-01: 877
   - threshold:
-      2023-10-01: 13
+      2017-10-01: 13
     amount:
+      2017-10-01: 731
+      2018-10-01: 743
+      2019-10-01: 765
       2023-10-01: 891
       2024-10-01: 935
       2025-10-01: 965
   - threshold:
-      2023-10-01: 14
+      2017-10-01: 14
     amount:
+      2017-10-01: 771
+      2018-10-01: 784
+      2019-10-01: 807
       2023-10-01: 940
       2024-10-01: 986
       2025-10-01: 1_017
   - threshold:
-      2023-10-01: 15
+      2017-10-01: 15
     amount:
+      2017-10-01: 837
+      2018-10-01: 851
+      2019-10-01: 875
       2023-10-01: 1_020
       2024-10-01: 1_070
       2025-10-01: 1_104

--- a/policyengine_us/parameters/gov/states/tx/tanf/resources/resource_limit.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/resources/resource_limit.yaml
@@ -1,6 +1,6 @@
 description: Texas limits countable resources to this amount under the Temporary Assistance for Needy Families program.
 values:
-  2023-01-01: 1_000
+  2009-09-01: 1_000
 
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/tx/tanf/resources/vehicle_exemption.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/resources/vehicle_exemption.yaml
@@ -1,6 +1,6 @@
 description: Texas exempts up to this value for one automobile under the Temporary Assistance for Needy Families program.
 values:
-  2023-01-01: 4_650
+  2009-09-01: 4_650
 
 metadata:
   unit: currency-USD


### PR DESCRIPTION
## Summary

Fixes #7262

Backdate Texas TANF parameters to provide historical data coverage.

## Changes

### Static Parameters (unchanged since original dates)

| Parameter | New Start Date | Source |
|-----------|---------------|--------|
| Resource limit ($1,000) | 2009-09-01 | [1 Tex. Admin. Code § 372.354](https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-354) |
| Vehicle exemption ($4,650) | 2009-09-01 | [1 Tex. Admin. Code § 372.354](https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-354) |
| Budgetary needs (all types) | 1994-03-01 | [Texas Works Handbook C-110](https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf) |
| Recognizable needs | 1994-03-01 | [Texas Works Handbook C-110](https://www.hhs.texas.gov/handbooks/texas-works-handbook/c-110-tanf) |

### Payment Standards (annual FPL-based adjustments)

Added values for 2017-10-01, 2018-10-01, 2019-10-01:

| Year | Source | Notes |
|------|--------|-------|
| 2019-10-01 | [Bulletin 19-08](https://www.hhs.texas.gov/sites/default/files/documents/laws-regulations/handbooks/twh/bulletin2020/19-08.pdf#page=6) | Actual values from official bulletin |
| 2017-10-01, 2018-10-01 | Estimated | Original bulletins unavailable |

### Estimation Method (2017-2018)

Per state law, Texas TANF maximum grants are adjusted to 17% of FPL. Values calculated using:
```
Rate = (17% × monthly FPL for size 3) ÷ budgetary needs for size 3
- 2017: 38.48%
- 2018: 39.15%
```
Rate applied uniformly to all family types/sizes via budgetary needs.

## Test Plan

- [x] Texas TANF tests pass (114 tests)