### PR TITLE
Backdate federal TANF income source parameters to 2010-07-01

### DIFF
--- a/changelog.d/backdate-federal-tanf-income-sources.changed.md
+++ b/changelog.d/backdate-federal-tanf-income-sources.changed.md
@@ -1,0 +1,1 @@
+Backdate federal TANF earned and unearned income source parameters to 2010-07-01.

--- a/policyengine_us/parameters/gov/hhs/tanf/cash/income/sources/earned.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/cash/income/sources/earned.yaml
@@ -1,6 +1,6 @@
 description: The Department of Health and Human Services counts these income sources as earned income under the Temporary Assistance for Needy Families program.
 values:
-  2020-01-01:
+  2010-07-01:
     - employment_income_before_lsr
     - self_employment_income_before_lsr
 metadata:

--- a/policyengine_us/parameters/gov/hhs/tanf/cash/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/cash/income/sources/unearned.yaml
@@ -1,6 +1,6 @@
 description: The Department of Health and Human Services counts these income sources as unearned income under the Temporary Assistance for Needy Families program.
 values:
-  2020-01-01:
+  2010-07-01:
     - veterans_benefits
     - rental_income
     - child_support_received


### PR DESCRIPTION
## Summary

Backdates federal TANF earned and unearned income source parameters from 2020-01-01 to 2010-07-01, aligning with other federal TANF cash parameters in the `age_limit/` folder.

Closes #7504

## Changes

- `earned.yaml`: 2020-01-01 → 2010-07-01
- `unearned.yaml`: 2020-01-01 → 2010-07-01

No values changed — only the effective date.

## Justification

The earned/unearned income categorizations (wages/self-employment as earned; benefits, investment income, support payments as unearned) have been stable across all federal means-tested programs since the SSI definitions (1974+). TANF delegates income definitions to states; these lists serve as a conventional baseline.

## Test plan

- [ ] Existing tests pass (no value changes)
- [ ] State TANF implementations that depend on federal variables unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)