### PR TITLE
fix: remove NJ taxable_social_security double exclusion

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Remove taxable_social_security from NJ subtractions to fix double exclusion
+      bug. Social Security was already excluded from NJ gross income.

--- a/policyengine_us/parameters/gov/states/nj/tax/income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/nj/tax/income/subtractions.yaml
@@ -2,6 +2,10 @@ description: Subtractions from federal adjusted gross income.
 metadata:
   unit: list
   label: New Jersey subtractions from federal adjusted gross income
+  reference:
+    - title: NJ-1040 Instructions (page 21)
+      href: https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf
 values:
-  2021-01-01:
-    - taxable_social_security
+  # Social Security is already excluded from NJ gross income (not in gross_income_sources.yaml)
+  # per NJ Statute 54A:6-15. No subtractions are needed.
+  2021-01-01: []

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/subtractions/nj_social_security_exclusion.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/subtractions/nj_social_security_exclusion.yaml
@@ -1,0 +1,32 @@
+- name: NJ should not double-exclude Social Security (fixes #6979)
+  # Social Security is already excluded from NJ gross income (not in gross_income_sources.yaml)
+  # per NJ Statute 54A:6-15, so it should NOT be subtracted again.
+  # Test case: Single, age 75, $37,274 wages, $27,262 gross SS
+  # Expected: NJ taxable income = wages - exemptions = $37,274 - $2,000 = $35,274
+  # (SS should have no effect since it's already excluded from gross income)
+  # Expected NJ tax: ~$552 per TaxAct
+  absolute_error_margin: 5
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 75
+        employment_income: 37_274
+        social_security: 27_262
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+    households:
+      household:
+        members: [person1]
+        state_fips: 34
+  output:
+    # $37,274 wages - $1,000 regular exemption - $1,000 senior exemption = $35,274
+    nj_taxable_income: 35_274
+    nj_income_tax: 552

--- a/policyengine_us/variables/gov/states/nj/tax/income/adjusted_gross_income/nj_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/adjusted_gross_income/nj_agi_subtractions.py
@@ -13,6 +13,10 @@ class nj_agi_subtractions(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.nj.tax.income
-        total_subtractions = add(person, period, p.subtractions)
+        subtractions_list = p.subtractions
+        # Handle empty subtractions list
+        if not subtractions_list:
+            return 0
+        total_subtractions = add(person, period, subtractions_list)
         # Prevent negative subtractions from acting as additions
         return max_(0, total_subtractions)


### PR DESCRIPTION
## Summary

- Remove `taxable_social_security` from NJ subtractions parameter list (now empty)
- Social Security was already excluded from NJ gross income (not in `gross_income_sources.yaml`) per NJ Statute 54A:6-15
- The prior subtraction created a double exclusion, incorrectly reducing taxable income

## Test plan

- [x] Added test case: Single, age 75, $37,274 wages, $27,262 gross SS
- [x] Verified NJ taxable income = $35,274 (wages - $2,000 exemptions, NOT reduced by SS)
- [x] Verified NJ tax = $552 (per TaxAct)
- [x] Test passes locally

Fixes #6979

---
Generated with [Claude Code](https://claude.ai/code)