### PR TITLE
Fix DC CDCC rate for TY2026+ (24.25% per FY2025 Budget Support Act)

### DIFF
--- a/changelog.d/cdcc-audit-batch-1.changed.md
+++ b/changelog.d/cdcc-audit-batch-1.changed.md
@@ -1,0 +1,1 @@
+Update DC CDCC match rate to 24.25% for tax year 2026+ per DC Code 47-1806.04(c)(1)(B), amended by the FY2025 Budget Support Act.

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/cdcc/match.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/cdcc/match.yaml
@@ -14,5 +14,8 @@ metadata:
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2024_D40_Booklet_011525.pdf#page=34
     - title: 2025 DC Form D-40 Booklet, Line 21
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2025_D40_Book_Final_wLinks_021226_v1.0.pdf#page=21
+    - title: DC Code 47-1806.04(c)(1)(B), amended by FY2025 Budget Support Act sec. 7032
+      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.04
 values:
   2021-01-01: 0.32
+  2026-01-01: 0.2425

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_cdcc.yaml
@@ -13,3 +13,19 @@
     state_code: DC
   output:
     dc_cdcc: 32  # = 100 * 0.32
+
+- name: DC CDCC 2025 rate still 32%
+  period: 2025
+  input:
+    cdcc_potential: 1_000
+    state_code: DC
+  output:
+    dc_cdcc: 320  # = 1_000 * 0.32
+
+- name: DC CDCC 2026 rate reduced to 24.25%
+  period: 2026
+  input:
+    cdcc_potential: 1_000
+    state_code: DC
+  output:
+    dc_cdcc: 242.5  # = 1_000 * 0.2425


### PR DESCRIPTION
## Summary

Audited 10 states' CDCC (child and dependent care credit) implementations across AR, CA, CO, DC, DE, GA, HI, IA, KS, and KY. Found one issue in DC.

## DC CDCC rate fix

DC Code 47-1806.04(c)(1)(B), amended by the FY2025 Budget Support Act (sec. 7032), requires the child and dependent care credit rate to drop from 32% to 24.25% for tax years beginning after December 31, 2025. The 32% rate continues through TY2025.

## Other states confirmed correct

AR, CA, CO, DE, GA, HI, IA, KS, and KY all have correct CDCC implementations and require no changes.

## Test plan

- DC CDCC parameter updated to reflect new rate effective TY2026
- Existing YAML tests validate calculation with updated match rate
- No behavioral changes to other states' implementations
