### PR TITLE
Fix student loan interest deduction eligibility (IRC § 221)

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix student loan interest deduction eligibility (IRC § 221) to remove incorrect AOC eligibility requirement. The previous implementation required is_eligible_for_american_opportunity_credit to be true, but this is not a legal requirement. While § 221(d)(3) references § 25A(b)(3) for the definition of "eligible student", this refers to the student's status when the loan was originally taken out, not current-year AOC eligibility.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/student_loan_interest/student_loan_interest_ald_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/student_loan_interest/student_loan_interest_ald_eligible.yaml
@@ -1,35 +1,39 @@
-- name: Eligible person
-  period: 2021
+- name: Eligible - head or spouse, not MFS
+  period: 2024
   input:
     is_tax_unit_head_or_spouse: true
     filing_status: JOINT
-    is_eligible_for_american_opportunity_credit: true
   output:
     student_loan_interest_ald_eligible: true
 
-- name: AOC ineligible
-  period: 2021
+- name: Eligible - single filer
+  period: 2024
   input:
     is_tax_unit_head_or_spouse: true
-    filing_status: JOINT
-    is_eligible_for_american_opportunity_credit: false
+    filing_status: SINGLE
   output:
-    student_loan_interest_ald_eligible: false
+    student_loan_interest_ald_eligible: true
 
-- name: Not head or spouse
-  period: 2021
+- name: Eligible - head of household filer
+  period: 2024
+  input:
+    is_tax_unit_head_or_spouse: true
+    filing_status: HEAD_OF_HOUSEHOLD
+  output:
+    student_loan_interest_ald_eligible: true
+
+- name: Ineligible - dependent (not head or spouse)
+  period: 2024
   input:
     is_tax_unit_head_or_spouse: false
     filing_status: JOINT
-    is_eligible_for_american_opportunity_credit: true
   output:
     student_loan_interest_ald_eligible: false
 
-- name: Separate filers ineligible
-  period: 2021
+- name: Ineligible - Married Filing Separately
+  period: 2024
   input:
     is_tax_unit_head_or_spouse: true
     filing_status: SEPARATE
-    is_eligible_for_american_opportunity_credit: true
   output:
     student_loan_interest_ald_eligible: false

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/student_loan_interest/student_loan_interest_ald_eligible.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/student_loan_interest/student_loan_interest_ald_eligible.py
@@ -7,12 +7,21 @@ class student_loan_interest_ald_eligible(Variable):
     label = "Eligible for the Student loan interest ALD"
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/uscode/text/26/221"
+    documentation = (
+        "Eligibility for the student loan interest above-the-line deduction. "
+        "Per IRC § 221, the taxpayer must not file as Married Filing Separately "
+        "(§ 221(e)(2)) and cannot be claimed as a dependent (§ 221(c)). "
+        "The MAGI phase-out is handled separately in the deduction calculation. "
+        "Note: While § 221(d)(3) references § 25A(b)(3) for the definition of "
+        "'eligible student', this refers to the student's status when the loan "
+        "was originally taken out, not current-year AOC eligibility. A person "
+        "who graduated years ago remains eligible to deduct student loan interest."
+    )
 
     def formula(person, period, parameters):
+        # Per IRC § 221(c), taxpayer cannot be claimed as a dependent
         head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        # Per IRC § 221(e)(2), taxpayer cannot file as Married Filing Separately
         filing_status = person.tax_unit("filing_status", period)
         separate = filing_status == filing_status.possible_values.SEPARATE
-        is_aoc_eligible = person(
-            "is_eligible_for_american_opportunity_credit", period
-        )
-        return head_or_spouse & ~separate & is_aoc_eligible
+        return head_or_spouse & ~separate


### PR DESCRIPTION
## Summary

- Remove incorrect American Opportunity Credit eligibility requirement from student loan interest deduction
- Add proper documentation explaining the § 25A reference in IRC § 221
- Update tests to reflect correct eligibility requirements

## Bug Description

The student loan interest deduction eligibility check incorrectly required `is_eligible_for_american_opportunity_credit` to be true. Since this is an input variable defaulting to `false`, most simulations incorrectly computed zero student loan interest deduction.

## Statutory Analysis

While IRC § 221(d)(3) references § 25A(b)(3) for the definition of "eligible student", this is for **definitional purposes only** - it asks whether the borrower was an "eligible student" **when the loan was taken out**, not whether they are currently eligible for the American Opportunity Credit.

| Scenario | Eligible for Student Loan Interest Deduction? | Eligible for AOC? |
|----------|----------------------------------------------|-------------------|
| Graduated 5 years ago, still paying loans | Yes ✓ | No (not enrolled) |
| 45-year-old paying off old loans | Yes ✓ | No |

## Actual IRC § 221 Requirements

Per [26 USC § 221](https://www.law.cornell.edu/uscode/text/26/221), eligibility requires:
1. Filing status is NOT Married Filing Separately (§ 221(e)(2))
2. Cannot be claimed as a dependent (§ 221(c))
3. MAGI below applicable limit (§ 221(b)(2)) - handled in deduction calculation

## Test plan

- [x] All existing student loan interest tests pass
- [x] New eligibility tests cover SINGLE, JOINT, HEAD_OF_HOUSEHOLD, and SEPARATE filing statuses
- [x] Tests verify dependents are ineligible

Fixes #7403

🤖 Generated with [Claude Code](https://claude.com/claude-code)