### PR TITLE
Add ms_cdcc to state CDCC aggregation list

### DIFF
--- a/changelog.d/cdcc-fix-ms.added.md
+++ b/changelog.d/cdcc-fix-ms.added.md
@@ -1,0 +1,1 @@
+Add ms_cdcc to state CDCC aggregation list so Mississippi's child and dependent care credit flows through to state_cdcc totals.

--- a/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
@@ -19,6 +19,7 @@ values:
     - md_cdcc  # Maryland
     - me_child_care_credit  # Maine
     - mn_cdcc  # Minnesota
+    - ms_cdcc  # Mississippi
     - ne_cdcc_nonrefundable  # Nebraska
     - ne_cdcc_refundable  # Nebraska
     - nj_cdcc  # New Jersey


### PR DESCRIPTION
## Summary

- `ms_cdcc` (Mississippi child and dependent care credit) was missing from the aggregation list in `state_cdccs.yaml`
- The variable existed and computed correctly under Mississippi Code Ann. § 27-7-22.21, but was never included in the `state_cdcc` household total
- Adds `- ms_cdcc  # Mississippi` in alphabetical order between `mn_cdcc` (Minnesota) and `ne_cdcc_nonrefundable` (Nebraska)

Closes #7678

## Test plan

- [ ] Verify that a Mississippi household with qualifying child/dependent care expenses now shows a non-zero `state_cdcc` value equal to `ms_cdcc`
- [ ] Confirm no other states are affected (list diff shows only the Mississippi entry added)
