### PR TITLE
Fix CT Social Security benefit adjustment

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - CT Social Security benefit adjustment now uses actual federal taxable Social Security amount instead of 85% of gross Social Security.

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/subtractions/ct_social_security_benefit_adjustment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/subtractions/ct_social_security_benefit_adjustment.yaml
@@ -22,7 +22,7 @@
   output:
     ct_social_security_benefit_adjustment: 12_000
 
-- name: Adjusted gross income under reduction threshold, joint
+- name: Adjusted gross income at reduction threshold, joint
   period: 2022
   input:
     state_code: CT
@@ -32,7 +32,11 @@
     tax_unit_social_security: 15_000
     filing_status: JOINT
   output:
-    ct_social_security_benefit_adjustment: 11_500
+    # Part C: min(15000, 5000) = 5000
+    # Part D: 5000 * 0.25 = 1250
+    # Part E: 12000 (actual federal taxable SS, not 15000 * 0.85)
+    # Part F: max(12000 - 1250, 0) = 10750
+    ct_social_security_benefit_adjustment: 10_750
 
 - name: Integration test
   absolute_error_margin: 0.01
@@ -51,3 +55,35 @@
         state_fips: 9  # CT
   output:  # expected results from patched TAXSIM35 2024-02-15 version
     ct_social_security_benefit_adjustment: 9_000
+
+# Test case from GitHub issue #7019 - verifies fix for using actual federal
+# taxable SS instead of 85% of gross SS
+- name: CT SS adjustment uses actual federal taxable SS (issue 7019)
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 75
+        social_security_retirement: 46_718.91
+        taxable_private_pension_income: 28_475.02
+        is_tax_unit_head: true
+      person2:
+        age: 75
+        social_security_retirement: 46_718.91
+        taxable_private_pension_income: 28_475.02
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 9
+  output:
+    ct_social_security_benefit_adjustment: 38_802
+    ct_agi: 43_544
+    ct_income_tax: 332

--- a/policyengine_us/variables/gov/states/ct/tax/income/subtractions/ct_social_security_benefit_adjustment.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/subtractions/ct_social_security_benefit_adjustment.py
@@ -7,51 +7,52 @@ class ct_social_security_benefit_adjustment(Variable):
     unit = USD
     label = "Connecticut social security benefit adjustment"
     reference = (
-        # Connecticut General Statutes, Chapter 229, Sec. 12-701, (20), (b), (x), (iii) and (iv)
-        "https://www.cga.ct.gov/current/pub/chap_229.htm#sec_12-701"
-        # 2022 Form CT-1040 Connecticut Resident Income Tax Return Instructions
-        "https://portal.ct.gov/-/media/DRS/Forms/2022/Income/2022-CT-1040-Instructions_1222.pdf#page=24"
+        "https://www.cga.ct.gov/current/pub/chap_229.htm#sec_12-701",
+        "https://portal.ct.gov/-/media/DRS/Forms/2024/Income/CT-1040-Instructions_1224.pdf#page=24",
     )
     definition_period = YEAR
     defined_for = StateCode.CT
 
     def formula(tax_unit, period, parameters):
         filing_status = tax_unit("filing_status", period)
-        # Part A
-        social_security = tax_unit("tax_unit_social_security", period)
-        # Part B
-        p_irs = parameters(period).gov.irs.social_security.taxability
-        ss_combined_income_excess = tax_unit(
-            "tax_unit_ss_combined_income_excess", period
-        )
-        # Part C
-        capped_social_security = min_(
-            social_security, ss_combined_income_excess
-        )
-        # Part D
         p = parameters(
             period
         ).gov.states.ct.tax.income.subtractions.social_security
+
+        # Part A: Gross Social Security
+        gross_social_security = tax_unit("tax_unit_social_security", period)
+
+        # Part B: Combined income excess
+        ss_combined_income_excess = tax_unit(
+            "tax_unit_ss_combined_income_excess", period
+        )
+
+        # Part C: Lesser of gross SS and combined income excess
+        capped_social_security = min_(
+            gross_social_security, ss_combined_income_excess
+        )
+
+        # Part D: Apply CT rate to capped amount
         capped_social_security_portion = capped_social_security * p.rate
-        # Part E (Line 18 from federal social security worksheet)
-        gross_ss = tax_unit("tax_unit_social_security", period)
-        adjusted_gross_social_security = (
-            gross_ss * p_irs.rate.additional.excess
-        )
-        # Part F
-        reduced_taxable_social_security = max_(
-            adjusted_gross_social_security - capped_social_security_portion,
-            0,
-        )
-        # Filers with AGI below the threshold can subtract the full amount of their
-        # taxable social security benefits
-        agi = tax_unit("adjusted_gross_income", period)
-        full_adjustment_eligible = agi < p.reduction_threshold[filing_status]
-        taxable_social_security = tax_unit(
+
+        # Part E: Federal taxable SS (Line 18 from federal SS worksheet)
+        federal_taxable_social_security = tax_unit(
             "tax_unit_taxable_social_security", period
         )
+
+        # Part F: Reduced taxable SS
+        reduced_taxable_social_security = max_(
+            federal_taxable_social_security - capped_social_security_portion,
+            0,
+        )
+
+        # Filers with AGI below the threshold can subtract the full amount
+        # of their taxable social security benefits
+        agi = tax_unit("adjusted_gross_income", period)
+        full_adjustment_eligible = agi < p.reduction_threshold[filing_status]
+
         return where(
             full_adjustment_eligible,
-            taxable_social_security,
+            federal_taxable_social_security,
             reduced_taxable_social_security,
         )


### PR DESCRIPTION
Closes #7019

## Summary
- CT Social Security benefit adjustment now uses the actual federal taxable Social Security amount (`tax_unit_taxable_social_security`) instead of 85% of gross Social Security
- The previous implementation incorrectly used `gross_ss * 0.85` for Line E of the worksheet
- Per CT-1040 Instructions, Line E should be the "Taxable amount of Social Security benefits reported on your 2024 federal Social Security Benefits Worksheet, Line 18"

## Changes
- Updated `ct_social_security_benefit_adjustment.py` to use `tax_unit_taxable_social_security` instead of `tax_unit_social_security * 0.85`
- Updated test expectations to reflect the correct calculation
- Added integration test case from issue #7019 (MFJ, both age 75)

## Test
- All existing tests pass
- New test verifies the fix matches TaxAct calculations:
  - CT SS Adjustment: $38,802 (not $61,505)
  - CT AGI: $43,544 (not $20,841)  
  - CT Tax: $332 (not $0)

Generated with [Claude Code](https://claude.ai/code)