### PR TITLE
Fix DE TANF deficit_rate parameter history gap

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Delaware TANF deficit rate parameter history extended to 2017 to cover full-year simulations.

--- a/policyengine_us/parameters/gov/states/de/dhss/tanf/benefit/deficit_rate.yaml
+++ b/policyengine_us/parameters/gov/states/de/dhss/tanf/benefit/deficit_rate.yaml
@@ -1,7 +1,7 @@
 description: Delaware uses this share of the deficit to calculate the grant remainder under the Temporary Assistance for Needy Families program.
 
 values:
-  2024-10-01: 0.5
+  2017-01-01: 0.5
 
 metadata:
   unit: /1


### PR DESCRIPTION
Fixes #7439.

## Summary

- Extended `deficit_rate.yaml` start date from `2024-10-01` to `2017-01-01`
- The 50% rate is confirmed in the [2017 Delaware TANF State Plan](https://dhss.delaware.gov/wp-content/uploads/sites/11/dss/pdf/detanfstateplan2017.pdf#page=7) and DSSM §4004.2
- Prevents `ParameterNotFoundError` for full-year simulations (e.g. `EnhancedCPS_2024`) that calculate values for months before October 2024

## Test plan

- [ ] Run `pytest policyengine_us/tests/ -k "de_tanf" -v` — all pass
- [ ] Verify `EnhancedCPS_2024` completes without `ParameterNotFoundError` for DE TANF

🤖 Generated with [Claude Code](https://claude.com/claude-code)