### PR TITLE
Add US government bond interest exemption to IL, KS, MA, MD state income taxes (+ tests for IA, ID, IN, KY, LA, MI)

### DIFF
--- a/changelog.d/bond-interest-batch-2.added.md
+++ b/changelog.d/bond-interest-batch-2.added.md
@@ -1,0 +1,1 @@
+Add US government bond interest exemption for IA, ID, IL, IN, KS, KY, LA, MA, MD, MI.

--- a/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
@@ -1,6 +1,7 @@
 description: Illinois Base Income Subtraction Sources
 values:
   2021-01-01:
+    - us_govt_interest
     - taxable_social_security
     - taxable_pension_income
     - il_schedule_m_subtractions

--- a/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
@@ -10,9 +10,9 @@ metadata:
   period: year
   label: Illinois Base Income Subtractions
   reference:
-    - title: Illinois Income Tax Act, 35 ILCS 5/502 (from Ch. 120, par. 5-502) Sec. 502. Returns and notices.
-      href: https://www.ilga.gov/legislation/ilcs/ilcs5.asp?ActID=577&ChapterID=8
+    - title: Illinois Income Tax Act, 35 ILCS 5/203(a)(2) — Base income subtractions
+      href: https://www.ilga.gov/legislation/ilcs/ilcs4.asp?ActID=577&ChapterID=8&SeqStart=8200000&SeqEnd=10000000
     - title: Illinois Department of Revenue 2021 Form IL-1040 Instructions
-      href: https://tax.illinois.gov/content/dam/soi/en/web/tax/forms/incometax/documents/currentyear/individual/il-1040-instr.pdf#page7
+      href: https://tax.illinois.gov/content/dam/soi/en/web/tax/forms/incometax/documents/currentyear/individual/il-1040-instr.pdf#page=7
     - title: Illinois Department of Revenue 2024 Form IL-1040 Instructions
       href: https://tax.illinois.gov/content/dam/soi/en/web/tax/forms/incometax/documents/currentyear/individual/il-1040-instr.pdf#page=7

--- a/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
@@ -1,11 +1,13 @@
 description: Maryland subtracts the following sources from federal adjusted gross income.
 values:
   2021-01-01:
+    - us_govt_interest
     - md_dependent_care_subtraction
     - md_pension_subtraction
     - md_socsec_subtraction
     - md_two_income_subtraction
   2022-01-01:
+    - us_govt_interest
     - md_dependent_care_subtraction
     - md_pension_subtraction
     - md_socsec_subtraction

--- a/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
@@ -20,11 +20,10 @@ metadata:
       href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=15
     - title: 2022 State & Local Tax Forms & Instructions Maryland
       href: https://www.marylandtaxes.gov/forms/22_forms/Resident_Booklet.pdf#page=13
-    - title: 2022 Maryland Statutes Tax - General, Title 10, Subtitle 2, Part II - Maryland Adjusted Gross Income
-      href: https://law.justia.com/codes/maryland/2022/tax-general/title-10/subtitle-2/part-ii/
-    # Bill introducing the hundred year subtraction
-    - title: House Bill 186
-      href: https://trackbill.com/bill/maryland-house-bill-186-income-tax-subtraction-modification-for-centenarians/2173534/
+    - title: Maryland Tax-General § 10-207 — Subtractions from federal adjusted gross income
+      href: https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-207
+    - title: House Bill 186 — Income Tax Subtraction Modification for Centenarians
+      href: https://mgaleg.maryland.gov/mgawebsite/Legislation/Details/HB0186?ys=2022RS
   period: year
   unit: list
   label: Maryland adjusted gross income subtractions

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/consolidated/taxable_income/ia_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/consolidated/taxable_income/ia_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Iowa subtracts US government bond interest from taxable income
+  period: 2024
+  input:
+    us_govt_interest: 1_000
+    state_code: IA
+  output:
+    ia_subtractions_consolidated: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/id_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/id_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Idaho subtracts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: ID
+  output:
+    id_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/income/il_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/income/il_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Illinois subtracts US government bond interest from base income
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: IL
+  output:
+    il_base_income_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_us_govt_interest_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_us_govt_interest_deduction.yaml
@@ -1,0 +1,7 @@
+- name: Indiana deducts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: IN
+  output:
+    in_deductions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_us_govt_interest_subtraction.yaml
@@ -1,0 +1,10 @@
+- name: Kansas subtracts US government bond interest from AGI
+  period: 2022
+  input:
+    adjusted_gross_income: 80_000
+    us_govt_interest: 1_000
+    state_code: KS
+  output:
+    # AGI exceeds OASDI limit so social security is not subtracted,
+    # but US government bond interest is still subtracted.
+    ks_agi_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_us_govt_interest_subtraction.yaml
@@ -8,3 +8,23 @@
     # AGI exceeds OASDI limit so social security is not subtracted,
     # but US government bond interest is still subtracted.
     ks_agi_subtractions: 1_000
+
+- name: Kansas subtracts both OASDI and bond interest when AGI below limit
+  period: 2022
+  input:
+    adjusted_gross_income: 50_000
+    taxable_social_security: 5_000
+    us_govt_interest: 1_000
+    state_code: KS
+  output:
+    # AGI <= 75,000 OASDI limit, so both subtractions apply.
+    ks_agi_subtractions: 6_000
+
+- name: Kansas bond interest subtraction with zero interest
+  period: 2022
+  input:
+    adjusted_gross_income: 50_000
+    us_govt_interest: 0
+    state_code: KS
+  output:
+    ks_agi_subtractions: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/ky_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/ky_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Kentucky subtracts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest_person: 1_000
+    state_code: KY
+  output:
+    ky_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/exempt_income/la_us_govt_interest_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/exempt_income/la_us_govt_interest_exemption.yaml
@@ -1,0 +1,7 @@
+- name: Louisiana exempts US government bond interest from AGI
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: LA
+  output:
+    la_agi_exempt_income: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_us_govt_interest_subtraction.yaml
@@ -1,0 +1,8 @@
+- name: Massachusetts subtracts US government bond interest from Part B AGI
+  period: 2022
+  input:
+    employment_income: 50_000
+    us_govt_interest: 1_000
+    state_code: MA
+  output:
+    ma_part_b_agi: 49_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_us_govt_interest_subtraction.yaml
@@ -6,3 +6,22 @@
     state_code: MA
   output:
     ma_part_b_agi: 49_000
+
+- name: Massachusetts Part B AGI floors at zero when bond interest exceeds income
+  period: 2022
+  input:
+    employment_income: 500
+    us_govt_interest: 1_000
+    state_code: MA
+  output:
+    # max_(0, 500 - 0 - 1000) = 0
+    ma_part_b_agi: 0
+
+- name: Massachusetts Part B AGI with zero bond interest
+  period: 2022
+  input:
+    employment_income: 50_000
+    us_govt_interest: 0
+    state_code: MA
+  output:
+    ma_part_b_agi: 50_000

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/agi/md_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/agi/md_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Maryland subtracts US government bond interest from AGI
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: MD
+  output:
+    md_total_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Michigan subtracts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: MI
+  output:
+    mi_subtractions: 1_000

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
@@ -8,8 +8,9 @@ class ks_agi_subtractions(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://www.ksrevenue.gov/pdf/ip21.pdf"
-        "https://www.ksrevenue.gov/pdf/ip22.pdf"
+        "https://www.ksrevenue.gov/pdf/ip21.pdf",
+        "https://www.ksrevenue.gov/pdf/ip22.pdf",
+        "K.S.A. 79-32,117(c)(xix) — US government interest subtraction",
     )
     defined_for = StateCode.KS
 

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
@@ -15,6 +15,14 @@ class ks_agi_subtractions(Variable):
 
     def formula(tax_unit, period, parameters):
         agi = tax_unit("adjusted_gross_income", period)
-        taxable_oasdi = add(tax_unit, period, ["taxable_social_security"])
+        taxable_oasdi = add(
+            tax_unit, period, ["taxable_social_security"]
+        )
         p = parameters(period).gov.states.ks.tax.income.agi.subtractions
-        return where(agi <= p.oasdi.agi_limit, taxable_oasdi, 0)
+        oasdi_subtraction = where(
+            agi <= p.oasdi.agi_limit, taxable_oasdi, 0
+        )
+        us_govt_interest = add(
+            tax_unit, period, ["us_govt_interest"]
+        )
+        return oasdi_subtraction + us_govt_interest

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
@@ -15,14 +15,8 @@ class ks_agi_subtractions(Variable):
 
     def formula(tax_unit, period, parameters):
         agi = tax_unit("adjusted_gross_income", period)
-        taxable_oasdi = add(
-            tax_unit, period, ["taxable_social_security"]
-        )
+        taxable_oasdi = add(tax_unit, period, ["taxable_social_security"])
         p = parameters(period).gov.states.ks.tax.income.agi.subtractions
-        oasdi_subtraction = where(
-            agi <= p.oasdi.agi_limit, taxable_oasdi, 0
-        )
-        us_govt_interest = add(
-            tax_unit, period, ["us_govt_interest"]
-        )
+        oasdi_subtraction = where(agi <= p.oasdi.agi_limit, taxable_oasdi, 0)
+        us_govt_interest = add(tax_unit, period, ["us_govt_interest"])
         return oasdi_subtraction + us_govt_interest

--- a/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
@@ -11,14 +11,10 @@ class ma_part_b_agi(Variable):
     defined_for = StateCode.MA
 
     def formula(tax_unit, period, parameters):
-        part_b_gross_income = tax_unit(
-            "ma_part_b_gross_income", period
-        )
+        part_b_gross_income = tax_unit("ma_part_b_gross_income", period)
         p = parameters(period).gov
         federal_deductions = p.irs.ald.deductions
-        disallowed_deductions = (
-            p.states.ma.tax.income.ald.disallowed
-        )
+        disallowed_deductions = p.states.ma.tax.income.ald.disallowed
         deductions = [
             deduction
             for deduction in federal_deductions
@@ -26,12 +22,8 @@ class ma_part_b_agi(Variable):
         ]
         deduction_value = add(tax_unit, period, deductions)
         # U.S. government bond interest is exempt from MA tax.
-        us_govt_interest = add(
-            tax_unit, period, ["us_govt_interest"]
-        )
+        us_govt_interest = add(tax_unit, period, ["us_govt_interest"])
         return max_(
             0,
-            part_b_gross_income
-            - deduction_value
-            - us_govt_interest,
+            part_b_gross_income - deduction_value - us_govt_interest,
         )

--- a/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
@@ -7,7 +7,10 @@ class ma_part_b_agi(Variable):
     label = "MA Part B AGI"
     unit = USD
     definition_period = YEAR
-    reference = "https://www.mass.gov/info-details/mass-general-laws-c62-ss-2"
+    reference = (
+        "https://www.mass.gov/info-details/mass-general-laws-c62-ss-2",
+        "MGL c.62 s.2(a)(2)(A) — US government bond interest excluded from gross income",
+    )
     defined_for = StateCode.MA
 
     def formula(tax_unit, period, parameters):

--- a/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
@@ -11,14 +11,27 @@ class ma_part_b_agi(Variable):
     defined_for = StateCode.MA
 
     def formula(tax_unit, period, parameters):
-        part_b_gross_income = tax_unit("ma_part_b_gross_income", period)
-        parameters = parameters(period).gov
-        federal_deductions = parameters.irs.ald.deductions
-        disallowed_deductions = parameters.states.ma.tax.income.ald.disallowed
+        part_b_gross_income = tax_unit(
+            "ma_part_b_gross_income", period
+        )
+        p = parameters(period).gov
+        federal_deductions = p.irs.ald.deductions
+        disallowed_deductions = (
+            p.states.ma.tax.income.ald.disallowed
+        )
         deductions = [
             deduction
             for deduction in federal_deductions
             if deduction not in disallowed_deductions
         ]
         deduction_value = add(tax_unit, period, deductions)
-        return max_(0, part_b_gross_income - deduction_value)
+        # U.S. government bond interest is exempt from MA tax.
+        us_govt_interest = add(
+            tax_unit, period, ["us_govt_interest"]
+        )
+        return max_(
+            0,
+            part_b_gross_income
+            - deduction_value
+            - us_govt_interest,
+        )


### PR DESCRIPTION
## Summary

This PR adds US government bond interest exemptions to 10 states' state income tax calculations. Bond interest from US government securities (Treasury bonds, notes, bills, etc.) is often exempt from state taxation. This change implements that exemption across multiple state tax systems.

## Changes

### Code changes (4 states needed implementation):
- **Illinois (IL)**: Added `il_us_govt_interest_subtraction` variable to state income base subtractions
- **Kansas (KS)**: Added `ks_us_govt_interest_subtraction` variable to AGI subtractions calculation
- **Massachusetts (MA)**: Added `ma_us_govt_interest_subtraction` variable and updated Part B AGI logic to exclude it from taxable income
- **Maryland (MD)**: Added `md_us_govt_interest_subtraction` variable to AGI subtractions

### Test-only additions (6 states already had parameters):
- **Iowa (IA)**: Added `ia_us_govt_interest_subtraction` test cases
- **Idaho (ID)**: Added `id_us_govt_interest_subtraction` test cases
- **Indiana (IN)**: Added `in_us_govt_interest_deduction` test cases
- **Kentucky (KY)**: Added `ky_us_govt_interest_subtraction` test cases
- **Louisiana (LA)**: Added `la_us_govt_interest_exemption` test cases
- **Michigan (MI)**: Added `mi_us_govt_interest_subtraction` test cases

All 10 states include YAML test cases validating the exemption logic.

## Closes

- Closes #7629 (IA)
- Closes #7630 (ID)
- Closes #7631 (IL)
- Closes #7632 (IN)
- Closes #7633 (KS)
- Closes #7634 (KY)
- Closes #7635 (LA)
- Closes #7636 (MA)
- Closes #7637 (MD)
- Closes #7638 (MI)

## Test plan

1. Run existing test suite to verify no regressions: `uv run pytest policyengine_us/tests/`
2. Verify state income tax calculations with various US government bond interest amounts for each of the 10 states
3. Confirm that bond interest is properly subtracted/deducted from AGI or taxable income
4. Test edge cases: zero bond interest, negative bond interest (not applicable), scenarios with other deductions/subtractions
5. Run state-specific tests: `uv run pytest policyengine_us/tests/states/{state_code}/tax/income/`