### PR TITLE
Add voluntary tax filer variable and update tax_unit_is_filer

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,6 +1,9 @@
 - bump: minor
   changes:
     added:
-      - Add would_file_taxes_voluntarily input variable for voluntary tax filers.
+      - Add tax_unit_is_required_to_file variable for rules-based filing requirement.
+      - Add eligible_for_refundable_credits variable for EITC/CTC eligibility check.
+      - Add would_file_if_eligible_for_refundable_credit propensity variable.
+      - Add would_file_taxes_voluntarily propensity variable for voluntary filers.
     changed:
-      - Update tax_unit_is_filer to use takes_up_eitc and would_file_taxes_voluntarily propensity variables from microdata.
+      - Refactor tax_unit_is_filer to use three-part filing logic with propensity variables.


### PR DESCRIPTION
## Summary
- Add `would_file_taxes_voluntarily` input variable for voluntary tax filers
- Update `tax_unit_is_filer` to use propensity variables from microdata

## Background
Previously, `tax_unit_is_filer` used a rules-based approach: file if required OR if income_tax < 0 (getting a refund). This deterministic approach didn't capture voluntary filing behavior.

The new approach uses propensity variables assigned during microdata construction:
1. **Required to file** - Income threshold logic from IRC § 6012 (unchanged)
2. **Takes up EITC** - Implies filing to claim refundable credits
3. **Would file voluntarily** - State requirements, documentation needs, habit

## Changes

### New variable: `would_file_taxes_voluntarily`
- Input variable with `default_value = False`
- Set to True in microdata for ~5% of tax units not taking up EITC
- Captures filing for reasons beyond refundable credits

### Updated: `tax_unit_is_filer`
- Changed from `value_type = float` to `value_type = bool`
- Removed redundant `unit = USD`
- Now returns: `required_to_file | takes_up_eitc | would_file_taxes_voluntarily`

## Related issues
- Closes #4286 - Impute probability of filing taxes among tax units with zero net tax
- Related to #4283 - Discussion on how well tax != 0 reflects filing

## Related PRs
- PolicyEngine/policyengine-us-data#513 - Adds `would_file_taxes_voluntarily` to CPS microdata

## Test plan
- [ ] Verify CI passes
- [ ] Confirm `would_file_taxes_voluntarily` variable is accessible
- [ ] Verify `tax_unit_is_filer` returns expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)