### PR TITLE
Update Mississippi income tax parameters for 2025

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+      - Update Mississippi income tax parameters with 2025 references and replace bill references with legal code citations.

--- a/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/adjustments.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/adjustments.yaml
@@ -21,3 +21,5 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=13 # Line 50 - 66
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=12
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=12

--- a/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/national_guard_or_reserve_pay/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/national_guard_or_reserve_pay/cap.yaml
@@ -15,3 +15,5 @@ metadata:
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=13 # Line 55
   - title: Mississippi Income Tax Instructions 2024, Line 55
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=12
+  - title: Mississippi Income Tax Instructions 2025, Line 55
+    href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=12

--- a/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/self_employment/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/self_employment/rate.yaml
@@ -16,3 +16,5 @@ metadata:
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=14 # Line 61
   - title: Mississippi Income Tax Instructions 2024, Line 61
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=13
+  - title: Mississippi Income Tax Instructions 2025, Line 61
+    href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=13

--- a/policyengine_us/parameters/gov/states/ms/tax/income/credits/cdcc/income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/credits/cdcc/income_limit.yaml
@@ -10,5 +10,7 @@ metadata:
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=20
   - title: Mississippi Income Tax Instructions 2024
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=19
+  - title: Mississippi Income Tax Instructions 2025
+    href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=19
   - title: Mississippi House Bill 1671 - Section 27-7-22.39 - Section 5 (2)
     href: https://legiscan.com/MS/text/HB1671/id/2767768

--- a/policyengine_us/parameters/gov/states/ms/tax/income/credits/cdcc/match.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/credits/cdcc/match.yaml
@@ -10,5 +10,7 @@ metadata:
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=20
   - title: Mississippi Income Tax Instructions 2024
     href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=19
+  - title: Mississippi Income Tax Instructions 2025
+    href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=19
   - title: Mississippi House Bill 1671 - Section 27-7-22.39 - Section 5 (2)
     href: https://legiscan.com/MS/text/HB1671/id/2767768

--- a/policyengine_us/parameters/gov/states/ms/tax/income/credits/charitable_contribution/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/credits/charitable_contribution/cap.yaml
@@ -18,6 +18,8 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80108228.pdf#page=1
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=18
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=18
 
 JOINT:
   2021-01-01: 1_000

--- a/policyengine_us/parameters/gov/states/ms/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/credits/non_refundable.yaml
@@ -11,3 +11,6 @@ metadata:
   unit: list
   period: year
   label: Mississippi non-refundable tax credits
+  reference:
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=17

--- a/policyengine_us/parameters/gov/states/ms/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/deductions/standard/amount.yaml
@@ -12,6 +12,8 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=6
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=5
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=5
   breakdown:
     - filing_status
 SINGLE:

--- a/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/aged/age_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/aged/age_threshold.yaml
@@ -12,5 +12,7 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=7
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=6
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=6
 values:
   2019-01-01: 65

--- a/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/aged/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/aged/amount.yaml
@@ -14,6 +14,8 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=7
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=6
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=6
 
 values:
   2020-01-01: 1_500

--- a/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/blind/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/blind/amount.yaml
@@ -14,5 +14,7 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=7
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=6
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=6
 values:
   2020-01-01: 1_500

--- a/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/dependents/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/dependents/amount.yaml
@@ -12,6 +12,8 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=7
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=6
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=6
 values:
   2020-01-01: 1_500
   

--- a/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/regular/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/exemptions/regular/amount.yaml
@@ -12,6 +12,8 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=6 # Line 1-5
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=5
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=5
   breakdown:
     - filing_status
 SINGLE:

--- a/policyengine_us/parameters/gov/states/ms/tax/income/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/income_sources.yaml
@@ -29,3 +29,5 @@ metadata:
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=11 # Line 38 - 48
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=10
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=10

--- a/policyengine_us/parameters/gov/states/ms/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/rate.yaml
@@ -50,17 +50,15 @@ metadata:
   label: Mississippi income tax rate
   period: year
   reference: 
-    - title: MS Code § 27-7-5 (2020) (1)
-      href: https://law.justia.com/codes/mississippi/2020/title-27/chapter-7/article-1/section-27-7-5/ 
+    - title: Miss. Code Ann. § 27-7-5
+      href: https://law.justia.com/codes/mississippi/title-27/chapter-7/article-1/section-27-7-5/
     - title: Mississippi Income Tax Instructions 2022
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100221.pdf#page=20
-    - title: Mississippi Income Tax Instructions 2023 - House Bill 531
-      href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=3  
+    - title: Mississippi Income Tax Instructions 2023
+      href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=3
     - title: Mississippi Department of Revenue - Tax Rates, Exemptions, & Deductions
       href: https://www.dor.ms.gov/individual/tax-rates
     - title: Mississippi Income Tax Instructions 2024
       href: https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100241.pdf#page=3
-    - title: House Bill 1 # Signed by Governor
-      href: https://billstatus.ls.state.ms.us/2025/pdf/history/HB/HB0001.xml
-    - title: House Bill 1 (Bill Text)
-      href: https://billstatus.ls.state.ms.us/documents/2025/pdf/HB/0001-0099/HB0001SG.pdf
+    - title: Mississippi Income Tax Instructions 2025
+      href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=3


### PR DESCRIPTION
## Summary

- Replace House Bill 1 (Build-Up Mississippi Act) references in rate.yaml with Miss. Code Ann. § 27-7-5 and 2025 Form 80-100 Instructions
- Clean up House Bill 531 reference from 2023 instructions title
- Add 2025 Form 80-100 Instructions references to all 15 Mississippi income tax parameter files
- Add reference to non_refundable.yaml (previously had none)

### Values confirmed unchanged for 2025:
- Tax rate: 4.4% on income over $10,000 (already encoded)
- Future rate reductions through 2030 (already encoded from Build-Up Mississippi Act)
- Standard deductions: $2,300 single, $4,600 joint, $3,400 HOH
- Regular exemptions: $6,000 single, $12,000 joint, $8,000 HOH
- Dependent exemption: $1,500
- Aged/blind exemptions: $1,500 each (age 65+)
- CDCC: 25% match, $50,000 income limit
- Charitable contribution credit caps: $1,500 single, $3,000 joint

### 2025 Legislative changes noted (already encoded):
- HB 1 (Build-Up Mississippi Act) signed March 27, 2025 - extends rate reductions to 3% by 2030 with potential further reductions after 2030 based on revenue triggers

## Test plan
- [x] All 117 Mississippi income tax tests pass
- [x] `make format` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)