### PR TITLE
Fix WA Working Families Tax Credit phaseout to $50 minimum

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fix WA Working Families Tax Credit phaseout to phase to $50 minimum instead of zero per RCW 82.08.0206(3)(f).

--- a/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
@@ -27,3 +27,57 @@
     eitc_child_count: 3
   output:
     wa_working_families_tax_credit: 0
+
+- name: At EITC AGI limit, credit phases to $50 minimum per RCW 82.08.0206(3)(f).
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    state_code: WA
+    eitc: 1
+    eitc_child_count: 1
+    eitc_agi_limit: 50_000
+    filer_adjusted_earnings: 50_000
+  output:
+    wa_working_families_tax_credit: 50
+
+- name: Mid-phaseout gives correctly reduced credit.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    state_code: WA
+    eitc: 1
+    eitc_child_count: 1
+    eitc_agi_limit: 50_000
+    filer_adjusted_earnings: 47_500
+  output:
+    wa_working_families_tax_credit: 345
+
+- name: Joint filer with 1 child and moderate income receives credit.
+  period: 2024
+  absolute_error_margin: 50
+  input:
+    people:
+      filer:
+        employment_income: 40_000
+        age: 30
+      spouse:
+        dividend_income: 11_000
+        age: 30
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [filer, spouse, child]
+        filing_status: JOINT
+    families:
+      family:
+        members: [filer, spouse, child]
+    spm_units:
+      spm_unit:
+        members: [filer, spouse, child]
+    households:
+      household:
+        members: [filer, spouse, child]
+        state_code: WA
+  output:
+    wa_working_families_tax_credit: 640

--- a/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.py
@@ -31,9 +31,11 @@ class wa_working_families_tax_credit(Variable):
         )
         phase_out_start = eitc_agi_limit - phase_out_start_reduction
         # The phase-out rates are hard-coded in the legal code, but HB 1888 (2021-22)
-        # instructs DOR to revise it to get to zero by the EITC AGI limit.
+        # instructs DOR to revise it to get to the minimum amount by the EITC AGI limit.
         # https://app.leg.wa.gov/billsummary?BillNumber=1888&Year=2021&Initiative=false
-        phase_out_rate = max_amount / phase_out_start_reduction
+        phase_out_rate = (
+            max_amount - p.min_amount
+        ) / phase_out_start_reduction
         earnings = tax_unit("filer_adjusted_earnings", period)
         excess = max_(0, earnings - phase_out_start)
         reduction = max_(0, excess * phase_out_rate)


### PR DESCRIPTION
## Summary
- Fixes phaseout rate formula to phase credit to $50 minimum instead of zero at EITC AGI limit per RCW 82.08.0206(3)(f)
- Changed `max_amount / phase_out_start_reduction` to `(max_amount - p.min_amount) / phase_out_start_reduction`
- Added 3 new tests: at EITC limit ($50 min), mid-phaseout, and integration test

## Test plan
- [x] All existing WA WFTC tests pass
- [x] New phaseout tests verify $50 minimum behavior
- [ ] CI passes

Closes #7398

🤖 Generated with [Claude Code](https://claude.com/claude-code)