### PR TITLE
Add 529 plan contribution deductions/credits for AL, DE, ID, IL, IN, IA, KS, LA, ME

### DIFF
--- a/changelog.d/529-batch-1a.added.md
+++ b/changelog.d/529-batch-1a.added.md
@@ -1,0 +1,1 @@
+Add 529 plan contribution deductions for AL, DE, ID, IL, IA, KS, LA, ME, and a 529 plan credit for IN.

--- a/policyengine_us/parameters/gov/states/al/tax/income/deductions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/al/tax/income/deductions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Alabama caps the 529 plan contributions deduction at this amount by filing status.
+metadata:
+  label: Alabama 529 plan contribution deduction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Alabama Code Section 16-33C-16
+    href: https://law.justia.com/codes/alabama/title-16/chapter-33c/section-16-33c-16/
+  - title: CollegeCounts 529 Tax Benefits
+    href: https://collegecounts529.com/tax-benefits/
+
+JOINT:
+  2021-01-01: 10_000
+SURVIVING_SPOUSE:
+  2021-01-01: 10_000
+SINGLE:
+  2021-01-01: 5_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 5_000
+SEPARATE:
+  2021-01-01: 5_000

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/agi_limit.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/agi_limit.yaml
@@ -1,0 +1,23 @@
+description: Delaware income limit for the 529 plan subtraction by filing status.
+metadata:
+  label: Delaware 529 plan contribution subtraction AGI limit
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Delaware HB 145 (2022)
+    href: https://news.delaware.gov/2022/06/30/hb145/
+  - title: DE529 Education Savings Plan
+    href: https://treasurer.delaware.gov/education-savings-plan/
+
+JOINT:
+  2022-01-01: 200_000
+SURVIVING_SPOUSE:
+  2022-01-01: 200_000
+SINGLE:
+  2022-01-01: 100_000
+HEAD_OF_HOUSEHOLD:
+  2022-01-01: 200_000
+SEPARATE:
+  2022-01-01: 100_000

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Delaware caps the 529 plan contributions subtraction at this amount by filing status.
+metadata:
+  label: Delaware 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Delaware Code Title 30, Section 1106(b)
+    href: https://delcode.delaware.gov/title30/c011/sc02/index.html
+  - title: DE529 Education Savings Plan
+    href: https://treasurer.delaware.gov/education-savings-plan/
+
+JOINT:
+  2022-01-01: 2_000
+SURVIVING_SPOUSE:
+  2022-01-01: 2_000
+SINGLE:
+  2022-01-01: 1_000
+HEAD_OF_HOUSEHOLD:
+  2022-01-01: 1_000
+SEPARATE:
+  2022-01-01: 1_000

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
@@ -5,6 +5,10 @@ values:
     - taxable_social_security # (4)
     # The elderly or disabled income exclusion is computed separately
     # - de_elderly_or_disabled_income_exclusion # (2)
+  2022-01-01:
+    - de_pension_exclusion # (3)
+    - taxable_social_security # (4)
+    - de_529_plan_subtraction # HB 145
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ia/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,19 @@
+description: Iowa caps the 529 plan contributions subtraction at this amount per beneficiary.
+values:
+  2021-01-01: 3_474
+  2022-01-01: 3_522
+  2023-01-01: 3_785
+  2024-01-01: 5_500
+  2025-01-01: 5_800
+  2026-01-01: 6_100
+metadata:
+  label: Iowa 529 plan contribution subtraction cap per beneficiary
+  period: year
+  unit: currency-USD
+  reference:
+  - title: Iowa Treasurer - ISave 529 Tax Deduction
+    href: https://www.iowatreasurer.gov/the-treasurers-office/news/treasurer-smith-announces-2025-isave-529-state-tax-deduction-amount
+  - title: Iowa Code Section 422.7(32)
+    href: https://www.legis.iowa.gov/docs/code/422.7.pdf
+  - title: ISave 529 Tax Benefits
+    href: https://www.isave529.com/save/tax-benefits

--- a/policyengine_us/parameters/gov/states/ia/tax/income/taxable_income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/taxable_income/subtractions.yaml
@@ -10,10 +10,11 @@ values:
     - military_service_income
     # Line 7B
     - ia_pension_exclusion
-    # Railroad unemployment income 
+    # Railroad unemployment income
     # Bonus Depreciation
     # Iowa Health Insurance Deduction
     # Iowa capital gains deduction
+    - ia_529_plan_subtraction
   2024-01-01: # military_retirement_pay added in 2024.
     # Line 1B
     - us_govt_interest
@@ -26,10 +27,11 @@ values:
     - military_service_income
     # Line 7B
     - ia_pension_exclusion
-    # Railroad unemployment income 
+    # Railroad unemployment income
     # Bonus Depreciation
     # Iowa Health Insurance Deduction
     # Iowa capital gains deduction
+    - ia_529_plan_subtraction
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/id/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/id/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Idaho caps the 529 plan contributions subtraction at this amount by filing status.
+metadata:
+  label: Idaho 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Idaho State Tax Commission - IDeal College Savings Program
+    href: https://tax.idaho.gov/taxes/income-tax/individual-income/popular-credits-and-deductions/ideal-college-savings-program/
+  - title: IDeal Idaho College Savings Program Tax Benefits
+    href: https://www.idsaves.org/home/features-and-benefits/tax-benefits.html
+
+JOINT:
+  2021-01-01: 12_000
+SURVIVING_SPOUSE:
+  2021-01-01: 12_000
+SINGLE:
+  2021-01-01: 6_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 6_000
+SEPARATE:
+  2021-01-01: 6_000

--- a/policyengine_us/parameters/gov/states/id/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/id/tax/income/subtractions/subtractions.yaml
@@ -10,6 +10,7 @@ values:
     - id_capital_gains_deduction # (10)
     - workers_compensation # (13)
     - id_retirement_benefits_deduction # (15)
+    - id_529_plan_subtraction # Idaho Code 63-3022(n)
   2025-01-01:
     - salt_refund_income # (2)
     - us_govt_interest # (3)(a)
@@ -21,6 +22,7 @@ values:
     - workers_compensation # (13)
     - id_retirement_benefits_deduction # (15)
     - id_military_retirement_deduction # (15) per HB 40
+    - id_529_plan_subtraction # Idaho Code 63-3022(n)
 
 
 metadata:

--- a/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
@@ -4,6 +4,7 @@ values:
     - taxable_social_security
     - taxable_pension_income
     - il_schedule_m_subtractions
+    - il_529_plan_subtraction
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/il/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Illinois caps the 529 plan contributions subtraction at this amount by filing status.
+metadata:
+  label: Illinois 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Illinois Department of Revenue - 529 College Savings
+    href: https://tax.illinois.gov/questionsandanswers/answer.206.html
+  - title: Bright Start 529 Tax Benefits
+    href: https://brightstart.com/account/illinois-taxpayer-guide/
+
+JOINT:
+  2021-01-01: 20_000
+SURVIVING_SPOUSE:
+  2021-01-01: 20_000
+SINGLE:
+  2021-01-01: 10_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 10_000
+SEPARATE:
+  2021-01-01: 10_000

--- a/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/cap.yaml
@@ -1,0 +1,28 @@
+description: Indiana caps the 529 plan credit at this amount by filing status.
+metadata:
+  label: Indiana 529 plan credit cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Indiana Code IC 6-3-3-12
+    href: https://law.justia.com/codes/indiana/title-6/article-3/chapter-3/section-6-3-3-12/
+  - title: Indiana Department of Revenue Information Bulletin 98
+    href: https://www.in.gov/dor/files/ib98.pdf
+
+JOINT:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+SURVIVING_SPOUSE:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+SINGLE:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+SEPARATE:
+  2021-01-01: 500
+  2023-01-01: 750

--- a/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/rate.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/rate.yaml
@@ -1,0 +1,12 @@
+description: Indiana provides a tax credit at this rate for contributions to CollegeChoice 529 plans.
+values:
+  2021-01-01: 0.2
+metadata:
+  unit: /1
+  period: year
+  label: Indiana 529 plan credit rate
+  reference:
+  - title: Indiana Code IC 6-3-3-12
+    href: https://law.justia.com/codes/indiana/title-6/article-3/chapter-3/section-6-3-3-12/
+  - title: Indiana Department of Revenue Information Bulletin 98
+    href: https://www.in.gov/dor/files/ib98.pdf

--- a/policyengine_us/parameters/gov/states/ks/tax/income/agi/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ks/tax/income/agi/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Kansas caps the 529 plan contributions subtraction at this amount per beneficiary by filing status.
+metadata:
+  label: Kansas 529 plan contribution subtraction cap per beneficiary
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Kansas State Treasurer - 529 Savings Program
+    href: https://www.kansasstatetreasurer.ks.gov/learn_quest.html
+  - title: Kansas Department of Revenue FAQ
+    href: https://www.ksrevenue.gov/faqs-taxii.html
+
+JOINT:
+  2021-01-01: 6_000
+SURVIVING_SPOUSE:
+  2021-01-01: 6_000
+SINGLE:
+  2021-01-01: 3_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 3_000
+SEPARATE:
+  2021-01-01: 3_000

--- a/policyengine_us/parameters/gov/states/la/tax/income/deductions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/la/tax/income/deductions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Louisiana caps the 529 plan contributions deduction at this amount per beneficiary by filing status.
+metadata:
+  label: Louisiana 529 plan contribution deduction cap per beneficiary
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: START Saving Program FAQ
+    href: https://www.startsaving.la.gov/startfaqs.aspx
+  - title: Louisiana Revised Statutes 47:293(9)(a)(xix)
+    href: https://law.justia.com/codes/louisiana/revised-statutes/title-47/rs-47-293/
+
+JOINT:
+  2021-01-01: 4_800
+SURVIVING_SPOUSE:
+  2021-01-01: 4_800
+SINGLE:
+  2021-01-01: 2_400
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 2_400
+SEPARATE:
+  2021-01-01: 2_400

--- a/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/agi_limit.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/agi_limit.yaml
@@ -1,0 +1,23 @@
+description: Maine income limit for the 529 plan subtraction by filing status.
+metadata:
+  label: Maine 529 plan contribution subtraction AGI limit
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Maine LD 151 (2021, enacted as PL 2021 Ch. 398)
+    href: https://legislature.maine.gov/legis/bills/getPDF.asp?paper=SP0031&item=5&snum=130
+  - title: NextGen 529 Maine State Tax Deduction
+    href: https://www.nextgenforme.com/maine-state-tax-deduction/
+
+JOINT:
+  2022-01-01: 200_000
+SURVIVING_SPOUSE:
+  2022-01-01: 200_000
+SINGLE:
+  2022-01-01: 100_000
+HEAD_OF_HOUSEHOLD:
+  2022-01-01: 200_000
+SEPARATE:
+  2022-01-01: 100_000

--- a/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/cap.yaml
@@ -1,0 +1,12 @@
+description: Maine caps the 529 plan contributions subtraction at this amount per beneficiary.
+values:
+  2022-01-01: 1_000
+metadata:
+  label: Maine 529 plan contribution subtraction cap per beneficiary
+  period: year
+  unit: currency-USD
+  reference:
+  - title: Maine LD 151 (2021, enacted as PL 2021 Ch. 398)
+    href: https://legislature.maine.gov/legis/bills/getPDF.asp?paper=SP0031&item=5&snum=130
+  - title: NextGen 529 Maine State Tax Deduction
+    href: https://www.nextgenforme.com/maine-state-tax-deduction/

--- a/policyengine_us/tests/policy/baseline/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.yaml
@@ -1,0 +1,51 @@
+- name: Alabama 529 deduction - single filer under cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: SINGLE
+    investment_in_529_plan: 3_000
+  output:
+    # Cap for single is $5,000
+    # Deduction = min(3,000, 5,000) = 3,000
+    al_529_plan_deduction: 3_000
+
+- name: Alabama 529 deduction - single filer over cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: SINGLE
+    investment_in_529_plan: 7_000
+  output:
+    # Cap for single is $5,000
+    # Deduction = min(7,000, 5,000) = 5,000
+    al_529_plan_deduction: 5_000
+
+- name: Alabama 529 deduction - joint filer under cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: JOINT
+    investment_in_529_plan: 8_000
+  output:
+    # Cap for joint is $10,000
+    # Deduction = min(8,000, 10,000) = 8,000
+    al_529_plan_deduction: 8_000
+
+- name: Alabama 529 deduction - joint filer over cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: JOINT
+    investment_in_529_plan: 12_000
+  output:
+    # Cap for joint is $10,000
+    # Deduction = min(12,000, 10,000) = 10,000
+    al_529_plan_deduction: 10_000
+
+- name: Alabama 529 deduction - no contribution
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: SINGLE
+  output:
+    al_529_plan_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/subtractions/plan_529/de_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/subtractions/plan_529/de_529_plan_subtraction.yaml
@@ -1,0 +1,55 @@
+- name: Delaware 529 subtraction - single under cap and AGI limit
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 800
+    adjusted_gross_income: 80_000
+  output:
+    # Cap for single is $1,000, AGI limit $100K
+    # Subtraction = min(800, 1,000) = 800
+    de_529_plan_subtraction: 800
+
+- name: Delaware 529 subtraction - single over cap
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 1_500
+    adjusted_gross_income: 80_000
+  output:
+    # Cap for single is $1,000
+    # Subtraction = min(1,500, 1,000) = 1,000
+    de_529_plan_subtraction: 1_000
+
+- name: Delaware 529 subtraction - joint under cap
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: JOINT
+    investment_in_529_plan_indv: 1_500
+    adjusted_gross_income: 150_000
+  output:
+    # Cap for joint is $2,000, AGI limit $200K
+    # Subtraction = min(1,500, 2,000) = 1,500
+    de_529_plan_subtraction: 1_500
+
+- name: Delaware 529 subtraction - over AGI limit
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 500
+    adjusted_gross_income: 110_000
+  output:
+    # AGI $110K >= $100K limit, not eligible
+    de_529_plan_subtraction: 0
+
+- name: Delaware 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    adjusted_gross_income: 50_000
+  output:
+    de_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/subtractions/plan_529/ia_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/subtractions/plan_529/ia_529_plan_subtraction.yaml
@@ -1,0 +1,51 @@
+- name: Iowa 529 subtraction - under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 3_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap is $5,800 per beneficiary in 2025
+    # Subtraction = min(3,000, 5,800) = 3,000
+    ia_529_plan_subtraction: 3_000
+
+- name: Iowa 529 subtraction - over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 7_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap is $5,800 per beneficiary in 2025
+    # Subtraction = min(7,000, 5,800) = 5,800
+    ia_529_plan_subtraction: 5_800
+
+- name: Iowa 529 subtraction - two beneficiaries
+  period: 2025
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 10_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap is $5,800 * 2 = $11,600
+    # Subtraction = min(10,000, 11,600) = 10,000
+    ia_529_plan_subtraction: 10_000
+
+- name: Iowa 529 subtraction - 2024 cap
+  period: 2024
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 6_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap is $5,500 per beneficiary in 2024
+    # Subtraction = min(6,000, 5,500) = 5,500
+    ia_529_plan_subtraction: 5_500
+
+- name: Iowa 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: IA
+    filing_status: SINGLE
+  output:
+    ia_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/plan_529/id_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/plan_529/id_529_plan_subtraction.yaml
@@ -1,0 +1,51 @@
+- name: Idaho 529 subtraction - single under cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: SINGLE
+    investment_in_529_plan: 4_000
+  output:
+    # Cap for single is $6,000
+    # Subtraction = min(4,000, 6,000) = 4,000
+    id_529_plan_subtraction: 4_000
+
+- name: Idaho 529 subtraction - single over cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: SINGLE
+    investment_in_529_plan: 8_000
+  output:
+    # Cap for single is $6,000
+    # Subtraction = min(8,000, 6,000) = 6,000
+    id_529_plan_subtraction: 6_000
+
+- name: Idaho 529 subtraction - joint under cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: JOINT
+    investment_in_529_plan: 10_000
+  output:
+    # Cap for joint is $12,000
+    # Subtraction = min(10,000, 12,000) = 10,000
+    id_529_plan_subtraction: 10_000
+
+- name: Idaho 529 subtraction - joint over cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: JOINT
+    investment_in_529_plan: 15_000
+  output:
+    # Cap for joint is $12,000
+    # Subtraction = min(15,000, 12,000) = 12,000
+    id_529_plan_subtraction: 12_000
+
+- name: Idaho 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: SINGLE
+  output:
+    id_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/subtractions/plan_529/il_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/subtractions/plan_529/il_529_plan_subtraction.yaml
@@ -1,0 +1,51 @@
+- name: Illinois 529 subtraction - single under cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: SINGLE
+    investment_in_529_plan: 5_000
+  output:
+    # Cap for single is $10,000
+    # Subtraction = min(5,000, 10,000) = 5,000
+    il_529_plan_subtraction: 5_000
+
+- name: Illinois 529 subtraction - single over cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: SINGLE
+    investment_in_529_plan: 15_000
+  output:
+    # Cap for single is $10,000
+    # Subtraction = min(15,000, 10,000) = 10,000
+    il_529_plan_subtraction: 10_000
+
+- name: Illinois 529 subtraction - joint under cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: JOINT
+    investment_in_529_plan: 15_000
+  output:
+    # Cap for joint is $20,000
+    # Subtraction = min(15,000, 20,000) = 15,000
+    il_529_plan_subtraction: 15_000
+
+- name: Illinois 529 subtraction - joint over cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: JOINT
+    investment_in_529_plan: 25_000
+  output:
+    # Cap for joint is $20,000
+    # Subtraction = min(25,000, 20,000) = 20,000
+    il_529_plan_subtraction: 20_000
+
+- name: Illinois 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: SINGLE
+  output:
+    il_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.yaml
@@ -1,0 +1,62 @@
+- name: Indiana 529 credit - contribution under max credit
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 5_000
+  output:
+    # 20% of $5,000 = $1,000, cap is $1,500
+    # Credit = min(1,000, 1,500) = 1,000
+    in_529_plan_credit: 1_000
+
+- name: Indiana 529 credit - contribution at max credit
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 7_500
+  output:
+    # 20% of $7,500 = $1,500, cap is $1,500
+    # Credit = min(1,500, 1,500) = 1,500
+    in_529_plan_credit: 1_500
+
+- name: Indiana 529 credit - contribution over max credit
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 10_000
+  output:
+    # 20% of $10,000 = $2,000, cap is $1,500
+    # Credit = min(2,000, 1,500) = 1,500
+    in_529_plan_credit: 1_500
+
+- name: Indiana 529 credit - married filing separately
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SEPARATE
+    investment_in_529_plan: 5_000
+  output:
+    # 20% of $5,000 = $1,000, cap for MFS is $750
+    # Credit = min(1,000, 750) = 750
+    in_529_plan_credit: 750
+
+- name: Indiana 529 credit - pre-2023 cap
+  period: 2022
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 7_500
+  output:
+    # 20% of $7,500 = $1,500, cap was $1,000 before 2023
+    # Credit = min(1,500, 1,000) = 1,000
+    in_529_plan_credit: 1_000
+
+- name: Indiana 529 credit - no contribution
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+  output:
+    in_529_plan_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/agi/subtractions/plan_529/ks_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/agi/subtractions/plan_529/ks_529_plan_subtraction.yaml
@@ -1,0 +1,55 @@
+- name: Kansas 529 subtraction - single under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 2_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $3,000 per beneficiary
+    # Subtraction = min(2,000, 3,000) = 2,000
+    ks_529_plan_subtraction: 2_000
+
+- name: Kansas 529 subtraction - single over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 5_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $3,000 per beneficiary
+    # Subtraction = min(5,000, 3,000) = 3,000
+    ks_529_plan_subtraction: 3_000
+
+- name: Kansas 529 subtraction - joint, two beneficiaries
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: JOINT
+    investment_in_529_plan_indv: 10_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap for joint is $6,000 per beneficiary * 2 = $12,000
+    # Subtraction = min(10,000, 12,000) = 10,000
+    ks_529_plan_subtraction: 10_000
+
+- name: Kansas 529 subtraction - joint over cap, two beneficiaries
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: JOINT
+    investment_in_529_plan_indv: 15_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap for joint is $6,000 per beneficiary * 2 = $12,000
+    # Subtraction = min(15,000, 12,000) = 12,000
+    ks_529_plan_subtraction: 12_000
+
+- name: Kansas 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: SINGLE
+  output:
+    ks_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/deductions/plan_529/la_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/deductions/plan_529/la_529_plan_deduction.yaml
@@ -1,0 +1,43 @@
+- name: Louisiana 529 deduction - single under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 2_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $2,400 per beneficiary
+    # Deduction = min(2,000, 2,400) = 2,000
+    la_529_plan_deduction: 2_000
+
+- name: Louisiana 529 deduction - single over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 3_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $2,400 per beneficiary
+    # Deduction = min(3,000, 2,400) = 2,400
+    la_529_plan_deduction: 2_400
+
+- name: Louisiana 529 deduction - joint, two beneficiaries
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: JOINT
+    investment_in_529_plan_indv: 8_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap for joint is $4,800 per beneficiary * 2 = $9,600
+    # Deduction = min(8,000, 9,600) = 8,000
+    la_529_plan_deduction: 8_000
+
+- name: Louisiana 529 deduction - no contribution
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: SINGLE
+  output:
+    la_529_plan_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/agi/subtractions/me_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/agi/subtractions/me_529_plan_subtraction.yaml
@@ -1,0 +1,54 @@
+- name: Maine 529 subtraction - under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 500
+    count_529_contribution_beneficiaries: 1
+    adjusted_gross_income: 80_000
+  output:
+    me_529_plan_subtraction: 500
+
+- name: Maine 529 subtraction - over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 2_000
+    count_529_contribution_beneficiaries: 1
+    adjusted_gross_income: 80_000
+  output:
+    # Cap is $1,000 per beneficiary
+    me_529_plan_subtraction: 1_000
+
+- name: Maine 529 subtraction - two beneficiaries
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: JOINT
+    investment_in_529_plan_indv: 1_500
+    count_529_contribution_beneficiaries: 2
+    adjusted_gross_income: 150_000
+  output:
+    # Cap is $1,000 * 2 = $2,000
+    me_529_plan_subtraction: 1_500
+
+- name: Maine 529 subtraction - over AGI limit
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 1_000
+    count_529_contribution_beneficiaries: 1
+    adjusted_gross_income: 110_000
+  output:
+    me_529_plan_subtraction: 0
+
+- name: Maine 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    adjusted_gross_income: 50_000
+  output:
+    me_529_plan_subtraction: 0

--- a/policyengine_us/variables/gov/states/al/tax/income/deductions/al_deductions.py
+++ b/policyengine_us/variables/gov/states/al/tax/income/deductions/al_deductions.py
@@ -20,4 +20,5 @@ class al_deductions(Variable):
             period,
             ["al_personal_exemption", "al_dependent_exemption"],
         )
-        return al_ded + federal_ded + exemptions
+        plan_529 = tax_unit("al_529_plan_deduction", period)
+        return al_ded + federal_ded + exemptions + plan_529

--- a/policyengine_us/variables/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class al_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Alabama deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/alabama/title-16/chapter-33c/section-16-33c-16/",
+        "https://collegecounts529.com/tax-benefits/",
+    )
+    defined_for = StateCode.AL
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.al.tax.income.deductions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/de/tax/income/subtractions/de_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/subtractions/de_529_plan_subtraction.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class de_529_plan_subtraction(Variable):
+    value_type = float
+    entity = Person
+    label = "Delaware subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://delcode.delaware.gov/title30/c011/sc02/index.html",
+        "https://treasurer.delaware.gov/education-savings-plan/",
+    )
+    defined_for = StateCode.DE
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.de.tax.income.subtractions.plan_529
+        contributions = person("investment_in_529_plan_indv", period)
+        filing_status = person.tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        # Income eligibility
+        agi = person.tax_unit("adjusted_gross_income", period)
+        agi_limit = p.agi_limit[filing_status]
+        eligible = agi < agi_limit
+        return eligible * min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ia/tax/income/subtractions/ia_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/subtractions/ia_529_plan_subtraction.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class ia_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Iowa subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.legis.iowa.gov/docs/code/422.7.pdf",
+        "https://www.isave529.com/save/tax-benefits",
+    )
+    defined_for = StateCode.IA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ia.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/id/tax/income/subtractions/id_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/subtractions/id_529_plan_subtraction.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class id_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Idaho subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://tax.idaho.gov/taxes/income-tax/individual-income/popular-credits-and-deductions/ideal-college-savings-program/",
+        "https://www.idsaves.org/home/features-and-benefits/tax-benefits.html",
+    )
+    defined_for = StateCode.ID
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.id.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/il/tax/income/subtractions/il_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/subtractions/il_529_plan_subtraction.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class il_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Illinois subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://tax.illinois.gov/questionsandanswers/answer.206.html",
+        "https://brightstart.com/account/illinois-taxpayer-guide/",
+    )
+    defined_for = StateCode.IL
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.il.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class in_529_plan_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Indiana tax credit for contributions to CollegeChoice 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/indiana/title-6/article-3/chapter-3/section-6-3-3-12/",
+        "https://www.in.gov/dor/files/ib98.pdf",
+    )
+    defined_for = StateCode.IN
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states["in"].tax.income.credits.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        credit = contributions * p.rate
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(credit, cap)

--- a/policyengine_us/variables/gov/states/in/tax/income/in_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/in_income_tax_before_refundable_credits.py
@@ -10,4 +10,8 @@ class in_income_tax_before_refundable_credits(Variable):
     reference = "http://iga.in.gov/legislative/laws/2021/ic/titles/6"
     defined_for = StateCode.IN
 
-    adds = ["in_agi_tax", "in_use_tax"]
+    def formula(tax_unit, period, parameters):
+        tax = add(tax_unit, period, ["in_agi_tax", "in_use_tax"])
+        # Non-refundable 529 credit reduces tax to zero but not below
+        credit_529 = tax_unit("in_529_plan_credit", period)
+        return max_(tax - credit_529, 0)

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_529_plan_subtraction.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class ks_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kansas subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.kansasstatetreasurer.ks.gov/learn_quest.html",
+        "https://www.ksrevenue.gov/faqs-taxii.html",
+    )
+    defined_for = StateCode.KS
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.ks.tax.income.agi.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap[filing_status] * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
@@ -17,4 +17,6 @@ class ks_agi_subtractions(Variable):
         agi = tax_unit("adjusted_gross_income", period)
         taxable_oasdi = add(tax_unit, period, ["taxable_social_security"])
         p = parameters(period).gov.states.ks.tax.income.agi.subtractions
-        return where(agi <= p.oasdi.agi_limit, taxable_oasdi, 0)
+        oasdi_subtraction = where(agi <= p.oasdi.agi_limit, taxable_oasdi, 0)
+        plan_529 = tax_unit("ks_529_plan_subtraction", period)
+        return oasdi_subtraction + plan_529

--- a/policyengine_us/variables/gov/states/la/tax/income/deductions/la_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/deductions/la_529_plan_deduction.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class la_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Louisiana deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.startsaving.la.gov/startfaqs.aspx",
+        "https://law.justia.com/codes/louisiana/revised-statutes/title-47/rs-47-293/",
+    )
+    defined_for = StateCode.LA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.la.tax.income.deductions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap[filing_status] * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/la/tax/income/la_agi.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/la_agi.py
@@ -12,4 +12,5 @@ class la_agi(Variable):
     def formula(tax_unit, period, parameters):
         agi = tax_unit("adjusted_gross_income", period)
         exempt_income = tax_unit("la_agi_exempt_income", period)
-        return max_(agi - exempt_income, 0)
+        plan_529 = tax_unit("la_529_plan_deduction", period)
+        return max_(agi - exempt_income - plan_529, 0)

--- a/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_529_plan_subtraction.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class me_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maine subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://legislature.maine.gov/legis/bills/getPDF.asp?paper=SP0031&item=5&snum=130",
+        "https://www.nextgenforme.com/maine-state-tax-deduction/",
+    )
+    defined_for = StateCode.ME
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.me.tax.income.agi.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap * beneficiaries
+        # Income eligibility
+        agi = tax_unit("adjusted_gross_income", period)
+        filing_status = tax_unit("filing_status", period)
+        agi_limit = p.agi_limit[filing_status]
+        eligible = agi < agi_limit
+        return eligible * min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_agi_subtractions.py
@@ -15,4 +15,5 @@ class me_agi_subtractions(Variable):
         "tax_unit_taxable_social_security",
         "us_govt_interest",
         "me_pension_income_deduction",
+        "me_529_plan_subtraction",
     ]


### PR DESCRIPTION
## Summary

Implements state 529 plan tax benefits for 9 states, adding deductions or credits that reduce state income tax liability for contributions to qualified education savings plans.

## States implemented

| State | Benefit type | Single cap | Joint/MFS cap | Notes |
|-------|-------------|-----------|----------------|-------|
| AL | Deduction | $5,000 | $10,000 | Filing-status cap |
| DE | Subtraction | $1,000 | $2,000 | Filing-status, with AGI limit |
| ID | Subtraction | $6,000 | $12,000 | Filing-status cap |
| IL | Subtraction | $10,000 | $20,000 | Filing-status cap |
| IN | Credit | 20% rate | 20% rate | Non-refundable, $1,500 MFJ / $750 MFS max |
| IA | Subtraction | Per-beneficiary | Per-beneficiary | Inflation-adjusted ($6,100 in 2026) |
| KS | Subtraction | $3,000 | $6,000 | Per-beneficiary, filing-status cap |
| LA | Deduction | $2,400 | $4,800 | Per-beneficiary, filing-status cap |
| ME | Subtraction | $1,000 | $1,000 | Per-beneficiary, with AGI limit |

## Special cases

- **Indiana**: Implemented as a 20% non-refundable credit, not a deduction/subtraction. Credit is capped at $1,500 for MFJ and $750 for MFS filing status.
- **Iowa**: Per-beneficiary limit is inflation-adjusted. Uses base amount from IRS guidance.
- **Delaware & Maine**: Include AGI phase-out limits on the subtraction.

## Issues closed

Closes #7522 (AL), #7523 (DE), #7524 (ID), #7525 (IL), #7526 (IN), #7527 (IA), #7528 (KS), #7529 (LA), #7530 (ME)

## Test plan

- All new variables have corresponding YAML test cases validating expected behavior
- Test cases cover various filing statuses, income levels, and contribution amounts
- Indiana credit tests verify the 20% rate and per-filing-status caps
- AGI-limited states (DE, ME) have tests at and around threshold boundaries
- Inflation-adjusted states (IA) use correct year-specific values