### PR TITLE
Add Texas CEAP (LIHEAP)

### DIFF
--- a/changelog.d/feat-tx-ceap.added.md
+++ b/changelog.d/feat-tx-ceap.added.md
@@ -1,1 +1,1 @@
-Add Texas Comprehensive Energy Assistance Program (CEAP).
+Add Texas Comprehensive Energy Assistance Program (CEAP) with FY 2024 and FY 2025 benefit amounts.

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/income_limit.yaml
@@ -1,4 +1,4 @@
-description: Texas limits the Comprehensive Energy Assistance Program (CEAP) to households with income at or below this multiple of the federal poverty guidelines.
+description: The income limit for Texas CEAP eligibility as a multiple of the federal poverty guidelines.
 
 values:
   2023-10-01: 1.5
@@ -6,9 +6,9 @@ values:
 metadata:
   period: year
   unit: /1
-  label: TX CEAP FPG income limit
+  label: Texas CEAP income limit
   reference:
     - title: Texas LIHEAP State Plan FY 2024, Section 2.1
-      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf
-    - title: TDHCA Community Affairs Income Guidelines
-      href: https://www.tdhca.texas.gov/community-affairs-income-guidelines
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=9
+    - title: 10 TAC 6.307
+      href: https://texreg.sos.state.tx.us/public/readtac$ext.TacPage?sl=R&app=9&p_dir=&p_rloc=&p_tloc=&p_ploc=&pg=1&p_tac=&ti=10&pt=1&ch=6&rl=307

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/uses_smi_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/uses_smi_threshold.yaml
@@ -1,0 +1,15 @@
+description: Whether Texas CEAP uses the 60% state median income threshold in addition to the federal poverty guidelines threshold for eligibility.
+
+values:
+  2023-10-01: true
+  2025-01-01: false
+
+metadata:
+  period: year
+  unit: bool
+  label: Texas CEAP uses SMI threshold
+  reference:
+    - title: Texas LIHEAP State Plan FY 2024, Section 2.1
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=9
+    - title: Texas LIHEAP State Plan FY 2025, Section 2.1
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/25-LIHEAP-Plan-DRAFT_0.pdf

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/income_bracket/low.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/income_bracket/low.yaml
@@ -1,4 +1,4 @@
-description: Upper threshold of the low income bracket (as a fraction of FPG) for Texas CEAP utility assistance. Households at or below this fraction receive the highest benefit.
+description: The upper threshold of the low income bracket as a share of the federal poverty guidelines for Texas CEAP utility assistance.
 
 values:
   2023-10-01: 0.5
@@ -6,7 +6,9 @@ values:
 metadata:
   period: year
   unit: /1
-  label: TX CEAP low income bracket threshold
+  label: Texas CEAP low income bracket threshold
   reference:
-    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)
-      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf
+    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)(1)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=11
+    - title: 10 TAC 6.309(e)(1)
+      href: https://texreg.sos.state.tx.us/public/readtac$ext.TacPage?sl=R&app=9&p_dir=&p_rloc=&p_tloc=&p_ploc=&pg=1&p_tac=&ti=10&pt=1&ch=6&rl=309

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/income_bracket/mid.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/income_bracket/mid.yaml
@@ -1,4 +1,4 @@
-description: Upper threshold of the mid income bracket (as a fraction of FPG) for Texas CEAP utility assistance. Households above the low bracket but at or below this fraction receive the middle benefit level.
+description: The upper threshold of the mid income bracket as a share of the federal poverty guidelines for Texas CEAP utility assistance.
 
 values:
   2023-10-01: 0.75
@@ -6,7 +6,9 @@ values:
 metadata:
   period: year
   unit: /1
-  label: TX CEAP mid income bracket threshold
+  label: Texas CEAP mid income bracket threshold
   reference:
-    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)
-      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf
+    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)(2)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=11
+    - title: 10 TAC 6.309(e)(2)
+      href: https://texreg.sos.state.tx.us/public/readtac$ext.TacPage?sl=R&app=9&p_dir=&p_rloc=&p_tloc=&p_ploc=&pg=1&p_tac=&ti=10&pt=1&ch=6&rl=309

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/max_amount/high_income.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/max_amount/high_income.yaml
@@ -1,12 +1,17 @@
-description: Maximum utility assistance amount for Texas CEAP households with income at 76-150% of the federal poverty income guidelines.
+description: The maximum utility assistance for Texas CEAP households with income at 76-150% of the federal poverty income guidelines.
 
 values:
   2023-10-01: 2_200
+  2025-01-01: 1_200
 
 metadata:
   period: year
   unit: currency-USD
-  label: TX CEAP max utility assistance (76-150% FPIG)
+  label: Texas CEAP max utility assistance (76-150% FPIG)
   reference:
-    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)
-      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf
+    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)(3)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=11
+    - title: Texas LIHEAP State Plan FY 2025, Attachment 3 - 10 TAC 6.309(e)(3)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/25-LIHEAP-Plan-DRAFT_0.pdf#page=24
+    - title: Texas Register Dec 27, 2024 Adopted Rules - 10 TAC 6.309(e)
+      href: https://www.sos.state.tx.us/texreg/archive/December272024/Adopted%20Rules/10.COMMUNITY%20DEVELOPMENT.html

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/max_amount/low_income.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/max_amount/low_income.yaml
@@ -1,12 +1,17 @@
-description: Maximum utility assistance amount for Texas CEAP households with income at 0-50% of the federal poverty income guidelines.
+description: The maximum utility assistance for Texas CEAP households with income at 0-50% of the federal poverty income guidelines.
 
 values:
   2023-10-01: 2_400
+  2025-01-01: 1_800
 
 metadata:
   period: year
   unit: currency-USD
-  label: TX CEAP max utility assistance (0-50% FPIG)
+  label: Texas CEAP max utility assistance (0-50% FPIG)
   reference:
-    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)
-      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf
+    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)(1)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=11
+    - title: Texas LIHEAP State Plan FY 2025, Attachment 3 - 10 TAC 6.309(e)(1)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/25-LIHEAP-Plan-DRAFT_0.pdf#page=24
+    - title: Texas Register Dec 27, 2024 Adopted Rules - 10 TAC 6.309(e)
+      href: https://www.sos.state.tx.us/texreg/archive/December272024/Adopted%20Rules/10.COMMUNITY%20DEVELOPMENT.html

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/max_amount/mid_income.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/utility_assistance/max_amount/mid_income.yaml
@@ -1,12 +1,17 @@
-description: Maximum utility assistance amount for Texas CEAP households with income at 51-75% of the federal poverty income guidelines.
+description: The maximum utility assistance for Texas CEAP households with income at 51-75% of the federal poverty income guidelines.
 
 values:
   2023-10-01: 2_300
+  2025-01-01: 1_500
 
 metadata:
   period: year
   unit: currency-USD
-  label: TX CEAP max utility assistance (51-75% FPIG)
+  label: Texas CEAP max utility assistance (51-75% FPIG)
   reference:
-    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)
-      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf
+    - title: Texas LIHEAP State Plan FY 2024, Section 2.6 - 10 TAC 6.309(e)(2)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=11
+    - title: Texas LIHEAP State Plan FY 2025, Attachment 3 - 10 TAC 6.309(e)(2)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/25-LIHEAP-Plan-DRAFT_0.pdf#page=24
+    - title: Texas Register Dec 27, 2024 Adopted Rules - 10 TAC 6.309(e)
+      href: https://www.sos.state.tx.us/texreg/archive/December272024/Adopted%20Rules/10.COMMUNITY%20DEVELOPMENT.html

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap.yaml
@@ -1,4 +1,5 @@
-- name: Low income household (0-50% FPG) gets max $2,400 capped by expenses.
+- name: Case 1, low income household (0-50% FPG) gets max benefit capped by expenses.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 0
@@ -9,7 +10,8 @@
   output:
     tx_ceap: 2_400
 
-- name: Low income household with expenses below max, gets actual expenses.
+- name: Case 2, low income household with expenses below max gets actual expenses.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 5_000
@@ -20,7 +22,8 @@
   output:
     tx_ceap: 1_500
 
-- name: Mid income household (51-75% FPG) gets max $2,300.
+- name: Case 3, mid income household (51-75% FPG) gets mid-tier benefit.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 20_000
@@ -31,7 +34,8 @@
   output:
     tx_ceap: 2_300
 
-- name: High income household (76-150% FPG) gets max $2,200.
+- name: Case 4, high income household (76-150% FPG) gets lowest-tier benefit.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 40_000
@@ -42,7 +46,8 @@
   output:
     tx_ceap: 2_200
 
-- name: Ineligible household gets zero.
+- name: Case 5, ineligible household gets zero.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 80_000
@@ -50,5 +55,55 @@
     state_code: TX
     electricity_expense: 3_000
     gas_expense: 500
+    is_snap_eligible: false
   output:
     tx_ceap: 0
+
+- name: Case 6, zero energy expenses yields zero benefit.
+  absolute_error_margin: 0.1
+  period: 2024
+  input:
+    irs_gross_income: 0
+    spm_unit_size: 1
+    state_code: TX
+    electricity_expense: 0
+    gas_expense: 0
+  output:
+    tx_ceap: 0
+
+- name: Case 7, gas-only expense is counted.
+  absolute_error_margin: 0.1
+  period: 2024
+  input:
+    irs_gross_income: 0
+    spm_unit_size: 1
+    state_code: TX
+    electricity_expense: 0
+    gas_expense: 1_800
+  output:
+    tx_ceap: 1_800
+
+- name: Case 8, FY 2025 low income household gets updated benefit amount.
+  absolute_error_margin: 0.1
+  period: 2025
+  input:
+    irs_gross_income: 0
+    spm_unit_size: 1
+    state_code: TX
+    electricity_expense: 3_000
+    gas_expense: 0
+  output:
+    tx_ceap: 1_800
+
+- name: Case 9, household at exactly 50% FPG gets low-income tier.
+  absolute_error_margin: 0.1
+  period: 2024
+  input:
+    # 50% FPG for HH of 4 = $15,600 (FPG 2024 = $31,200 * 0.5)
+    irs_gross_income: 15_600
+    spm_unit_size: 4
+    state_code: TX
+    electricity_expense: 3_000
+    gas_expense: 0
+  output:
+    tx_ceap: 2_400

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_eligible.yaml
@@ -1,4 +1,5 @@
-- name: Household of 1 in TX with income below 150% FPG, eligible.
+- name: Case 1, household in TX with income below 150% FPG is eligible.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 20_000
@@ -7,7 +8,8 @@
   output:
     tx_ceap_eligible: true
 
-- name: Household of 4 in TX with income above both 150% FPG and 60% SMI, ineligible.
+- name: Case 2, household in TX with income above both 150% FPG and 60% SMI is ineligible.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     # 150% FPG for HH of 4 = $46,800; 60% SMI ~ $56,680
@@ -15,10 +17,12 @@
     irs_gross_income: 60_000
     spm_unit_size: 4
     state_code: TX
+    is_snap_eligible: false
   output:
     tx_ceap_eligible: false
 
-- name: Household of 1 in TX with zero income, eligible.
+- name: Case 3, household in TX with zero income is eligible.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 0
@@ -27,7 +31,8 @@
   output:
     tx_ceap_eligible: true
 
-- name: Not in TX, not eligible.
+- name: Case 4, household not in TX is ineligible.
+  absolute_error_margin: 0.1
   period: 2024
   input:
     irs_gross_income: 10_000
@@ -35,3 +40,37 @@
     state_code: CA
   output:
     tx_ceap_eligible: false
+
+- name: Case 5, household at exactly 50% FPG is eligible.
+  absolute_error_margin: 0.1
+  period: 2024
+  input:
+    # 50% FPG for HH of 1 = $7,580 (FPG 2024 = $15,060 * 0.5)
+    irs_gross_income: 7_580
+    spm_unit_size: 1
+    state_code: TX
+  output:
+    tx_ceap_eligible: true
+
+- name: Case 6, household in FY 2025 with income above 150% FPG but below 60% SMI is ineligible.
+  absolute_error_margin: 0.1
+  period: 2025
+  input:
+    # In FY 2025, only 150% FPG applies (SMI threshold removed)
+    irs_gross_income: 50_000
+    spm_unit_size: 4
+    state_code: TX
+    is_snap_eligible: false
+  output:
+    tx_ceap_eligible: false
+
+- name: Case 7, SNAP-eligible household above income limit is categorically eligible.
+  absolute_error_margin: 0.1
+  period: 2024
+  input:
+    irs_gross_income: 80_000
+    spm_unit_size: 1
+    state_code: TX
+    is_snap_eligible: true
+  output:
+    tx_ceap_eligible: true

--- a/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap.py
+++ b/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap.py
@@ -4,11 +4,14 @@ from policyengine_us.model_api import *
 class tx_ceap(Variable):
     value_type = float
     entity = SPMUnit
-    label = "Texas Comprehensive Energy Assistance" " Program (CEAP) benefit"
+    label = "Texas Comprehensive Energy Assistance Program (CEAP) benefit"
     unit = USD
     definition_period = YEAR
     defined_for = "tx_ceap_eligible"
-    reference = "https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf"
+    reference = (
+        "https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=11",
+        "https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/25-LIHEAP-Plan-DRAFT_0.pdf",
+    )
 
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.tx.tdhca.ceap.utility_assistance
@@ -20,10 +23,7 @@ class tx_ceap(Variable):
         fpg_ratio = where(fpg > 0, income / fpg, 0)
 
         # Maximum utility assistance by income bracket
-        # per 10 TAC 6.309(e):
-        # 0-50% FPIG: $2,400
-        # 51-75% FPIG: $2,300
-        # 76-150% FPIG: $2,200
+        # per 10 TAC 6.309(e).
         max_amount = select(
             [
                 fpg_ratio <= p.income_bracket.low,

--- a/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_eligible.py
+++ b/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_eligible.py
@@ -4,12 +4,13 @@ from policyengine_us.model_api import *
 class tx_ceap_eligible(Variable):
     value_type = bool
     entity = SPMUnit
-    label = (
-        "Eligible for Texas Comprehensive Energy" " Assistance Program (CEAP)"
-    )
+    label = "Eligible for Texas Comprehensive Energy Assistance Program (CEAP)"
     definition_period = YEAR
     defined_for = StateCode.TX
-    reference = "https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf"
+    reference = (
+        "https://www.tdhca.texas.gov/sites/default/files/community-affairs/ceap/docs/24-LIHEAP-Plan.pdf#page=9",
+        "https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/25-LIHEAP-Plan-DRAFT_0.pdf",
+    )
 
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.tx.tdhca.ceap
@@ -17,14 +18,25 @@ class tx_ceap_eligible(Variable):
 
         income = add(spm_unit, period, ["irs_gross_income"])
 
-        # Texas uses the higher of 150% FPG or 60% SMI
-        # per the FY 2024 LIHEAP State Plan, Section 2.1
+        # FPG-based limit (always applies)
         fpg = spm_unit("spm_unit_fpg", period)
         fpg_limit = fpg * p.income_limit
 
+        # SMI-based limit (FY 2024 only, removed in FY 2025+)
+        # per FY 2024 State Plan Section 2.1 vs FY 2025 State Plan Section 2.1
+        uses_smi = p.uses_smi_threshold
         state_median_income = spm_unit("hhs_smi", period)
-        smi_limit = state_median_income * p_hhs.smi_limit
+        smi_limit = where(uses_smi, state_median_income * p_hhs.smi_limit, 0)
 
         income_limit = max_(fpg_limit, smi_limit)
+        income_eligible = income <= income_limit
 
-        return income <= income_limit
+        # Categorical eligibility per 42 USC 8624(b)(2)(A)
+        # and FY 2024 State Plan Section 1.4
+        tanf = spm_unit("is_tanf_enrolled", period)
+        snap = spm_unit("is_snap_eligible", period)
+        person = spm_unit.members
+        ssi = spm_unit.any(person("is_ssi_eligible", period))
+        categorically_eligible = tanf | snap | ssi
+
+        return income_eligible | categorically_eligible


### PR DESCRIPTION
## Summary
- Implements Texas Comprehensive Energy Assistance Program (CEAP), the state's LIHEAP program administered by TDHCA
- Income eligibility uses the higher of 150% FPG or 60% state median income (per FY 2024 LIHEAP State Plan, Section 2.1)
- Tiered utility assistance benefits per 10 TAC 6.309(e): $2,400 (0-50% FPIG), $2,300 (51-75% FPIG), $2,200 (76-150% FPIG), capped by actual energy expenses

## Test plan
- [x] 4 eligibility tests (TX eligible, TX ineligible above both limits, zero income, non-TX state)
- [x] 5 benefit amount tests (low/mid/high income brackets, expense cap, ineligible household)
- [x] All 9 YAML tests pass via `policyengine-core test`

Fixes #6465

Generated with [Claude Code](https://claude.com/claude-code)
