### PR TITLE
Fix EITC/CDCC: allow SE losses to reduce earned income per IRS Worksheet B

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed EITC and CDCC earned income computation to allow self-employment losses
+      to reduce earned income per-person, with the zero floor applied only to the
+      combined tax-unit total per IRS EIC Worksheet B Line 4b and Form 2441 instructions.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/adjusted_earnings.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/adjusted_earnings.yaml
@@ -1,0 +1,29 @@
+# Tests that SE losses correctly reduce adjusted earnings (no per-person floor)
+# Per IRC 32(c)(2)(A)(ii) and IRS EIC Worksheet B, Line 4b:
+# SE losses reduce earned income, with the floor at zero applied only
+# to the combined tax-unit total (filer_adjusted_earnings), not per-person.
+
+- name: SE loss reduces adjusted earnings below zero
+  period: 2024
+  input:
+    employment_income: 5_000
+    self_employment_income: -10_000
+  output:
+    adjusted_earnings: -5_000
+
+- name: Positive SE income gives positive adjusted earnings
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    employment_income: 30_000
+    self_employment_income: 10_000
+  output:
+    adjusted_earnings: 39_293.52
+
+- name: Zero SE income gives wages-only adjusted earnings
+  period: 2024
+  input:
+    employment_income: 20_000
+    self_employment_income: 0
+  output:
+    adjusted_earnings: 20_000

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/filer_adjusted_earnings.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/filer_adjusted_earnings.yaml
@@ -1,0 +1,41 @@
+# Tests that the zero floor applies at the tax-unit level, not per-person.
+# Per IRS EIC Worksheet B, Line 4b:
+# "If line 4b is zero or less, You can't take the credit."
+
+- name: Joint filers - SE loss partially offsets spouse wages
+  period: 2024
+  input:
+    people:
+      head:
+        employment_income: 30_000
+        self_employment_income: 0
+      spouse:
+        employment_income: 0
+        self_employment_income: -10_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+  output:
+    # head adjusted_earnings = 30000
+    # spouse adjusted_earnings = -10000
+    # combined = 20000 (floor at 0 does not bind)
+    filer_adjusted_earnings: 20_000
+
+- name: Joint filers - SE loss fully offsets wages, floor at zero
+  period: 2024
+  input:
+    people:
+      head:
+        employment_income: 5_000
+        self_employment_income: 0
+      spouse:
+        employment_income: 0
+        self_employment_income: -20_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+  output:
+    # head adjusted_earnings = 5000
+    # spouse adjusted_earnings = -20000
+    # combined = -15000, floored at 0
+    filer_adjusted_earnings: 0

--- a/policyengine_us/variables/gov/irs/income/adjusted_earnings.py
+++ b/policyengine_us/variables/gov/irs/income/adjusted_earnings.py
@@ -7,12 +7,24 @@ class adjusted_earnings(Variable):
     definition_period = YEAR
     label = "Personal earned income adjusted for self-employment tax"
     unit = USD
+    reference = "https://www.law.cornell.edu/uscode/text/26/32#c_2_A"
 
     def formula(person, period, parameters):
+        # Per IRC 32(c)(2)(A), EITC earned income = wages + net SE earnings
+        # (within the meaning of IRC 1402(a)), determined with regard to
+        # the IRC 164(f) deduction (one-half of SE tax).
+        #
+        # Per IRS EIC Worksheet B (Form 1040 Instructions), Line 4b:
+        # "Combine lines 1e, 2c, 3, and 4a" — SE losses reduce earned
+        # income with no per-person floor. The floor at zero applies only
+        # to the combined tax-unit total (see filer_adjusted_earnings).
+        #
+        # Per IRS Form 2441 instructions (CDCC): "You must reduce your
+        # earned income by any loss from self-employment."
         p = parameters(period).gov.irs.ald.misc
         adjustment = (
             (1 - p.self_emp_tax_adj)
             * p.employer_share
             * person("self_employment_tax", period)
         )
-        return max_(0, person("earned_income", period) - adjustment)
+        return person("earned_income", period) - adjustment

--- a/policyengine_us/variables/gov/irs/income/filer_adjusted_earnings.py
+++ b/policyengine_us/variables/gov/irs/income/filer_adjusted_earnings.py
@@ -7,6 +7,12 @@ class filer_adjusted_earnings(Variable):
     definition_period = YEAR
     label = "Filer earned income adjusted for self-employment tax"
     unit = USD
+    reference = "https://www.law.cornell.edu/uscode/text/26/32#c_2_A"
 
     def formula(tax_unit, period, parameters):
-        return tax_unit_non_dep_sum("adjusted_earnings", tax_unit, period)
+        # Per IRS EIC Worksheet B (Form 1040 Instructions), Line 4b:
+        # "If line 4b is zero or less, You can't take the credit."
+        # The floor applies to the combined tax-unit total, not per-person.
+        return max_(
+            0, tax_unit_non_dep_sum("adjusted_earnings", tax_unit, period)
+        )


### PR DESCRIPTION
## Summary

- Removes the per-person `max_(0, ...)` floor from `adjusted_earnings.py` that incorrectly clipped self-employment losses, preventing them from reducing earned income
- Adds the zero floor at the tax-unit level in `filer_adjusted_earnings.py`, matching IRS EIC Worksheet B Line 4b: "If line 4b is zero or less, You can't take the credit"
- Adds test coverage for both SE loss scenarios and the tax-unit-level floor

## Legal Authority

**IRC 32(c)(2)(A)(ii)**: EITC earned income includes "the amount of the taxpayer's net earnings from self-employment for the taxable year (within the meaning of section 1402(a))". Per IRC 1402(a), net earnings can be negative ("income or loss").

**IRS EIC Worksheet B** (Form 1040 Instructions, Line 4b): "Combine lines 1e, 2c, 3, and 4a. This is your total earned income." — No per-component or per-person floor. "If line 4b is zero or less, You can't take the credit." — Floor applies only to the combined total.

**IRS Form 2441 Instructions** (CDCC, Lines 4-5): "You must reduce your earned income by any loss from self-employment."

**Note**: Pub 596's "don't subtract losses on Schedule C or F from wages" applies **only** to Form 4029 filers (religious exemption from SE tax), not to general EITC filers.

## Example

MFJ couple: Head has $30,000 wages, Spouse has -$10,000 SE loss.

| | Before (bug) | After (fix) | IRS Worksheet B |
|---|---|---|---|
| Head adjusted_earnings | $30,000 | $30,000 | $30,000 |
| Spouse adjusted_earnings | **$0** (clipped) | **-$10,000** | -$10,000 |
| filer_adjusted_earnings | $30,000 | **$20,000** | $20,000 |

## Test plan

- [x] New tests: `adjusted_earnings.yaml` (3 tests) — SE loss, positive SE, zero SE
- [x] New tests: `filer_adjusted_earnings.yaml` (2 tests) — partial offset, full offset with floor
- [x] All existing EITC tests pass (37 tests)
- [x] All existing CDCC tests pass (37 tests)
- [x] AMT exemption tests pass (5 tests)
- [x] TAXSIM EITC contrib test passes
- [x] State EITC/WFC tests pass (WA, MN, CA — 31 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)