### PR TITLE
Replace placeholder description in pyproject.toml

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Replace placeholder description in pyproject.toml with actual project description.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "policyengine-us"
 version = "1.572.5"
-description = "Add your description here."
+description = "PolicyEngine tax-benefit microsimulation model for the United States"
 readme = "README.md"
 authors = [
     { name = "PolicyEngine", email = "hello@policyengine.org" }


### PR DESCRIPTION
## Summary
- Replaces "Add your description here." placeholder with actual project description

Supersedes #7306 (which had merge conflicts).

## Test plan
- [x] No functional change, just metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)