### PR TITLE
Fix RI retirement income subtraction per-person cap

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix Rhode Island retirement income subtraction to apply the cap per person instead of per tax unit.

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/agi/subtractions/taxable_retirement_income/ri_retirement_income_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/agi/subtractions/taxable_retirement_income/ri_retirement_income_subtraction.yaml
@@ -56,3 +56,52 @@
     taxable_pension_income: 75_000
   output:
     ri_retirement_income_subtraction: 50_000
+
+# Per-person cap tests for joint filers
+- name: 2024 - Joint filers each get $20K cap (cap is per-person, not per tax unit)
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 75
+        taxable_pension_income: 42_767
+        is_tax_unit_head: true
+      person2:
+        age: 75
+        taxable_pension_income: 42_767
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ri_retirement_income_subtraction_eligible: true
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 44
+  output:
+    ri_retirement_income_subtraction: 40_000
+
+- name: 2025 - Joint filers each get $50K cap (cap is per-person, not per tax unit)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 75
+        taxable_pension_income: 60_000
+        is_tax_unit_head: true
+      person2:
+        age: 75
+        taxable_pension_income: 60_000
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ri_retirement_income_subtraction_eligible: true
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 44
+  output:
+    ri_retirement_income_subtraction: 100_000

--- a/policyengine_us/variables/gov/states/ri/tax/income/agi/subtractions/taxable_retirement_income/ri_retirement_income_subtraction.py
+++ b/policyengine_us/variables/gov/states/ri/tax/income/agi/subtractions/taxable_retirement_income/ri_retirement_income_subtraction.py
@@ -17,5 +17,6 @@ class ri_retirement_income_subtraction(Variable):
         p = parameters(
             period
         ).gov.states.ri.tax.income.agi.subtractions.taxable_retirement_income
-        total_taxable_pension = tax_unit.sum(taxable_pension * head_or_spouse)
-        return min_(total_taxable_pension, p.cap)
+        # Cap applies per person, not per tax unit
+        capped_per_person = min_(taxable_pension, p.cap) * head_or_spouse
+        return tax_unit.sum(capped_per_person)


### PR DESCRIPTION
Closes #7022

## Summary
- Rhode Island retirement income subtraction now correctly applies the cap per person instead of per tax unit
- Joint filers can now receive up to $40K (2024) or $100K (2025) in subtractions when both spouses have qualifying pension income

## Changes
- Changed `ri_retirement_income_subtraction.py` to apply `min_(taxable_pension, p.cap)` per person before summing
- Added test cases for joint filers with per-person cap verification

## Test
- Added integration tests verifying:
  - 2024: Joint filers each get $20K cap ($40K total)
  - 2025: Joint filers each get $50K cap ($100K total)

Generated with [Claude Code](https://claude.ai/code)