### PR TITLE
Add New Mexico SSI state supplement

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Add New Mexico SSI state supplement for ARSCH residents

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -19,6 +19,8 @@ values:
     - ca_state_supplement
     # Nebraska benefits
     - ne_child_care_subsidies
+    # New Mexico benefits
+    - nm_ssi_state_supplement
     # Massachusetts benefits
     - ma_eaedc
     - ma_tafdc
@@ -41,6 +43,8 @@ values:
     - ca_state_supplement
     # Nebraska benefits
     - ne_child_care_subsidies
+    # New Mexico benefits
+    - nm_ssi_state_supplement
     # North Carolina benefits
     - nc_scca
     # Massachusetts benefits

--- a/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/amount.yaml
@@ -1,0 +1,14 @@
+description: New Mexico provides this amount as the monthly supplement under the Supplemental Security Income state supplement program.
+
+values:
+  2004-07-01: 100
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: New Mexico SSI state supplement amount
+  reference:
+    - title: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+      href: https://srca.nm.gov/parts/title08/08.106.0500.html
+    - title: SSA State Assistance Programs for SSI Recipients - New Mexico (2011)
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/nm.html

--- a/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/min_age.yaml
+++ b/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/min_age.yaml
@@ -1,0 +1,12 @@
+description: New Mexico limits the Supplemental Security Income state supplement program to individuals at or above this age.
+
+values:
+  2004-07-01: 18
+
+metadata:
+  unit: year
+  period: year
+  label: New Mexico SSI state supplement minimum age
+  reference:
+    - title: SSA State Assistance Programs for SSI Recipients - New Mexico (2011)
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/nm.html

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/integration.yaml
@@ -1,0 +1,166 @@
+# New Mexico SSI State Supplement Integration Tests
+# Tests the full eligibility and benefit calculation pipeline
+# Source: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+# Program: $100/month flat payment for SSI recipients in licensed ARSCH facilities
+
+- name: Case 1, elderly SSI recipient in ARSCH facility receives supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Eligibility: SSI-eligible (true) AND age >= 18 (70 >= 18) AND in ARSCH (true)
+        nm_ssi_state_supplement_eligible: true
+        # Benefit: $100/month * 12 = $1,200/year (flat payment)
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 2, disabled adult SSI recipient in ARSCH facility receives supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 35
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Eligibility: SSI-eligible (true) AND age >= 18 (35 >= 18) AND in ARSCH (true)
+        nm_ssi_state_supplement_eligible: true
+        # Benefit: $100/month * 12 = $1,200/year
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 3, SSI couple both in ARSCH facility each receive supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 68
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+      person2:
+        age: 66
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Person 1: SSI-eligible, age 68 >= 18, in ARSCH
+        nm_ssi_state_supplement_eligible: true
+        # $100/month * 12 = $1,200/year per person
+        nm_ssi_state_supplement: 1_200
+      person2:
+        # Person 2: SSI-eligible, age 66 >= 18, in ARSCH
+        # Per 8.106.400.10 NMAC: couples in ARSCH are two separate benefit groups
+        nm_ssi_state_supplement_eligible: true
+        # $100/month * 12 = $1,200/year per person
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 4, NM resident not in ARSCH facility receives no supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 72
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: false
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Not in ARSCH facility: ineligible regardless of SSI status
+        nm_ssi_state_supplement_eligible: false
+        nm_ssi_state_supplement: 0
+
+- name: Case 5, age 18 boundary in ARSCH facility is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 18
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Age exactly 18: meets the 18+ requirement
+        nm_ssi_state_supplement_eligible: true
+        # $100/month * 12 = $1,200/year
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 6, household with one eligible and one ineligible person.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 60
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+      person2:
+        age: 45
+        is_ssi_eligible_individual: false
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Person 1: SSI-eligible, age 60 >= 18, in ARSCH = eligible
+        nm_ssi_state_supplement_eligible: true
+        nm_ssi_state_supplement: 1_200
+      person2:
+        # Person 2: NOT SSI-eligible = ineligible even though in ARSCH
+        nm_ssi_state_supplement_eligible: false
+        nm_ssi_state_supplement: 0
+
+- name: Case 7, SSI recipient in ARSCH facility but outside NM receives nothing.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    people:
+      person1:
+        # Wrong state: defined_for = StateCode.NM excludes non-NM residents
+        nm_ssi_state_supplement_eligible: false
+        nm_ssi_state_supplement: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.yaml
@@ -1,0 +1,76 @@
+# New Mexico SSI State Supplement Benefit Amount Unit Tests
+# Tests the flat $100/month ($1,200/year) payment for eligible individuals
+# Source: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+
+- name: Case 1, eligible person receives full annual supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # $100/month * 12 months = $1,200/year
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 2, not SSI-eligible receives zero.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: false
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement: 0
+
+- name: Case 3, not in ARSCH facility receives zero.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: false
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement: 0
+
+- name: Case 4, underage person receives zero.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 17
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.yaml
@@ -1,0 +1,129 @@
+# New Mexico SSI State Supplement Eligibility Unit Tests
+# Tests eligibility for the ARSCH shelter care supplement
+# Source: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+
+- name: Case 1, elderly SSI recipient in ARSCH facility in NM is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: true
+
+- name: Case 2, younger adult SSI recipient in ARSCH facility in NM is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: true
+
+- name: Case 3, not SSI-eligible person in ARSCH facility in NM is ineligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: false
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false
+
+- name: Case 4, underage person is ineligible even if SSI-eligible and in ARSCH.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 17
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false
+
+- name: Case 5, exactly age 18 boundary is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 18
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: true
+
+- name: Case 6, SSI-eligible adult NOT in ARSCH facility is ineligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: false
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false
+
+- name: Case 7, SSI-eligible adult in ARSCH but wrong state is ineligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/is_in_adult_residential_care.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/is_in_adult_residential_care.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class is_in_adult_residential_care(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether the person lives in a licensed adult residential shelter care home"
+    definition_period = YEAR
+    default_value = False
+    reference = "https://srca.nm.gov/parts/title08/08.106.0100.html"

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class nm_ssi_state_supplement(Variable):
+    value_type = float
+    entity = Person
+    label = "New Mexico SSI state supplement"
+    definition_period = YEAR
+    defined_for = "nm_ssi_state_supplement_eligible"
+    unit = USD
+    reference = "https://srca.nm.gov/parts/title08/08.106.0500.html"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.nm.hca.ssi_supplement
+        return p.amount * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class nm_ssi_state_supplement_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "New Mexico SSI state supplement eligible"
+    definition_period = YEAR
+    defined_for = StateCode.NM
+    reference = (
+        "https://srca.nm.gov/parts/title08/08.106.0500.html",
+        "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/nm.html",
+    )
+
+    def formula(person, period, parameters):
+        ssi_eligible = person("is_ssi_eligible_individual", period)
+        age = person("age", period)
+        p = parameters(period).gov.states.nm.hca.ssi_supplement
+        meets_age = age >= p.min_age
+        in_residential_care = person("is_in_adult_residential_care", period)
+        return ssi_eligible & meets_age & in_residential_care


### PR DESCRIPTION
## Summary

Implements the New Mexico SSI State Supplement, a flat $100/month payment for SSI recipients living in licensed Adult Residential Shelter Care Homes (ARSCH). Replaces #7346 (rebased from upstream/main to resolve conflicts).

Closes #7345

## Regulatory authority

- **Statute**: NMSA 1978, Section 27-2-9.1
- **Regulations**: 8.106.500.10 NMAC (effective March 1, 2025)
- **Administering agency**: New Mexico Health Care Authority (HCA), Income Support Division

## Eligibility criteria (8.106.500.10 NMAC)

1. Must be receiving SSI under Title XVI
2. Must reside in a licensed ARSCH facility
3. Must be age 18 or older

## Benefit calculation

```
If eligible: $100/month x 12 = $1,200/year
If not eligible: $0
```

## Files added/modified

- 2 parameter files (amount, min_age)
- 3 variable files (eligibility, benefit, is_in_adult_residential_care input)
- 3 test files (18 test cases)
- Modified `household_state_benefits.yaml`

## Test plan

- [x] All YAML tests written with step-by-step comments
- [x] `make format` passes
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)