### PR TITLE
Fix DC CDCC rate to 24.25% for TY2026+ (currently 32%)

### DIFF
--- a/changelog.d/dc-cdcc-2026-rate.changed.md
+++ b/changelog.d/dc-cdcc-2026-rate.changed.md
@@ -1,0 +1,1 @@
+Update DC CDCC match rate to 24.25% for tax year 2026+ per DC Code 47-1806.04(c)(1)(B), as amended by the FY2025 Budget Support Act (D.C. Act 25-506, sec. 7032).

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/cdcc/match.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/cdcc/match.yaml
@@ -14,5 +14,8 @@ metadata:
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2024_D40_Booklet_011525.pdf#page=34
     - title: 2025 DC Form D-40 Booklet, Line 21
       href: https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2025_D40_Book_Final_wLinks_021226_v1.0.pdf#page=21
+    - title: DC Code 47-1806.04(c)(1)(B), as amended by FY2025 Budget Support Act (D.C. Act 25-506, sec. 7032)
+      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.04
 values:
   2021-01-01: 0.32
+  2026-01-01: 0.2425

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_cdcc.yaml
@@ -13,3 +13,19 @@
     state_code: DC
   output:
     dc_cdcc: 32  # = 100 * 0.32
+
+- name: DC CDCC 2025 rate still 32%
+  period: 2025
+  input:
+    cdcc_potential: 1_000
+    state_code: DC
+  output:
+    dc_cdcc: 320  # = 1_000 * 0.32
+
+- name: DC CDCC 2026 rate reduced to 24.25%
+  period: 2026
+  input:
+    cdcc_potential: 1_000
+    state_code: DC
+  output:
+    dc_cdcc: 242.5  # = 1_000 * 0.2425


### PR DESCRIPTION
## Summary

Fixes #7677.

DC Code § 47-1806.04(c)(1)(B), as amended by the Fiscal Year 2025 Budget Support Act of 2024 (D.C. Act 25-506, sec. 7032, signed July 15, 2024), requires the DC CDCC match rate to drop from 32% to 24.25% for tax years beginning after December 31, 2025.

The statute states:

> "(B) For each full calendar or fiscal year beginning after December 31, 2025, there is allowed a credit against the tax imposed by § 47-1806.03 in an amount equal to 24.25% of the amount of the credit to which the resident may be entitled under section 21 of the Internal Revenue Code of 1986"

## Changes

- Added `2026-01-01: 0.2425` entry to `match.yaml`
- Added statute reference to the parameter metadata
- Added two new test cases: TY2025 (still 32%) and TY2026 (24.25%)

## Test plan

- [ ] Existing TY2021 and TY2022 tests continue to pass at 32%
- [ ] New TY2025 test confirms 32% rate still applies
- [ ] New TY2026 test confirms 24.25% rate applies
