### PR TITLE
Fix Maryland CTC AGI eligibility boundary

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fix Maryland Child Tax Credit AGI eligibility boundary to include filers with exactly $24,000 AGI per Worksheet 21C.

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/ctc/phase_out/max_agi.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/ctc/phase_out/max_agi.yaml
@@ -1,7 +1,7 @@
 description: Maryland limits its Child Tax Credit to filers with federal adjusted gross income below this amount under the phase-out structure.
 values:
   2024-01-01: .inf
-  2025-01-01: 24_000
+  2025-01-01: 24_001
 metadata:
   unit: currency-USD
   period: year

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/ctc/md_ctc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/ctc/md_ctc_eligible.yaml
@@ -71,7 +71,7 @@
   output:
     md_ctc_eligible: true
 
-- name: 2025 ineligible with qualifying child but AGI at cap
+- name: 2025 eligible with qualifying child and AGI at cap boundary
   period: 2025
   input:
     people:
@@ -89,9 +89,29 @@
         members: [person1, person2]
         state_code: MD
   output:
+    md_ctc_eligible: true
+
+- name: 2025 ineligible with qualifying child and AGI just above cap
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 35
+      person2:
+        age: 4
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        adjusted_gross_income: 24_001
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
     md_ctc_eligible: false
 
-- name: 2025 ineligible with qualifying child and AGI above cap
+- name: 2025 ineligible with qualifying child and AGI well above cap
   period: 2025
   input:
     people:

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/ctc/md_ctc_eligible.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/ctc/md_ctc_eligible.py
@@ -28,8 +28,9 @@ class md_ctc_eligible(Variable):
         qualifying_child = dependent & meets_age_limit
         has_qualifying_child = tax_unit.sum(qualifying_child) > 0
 
-        # When phase-out applies (2025+): must have qualifying child AND AGI < max_agi
-        # Per Worksheet 21C: "If Line 1 [AGI] is $24,001 or greater, STOP. YOU ARE NOT ELIGIBLE."
+        # When phase-out applies (2025+): must have qualifying child AND AGI below max_agi
+        # Per Worksheet 21C: "$24,000 or less" is eligible; "$24,001 or greater, STOP."
+        # max_agi is set to 24_001 so that agi < 24_001 includes $24,000.
         agi_eligible = agi < p.phase_out.max_agi
         phase_out_eligible = has_qualifying_child & agi_eligible
 


### PR DESCRIPTION
## Summary
- Fixes the Maryland Child Tax Credit AGI eligibility boundary so that filers with exactly $24,000 AGI are correctly eligible per 2025 Worksheet 21C
- The worksheet states "$24,000 or less" is eligible and "$24,001 or greater" triggers STOP, but the previous parameter value of 24,000 with strict `<` comparison made $24,000 ineligible
- Changes `max_agi` from 24,000 to 24,001 so that `agi < 24,001` correctly includes $24,000

## Audit Finding
This issue was identified during an automated audit of PR #7350 against the [Maryland 2025 Resident Tax Booklet](https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=27), Worksheet 21C.

See audit comment: https://github.com/PolicyEngine/policyengine-us/pull/7350#issuecomment-3906146935

## Changes
- `max_agi.yaml`: 24,000 -> 24,001
- `md_ctc_eligible.py`: Updated comment to clarify the boundary logic
- `md_ctc_eligible.yaml`: Fixed test for AGI=$24,000 (now expects eligible=true) and added test for AGI=$24,001 (expects eligible=false)

## Test plan
- [ ] Existing Maryland CTC tests pass with updated boundary
- [ ] AGI=$24,000 now correctly returns eligible=true
- [ ] AGI=$24,001 correctly returns eligible=false
- [ ] AGI=$23,000 still returns eligible=true (unchanged)
- [ ] AGI=$50,000 still returns eligible=false (unchanged)

Generated with [Claude Code](https://claude.ai/code)