### PR TITLE
Fix black formatting in snap_assets.py

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed black formatting in snap_assets.py.

--- a/policyengine_us/variables/gov/usda/snap/eligibility/snap_assets.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/snap_assets.py
@@ -13,8 +13,6 @@ class snap_assets(Variable):
     )
     label = "SNAP assets"
     unit = USD
-    reference = (
-        "https://www.law.cornell.edu/uscode/text/7/2014#g",
-    )
+    reference = ("https://www.law.cornell.edu/uscode/text/7/2014#g",)
 
     adds = ["spm_unit_cash_assets"]


### PR DESCRIPTION
## Summary

- Fixes black formatting violation in `snap_assets.py` that was causing lint failures on unrelated PRs

## Test plan

- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)