### PR TITLE
Split charitable deduction AGI cap by organization type

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-    - Split non-cash charitable deduction AGI cap by organization type per 26 USC 170(b)(1)(A)-(B). Non-cash donations to 50-percent limit organizations are capped at 50% of AGI, while donations to other organizations are capped at 30% of AGI.
+    - Split non-cash charitable deduction AGI cap by organization type per 26 USC 170(b)(1). Non-cash donations to 50-percent limit organizations are capped at 50% of AGI, while donations to other organizations are capped at 30% of AGI.

--- a/policyengine_us/parameters/gov/irs/deductions/itemized/charity/ceiling/non_cash_to_non_50_pct_org.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/itemized/charity/ceiling/non_cash_to_non_50_pct_org.yaml
@@ -1,10 +1,16 @@
-description: Ceiling (as a fraction of AGI) for noncash charitable contributions to organizations other than 50-percent limit organizations.
+description: >-
+  Ceiling (as a fraction of AGI) for noncash charitable contributions
+  to organizations other than 50-percent limit organizations.
+  Note: 170(b)(1)(D) sets a stricter 20% cap for capital gain property
+  to these organizations, which is not yet modeled separately.
 metadata:
   unit: /1
   period: year
   label: Non-cash charitable deduction limit for non-50% limit organizations
   reference:
-    - title: 26 U.S. Code § 170 - Charitable, etc., contributions and gifts (b)(1)(B)
+    - title: 26 U.S. Code 170(b)(1)(B) - General 30% limit for non-50% limit organizations
       href: https://www.law.cornell.edu/uscode/text/26/170#b_1_B
+    - title: 26 U.S. Code 170(b)(1)(D) - 20% limit for capital gain property to non-50% limit organizations
+      href: https://www.law.cornell.edu/uscode/text/26/170#b_1_D
 values:
   2013-01-01: 0.3

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/itemizing/charitable_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/itemizing/charitable_deduction.yaml
@@ -5,7 +5,7 @@
     charitable_non_cash_donations: 500
     positive_agi: 1_000
     charitable_deduction_for_non_itemizers: 0
-  output: # min(min(500, 1000 * 0.3) + 300, 1000 * 0.5)
+  output: # min(min(500, 1000 * 0.5) + 300, 1000 * 0.5)
     charitable_deduction: 500
 
 - name: 2018 filer
@@ -14,7 +14,7 @@
     charitable_cash_donations: 500
     charitable_non_cash_donations: 200
     positive_agi: 1_000
-  output: # min(min(200, 1000 * 0.3) + 500, 1000 * 0.6)
+  output: # min(min(200, 1000 * 0.5) + 500, 1000 * 0.6)
     charitable_deduction: 600
 
 - name: 2020 filer
@@ -24,7 +24,7 @@
     charitable_non_cash_donations: 200
     positive_agi: 1_000
     charitable_deduction_for_non_itemizers: 0
-  output: # min(min(200, 1000 * 0.3) + 500, 1000 * 1)
+  output: # min(min(200, 1000 * 0.5) + 500, 1000 * 1)
     charitable_deduction: 700
 
 - name: 2021 filer
@@ -34,7 +34,7 @@
     charitable_non_cash_donations: 200
     positive_agi: 1_000
     charitable_deduction_for_non_itemizers: 300
-  output: # min(min(200, 1000 * 0.3) + (500 - 300), 1000 * 0.6)
+  output: # min(min(200, 1000 * 0.5) + (500 - 300), 1000 * 0.6)
     charitable_deduction: 600
 
 - name: 2021 filer 2
@@ -44,7 +44,7 @@
     charitable_non_cash_donations: 200
     positive_agi: 1_000
     charitable_deduction_for_non_itemizers: 600
-  output: # min(min(200, 1000 * 0.3) + min(500 - 600, 0), 1000 * 0.6)
+  output: # min(min(200, 1000 * 0.5) + max(500 - 600, 0), 1000 * 0.6)
     charitable_deduction: 600
 
 - name: No AGI
@@ -97,7 +97,7 @@
   input:
     charitable_cash_donations: 0
     charitable_non_cash_donations: 500
-    charitable_non_cash_donations_to_non_50_percent_limit_orgs: 500
+    charitable_non_cash_donations_non_50_pct_orgs: 500
     positive_agi: 1_000
   output:
     # 50% org non-cash = 0
@@ -110,7 +110,7 @@
   input:
     charitable_cash_donations: 0
     charitable_non_cash_donations: 600
-    charitable_non_cash_donations_to_non_50_percent_limit_orgs: 200
+    charitable_non_cash_donations_non_50_pct_orgs: 200
     positive_agi: 1_000
   output:
     # 50% org: min(400, 500) = 400
@@ -123,7 +123,7 @@
   input:
     charitable_cash_donations: 0
     charitable_non_cash_donations: 800
-    charitable_non_cash_donations_to_non_50_percent_limit_orgs: 400
+    charitable_non_cash_donations_non_50_pct_orgs: 400
     positive_agi: 1_000
   output:
     # 50% org: min(400, 500) = 400
@@ -136,7 +136,7 @@
   input:
     charitable_cash_donations: 0
     charitable_non_cash_donations: 400
-    charitable_non_cash_donations_to_non_50_percent_limit_orgs: 400
+    charitable_non_cash_donations_non_50_pct_orgs: 400
     positive_agi: 1_000
   output:
     # non-50% org: min(400, 300) = 300
@@ -148,7 +148,7 @@
   input:
     charitable_cash_donations: 5_000
     charitable_non_cash_donations: 20_000
-    charitable_non_cash_donations_to_non_50_percent_limit_orgs: 5_000
+    charitable_non_cash_donations_non_50_pct_orgs: 5_000
     positive_agi: 100_000
   output:
     # floor = 0.005 * 100000 = 500

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/itemizing/charitable_deduction.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/itemizing/charitable_deduction.py
@@ -11,6 +11,16 @@ class charitable_deduction(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/26/170"
 
     def formula(tax_unit, period, parameters):
+        # TODO: 26 USC 170(b)(1) defines 4 contribution categories with
+        # separate AGI caps:
+        #   (G) Cash to 50% limit orgs: 60% AGI (post-TCJA)
+        #   (B) Cash to non-50% limit orgs: 30% AGI
+        #   (C) Capital gain property to 50% limit orgs: 30% AGI
+        #       (or 50% with basis-reduction election)
+        #   (D) Capital gain property to non-50% limit orgs: 20% AGI
+        # Currently we model two non-cash categories (50% vs 30% cap)
+        # and treat all cash as subject to the overall cap only.
+        # The cash split and the 20% category are not yet modeled.
         cash_donations = add(tax_unit, period, ["charitable_cash_donations"])
         non_cash_donations = add(
             tax_unit, period, ["charitable_non_cash_donations"]
@@ -18,41 +28,46 @@ class charitable_deduction(Variable):
         non_cash_to_non_50_pct = add(
             tax_unit,
             period,
-            ["charitable_non_cash_donations_to_non_50_percent_limit_orgs"],
+            ["charitable_non_cash_donations_non_50_pct_orgs"],
         )
         non_cash_to_50_pct = non_cash_donations - non_cash_to_non_50_pct
         positive_agi = tax_unit("positive_agi", period)
         p = parameters(period).gov.irs.deductions.itemized.charity
 
-        # Cap non-cash to 50% limit orgs at 50% of AGI per
-        # 26 USC 170(b)(1)(A).
+        # Non-cash to 50% limit orgs capped at 50% of AGI.
+        # Note: this models the basis-reduction election under
+        # 170(b)(1)(C)(iii); the default cap for capital gain
+        # property is 30% per 170(b)(1)(C)(i).
         capped_non_cash_50 = min_(
             non_cash_to_50_pct, p.ceiling.non_cash * positive_agi
         )
-        # Cap non-cash to non-50% limit orgs at 30% of AGI per
-        # 26 USC 170(b)(1)(B).
-        capped_non_cash_30 = min_(
+        # Non-cash to non-50% limit orgs capped at 30% of AGI
+        # per 170(b)(1)(B). Note: the stricter 20% cap for
+        # capital gain property under 170(b)(1)(D) is not yet
+        # modeled separately.
+        capped_non_cash_non_50 = min_(
             non_cash_to_non_50_pct,
             p.ceiling.non_cash_to_non_50_pct_org * positive_agi,
         )
-        capped_non_cash = capped_non_cash_50 + capped_non_cash_30
+        capped_non_cash = capped_non_cash_50 + capped_non_cash_non_50
 
         total_cap = p.ceiling.all * positive_agi
         if p.floor.applies:
             deduction_floor = p.floor.amount * positive_agi
             reduced_non_cash_50 = max_(non_cash_to_50_pct - deduction_floor, 0)
             capped_reduced_non_cash_50 = min_(
-                reduced_non_cash_50, p.ceiling.non_cash * positive_agi
+                reduced_non_cash_50,
+                p.ceiling.non_cash * positive_agi,
             )
 
             remaining_floor_after_50 = max_(
                 deduction_floor - non_cash_to_50_pct, 0
             )
-            reduced_non_cash_30 = max_(
+            reduced_non_cash_non_50 = max_(
                 non_cash_to_non_50_pct - remaining_floor_after_50, 0
             )
-            capped_reduced_non_cash_30 = min_(
-                reduced_non_cash_30,
+            capped_reduced_non_cash_non_50 = min_(
+                reduced_non_cash_non_50,
                 p.ceiling.non_cash_to_non_50_pct_org * positive_agi,
             )
 
@@ -62,7 +77,7 @@ class charitable_deduction(Variable):
             reduced_cash_donations = max_(cash_donations - remaining_floor, 0)
             return min_(
                 capped_reduced_non_cash_50
-                + capped_reduced_non_cash_30
+                + capped_reduced_non_cash_non_50
                 + reduced_cash_donations,
                 total_cap,
             )

--- a/policyengine_us/variables/household/expense/charitable/charitable_non_cash_donations_non_50_pct_orgs.py
+++ b/policyengine_us/variables/household/expense/charitable/charitable_non_cash_donations_non_50_pct_orgs.py
@@ -1,17 +1,17 @@
 from policyengine_us.model_api import *
 
 
-class charitable_non_cash_donations_to_non_50_percent_limit_orgs(Variable):
+class charitable_non_cash_donations_non_50_pct_orgs(Variable):
     value_type = float
     entity = Person
     label = "Charitable non-cash donations to non-50% limit organizations"
     unit = USD
     documentation = (
         "Non-cash charitable donations to organizations other than "
-        "50-percent limit organizations described in 26 USC 170(b)(1)(A), "
-        "such as private non-operating foundations. These donations are "
-        "subject to a 30% AGI ceiling under 26 USC 170(b)(1)(B), rather "
-        "than the 50% ceiling for 50-percent limit organizations."
+        "50-percent limit organizations described in "
+        "26 USC 170(b)(1)(A), such as private non-operating "
+        "foundations. These are subject to a lower AGI ceiling "
+        "than donations to 50-percent limit organizations."
     )
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/uscode/text/26/170#b_1_B"


### PR DESCRIPTION
## Summary
- Splits the non-cash charitable deduction AGI cap by organization type per 26 USC 170(b)(1)
- Adds new input variable `charitable_non_cash_donations_non_50_pct_orgs` (defaults to 0 for backward compatibility)
- Adds parameter `ceiling/non_cash_to_non_50_pct_org.yaml` = 0.3 (30% AGI cap)
- Updates `charitable_deduction.py` to apply separate caps per org type, including proper interaction with OBBBA floor logic (2026+)
- 5 new test cases, all 15 tests passing
- Fixes pre-existing incorrect test comments (non_cash ceiling is 0.5, not 0.3)

## Known simplifications (documented with TODOs)
26 USC 170(b)(1) defines 4 contribution categories with separate AGI caps:
1. **(G)** Cash to 50% limit orgs: 60% AGI (post-TCJA) -- modeled via `ceiling.all`
2. **(B)** Cash to non-50% limit orgs: 30% AGI -- **not yet split from #1**
3. **(C)** Capital gain property to 50% limit orgs: 30% AGI (or 50% with basis-reduction election) -- modeled at 50% (the election)
4. **(D)** Capital gain property to non-50% limit orgs: 20% AGI -- **modeled at 30% using the general (B) limit**

These simplifications are acceptable because:
- Microdata (CPS/PUF) doesn't distinguish these categories
- The 50%/30% split is the most impactful distinction
- The variable defaults to 0, preserving backward compatibility

## Test plan
- [x] All 10 existing charitable deduction tests pass unchanged
- [x] 5 new tests cover: 30% cap binding, mixed org types, overall ceiling binding, 30% cap alone, floor+split interaction
- [ ] CI passes

Closes #6418

Generated with [Claude Code](https://claude.com/claude-code)