### PR TITLE
Fix RI reform exports to match standard pattern

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix RI high earner tax and social security exemption reform exports to match standard pattern

--- a/policyengine_us/reforms/states/ri/high_earner_tax/__init__.py
+++ b/policyengine_us/reforms/states/ri/high_earner_tax/__init__.py
@@ -1,4 +1,1 @@
-from policyengine_us.reforms.states.ri.high_earner_tax.ri_high_earner_tax_reform import (
-    create_ri_high_earner_tax_reform,
-    ri_high_earner_tax,
-)
+from .ri_high_earner_tax_reform import create_ri_high_earner_tax_reform

--- a/policyengine_us/reforms/states/ri/social_security_exemption/__init__.py
+++ b/policyengine_us/reforms/states/ri/social_security_exemption/__init__.py
@@ -1,4 +1,3 @@
-from policyengine_us.reforms.states.ri.social_security_exemption.ri_social_security_exemption_reform import (
+from .ri_social_security_exemption_reform import (
     create_ri_social_security_exemption_reform,
-    ri_social_security_exemption,
 )


### PR DESCRIPTION
## Summary
- Fixes RI high earner tax and social security exemption reform exports to match standard pattern used by RI CTC
- Changes `__init__.py` files to only export factory function, not pre-built reform

## Test plan
- [x] RI high earner tax tests pass
- [x] RI social security exemption tests pass

Closes #7327

🤖 Generated with [Claude Code](https://claude.com/claude-code)