### PR TITLE
Fix Stay NJ benefit formula and add Senior Freeze offset

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fix Stay NJ benefit formula order of operations and add Senior Freeze offset per P.L. 2024 c.88.

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/credits/staynj/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/credits/staynj/integration.yaml
@@ -1,6 +1,6 @@
 # Integration tests for New Jersey Stay NJ Property Tax Credit
 # Tests the full calculation pipeline from income to eligibility to benefit
-# Stay NJ: 50% of property taxes paid, maximum $6,500, age 65+, income < $500K
+# Formula per P.L. 2024 c.88: Stay NJ = max(min(property_taxes * 50%, $6,500) - ANCHOR - Senior_Freeze, 0)
 # Note: Stay NJ begins in 2026
 
 - name: Case 1, senior couple homeowner with moderate income and property tax.
@@ -30,13 +30,11 @@
   output:
     # Combined income: $100K + $50K = $150K < $500K limit
     # At least one person age 68 >= 65
-    # Homeowner with mortgage
-    # Property tax: $10,000
-    # ANCHOR benefit: $1,750 (income $150K qualifies for homeowner tier 2)
-    # Net property tax: $10,000 - $1,750 = $8,250
-    # Benefit: 50% * $8,250 = $4,125
+    # min($10,000 * 50%, $6,500) = min($5,000, $6,500) = $5,000
+    # ANCHOR = $1,750 (senior, income $150K <= $150K)
+    # max($5,000 - $1,750 - $0, 0) = $3,250
     nj_staynj_eligible: true
-    nj_staynj: 4_125
+    nj_staynj: 3_250
 
 - name: Case 2, wealthy senior homeowner capped at maximum.
   period: 2026
@@ -59,11 +57,9 @@
         members: [person1]
         state_fips: 34
   output:
-    # Income $400K < $500K limit
-    # Age 72 >= 65
-    # Property tax: $25,000
-    # 50% * $25,000 = $12,500 > $6,500 max
-    # Capped at: $6,500
+    # Income $400K < $500K limit, but > $250K ANCHOR limit - no ANCHOR
+    # min($25,000 * 50%, $6,500) = min($12,500, $6,500) = $6,500
+    # max($6,500 - $0 - $0, 0) = $6,500
     nj_staynj_eligible: true
     nj_staynj: 6_500
 
@@ -89,13 +85,11 @@
         state_fips: 34
   output:
     # Income: $36K (Social Security) < $500K
-    # Age 75 >= 65
-    # Property tax: $8,000
-    # ANCHOR benefit: $1,750 (income $36K qualifies for homeowner tier 2)
-    # Net property tax: $8,000 - $1,750 = $6,250
-    # 50% * $6,250 = $3,125
+    # min($8,000 * 50%, $6,500) = min($4,000, $6,500) = $4,000
+    # ANCHOR = $1,750 (senior, income $36K <= $150K)
+    # max($4,000 - $1,750 - $0, 0) = $2,250
     nj_staynj_eligible: true
-    nj_staynj: 3_125
+    nj_staynj: 2_250
 
 - name: Case 4, non-senior homeowner is ineligible.
   period: 2026
@@ -119,8 +113,6 @@
         state_fips: 34
   output:
     # Age 60 < 65 - fails age requirement
-    # Even though income and homeownership qualify
-    # Ineligible
     nj_staynj_eligible: false
     nj_staynj: 0
 
@@ -144,10 +136,7 @@
         members: [person1]
         state_fips: 34
   output:
-    # Age 70 >= 65 - passes age
-    # Income $80K < $500K - passes income
     # RENTER - fails homeowner requirement
-    # Stay NJ is only for homeowners
     nj_staynj_eligible: false
     nj_staynj: 0
 
@@ -172,8 +161,7 @@
         members: [person1]
         state_fips: 34
   output:
-    # Income $550K >= $500K limit
-    # Fails income requirement
+    # Income $550K >= $500K limit - fails income requirement
     nj_staynj_eligible: false
     nj_staynj: 0
 
@@ -204,10 +192,8 @@
   output:
     # At least one spouse (person1) is 65+
     # Combined income: $80K + $70K = $150K < $500K
-    # Homeowner
-    # Property tax: $11,000
-    # ANCHOR benefit: $1,750 (income $150K qualifies for homeowner tier 2)
-    # Net property tax: $11,000 - $1,750 = $9,250
-    # 50% * $9,250 = $4,625
+    # min($11,000 * 50%, $6,500) = min($5,500, $6,500) = $5,500
+    # ANCHOR = $1,750 (senior, income $150K <= $150K)
+    # max($5,500 - $1,750 - $0, 0) = $3,750
     nj_staynj_eligible: true
-    nj_staynj: 4_625
+    nj_staynj: 3_750

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/credits/staynj/nj_staynj.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/credits/staynj/nj_staynj.yaml
@@ -1,8 +1,7 @@
 # Unit tests for nj_staynj variable
 # Tests benefit amounts for Stay NJ Property Tax Credit
-# Formula: Stay NJ = min((property_taxes - ANCHOR) * 0.5, $6,500)
+# Formula per P.L. 2024 c.88: Stay NJ = max(min(property_taxes * 50%, $6,500) - ANCHOR - Senior_Freeze, 0)
 # Note: Stay NJ begins in 2026
-# Note: Stay NJ is calculated AFTER subtracting ANCHOR benefits from property taxes
 #
 # ANCHOR benefit amounts for homeowners (income <= $250K):
 #   - Senior (65+), income <= $150K: $1,750
@@ -10,7 +9,7 @@
 #   - Non-senior, income <= $150K: $1,500
 #   - Non-senior, income $150K-$250K: $1,000
 
-- name: Case 1, eligible senior receives 50 percent of property tax after ANCHOR offset.
+- name: Case 1, eligible senior receives benefit per corrected formula.
   period: 2026
   input:
     people:
@@ -31,12 +30,12 @@
         members: [person1]
         state_fips: 34  # New Jersey
   output:
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: $10,000 - $1,750 = $8,250
-    # Stay NJ: 50% * $8,250 = $4,125 (under $6,500 max)
-    nj_staynj: 4_125
+    # min($10,000 * 50%, $6,500) = min($5,000, $6,500) = $5,000
+    # ANCHOR = $1,750 (senior, income <= $150K)
+    # max($5,000 - $1,750 - $0, 0) = $3,250
+    nj_staynj: 3_250
 
-- name: Case 2, benefit capped at maximum of $6,500.
+- name: Case 2, benefit capped at maximum minus ANCHOR.
   period: 2026
   input:
     people:
@@ -57,11 +56,10 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $200K in $150K-$250K range: ANCHOR = $1,250
-    # Net property tax: $20,000 - $1,250 = $18,750
-    # 50% * $18,750 = $9,375
-    # Capped at max: $6,500
-    nj_staynj: 6_500
+    # min($20,000 * 50%, $6,500) = min($10,000, $6,500) = $6,500
+    # ANCHOR = $1,250 (senior, income $150K-$250K)
+    # max($6,500 - $1,250 - $0, 0) = $5,250
+    nj_staynj: 5_250
 
 - name: Case 3, benefit under maximum with ANCHOR offset.
   period: 2026
@@ -84,12 +82,12 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $150K <= $150K: ANCHOR = $1,750
-    # Net property tax: $13,000 - $1,750 = $11,250
-    # 50% * $11,250 = $5,625 (under cap)
-    nj_staynj: 5_625
+    # min($13,000 * 50%, $6,500) = min($6,500, $6,500) = $6,500
+    # ANCHOR = $1,750 (senior, income $150K <= $150K)
+    # max($6,500 - $1,750 - $0, 0) = $4,750
+    nj_staynj: 4_750
 
-- name: Case 4, low property tax results in low benefit after ANCHOR offset.
+- name: Case 4, low property tax results in low benefit.
   period: 2026
   input:
     people:
@@ -110,10 +108,10 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $80K <= $150K: ANCHOR = $1,750
-    # Net property tax: $4,000 - $1,750 = $2,250
-    # 50% * $2,250 = $1,125
-    nj_staynj: 1_125
+    # min($4,000 * 50%, $6,500) = min($2,000, $6,500) = $2,000
+    # ANCHOR = $1,750 (senior, income <= $150K)
+    # max($2,000 - $1,750 - $0, 0) = $250
+    nj_staynj: 250
 
 - name: Case 5, ineligible due to age receives $0.
   period: 2026
@@ -161,7 +159,6 @@
         state_fips: 34
   output:
     # Income $600K >= $500K limit - ineligible for Stay NJ
-    # (Also ineligible for ANCHOR due to income > $250K)
     nj_staynj: 0
 
 - name: Case 7, ineligible renter receives $0.
@@ -208,9 +205,7 @@
         members: [person1]
         state_fips: 34
   output:
-    # Property tax $0, no ANCHOR (not paying property taxes)
-    # Net: $0 - $0 = $0
-    # 50% * $0 = $0
+    # Property tax $0 - ineligible (not homeowner)
     nj_staynj: 0
 
 - name: Case 9, senior at income above ANCHOR limit but below Stay NJ limit.
@@ -236,15 +231,71 @@
   output:
     # Income $499K > $250K ANCHOR limit - no ANCHOR benefit
     # Income $499K < $500K Stay NJ limit - eligible for Stay NJ
-    # Net property tax: $12,000 - $0 = $12,000
-    # 50% * $12,000 = $6,000
+    # min($12,000 * 50%, $6,500) = min($6,000, $6,500) = $6,000
+    # max($6,000 - $0 - $0, 0) = $6,000
     nj_staynj: 6_000
+
+- name: Case 10, Senior Freeze benefit subtracted from Stay NJ.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        employment_income: 100_000
+        real_estate_taxes: 10_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        nj_senior_freeze: 1_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+        spm_unit_tenure_type: OWNER_WITH_MORTGAGE
+    households:
+      household:
+        members: [person1]
+        state_fips: 34
+  output:
+    # min($10,000 * 50%, $6,500) = min($5,000, $6,500) = $5,000
+    # ANCHOR = $1,750 (senior, income <= $150K)
+    # Senior Freeze = $1,000
+    # max($5,000 - $1,750 - $1,000, 0) = $2,250
+    nj_staynj: 2_250
+
+- name: Case 11, large Senior Freeze and ANCHOR exceed target, benefit is zero.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        employment_income: 100_000
+        real_estate_taxes: 4_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        nj_senior_freeze: 2_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+        spm_unit_tenure_type: OWNER_WITH_MORTGAGE
+    households:
+      household:
+        members: [person1]
+        state_fips: 34
+  output:
+    # min($4,000 * 50%, $6,500) = min($2,000, $6,500) = $2,000
+    # ANCHOR = $1,750 (senior, income <= $150K)
+    # Senior Freeze = $2,000
+    # max($2,000 - $1,750 - $2,000, 0) = max(-$1,750, 0) = $0
+    nj_staynj: 0
 
 # ==============================================================================
 # EDGE CASES - Boundary conditions and corner cases
 # ==============================================================================
 
-- name: Edge case 1, property tax $13,000 with ANCHOR offset.
+- name: Edge case 1, property tax $13,000 hits cap exactly.
   period: 2026
   input:
     people:
@@ -265,12 +316,12 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: $13,000 - $1,750 = $11,250
-    # 50% * $11,250 = $5,625
-    nj_staynj: 5_625
+    # min($13,000 * 50%, $6,500) = min($6,500, $6,500) = $6,500
+    # ANCHOR = $1,750 (senior, income <= $150K)
+    # max($6,500 - $1,750 - $0, 0) = $4,750
+    nj_staynj: 4_750
 
-- name: Edge case 2, property tax one dollar above previous cap threshold.
+- name: Edge case 2, property tax one dollar above cap threshold.
   period: 2026
   input:
     people:
@@ -291,12 +342,12 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: $13,001 - $1,750 = $11,251
-    # 50% * $11,251 = $5,625.50
-    nj_staynj: 5_625.5
+    # min($13,001 * 50%, $6,500) = min($6,500.50, $6,500) = $6,500
+    # ANCHOR = $1,750
+    # max($6,500 - $1,750 - $0, 0) = $4,750
+    nj_staynj: 4_750
 
-- name: Edge case 3, property tax one dollar below previous cap threshold.
+- name: Edge case 3, property tax one dollar below cap threshold.
   period: 2026
   input:
     people:
@@ -317,12 +368,12 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: $12,999 - $1,750 = $11,249
-    # 50% * $11,249 = $5,624.50
-    nj_staynj: 5_624.5
+    # min($12,999 * 50%, $6,500) = min($6,499.50, $6,500) = $6,499.50
+    # ANCHOR = $1,750
+    # max($6,499.50 - $1,750 - $0, 0) = $4,749.50
+    nj_staynj: 4_749.5
 
-- name: Edge case 4, very high property tax capped at maximum.
+- name: Edge case 4, very high property tax capped at maximum minus ANCHOR.
   period: 2026
   input:
     people:
@@ -343,11 +394,10 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $200K in $150K-$250K range: ANCHOR = $1,250
-    # Net property tax: $50,000 - $1,250 = $48,750
-    # 50% * $48,750 = $24,375
-    # Capped at max: $6,500
-    nj_staynj: 6_500
+    # min($50,000 * 50%, $6,500) = min($25,000, $6,500) = $6,500
+    # ANCHOR = $1,250 (senior, income $150K-$250K)
+    # max($6,500 - $1,250 - $0, 0) = $5,250
+    nj_staynj: 5_250
 
 - name: Edge case 5, income exactly $499,999 one dollar below limit.
   period: 2026
@@ -371,9 +421,9 @@
         state_fips: 34
   output:
     # Income $499,999 > $250K - no ANCHOR
-    # Income $499,999 < $500,000 (strict less than) - eligible for Stay NJ
-    # Net property tax: $10,000 - $0 = $10,000
-    # 50% * $10,000 = $5,000
+    # Income $499,999 < $500,000 - eligible for Stay NJ
+    # min($10,000 * 50%, $6,500) = min($5,000, $6,500) = $5,000
+    # max($5,000 - $0 - $0, 0) = $5,000
     nj_staynj: 5_000
 
 - name: Edge case 6, income exactly at $500,000 limit is ineligible.
@@ -397,7 +447,7 @@
         members: [person1]
         state_fips: 34
   output:
-    # Income $500,000 NOT < $500,000 (strict less than) - ineligible
+    # Income $500,000 NOT < $500,000 - ineligible
     nj_staynj: 0
 
 - name: Edge case 7, age exactly 65 at boundary.
@@ -421,11 +471,11 @@
         members: [person1]
         state_fips: 34
   output:
-    # Age 65 >= 65 (uses >=) - eligible
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: $8,000 - $1,750 = $6,250
-    # 50% * $6,250 = $3,125
-    nj_staynj: 3_125
+    # Age 65 >= 65 - eligible
+    # min($8,000 * 50%, $6,500) = min($4,000, $6,500) = $4,000
+    # ANCHOR = $1,750 (senior, income <= $150K)
+    # max($4,000 - $1,750 - $0, 0) = $2,250
+    nj_staynj: 2_250
 
 - name: Edge case 8, zero income still receives benefit.
   period: 2026
@@ -448,10 +498,10 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $0 <= $150K: ANCHOR = $1,750
-    # Net property tax: $6,000 - $1,750 = $4,250
-    # 50% * $4,250 = $2,125
-    nj_staynj: 2_125
+    # min($6,000 * 50%, $6,500) = min($3,000, $6,500) = $3,000
+    # ANCHOR = $1,750 (senior, income $0 <= $150K)
+    # max($3,000 - $1,750 - $0, 0) = $1,250
+    nj_staynj: 1_250
 
 - name: Edge case 9, very low property tax below ANCHOR amount.
   period: 2026
@@ -474,9 +524,9 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: max($100 - $1,750, 0) = $0
-    # 50% * $0 = $0
+    # min($100 * 50%, $6,500) = min($50, $6,500) = $50
+    # ANCHOR = $1,750
+    # max($50 - $1,750, 0) = $0
     nj_staynj: 0
 
 - name: Edge case 10, couple where only spouse is 65 plus.
@@ -505,10 +555,10 @@
         state_fips: 34
   output:
     # Uses greater_age_head_spouse = max(50, 66) = 66 >= 65 - senior
-    # Senior, income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: $14,000 - $1,750 = $12,250
-    # 50% * $12,250 = $6,125
-    nj_staynj: 6_125
+    # min($14,000 * 50%, $6,500) = min($7,000, $6,500) = $6,500
+    # ANCHOR = $1,750 (senior, income $100K <= $150K)
+    # max($6,500 - $1,750 - $0, 0) = $4,750
+    nj_staynj: 4_750
 
 - name: Edge case 11, mixed household paying both rent and taxes receives $0.
   period: 2026
@@ -531,8 +581,7 @@
         members: [person1]
         state_fips: 34
   output:
-    # Implementation: is_homeowner = pays_taxes & ~pays_rent
-    # Pays both - is_homeowner = false - ineligible
+    # Pays both rent and property taxes - is_homeowner = false - ineligible
     nj_staynj: 0
 
 - name: Edge case 12, very high income senior is ineligible.
@@ -559,7 +608,7 @@
     # Income $1M far exceeds $500K limit - ineligible
     nj_staynj: 0
 
-- name: Edge case 13, property tax at $1 below ANCHOR gives zero benefit.
+- name: Edge case 13, property tax at $1 gives minimal benefit.
   period: 2026
   input:
     people:
@@ -580,38 +629,12 @@
         members: [person1]
         state_fips: 34
   output:
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: max($1 - $1,750, 0) = $0
-    # 50% * $0 = $0
+    # min($1 * 50%, $6,500) = $0.50
+    # ANCHOR = $1,750
+    # max($0.50 - $1,750, 0) = $0
     nj_staynj: 0
 
-- name: Edge case 14, property tax just under previous double cap.
-  period: 2026
-  input:
-    people:
-      person1:
-        age: 65
-        employment_income: 100_000
-        real_estate_taxes: 12_998
-        is_tax_unit_head: true
-    tax_units:
-      tax_unit:
-        members: [person1]
-    spm_units:
-      spm_unit:
-        members: [person1]
-        spm_unit_tenure_type: OWNER_WITH_MORTGAGE
-    households:
-      household:
-        members: [person1]
-        state_fips: 34
-  output:
-    # Senior (65+), income $100K <= $150K: ANCHOR = $1,750
-    # Net property tax: $12,998 - $1,750 = $11,248
-    # 50% * $11,248 = $5,624
-    nj_staynj: 5_624
-
-- name: Edge case 15, senior who neither owns nor rents is ineligible.
+- name: Edge case 14, senior who neither owns nor rents is ineligible.
   period: 2026
   input:
     people:
@@ -622,7 +645,6 @@
     tax_units:
       tax_unit:
         members: [person1]
-        # No rent - defaults to 0
     spm_units:
       spm_unit:
         members: [person1]
@@ -632,7 +654,5 @@
         members: [person1]
         state_fips: 34
   output:
-    # Not homeowner (no property taxes) and not renter (no rent paid)
-    # Formula: is_homeowner = pays_taxes & ~pays_rent = false
-    # Ineligible
+    # Not homeowner - ineligible
     nj_staynj: 0

--- a/policyengine_us/variables/gov/states/nj/tax/income/credits/staynj/nj_senior_freeze.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/credits/staynj/nj_senior_freeze.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class nj_senior_freeze(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "New Jersey Senior Freeze (Property Tax Reimbursement) benefit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.nj.gov/treasury/taxation/ptr/index.shtml"

--- a/policyengine_us/variables/gov/states/nj/tax/income/credits/staynj/nj_staynj.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/credits/staynj/nj_staynj.py
@@ -19,14 +19,11 @@ class nj_staynj(Variable):
         # Get property taxes paid
         property_taxes = add(tax_unit, period, ["real_estate_taxes"])
 
-        # Get ANCHOR benefit received (must be subtracted per NJ Treasury)
+        # Per P.L. 2024 c.88: Stay NJ = max(min(property_taxes * rate, max_benefit) - ANCHOR - Senior Freeze, 0)
+        target_benefit = min_(property_taxes * p.rate, p.max_benefit)
+
+        # Subtract ANCHOR and Senior Freeze benefits
         anchor_benefit = tax_unit("nj_anchor", period)
+        senior_freeze = tax_unit("nj_senior_freeze", period)
 
-        # Calculate 50% of (property taxes minus ANCHOR)
-        # Per NJ Treasury: Stay NJ benefit is 50% of property taxes
-        # MINUS any payments received through ANCHOR
-        net_property_taxes = max_(property_taxes - anchor_benefit, 0)
-        calculated_benefit = net_property_taxes * p.rate
-
-        # Cap at maximum benefit
-        return min_(calculated_benefit, p.max_benefit)
+        return max_(target_benefit - anchor_benefit - senior_freeze, 0)


### PR DESCRIPTION
## Summary
- **Wrong order of operations**: Changed from `min((taxes - ANCHOR) * 50%, $6,500)` to `max(min(taxes * 50%, $6,500) - ANCHOR - Senior_Freeze, 0)` per official NJ Treasury formula
- **Senior Freeze offset**: Added `nj_senior_freeze` input variable and subtracted it from the benefit calculation alongside ANCHOR
- Example: $10K property taxes, $1,750 ANCHOR → was $4,125 (wrong), now $3,250 (correct)
- Updated 25 unit tests and 7 integration tests with corrected expected values, added 2 Senior Freeze tests

## Test plan
- [x] All 50 NJ Stay NJ tests pass with corrected values
- [x] Senior Freeze offset tests verify proper deduction
- [ ] CI passes

Closes #7417

🤖 Generated with [Claude Code](https://claude.com/claude-code)