### PR TITLE
Add Texas SSI state supplement

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Add Texas SSI State Supplement (Optional State Supplement) for SSI recipients in Medicaid-funded nursing facilities and ICF/IID

--- a/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/couple.yaml
+++ b/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/couple.yaml
@@ -1,0 +1,14 @@
+description: The Social Security Administration provides this reduced Supplemental Security Income amount for an eligible couple both residing in a Medicaid-funded institution.
+
+values:
+  1988-07-01: 60
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Federal SSI reduced institutional payment for couples
+  reference:
+    - title: 42 USC 1382(e)(1)(B)
+      href: https://www.law.cornell.edu/uscode/text/42/1382
+    - title: HHSC MEPD Handbook Section H-6000 - Co-Payment for SSI Cases
+      href: https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases

--- a/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/individual.yaml
+++ b/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/individual.yaml
@@ -1,0 +1,14 @@
+description: The Social Security Administration provides this reduced Supplemental Security Income amount for an eligible individual residing in a Medicaid-funded institution.
+
+values:
+  1988-07-01: 30
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Federal SSI reduced institutional payment for individuals
+  reference:
+    - title: 42 USC 1382(e)(1)(B)
+      href: https://www.law.cornell.edu/uscode/text/42/1382
+    - title: HHSC MEPD Handbook Section H-6000 - Co-Payment for SSI Cases
+      href: https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases

--- a/policyengine_us/parameters/gov/states/tx/hhsc/ssi_state_supplement/personal_needs_allowance.yaml
+++ b/policyengine_us/parameters/gov/states/tx/hhsc/ssi_state_supplement/personal_needs_allowance.yaml
@@ -1,0 +1,18 @@
+description: Texas provides this amount as the personal needs allowance for Supplemental Security Income recipients in Medicaid-funded long-term care facilities under the Optional State Supplement program.
+
+values:
+  1999-09-01: 45
+  2001-09-01: 60
+  2003-09-01: 45
+  2006-01-01: 60
+  2024-01-01: 75
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Texas SSI State Supplement personal needs allowance
+  reference:
+    - title: Texas Human Resources Code Section 32.024(w)
+      href: https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm
+    - title: HHSC MEPD Handbook Section H-1500 - Personal Needs Allowance
+      href: https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-1500-personal-needs-allowance

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/integration.yaml
@@ -1,0 +1,213 @@
+# Integration tests for Texas SSI State Supplement
+# Tests realistic scenarios with full eligibility and benefit calculations
+#
+# Key Texas SSI State Supplement rules:
+# - Only for SSI recipients in Medicaid-funded nursing facilities or ICF/IID
+# - Supplement = PNA - Federal reduced SSI benefit
+# - 2024 PNA: $75/month, Federal reduced SSI: $30/month individual
+# - Individual supplement: $45/month = $540/year
+# - No additional state income rules beyond federal SSI
+#
+# Reference: Texas Human Resources Code Section 32.024(w)
+# Reference: SSA State Assistance Programs for SSI Recipients - Texas
+
+- name: Scenario 1, SSI-eligible elderly individual in Texas Medicaid facility.
+  # 70-year-old SSI recipient in a nursing facility receives state supplement
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Eligibility: SSI eligible + in Medicaid facility + TX = eligible
+    tx_ssi_state_supplement_eligible: true
+    # Supplement: ($75 PNA - $30 federal reduced SSI) * 12 = $540/year
+    tx_ssi_state_supplement: 540
+
+- name: Scenario 2, SSI-eligible disabled individual in Texas Medicaid facility.
+  # 45-year-old disabled SSI recipient in ICF/IID
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 45
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Eligibility: SSI eligible + in Medicaid facility + TX = eligible
+    tx_ssi_state_supplement_eligible: true
+    # Supplement: ($75 - $30) * 12 = $540/year
+    tx_ssi_state_supplement: 540
+
+- name: Scenario 3, SSI-eligible individual NOT in Medicaid facility.
+  # SSI recipient living in community - no supplement
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Not in Medicaid facility = not eligible
+    tx_ssi_state_supplement_eligible: false
+    tx_ssi_state_supplement: 0
+
+- name: Scenario 4, person in Medicaid facility but NOT SSI eligible.
+  # Non-SSI recipient in nursing facility - no supplement
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 50
+        is_ssi_eligible_individual: false
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Not SSI eligible = not eligible for supplement
+    tx_ssi_state_supplement_eligible: false
+    tx_ssi_state_supplement: 0
+
+- name: Scenario 5, SSI-eligible individual in Medicaid facility in another state.
+  # SSI recipient in facility but not in Texas
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 68
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    # Not in Texas = TX supplement does not apply (defined_for TX)
+    tx_ssi_state_supplement_eligible: false
+    tx_ssi_state_supplement: 0
+
+- name: Scenario 6, couple both SSI-eligible in Texas Medicaid facility.
+  # Both members of a couple in a nursing facility
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 72
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+      person2:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    # Both persons are eligible
+    tx_ssi_state_supplement_eligible: [true, true]
+    # Each person: ($75 - $30) * 12 = $540/year
+    tx_ssi_state_supplement: [540, 540]
+
+- name: Scenario 7, historical 2023 period with lower PNA.
+  # Tests pre-2024 PNA of $60/month
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 75
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: true
+    # 2023 PNA: $60/month, Federal reduced SSI: $30/month
+    # Supplement: ($60 - $30) * 12 = $360/year
+    tx_ssi_state_supplement: 360
+
+- name: Scenario 8, historical 2005 period with $45 PNA.
+  # Tests 2003-2005 PNA of $45/month (PNA dropped back from $60)
+  period: 2005
+  input:
+    people:
+      person1:
+        age: 80
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: true
+    # 2005 PNA: $45/month (set 2003-09-01), Federal reduced SSI: $30/month
+    # Supplement: ($45 - $30) * 12 = $180/year
+    tx_ssi_state_supplement: 180

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.yaml
@@ -1,0 +1,29 @@
+# Unit tests for Texas SSI State Supplement benefit amount
+# Supplement = max(0, (PNA - Federal institutional SSI rate) * 12)
+# For 2024: ($75 - $30) * 12 = $45/month * 12 = $540/year
+# Reference: Texas Human Resources Code Section 32.024(w)
+
+- name: Case 1, eligible individual receives full supplement.
+  period: 2024
+  input:
+    tx_ssi_state_supplement_eligible: true
+  output:
+    # PNA = $75/month, Federal reduced SSI = $30/month
+    # Supplement = ($75 - $30) * 12 = $540/year
+    tx_ssi_state_supplement: 540
+
+- name: Case 2, not eligible receives zero.
+  period: 2024
+  input:
+    tx_ssi_state_supplement_eligible: false
+  output:
+    tx_ssi_state_supplement: 0
+
+- name: Case 3, eligible individual in 2023 with lower PNA.
+  period: 2023
+  input:
+    tx_ssi_state_supplement_eligible: true
+  output:
+    # PNA = $60/month (2006-2023), Federal reduced SSI = $30/month
+    # Supplement = ($60 - $30) * 12 = $360/year
+    tx_ssi_state_supplement: 360

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.yaml
@@ -1,0 +1,40 @@
+# Unit tests for Texas SSI State Supplement eligibility
+# Eligible if: SSI eligible individual AND residing in a Medicaid-funded facility
+# AND in Texas
+# Reference: Texas Human Resources Code Section 32.024(w)
+
+- name: Case 1, SSI eligible and in Medicaid facility in Texas.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: true
+    is_in_medicaid_facility: true
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: true
+
+- name: Case 2, SSI eligible but not in Medicaid facility.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: true
+    is_in_medicaid_facility: false
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: false
+
+- name: Case 3, not SSI eligible but in Medicaid facility.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: false
+    is_in_medicaid_facility: true
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: false
+
+- name: Case 4, neither SSI eligible nor in Medicaid facility.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: false
+    is_in_medicaid_facility: false
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: false

--- a/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
+++ b/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
@@ -1,0 +1,9 @@
+from policyengine_us.model_api import *
+
+
+class is_in_medicaid_facility(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether the person resides in a Medicaid-funded nursing facility or ICF/IID"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/42/1382"

--- a/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class tx_ssi_state_supplement(Variable):
+    value_type = float
+    entity = Person
+    label = "Texas SSI State Supplement"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "tx_ssi_state_supplement_eligible"
+    reference = (
+        "https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm",
+        "https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases",
+    )
+
+    def formula(person, period, parameters):
+        # Per 42 USC 1382(e)(1)(B) and Texas HR Code 32.024(w)
+        p = parameters(period).gov.states.tx.hhsc.ssi_state_supplement
+        pna = p.personal_needs_allowance
+        federal_reduced = parameters(
+            period
+        ).gov.ssa.ssi.amount.institutional.individual
+        return max_(pna - federal_reduced, 0) * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class tx_ssi_state_supplement_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Texas SSI State Supplement eligible"
+    definition_period = YEAR
+    defined_for = StateCode.TX
+    reference = (
+        "https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm",
+        "https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases",
+    )
+
+    def formula(person, period, parameters):
+        ssi_eligible = person("is_ssi_eligible_individual", period)
+        in_facility = person("is_in_medicaid_facility", period)
+        return ssi_eligible & in_facility

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -19,6 +19,8 @@ class spm_unit_benefits(Variable):
             "co_ccap_subsidy",
             "co_state_supplement",
             "co_oap",
+            # Texas programs.
+            "tx_ssi_state_supplement",
             "snap",
             "wic",
             "free_school_meals",


### PR DESCRIPTION
## Summary

Implements the Texas Optional State Supplement (OSS) for SSI recipients in Medicaid-funded nursing facilities and ICF/IID facilities. Closes #7340.

Texas provides one of the most minimal SSI state supplements in the nation — available **only** to SSI recipients residing in Medicaid-funded long-term care facilities (nursing facilities and ICF/IID). The supplement brings the total personal spending money up to the state's Personal Needs Allowance (PNA).

**Current benefit (2024+):** $45/month ($540/year) per individual = $75 PNA - $30 federal reduced SSI

## Regulatory authority

| Authority | Citation |
|-----------|----------|
| State PNA statute | [Texas Human Resources Code § 32.024(w)](https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm) |
| PNA increase to $75 | [HB 54, 88th Legislature (2023)](https://capitol.texas.gov/tlodocs/88R/billtext/html/HB00054F.HTM) |
| Federal reduced SSI benefit | [42 USC § 1382(e)(1)(B)](https://www.law.cornell.edu/uscode/text/42/1382) |
| HHSC PNA handbook | [MEPD Handbook H-1500](https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-1500-personal-needs-allowance) |
| HHSC co-payment rules | [MEPD Handbook H-6000](https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases) |

## Benefit calculation

```
State Supplement = max(0, Personal Needs Allowance - Federal Reduced SSI Benefit) × 12

Individual: ($75 - $30) × 12 = $540/year
Couple (both in facility): each person gets ($75 - $30) × 12 = $540/year
```

## Historical PNA values

| Period | PNA (monthly) | Supplement (monthly) |
|--------|--------------|---------------------|
| Sep 1999 | $45 | $15 |
| Sep 2001 | $60 | $30 |
| Sep 2003 | $45 | $15 |
| Jan 2006 | $60 | $30 |
| Jan 2024 | $75 | $45 |

## Files added

**Parameters (3):**
- `gov/states/tx/hhsc/ssi_state_supplement/personal_needs_allowance.yaml` — TX PNA amount
- `gov/ssa/ssi/amount/institutional/individual.yaml` — Federal $30/month reduced SSI
- `gov/ssa/ssi/amount/institutional/couple.yaml` — Federal $60/month reduced SSI (couple)

**Variables (3 new, 1 modified):**
- `gov/ssa/ssi/is_in_medicaid_facility.py` — Federal input: whether person is in Medicaid facility
- `gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.py` — Eligibility
- `gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py` — Benefit amount
- `household/income/spm_unit/spm_unit_benefits.py` — Added tx_ssi_state_supplement

**Tests (3 files, 15 tests):**
- `tx_ssi_state_supplement_eligible.yaml` — 4 unit tests (eligibility logic)
- `tx_ssi_state_supplement.yaml` — 3 unit tests (benefit amounts)
- `integration.yaml` — 8 integration tests (realistic scenarios including couples, historical periods, out-of-state)

## Test plan

- [x] All 15 YAML tests pass locally
- [x] `make format` passes
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)