### PR TITLE
Add income_tax_positive variable for CBO-consistent calibration

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Added income_tax_positive variable for CBO-consistent calibration

--- a/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/income_tax_positive.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/income_tax_positive.yaml
@@ -1,0 +1,20 @@
+- name: Income tax positive when tax is positive
+  period: 2024
+  input:
+    income_tax: 5000
+  output:
+    income_tax_positive: 5000
+
+- name: Income tax positive floors negative tax at zero
+  period: 2024
+  input:
+    income_tax: -2000
+  output:
+    income_tax_positive: 0
+
+- name: Income tax positive with zero tax
+  period: 2024
+  input:
+    income_tax: 0
+  output:
+    income_tax_positive: 0

--- a/policyengine_us/variables/gov/irs/tax/federal_income/income_tax_positive.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/income_tax_positive.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class income_tax_positive(Variable):
+    value_type = float
+    entity = TaxUnit
+    definition_period = YEAR
+    unit = USD
+    label = "Federal income tax (non-negative)"
+    documentation = (
+        "Federal income tax liability, floored at zero. This matches the CBO "
+        "definition of income tax receipts, where refundable credit payments "
+        "in excess of tax liability are classified as outlays rather than "
+        "negative receipts."
+    )
+    reference = "https://www.cbo.gov/publication/43767"
+
+    def formula(tax_unit, period, parameters):
+        income_tax = tax_unit("income_tax", period)
+        return max_(income_tax, 0)


### PR DESCRIPTION
## Summary

- Adds `income_tax_positive` variable that floors `income_tax` at zero
- Matches CBO's definition of income tax receipts

## Context

CBO reports income tax receipts where refundable credit payments *in excess of tax liability* are classified as **outlays** (spending), not negative receipts. PolicyEngine's `income_tax` can be negative when refundable credits exceed liability.

From [CBO](https://www.cbo.gov/publication/43767):
> "the portion of refundable credits that reduces the amount of taxes owed is counted as a reduction in revenues, and the portion that exceeds people's tax liabilities is treated as an outlay"

This variable enables correct calibration to CBO income tax projections in policyengine-us-data.

See: https://github.com/PolicyEngine/policyengine-us-data/issues/494

## Test plan

- [x] Added YAML tests for positive, negative, and zero income tax cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)