### PR TITLE
Fix incorrect label for ca_ala_general_assistance_countable_income_person

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed incorrect label for ca_ala_general_assistance_countable_income_person variable.

--- a/policyengine_us/variables/gov/local/ca/ala/ga/income/ca_ala_general_assistance_countable_income_person.py
+++ b/policyengine_us/variables/gov/local/ca/ala/ga/income/ca_ala_general_assistance_countable_income_person.py
@@ -6,7 +6,9 @@ class ca_ala_general_assistance_countable_income_person(Variable):
     entity = Person
     unit = USD
     definition_period = MONTH
-    label = "Eligible for Alameda County General Assistance based on age requirements"
+    label = (
+        "Alameda County General Assistance countable income for each person"
+    )
     defined_for = "is_tax_unit_head_or_spouse"
     reference = "https://www.alamedacountysocialservices.org/acssa-assets/PDF/GA-Policies/GA-Regulations.pdf#page=29"
 


### PR DESCRIPTION
## Summary
- Fixed mislabeled variable `ca_ala_general_assistance_countable_income_person`
- Old label: "Eligible for Alameda County General Assistance based on age requirements"
- New label: "Alameda County General Assistance countable income for each person"

The variable is a `float` measuring USD income, not a boolean eligibility flag. The label was copy-pasted from a different variable and never corrected.

## Test plan
- [ ] No behavioral changes - label metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)