### PR TITLE
Fix ga_exemptions and ks_exemptions in repeal_state_dependent_exemptions reform

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix ga_exemptions formula in repeal_state_dependent_exemptions reform to use correct parameter path.
+      - Fix ks_exemptions in repeal_state_dependent_exemptions reform to handle 2024+ by_filing_status branch.

--- a/policyengine_us/reforms/state_dependent_exemptions/repeal_state_dependent_exemptions.py
+++ b/policyengine_us/reforms/state_dependent_exemptions/repeal_state_dependent_exemptions.py
@@ -274,13 +274,11 @@ def create_repeal_state_dependent_exemptions() -> Reform:
 
         def formula(tax_unit, period, parameters):
             p = parameters(period).gov.states.ga.tax.income.exemptions
-            filing_status = tax_unit("filing_status", period)
-
-            # Personal Exemptions
-            personal_exemptions = p.personal[filing_status]
-
-            # total exemptions
-            return personal_exemptions
+            # Personal exemptions only (dependent exemptions excluded)
+            if p.personal.availability:
+                filing_status = tax_unit("filing_status", period)
+                return p.personal.amount[filing_status]
+            return 0
 
     class in_base_exemptions(Variable):
         value_type = float
@@ -330,25 +328,43 @@ def create_repeal_state_dependent_exemptions() -> Reform:
                 + additional_count * exemption.additional
             )
 
-    class ks_count_exemptions(Variable):
+    class ks_exemptions(Variable):
         value_type = float
         entity = TaxUnit
-        label = "number of KS exemptions"
+        label = "Kansas exemptions amount"
         unit = USD
         definition_period = YEAR
-        reference = (
-            "https://www.ksrevenue.gov/pdf/ip21.pdf"
-            "https://www.ksrevenue.gov/pdf/ip22.pdf"
-        )
+        reference = "https://law.justia.com/codes/kansas/chapter-79/article-32/section-79-32-121/"
         defined_for = StateCode.KS
 
         def formula(tax_unit, period, parameters):
+            p = parameters(period).gov.states.ks.tax.income.exemptions
+            veteran_exemptions_count = add(
+                tax_unit,
+                period,
+                ["ks_disabled_veteran_exemptions_eligible_person"],
+            )
+            veterans_exemption_amount = (
+                veteran_exemptions_count * p.disabled_veteran.base
+            )
+            if p.by_filing_status.in_effect:
+                filing_status = tax_unit("filing_status", period)
+                base_amount = p.by_filing_status.amount[filing_status]
+                head_of_household = (
+                    filing_status
+                    == filing_status.possible_values.HEAD_OF_HOUSEHOLD
+                )
+                hoh_additional = (
+                    head_of_household
+                    * p.by_filing_status.hoh_additional_amount
+                )
+                return base_amount + veterans_exemption_amount + hoh_additional
             filing_status = tax_unit("filing_status", period)
             statuses = filing_status.possible_values
             joint = filing_status == statuses.JOINT
             hoh = filing_status == statuses.HEAD_OF_HOUSEHOLD
             adults = where(joint | hoh, 2, 1)
-            return adults
+            return adults * p.consolidated.amount + veterans_exemption_amount
 
     class ma_income_tax_exemption_threshold(Variable):
         value_type = float
@@ -493,7 +509,7 @@ def create_repeal_state_dependent_exemptions() -> Reform:
             self.update_variable(ca_exemptions)
             self.update_variable(ga_exemptions)
             self.update_variable(in_base_exemptions)
-            self.update_variable(ks_count_exemptions)
+            self.update_variable(ks_exemptions)
             self.update_variable(ma_income_tax_exemption_threshold)
             self.update_variable(wi_base_exemption)
             self.update_variable(ia_exemption_credit)


### PR DESCRIPTION
## Summary
- Fix `ga_exemptions` formula to use correct parameter path (`p.personal.amount[filing_status]` instead of `p.personal[filing_status]`) and add `p.personal.availability` check
- Replace `ks_count_exemptions` update with `ks_exemptions` to handle the 2024+ `by_filing_status` branch that bypasses `ks_count_exemptions`

## Test plan
- [ ] Run microsimulation to verify GA and KS show non-zero impacts under the repeal reform
- [ ] Verify no regressions in other affected states

🤖 Generated with [Claude Code](https://claude.com/claude-code)