### PR TITLE
Add US government bond interest exemption to OR, PA, UT, WI state income taxes (+ tests for OK, RI, SC, VA, WV)

### DIFF
--- a/changelog.d/bond-interest-batch-4.added.md
+++ b/changelog.d/bond-interest-batch-4.added.md
@@ -1,0 +1,1 @@
+Add US government bond interest exemption for OK, OR, PA, RI, SC, UT, VA, WI, and WV.

--- a/policyengine_us/parameters/gov/states/or/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/subtractions/subtractions.yaml
@@ -20,3 +20,4 @@ values:
   2020-01-01:
     - or_federal_tax_liability_subtraction
     - taxable_social_security
+    - us_govt_interest

--- a/policyengine_us/parameters/gov/states/pa/tax/income/nontaxable_income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/pa/tax/income/nontaxable_income_sources.yaml
@@ -4,6 +4,7 @@ values:
     - pa_nontaxable_pension_income
     - taxable_unemployment_compensation
     - taxable_social_security
+    - us_govt_interest
 metadata:
   unit: currency-USD
   label: PA nontaxable income sources

--- a/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/sources.yaml
@@ -6,11 +6,13 @@ values:
     - wi_capital_gain_loss_subtraction
     - wi_childcare_expense_subtraction
     - wi_retirement_income_subtraction
+    - us_govt_interest
   2022-01-01:
     - wi_unemployment_compensation_subtraction
     - tax_unit_taxable_social_security
     - wi_capital_gain_loss_subtraction
     - wi_retirement_income_subtraction
+    - us_govt_interest
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: OK includes US government bond interest in AGI subtractions
+  period: 2024
+  input:
+    state_code: OK
+    us_govt_interest: 5_000
+  output:
+    ok_agi_subtractions: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/subtractions/or_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/subtractions/or_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: OR includes US government bond interest in income subtractions
+  period: 2024
+  input:
+    state_code: OR
+    us_govt_interest: 5_000
+  output:
+    or_income_subtractions: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_us_govt_bond_interest.yaml
@@ -1,0 +1,8 @@
+- name: PA excludes US government bond interest from total taxable income
+  period: 2024
+  input:
+    state_code: PA
+    us_govt_interest: 5_000
+    irs_gross_income: 50_000
+  output:
+    pa_total_taxable_income: 45_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/agi/subtractions/ri_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/agi/subtractions/ri_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: RI includes US government bond interest in AGI subtractions
+  period: 2024
+  input:
+    state_code: RI
+    us_govt_interest: 5_000
+  output:
+    ri_subtractions: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/sc_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/sc_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: SC includes US government bond interest in subtractions
+  period: 2024
+  input:
+    state_code: SC
+    us_govt_interest: 5_000
+  output:
+    sc_subtractions: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/taxable_income/ut_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/taxable_income/ut_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: UT includes US government bond interest in subtractions
+  period: 2024
+  input:
+    state_code: UT
+    us_govt_interest: 5_000
+  output:
+    ut_subtractions: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/va_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/va_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: VA includes US government bond interest in subtractions
+  period: 2024
+  input:
+    state_code: VA
+    us_govt_interest: 5_000
+  output:
+    va_subtractions: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: WI includes US government bond interest in income subtractions
+  period: 2024
+  input:
+    state_code: WI
+    us_govt_interest: 5_000
+  output:
+    wi_income_subtractions: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/wv_us_govt_bond_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/wv_us_govt_bond_interest.yaml
@@ -1,0 +1,7 @@
+- name: WV includes US government bond interest in subtractions
+  period: 2024
+  input:
+    state_code: WV
+    us_govt_interest: 5_000
+  output:
+    wv_subtractions: 5_000

--- a/policyengine_us/variables/gov/states/ut/tax/income/taxable_income/ut_subtractions.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/taxable_income/ut_subtractions.py
@@ -10,3 +10,5 @@ class ut_subtractions(Variable):
     definition_period = YEAR
     defined_for = StateCode.UT
     reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S114.html?v=C59-10-S114_2022032320220323"
+
+    adds = ["us_govt_interest"]


### PR DESCRIPTION
## Summary

Adds US government bond interest exemption to state income tax calculations for four states that were missing this deduction: Oregon, Pennsylvania, Utah, and Wisconsin.

Additionally, adds YAML test cases for a total of nine states (the four above plus Oklahoma, Rhode Island, South Carolina, Virginia, and West Virginia) to ensure the exemption correctly flows through to state-level calculations.

## States needing code changes
- Oregon (OR)
- Pennsylvania (PA)
- Utah (UT)
- Wisconsin (WI)

## States with tests only
These states already had the exemption implemented but now have explicit test coverage:
- Oklahoma (OK)
- Rhode Island (RI)
- South Carolina (SC)
- Virginia (VA)
- West Virginia (WV)

## Closes
Closes #7649 (OK)
Closes #7650 (OR)
Closes #7651 (PA)
Closes #7652 (RI)
Closes #7653 (SC)
Closes #7654 (UT)
Closes #7655 (VA)
Closes #7656 (WI)
Closes #7657 (WV)

## Test plan

1. Run the new YAML test cases for all nine states to verify US government bond interest is properly recognized as a deductible item for state income tax purposes
2. Verify the implementation follows the same pattern as previously implemented states (batch 1-3)
3. Confirm the exemption amount flows through to the appropriate state AGI/taxable income subtraction variables
