### PR TITLE
Update NH 2025 income tax parameters for I&D tax repeal

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     changed:
-      - Add 2025 rate of 0 for repealed NH Interest and Dividends tax and add TIR 2025-001 repeal reference to remaining parameter files.
+      - Add 2025 rate of 0 for repealed NH Interest and Dividends tax, add TIR 2025-001 repeal reference to remaining parameter files, fix unit metadata on age parameters, and update broken statute URLs to gc.nh.gov.

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/base.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/base.yaml
@@ -9,7 +9,7 @@ metadata:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: TITLE V - TAXATION - CHAPTER 77 - TAXATION OF INCOMES - Section 77:5
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-5.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2024 New Hampshire DP-10 Form Instructions
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-instructions-2024.pdf#page=6
     - title: 2023 DP-10 Interest and Dividends Tax Return Instructions

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/blind_addition.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/blind_addition.yaml
@@ -6,7 +6,7 @@ metadata:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: TITLE V - TAXATION - CHAPTER 77 - TAXATION OF INCOMES - Section 77:5
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-5.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2024 New Hampshire DP-10 Form Instructions
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-instructions-2024.pdf#page=6
     - title: 2023 DP-10 Interest and Dividends Tax Return Instructions

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/disabled_addition.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/disabled_addition.yaml
@@ -6,7 +6,7 @@ metadata:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: TITLE V - TAXATION - CHAPTER 77 - TAXATION OF INCOMES - Section 77:5
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-5.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2024 New Hampshire DP-10 Form Instructions
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-instructions-2024.pdf#page=6
     - title: 2023 DP-10 Interest and Dividends Tax Return Instructions

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/old_age_addition.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/amount/old_age_addition.yaml
@@ -6,7 +6,7 @@ metadata:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: TITLE V - TAXATION - CHAPTER 77 - TAXATION OF INCOMES - Section 77:5
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-5.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2024 New Hampshire DP-10 Form Instructions
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-instructions-2024.pdf#page=6
     - title: 2023 DP-10 Interest and Dividends Tax Return Instructions

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/disability_age_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/disability_age_threshold.yaml
@@ -1,12 +1,12 @@
 description: New Hampshire provides an exemption for disabled filers below this age. 
 metadata:
-  unit: currency-USD
+  unit: year
   label: New Hampshire disabled exemption age threshold
   reference:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: TITLE V - TAXATION - CHAPTER 77 - TAXATION OF INCOMES - Section 77:5
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-5.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2021 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-2021-print.pdf#page=3
     - title: 2020 New Hampshire DP-10 Form

--- a/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/old_age_eligibility.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/exemptions/old_age_eligibility.yaml
@@ -1,12 +1,12 @@
 description: New Hampshire provides an exemption for taxpayers on or older than this age. 
 metadata:
-  unit: currency-USD
+  unit: year
   label: New Hampshire old age exemption eligibility
   reference:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: TITLE V - TAXATION - CHAPTER 77 - TAXATION OF INCOMES - Section 77:5
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-5.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2021 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/dp-10-2021-print.pdf#page=3
     - title: 2020 New Hampshire DP-10 Form

--- a/policyengine_us/parameters/gov/states/nh/tax/income/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/in_effect.yaml
@@ -10,7 +10,7 @@ metadata:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: New Hampshire Statutes - TITLE V - CHAPTER 77 - Section 77:1
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-1.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2020 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/forms/2021/documents/dp-10-2020-print.pdf#page=4
     - title: 2021 New Hampshire DP-10 Form

--- a/policyengine_us/parameters/gov/states/nh/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/nh/tax/income/rate.yaml
@@ -13,9 +13,9 @@ metadata:
     - title: TECHNICAL INFORMATION RELEASE TIR 2025-001 I&D Tax Repealed Effective January 1, 2025
       href: https://www.revenue.nh.gov/sites/g/files/ehbemt736/files/documents/2025-001-technical-information-release-repeal.pdf
     - title: New Hampshire Statutes - TITLE V - CHAPTER 77 - Section 77:1
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-1.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: New Hampshire Statutes - TITLE V - CHAPTER 77 - Section 77:4
-      href: https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm
+      href: https://gc.nh.gov/rsa/html/V/77/77-mrg.htm
     - title: 2020 New Hampshire DP-10 Form
       href: https://www.revenue.nh.gov/forms/2021/documents/dp-10-2020-print.pdf#page=4
     - title: 2021 New Hampshire DP-10 Form

--- a/policyengine_us/variables/gov/states/nh/tax/credits/nh_education_tax_credit.py
+++ b/policyengine_us/variables/gov/states/nh/tax/credits/nh_education_tax_credit.py
@@ -7,9 +7,7 @@ class nh_education_tax_credit(Variable):
     label = "New Hampshire Education Tax Credit"
     unit = USD
     definition_period = YEAR
-    reference = (
-        "https://www.gencourt.state.nh.us/rsa/html/NHTOC/NHTOC-V-77-G.htm"
-    )
+    reference = "https://gc.nh.gov/rsa/html/NHTOC/NHTOC-V-77-G.htm"
     defined_for = StateCode.NH
 
     def formula(tax_unit, period, parameters):

--- a/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
+++ b/policyengine_us/variables/gov/states/nh/tax/income/nh_taxable_income.py
@@ -8,7 +8,7 @@ class nh_taxable_income(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://www.gencourt.state.nh.us/rsa/html/V/77/77-4.htm",
+        "https://gc.nh.gov/rsa/html/V/77/77-mrg.htm",
         "https://www.revenue.nh.gov/forms/2023/documents/dp-10-2022-print.pdf",
     )
     defined_for = StateCode.NH


### PR DESCRIPTION
## Summary
- Add explicit `2025-01-01: 0` rate entry to `rate.yaml` to show the I&D tax rate is 0 after repeal (complements the existing `in_effect: false` entry)
- Add TIR 2025-001 repeal reference to `disability_age_threshold.yaml` and `old_age_eligibility.yaml` (the 2 remaining files that were missing it)

All 9 NH income tax parameter files now reference TIR 2025-001 confirming the Interest & Dividends tax repeal effective January 1, 2025. The education tax credit (Chapter 77-G) is unchanged for 2025.

## Test plan
- [x] All 47 NH tax tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)