### PR TITLE
Add tax_unit_is_filer tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.534.3] - 2026-01-31 10:58:57
-
-### Added
-
-- Tests for tax_unit_is_filer variable covering filing requirement logic.
-
 ## [1.534.2] - 2026-01-31 03:23:17
 
 ### Added
@@ -14687,7 +14681,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-[1.534.3]: https://github.com/PolicyEngine/policyengine-us/compare/1.534.2...1.534.3
 [1.534.2]: https://github.com/PolicyEngine/policyengine-us/compare/1.534.1...1.534.2
 [1.534.1]: https://github.com/PolicyEngine/policyengine-us/compare/1.534.0...1.534.1
 [1.534.0]: https://github.com/PolicyEngine/policyengine-us/compare/1.533.0...1.534.0

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -12600,8 +12600,3 @@
     - Add 2018 CHIP FCEP pregnant income limits from MACPAC MACStats December 2018
       Data Book.
   date: 2026-01-31 03:23:17
-- bump: patch
-  changes:
-    added:
-    - Tests for tax_unit_is_filer variable covering filing requirement logic.
-  date: 2026-01-31 10:58:57

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Tests for tax_unit_is_filer variable covering filing requirement logic.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "policyengine-us"
-version = "1.534.3"
+version = "1.534.2"
 description = "Add your description here."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Add YAML tests for `tax_unit_is_filer` variable to improve code coverage

## Test cases added
- High income - required to file
- Low income with refund (EITC-eligible) - files anyway
- Married filing separately - lower threshold applies
- Low income but high unearned income - required to file
- Senior with low income - files due to refund
- Zero income - not required to file

## Context
Part of effort to improve policyengine-us code coverage. These tests exercise the filing requirement logic in `policyengine_us/variables/gov/irs/tax_unit_is_filer.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)