### PR TITLE
Fix Michigan surtax reform not activating when in_effect is toggled

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Michigan surtax reform now activates correctly when in_effect parameter is toggled in the app.

--- a/policyengine_us/tests/policy/contrib/states/mi/mi_surtax.yaml
+++ b/policyengine_us/tests/policy/contrib/states/mi/mi_surtax.yaml
@@ -89,3 +89,14 @@
   output:
     # (2_000_000 - 1_000_000) * 0.05 = 1_000_000 * 0.05 = 50_000
     mi_surtax: 50_000
+
+- name: Surtax is zero when in_effect is false
+  period: 2027
+  reforms: policyengine_us.reforms.states.mi.surtax.mi_surtax
+  input:
+    gov.contrib.states.mi.surtax.in_effect: False
+    mi_taxable_income: 2_000_000
+    filing_status: SINGLE
+    state_code: MI
+  output:
+    mi_surtax: 0


### PR DESCRIPTION
## Summary

Fixes #7376

The Michigan surtax ballot initiative reform was not working in the app when users toggled `in_effect` to true. Users reported "no results" even for high-income filers in 2027.

## Root Cause

The `create_mi_surtax_reform` function was checking `in_effect` at **system initialization time**, when the parameter always has its default value of `false`. When users later change the parameter to `true` in the app, the structural reform check has already happened and the reform was never applied.

## Fix

1. **Always apply the structural reform** - removed the `in_effect` check from `create_mi_surtax_reform`
2. **Check `in_effect` in the formula** - the `mi_surtax` formula now checks `in_effect` at calculation time and returns 0 when false

This follows the correct pattern for user-toggled reform parameters.

## Test plan

- [x] All 9 existing + new tests pass
- [x] Added test case verifying surtax is 0 when `in_effect` is false
- [ ] Verify in app that toggling `in_effect` to true now shows impact for MI high-income filers in 2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)