### PR TITLE
Add pandas 2+3 CI compatibility testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -207,3 +207,34 @@ jobs:
         run: |
           echo "Running structural YAML tests (contrib excl states)..."
           uv run make test-yaml-structural
+
+  Pandas-Compatibility:
+    name: Pandas ${{ matrix.pandas-version }} Compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pandas-version: ["2", "3"]
+      fail-fast: false
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Install pandas ${{ matrix.pandas-version }}
+        run: |
+          if [ "${{ matrix.pandas-version }}" = "2" ]; then
+            uv pip install "pandas>=2,<3" --system
+          else
+            uv pip install "pandas>=3,<4" --system
+          fi
+      - name: Turn off default branching
+        shell: bash
+        run: ./update_itemization.sh
+      - name: Run pandas compatibility tests
+        run: uv run pytest policyengine_us/tests/core/test_pandas3_compatibility.py -v

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Added pandas 2 and 3 CI compatibility testing to ensure both major versions work.


### PR DESCRIPTION
## Summary
- Adds a focused "Pandas Compatibility" CI job that tests against both pandas 2.x and 3.x
- Runs the pandas compatibility test suite (`test_pandas3_compatibility.py`) with each major version
- Lightweight addition that doesn't double the full test suite
- Ensures policyengine-us remains compatible with both pandas 2.x and 3.x

## Test plan
- [ ] CI passes with pandas 2 matrix
- [ ] CI passes with pandas 3 matrix


🤖 Generated with [Claude Code](https://claude.com/claude-code)