### PR TITLE
Fix Maryland CDCC to use federal credit allowed

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fix Maryland CDCC to use the federal credit allowed (cdcc) instead of the potential credit (cdcc_potential).

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_cdcc.yaml
@@ -1,7 +1,7 @@
 - name: Single parent over the AGI limit
   period: 2021
   input:
-    cdcc_potential: 100
+    cdcc: 100
     filing_status: SINGLE
     adjusted_gross_income: 95_901  # $95,900 is the limit.
     state_code: MD
@@ -11,7 +11,7 @@
 - name: Joint filer over the AGI limit
   period: 2021
   input:
-    cdcc_potential: 100
+    cdcc: 100
     filing_status: JOINT
     adjusted_gross_income: 149_051  # $149,050 is the limit.
     state_code: MD
@@ -21,7 +21,7 @@
 - name: Single parent with no income will get 32% of the CDCC
   period: 2021
   input:
-    cdcc_potential: 100
+    cdcc: 100
     filing_status: SINGLE
     adjusted_gross_income: 0
     state_code: MD
@@ -31,7 +31,7 @@
 - name: Joint filer with no income will get 32% of the CDCC
   period: 2021
   input:
-    cdcc_potential: 100
+    cdcc: 100
     filing_status: JOINT
     adjusted_gross_income: 0
     state_code: MD
@@ -41,7 +41,7 @@
 - name: Joint filer with $50,000 income will get 32% of the CDCC
   period: 2021
   input:
-    cdcc_potential: 100
+    cdcc: 100
     filing_status: JOINT
     adjusted_gross_income: 50_000
     state_code: MD
@@ -51,7 +51,7 @@
 - name: Single parent with $80,000 income will get 24% of the CDCC
   period: 2021
   input:
-    cdcc_potential: 100
+    cdcc: 100
     filing_status: SINGLE
     adjusted_gross_income: 80_000
     state_code: MD
@@ -61,7 +61,7 @@
 - name: Joint filer with $125,000 income will get 24% of the CDCC
   period: 2021
   input:
-    cdcc_potential: 100
+    cdcc: 100
     filing_status: JOINT
     adjusted_gross_income: 125_000
     state_code: MD

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
@@ -18,8 +18,8 @@ class md_cdcc(Variable):
         # Eligibility is based on AGI.
         eligible = agi <= p.eligibility.agi_cap[filing_status]
         # Maximum is a percent of federal.
-        # Maryland matches the potential federal credit
-        max_cdcc = p.percent * tax_unit("cdcc_potential", period)
+        # Maryland matches the federal credit allowed (after Credit Limit Worksheet)
+        max_cdcc = p.percent * tax_unit("cdcc", period)
         # Phases out based on filing status.
         phase_out_start = p.phase_out.start[filing_status]
         excess = max_(0, agi - phase_out_start)


### PR DESCRIPTION
## Summary
- Fixes Maryland CDCC (`md_cdcc`) to use `cdcc` (federal credit allowed after Credit Limit Worksheet, Form 2441 line 11) instead of `cdcc_potential` (Form 2441 line 9c, before tax liability limit)
- Updates all 7 test cases to use `cdcc` as input instead of `cdcc_potential`

Closes #7410

## Why `cdcc` is correct

### Federal Form 2441 chain

| Form 2441 Line | What it represents | PolicyEngine variable |
|---|---|---|
| Line 9c | Tentative credit (expenses × rate) — **before** tax liability limit | `cdcc_potential` |
| Line 10 | Credit Limit Worksheet — your available tax liability | `cdcc_credit_limit` |
| Line 11 | `min(line 9c, line 10)` — the **final allowed credit** → Schedule 3 | `cdcc` |

### Maryland statute §10-716

The statute defines:
> **"Federal child and dependent care credit"** means the child and dependent care credit **properly claimed** by an individual for the taxable year under § 21 of the Internal Revenue Code.

"Properly claimed" means the credit actually taken on the federal return — which is **Line 11** (after the Credit Limit Worksheet), not Line 9c (the tentative amount). You cannot "properly claim" more than your tax liability allows.

### Maryland Form 502CR Part B

Form 502CR Part B, Line 2 says: "Enter your federal Child and Dependent Care Credit from federal Form 2441" — which is Line 11, the final credit reported on Schedule 3.

### Practical impact

A taxpayer with $2,000 of qualified expenses at the 20% rate has `cdcc_potential = $400`. But if their federal tax liability is only $200, their actual `cdcc = $200` (Form 2441 Line 11). Maryland should compute 32% x $200 = $64, not 32% x $400 = $128.

## Sources
- [Maryland §10-716 statute text](https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-716)
- [IRS Form 2441 Instructions](https://www.irs.gov/instructions/i2441)
- [Maryland Form 502CR (2024)](https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/forms/2024/502CR.pdf)

## Test plan
- [x] All 7 `md_cdcc.yaml` tests pass
- [x] Both `md_refundable_cdcc.yaml` tests pass
- [x] `make format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)