### PR TITLE
Fix OH and WI CDCC implementations (wrong credit base, missing state expense limits)

### DIFF
--- a/changelog.d/cdcc-audit-batch-3.fixed.md
+++ b/changelog.d/cdcc-audit-batch-3.fixed.md
@@ -1,0 +1,1 @@
+Fix Ohio and Wisconsin child and dependent care credit (CDCC) implementations.

--- a/policyengine_us/parameters/gov/states/oh/tax/income/credits/cdcc/low_income_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/oh/tax/income/credits/cdcc/low_income_threshold.yaml
@@ -1,0 +1,10 @@
+description: Ohio provides the full federal CDCC (without section 26 limitation) to filers with modified AGI below this threshold.
+values:
+  2021-01-01: 20_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Ohio CDCC low-income threshold
+  reference:
+    - title: Ohio Revised Code Section 5747.054
+      href: https://codes.ohio.gov/ohio-revised-code/section-5747.054

--- a/policyengine_us/parameters/gov/states/wi/tax/income/credits/childcare_expense/max_expense.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/credits/childcare_expense/max_expense.yaml
@@ -1,0 +1,15 @@
+description: Wisconsin limits child and dependent care expenses per qualifying individual for the credit calculation.
+values:
+  2022-01-01: 0
+  2024-01-01: 10_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Wisconsin CDCC maximum expense per qualifying individual
+  reference:
+    - title: 2024 Wisconsin Statutes 71.07(9g)(c)5
+      href: https://docs.legis.wisconsin.gov/statutes/statutes/71/i/07/9g/c/5
+    - title: 2024 Schedule WI-2441 Instructions
+      href: https://www.revenue.wi.gov/TaxForms2024/2024-ScheduleWI-2441-Inst.pdf
+    - title: 2025 Schedule WI-2441 Instructions
+      href: https://www.revenue.wi.gov/TaxForms2025/2025-ScheduleWI-2441-Inst.pdf

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_cdcc.yaml
@@ -1,22 +1,26 @@
-- name: child and dependent care credit low AGI (full eligibility)
+- name: Child and dependent care credit low AGI (full potential credit)
   period: 2021
   input:
     state_code: OH
     oh_modified_agi: 19_999
-    cdcc: 2_000
+    cdcc_potential: 2_000
   output:
+    # Per ORC 5747.054, filers with AGI < $20,000 get the full
+    # federal credit without regard to section 26 limitation.
     oh_cdcc: 2_000
 
-- name: child and dependent care credit test, just above lower threshold AGI (.25 * federal CDCC)
+- name: Child and dependent care credit, just above low-income threshold
   period: 2021
   input:
     state_code: OH
     oh_modified_agi: 20_000
     cdcc: 2_000
   output:
+    # Per ORC 5747.054, filers with $20,000 <= AGI < $40,000 get
+    # 25% of the federal credit (with section 26 limitation).
     oh_cdcc: 500
 
-- name: child and dependent care credit test, solidly above lower threshold AGI (.25 * federal CDCC)
+- name: Child and dependent care credit, solidly above low-income threshold
   period: 2021
   input:
     state_code: OH
@@ -25,7 +29,7 @@
   output:
     oh_cdcc: 500
 
-- name: child and dependent care credit test above upper threshold (ineligible)
+- name: Child and dependent care credit above upper threshold (ineligible)
   period: 2021
   input:
     state_code: OH
@@ -33,3 +37,25 @@
     cdcc: 2_000
   output:
     oh_cdcc: 0
+
+- name: Low AGI, potential credit exceeds actual credit
+  period: 2024
+  input:
+    state_code: OH
+    oh_modified_agi: 15_000
+    cdcc_potential: 1_000
+    cdcc: 500
+  output:
+    # Uses cdcc_potential (1000) not cdcc (500) for low-income filers
+    oh_cdcc: 1_000
+
+- name: Mid AGI, potential credit exceeds actual credit
+  period: 2024
+  input:
+    state_code: OH
+    oh_modified_agi: 25_000
+    cdcc_potential: 1_000
+    cdcc: 500
+  output:
+    # Uses cdcc (500) not cdcc_potential (1000) for mid-income filers
+    oh_cdcc: 125

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_credit.yaml
@@ -1,4 +1,4 @@
-- name: The credit was introduced in 2022
+- name: 2022, 50% of federal CDCC potential
   absolute_error_margin: 0.01
   period: 2022
   input:
@@ -7,11 +7,64 @@
   output:
     wi_childcare_expense_credit: 400 # 800 * 0.5
 
-- name: 2024 CDCC
+- name: 2024 with expenses under WI limit, one child
   absolute_error_margin: 0.01
   period: 2024
   input:
-    cdcc_potential: 800
     state_code: WI
+    tax_unit_childcare_expenses: 5_000
+    capped_count_cdcc_eligible: 1
+    min_head_spouse_earned: 50_000
+    cdcc_rate: 0.20
   output:
-    wi_childcare_expense_credit: 800 # 800 * 1
+    # WI limit: $10,000 * 1 = $10,000
+    # Capped expenses: min(5000, 10000) = 5000
+    # Relevant: min(5000, 50000) = 5000
+    # Credit: 5000 * 0.20 * 1.0 = 1000
+    wi_childcare_expense_credit: 1_000
+
+- name: 2024 with expenses over WI limit, one child
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    state_code: WI
+    tax_unit_childcare_expenses: 15_000
+    capped_count_cdcc_eligible: 1
+    min_head_spouse_earned: 50_000
+    cdcc_rate: 0.20
+  output:
+    # WI limit: $10,000 * 1 = $10,000
+    # Capped expenses: min(15000, 10000) = 10000
+    # Credit: 10000 * 0.20 * 1.0 = 2000
+    wi_childcare_expense_credit: 2_000
+
+- name: 2024 with two children, expenses over WI limit
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    state_code: WI
+    tax_unit_childcare_expenses: 25_000
+    capped_count_cdcc_eligible: 2
+    min_head_spouse_earned: 50_000
+    cdcc_rate: 0.20
+  output:
+    # WI limit: $10,000 * 2 = $20,000
+    # Capped expenses: min(25000, 20000) = 20000
+    # Credit: 20000 * 0.20 * 1.0 = 4000
+    wi_childcare_expense_credit: 4_000
+
+- name: 2024 capped by lower earnings
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    state_code: WI
+    tax_unit_childcare_expenses: 15_000
+    capped_count_cdcc_eligible: 1
+    min_head_spouse_earned: 8_000
+    cdcc_rate: 0.20
+  output:
+    # WI limit: $10,000 * 1 = $10,000
+    # Capped expenses: min(15000, 10000) = 10000
+    # Relevant: min(10000, 8000) = 8000
+    # Credit: 8000 * 0.20 * 1.0 = 1600
+    wi_childcare_expense_credit: 1_600

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
@@ -9,6 +9,7 @@ class oh_cdcc(Variable):
     definition_period = YEAR
     reference = (
         "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=20",
+        "https://codes.ohio.gov/ohio-revised-code/section-5747.054",
     )
     defined_for = StateCode.OH
 
@@ -16,11 +17,21 @@ class oh_cdcc(Variable):
         p = parameters(period).gov.states.oh.tax.income.credits.cdcc
 
         agi = tax_unit("oh_modified_agi", period)
-        # Ohio matches the federal credit taken
-        us_cdcc = tax_unit("cdcc", period)
+        # Per ORC 5747.054:
+        # For AGI < $20,000: 100% of the federal credit without
+        # regard to section 26 limitation (i.e., the potential
+        # credit before the tax liability cap).
+        # For $20,000 <= AGI < $40,000: 25% of the federal credit
+        # (with section 26 limitation applied).
+        # For AGI >= $40,000: no credit.
+        cdcc_potential = tax_unit("cdcc_potential", period)
+        cdcc_actual = tax_unit("cdcc", period)
+        low_income_threshold = p.low_income_threshold
+        us_cdcc = where(
+            agi < low_income_threshold,
+            cdcc_potential,
+            cdcc_actual,
+        )
 
         rate = p.match.calc(agi)
-        # qualify for full CDCC amount when AGI < 20_000
-        # qualify for 25% percent of CDCC when 20000 <= AGI < 40_000
-        # not qualify when AGI >= 40_000
         return rate * us_cdcc

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
@@ -8,14 +8,32 @@ class wi_childcare_expense_credit(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2"
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17"
-        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2",
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17",
+        "https://docs.legis.wisconsin.gov/statutes/statutes/71/i/07/9g",
     )
     defined_for = StateCode.WI
 
     def formula(tax_unit, period, parameters):
-        # Wisconsin matches the potential federal credit
-        us_cdcc = tax_unit("cdcc_potential", period)
-        p = parameters(period).gov.states.wi.tax.income
-        return us_cdcc * p.credits.childcare_expense.fraction
+        p = parameters(period).gov.states.wi.tax.income.credits
+        wi_max_expense = p.childcare_expense.max_expense
+        fraction = p.childcare_expense.fraction
+        has_wi_expense_limit = wi_max_expense > 0
+        # For 2024+, Wisconsin recomputes the credit using its own
+        # higher expense limits ($10,000/$20,000) per 71.07(9g)(c)5.
+        # For 2022-2023, it uses a fraction of the federal credit.
+        federal_cdcc_potential = tax_unit("cdcc_potential", period)
+        # Recompute with WI limits when applicable.
+        expenses = tax_unit("tax_unit_childcare_expenses", period)
+        capped_eligible = tax_unit("capped_count_cdcc_eligible", period)
+        wi_expense_cap = wi_max_expense * capped_eligible
+        wi_capped_expenses = min_(expenses, wi_expense_cap)
+        lower_earnings = tax_unit("min_head_spouse_earned", period)
+        wi_relevant_expenses = min_(wi_capped_expenses, lower_earnings)
+        cdcc_rate = tax_unit("cdcc_rate", period)
+        wi_cdcc_potential = wi_relevant_expenses * cdcc_rate
+        return where(
+            has_wi_expense_limit,
+            fraction * wi_cdcc_potential,
+            fraction * federal_cdcc_potential,
+        )


### PR DESCRIPTION
## Summary

Audited 11 states' CDCC implementations (NM, NY, OH, OK, OR, PA, RI, SC, VT, WI, WV). Found 2 bugs in Ohio and Wisconsin; other 9 states confirmed correct.

## Bugs fixed

### Ohio fix

Low-income filers (AGI < $20,000) should use `cdcc_potential` (federal credit without section 26 limitation) per ORC 5747.054, but the code was using `cdcc` (federal credit after section 26 limitation) for all filers. Added a new parameter `oh_cdcc_low_income_threshold` and logic to use the full potential credit for below-threshold filers.

### Wisconsin fix

For 2024+, Wisconsin enacted its own expense limits ($10,000/$20,000 per qualifying individual) via Act 101 of 2023 (codified in 71.07(9g)(c)5), but the code was still using federal limits ($3,000/$6,000). Added new parameter `wi_childcare_expense/max_expense` and updated the `wi_childcare_credit` formula to recompute the credit using Wisconsin's limits when applicable.

## Test plan

- Verify Ohio CDCC: low-income filers get full potential credit; higher-income filers get 25% of actual (section 26 limited) credit
- Verify Wisconsin CDCC: 2024+ filers use $10k/$20k limits; 2022-2023 filers use federal fraction approach
- Run full CDCC test suite for all 11 audited states to confirm no regressions
