### PR TITLE
Implement South Carolina SSI State Supplement

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Implement South Carolina SSI State Supplement (OSS) for CRCF residents

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -19,6 +19,8 @@ values:
     - ca_state_supplement
     # Nebraska benefits
     - ne_child_care_subsidies
+    # South Carolina benefits
+    - sc_ssi_state_supplement
     # Massachusetts benefits
     - ma_eaedc
     - ma_tafdc
@@ -41,6 +43,8 @@ values:
     - ca_state_supplement
     # Nebraska benefits
     - ne_child_care_subsidies
+    # South Carolina benefits
+    - sc_ssi_state_supplement
     # North Carolina benefits
     - nc_scca
     # Massachusetts benefits

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/maximum_facility_payment.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/maximum_facility_payment.yaml
@@ -1,0 +1,27 @@
+description: South Carolina provides this amount as the maximum facility payment under the Optional State Supplementation program.
+
+values:
+  2022-07-01: 1_620
+  2023-01-01: 1_620
+  2023-07-01: 1_645
+  2024-01-01: 1_672
+  2025-01-01: 1_694
+  2026-01-01: 1_719
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement maximum facility payment
+  reference:
+    - title: S.C. Code Regs. 126-910(B)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/net_income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/net_income_limit.yaml
@@ -1,0 +1,27 @@
+description: South Carolina limits net income to this amount under the Optional State Supplementation program.
+
+values:
+  2022-07-01: 1_626
+  2023-01-01: 1_699
+  2023-07-01: 1_724
+  2024-01-01: 1_753
+  2025-01-01: 1_777
+  2026-01-01: 1_804
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement net income limit
+  reference:
+    - title: S.C. Code Regs. 126-910(D)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/other_income.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/other_income.yaml
@@ -1,0 +1,27 @@
+description: South Carolina provides this amount as a personal needs allowance under the Optional State Supplementation program for recipients with income beyond Supplemental Security Income.
+
+values:
+  2022-07-01: 97
+  2023-01-01: 99
+  2023-07-01: 99
+  2024-01-01: 101
+  2025-01-01: 103
+  2026-01-01: 105
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement personal needs allowance (other income)
+  reference:
+    - title: S.C. Code Regs. 126-910(G)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/ssi_only.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/ssi_only.yaml
@@ -1,0 +1,27 @@
+description: South Carolina provides this amount as a personal needs allowance under the Optional State Supplementation program for recipients with only Supplemental Security Income.
+
+values:
+  2022-07-01: 77
+  2023-01-01: 79
+  2023-07-01: 79
+  2024-01-01: 81
+  2025-01-01: 83
+  2026-01-01: 85
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement personal needs allowance (SSI-only income)
+  reference:
+    - title: S.C. Code Regs. 126-910(G)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/integration.yaml
@@ -1,0 +1,201 @@
+- name: Case 1, aged SSI recipient in CRCF with SSI only.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 0
+        ssi: 11_928
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Eligibility: aged (70 >= 65) + in CRCF + SC + income < NIL
+    sc_ssi_state_supplement_eligible: [true]
+
+    # PNA: SSI-only (no non-SSI income) = $85/month * 12 = $1,020/year
+    sc_ssi_state_supplement_pna: [1_020]
+
+    # OSS amount:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $0 + $11,928 = $11,928
+    # OSS = $21,648 - $11,928 = $9,720
+    sc_ssi_state_supplement: [9_720]
+
+- name: Case 2, disabled person in CRCF with SSI and Social Security.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_blind: false
+        is_ssi_disabled: true
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 2_400
+        ssi: 11_928
+        ssi_unearned_income: 2_400
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Eligibility: disabled + in CRCF + SC + income < NIL
+    # Total countable = $2,400 + $11,928 = $14,328 < $21,648 NIL
+    sc_ssi_state_supplement_eligible: [true]
+
+    # PNA: has non-SSI income ($2,400 unearned) = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: [1_260]
+
+    # OSS amount:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $2,400 + $11,928 = $14,328
+    # OSS = $21,648 - $14,328 = $7,320
+    sc_ssi_state_supplement: [7_320]
+
+- name: Case 3, blind person in CRCF, no SSI, income below NIL.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 50
+        is_blind: true
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 15_000
+        ssi: 0
+        ssi_unearned_income: 15_000
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Eligibility: blind + in CRCF + SC + income < NIL
+    # Total countable = $15,000 + $0 = $15,000 < $21,648 NIL
+    sc_ssi_state_supplement_eligible: [true]
+
+    # PNA: has non-SSI income ($15,000 unearned) = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: [1_260]
+
+    # OSS amount:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $15,000 + $0 = $15,000
+    # OSS = $21,648 - $15,000 = $6,648
+    sc_ssi_state_supplement: [6_648]
+
+- name: Case 4, aged person NOT in CRCF is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: false
+        ssi_countable_income: 0
+        ssi: 11_928
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Not in CRCF so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]
+
+- name: Case 5, non-disabled non-aged person in CRCF is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: false
+        is_in_residential_care_facility: true
+        ssi_countable_income: 0
+        ssi: 0
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Not aged/blind/disabled so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]
+
+- name: Case 6, income above NIL makes person ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 12_000
+        ssi: 11_928
+        ssi_unearned_income: 12_000
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Income check: total countable = $12,000 + $11,928 = $23,928
+    # NIL annual = $1,804 * 12 = $21,648
+    # $23,928 > $21,648 so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]
+
+- name: Case 7, person in wrong state is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 0
+        ssi: 11_928
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: GA
+  output:
+    # Wrong state (GA, not SC) so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.yaml
@@ -1,0 +1,95 @@
+- name: Case 1, SSI-only recipient.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $0 + $11,928 = $11,928
+    # OSS = $21,648 - $11,928 = $9,720
+    sc_ssi_state_supplement: 9_720
+
+- name: Case 2, SSI plus Social Security income.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 2_400
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $2,400 + $11,928 = $14,328
+    # OSS = $21,648 - $14,328 = $7,320
+    sc_ssi_state_supplement: 7_320
+
+- name: Case 3, income above NIL.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 12_000
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $12,000 + $11,928 = $23,928
+    # OSS = max(0, $21,648 - $23,928) = $0
+    sc_ssi_state_supplement: 0
+
+- name: Case 4, not eligible.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: false
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    # Not eligible so OSS = $0 (defined_for gates this)
+    sc_ssi_state_supplement: 0
+
+- name: Case 5, non-SSI recipient with countable income below NIL.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 15_000
+    ssi: 0
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $15,000 + $0 = $15,000
+    # OSS = $21,648 - $15,000 = $6,648
+    sc_ssi_state_supplement: 6_648
+
+- name: Case 6, income exactly at NIL.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 9_720
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $9,720 + $11,928 = $21,648
+    # OSS = max(0, $21,648 - $21,648) = $0
+    sc_ssi_state_supplement: 0
+
+# Edge case tests
+
+- name: Edge case - zero income, maximum OSS.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $0 + $0 = $0
+    # OSS = $21,648 - $0 = $21,648 (maximum possible supplement)
+    sc_ssi_state_supplement: 21_648
+
+- name: Edge case - very small countable income with no SSI.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 1
+    ssi: 0
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $1 + $0 = $1
+    # OSS = $21,648 - $1 = $21,647
+    sc_ssi_state_supplement: 21_647

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.yaml
@@ -1,0 +1,146 @@
+- name: Case 1, aged person in CRCF in SC with low income.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Case 2, aged person NOT in CRCF.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: false
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: false
+
+- name: Case 3, non-disabled person under 65 in CRCF.
+  period: 2026
+  input:
+    age: 30
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: false
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    sc_ssi_state_supplement_eligible: false
+
+- name: Case 4, person in wrong state.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: GA
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: false
+
+- name: Case 5, disabled person under 65 in CRCF.
+  period: 2026
+  input:
+    age: 45
+    is_ssi_disabled: true
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Case 6, blind person in CRCF.
+  period: 2026
+  input:
+    age: 50
+    is_blind: true
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Case 7, income above net income limit.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 12_000
+    ssi: 11_928
+  output:
+    # Total countable = 12_000 + 11_928 = 23_928
+    # NIL annual = 1_804 * 12 = 21_648
+    # 23_928 > 21_648 so not eligible
+    sc_ssi_state_supplement_eligible: false
+
+# Edge case tests
+
+- name: Edge case - income exactly at NIL boundary (strict less-than).
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 9_720
+    ssi: 11_928
+  output:
+    # Total = 9_720 + 11_928 = 21_648
+    # NIL annual = 1_804 * 12 = 21_648
+    # Uses strict < so 21_648 < 21_648 is false
+    sc_ssi_state_supplement_eligible: false
+
+- name: Edge case - income one dollar below NIL boundary.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 9_719
+    ssi: 11_928
+  output:
+    # Total = 9_719 + 11_928 = 21_647
+    # NIL annual = 21_648
+    # 21_647 < 21_648 is true
+    sc_ssi_state_supplement_eligible: true
+
+- name: Edge case - person aged exactly 65 in CRCF (meets SSI aged threshold).
+  period: 2026
+  input:
+    age: 65
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Edge case - person aged 64, not disabled or blind, in CRCF.
+  period: 2026
+  input:
+    age: 64
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: false
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    # Age 64 does not meet SSI aged threshold (65+)
+    # Not disabled or blind, so is_ssi_aged_blind_disabled = false
+    sc_ssi_state_supplement_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.yaml
@@ -1,0 +1,52 @@
+- name: Case 1, SSI-only recipient gets lower PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    state_code: SC
+  output:
+    # PNA for SSI-only = $85/month * 12 = $1,020/year
+    sc_ssi_state_supplement_pna: 1_020
+
+- name: Case 2, recipient with other income gets higher PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 2_400
+    state_code: SC
+  output:
+    # PNA for other income = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: 1_260
+
+- name: Case 3, not eligible gets zero PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: false
+    ssi_countable_income: 0
+    state_code: SC
+  output:
+    sc_ssi_state_supplement_pna: 0
+
+# Edge case tests
+
+- name: Edge case - countable income exactly zero, SSI-only PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    state_code: SC
+  output:
+    # ssi_countable_income == 0 triggers SSI-only PNA
+    # PNA = $85/month * 12 = $1,020/year
+    sc_ssi_state_supplement_pna: 1_020
+
+- name: Edge case - countable income of one dollar, triggers other-income PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 1
+    state_code: SC
+  output:
+    # ssi_countable_income == 1 != 0, so other-income PNA applies
+    # PNA = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: 1_260

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class sc_ssi_state_supplement(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "South Carolina SSI State Supplement"
+    unit = USD
+    reference = (
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-910",
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-920",
+    )
+    defined_for = "sc_ssi_state_supplement_eligible"
+
+    def formula(person, period, parameters):
+        # Per S.C. Code Regs. 126-910: OSS = max(0, NIL - countable income)
+        p = parameters(period).gov.states.sc.scdhhs.ssi_state_supplement
+        nil = p.net_income_limit * MONTHS_IN_YEAR
+        countable_income = person("ssi_countable_income", period)
+        ssi = person("ssi", period)
+        return max_(0, nil - countable_income - ssi)

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class sc_ssi_state_supplement_eligible(Variable):
+    value_type = bool
+    entity = Person
+    definition_period = YEAR
+    label = "South Carolina SSI State Supplement eligible"
+    reference = (
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-920",
+        "https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0",
+    )
+    defined_for = StateCode.SC
+
+    def formula(person, period, parameters):
+        # Per S.C. Code Regs. 126-920: aged/blind/disabled + CRCF + income < NIL
+        is_aged_blind_disabled = person("is_ssi_aged_blind_disabled", period)
+        in_facility = person("is_in_residential_care_facility", period)
+        p = parameters(period).gov.states.sc.scdhhs.ssi_state_supplement
+        nil = p.net_income_limit * MONTHS_IN_YEAR
+        countable_income = person("ssi_countable_income", period)
+        ssi = person("ssi", period)
+        income_eligible = (countable_income + ssi) < nil
+        return is_aged_blind_disabled & in_facility & income_eligible

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class sc_ssi_state_supplement_pna(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "South Carolina SSI State Supplement personal needs allowance"
+    unit = USD
+    reference = (
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-910",
+        "https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0",
+    )
+    defined_for = "sc_ssi_state_supplement_eligible"
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.sc.scdhhs.ssi_state_supplement.personal_needs_allowance
+        # Per S.C. Code Regs. 126-910(G): SSI-only PNA if no other
+        # countable income; higher PNA if other income sources exist
+        ssi_only = person("ssi_countable_income", period) == 0
+        return where(ssi_only, p.ssi_only, p.other_income) * MONTHS_IN_YEAR

--- a/policyengine_us/variables/household/demographic/person/is_in_residential_care_facility.py
+++ b/policyengine_us/variables/household/demographic/person/is_in_residential_care_facility.py
@@ -1,0 +1,8 @@
+from policyengine_us.model_api import *
+
+
+class is_in_residential_care_facility(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether the person lives in a residential care facility"
+    definition_period = YEAR

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -19,6 +19,8 @@ class spm_unit_benefits(Variable):
             "co_ccap_subsidy",
             "co_state_supplement",
             "co_oap",
+            # South Carolina programs.
+            "sc_ssi_state_supplement",
             "snap",
             "wic",
             "free_school_meals",


### PR DESCRIPTION
## Summary

Implements the South Carolina SSI State Supplement (Optional State Supplementation / OSS) program. Replaces #7344 (rebased from upstream/main to resolve conflicts).

Closes #7343

SC's OSS program supplements the income of eligible individuals residing in licensed Community Residential Care Facilities (CRCFs). The program:

- Is available **only** to individuals in CRCFs (not community residents or nursing home residents)
- Covers both SSI recipients **and** non-SSI individuals who meet SSA criteria for aged/blind/disabled
- Provides substantial facility payment support (up to $1,719/month to the facility as of 2026)
- Is state-administered by SCDHHS (not federally administered by SSA)

## Regulatory authority

- **S.C. Code Regs. 126-910** -- Program Definitions
- **S.C. Code Regs. 126-920** -- Eligibility
- **SCDHHS MB# 26-001** (Jan 8, 2026) -- Current payment amounts

## Benefit calculation

```
OSS = max(0, NIL - ssi_countable_income - ssi)
```

## Files added/modified

- 4 parameter files (net income limit, max facility payment, PNA tiers)
- 3 variable files (eligibility, benefit amount, PNA)
- 1 new input variable (`is_in_residential_care_facility`)
- 4 test files (31 test cases)
- Modified `spm_unit_benefits.py` and `household_state_benefits.yaml`

## Test plan

- [x] All YAML tests written with step-by-step calculation comments
- [x] `make format` passes
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)