### PR TITLE
Fix LA non-refundable CDCC to use claimed federal credit

### DIFF
--- a/changelog.d/cdcc-fix-la.fixed.md
+++ b/changelog.d/cdcc-fix-la.fixed.md
@@ -1,0 +1,1 @@
+Fix LA non-refundable CDCC to use cdcc (claimed federal credit) instead of cdcc_potential, per RS 47:297.4(B).

--- a/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
@@ -14,7 +14,10 @@ class la_non_refundable_cdcc(Variable):
         p = parameters(
             period
         ).gov.states.la.tax.income.credits.cdcc.non_refundable
-        # Louisiana matches the potential federal credit
+        # Louisiana non-refundable tier uses the claimed federal credit (cdcc),
+        # per RS 47:297.4(B): "...claimed on the resident individual's federal
+        # tax return." This means the actual credit after the IRC 26 tax
+        # liability cap, not cdcc_potential (which ignores that cap).
         us_cdcc = tax_unit("cdcc", period)
         us_agi = tax_unit("adjusted_gross_income", period)
         match = p.match.calc(us_agi, right=True)


### PR DESCRIPTION
## Summary

The Louisiana non-refundable CDCC (`la_non_refundable_cdcc`) previously used `cdcc_potential` instead of `cdcc` as the federal credit base. This was corrected in commit d9c7ddf, but the in-code comment still said "Louisiana matches the potential federal credit" — which is now incorrect and contradicts the code.

This PR:
- Updates the stale comment to accurately document why `cdcc` (not `cdcc_potential`) is correct for the non-refundable tier
- Adds a `changelog.d/` fragment (the original fix used the deprecated `changelog_entry.yaml` format)

## Statutory basis

**RS 47:297.4(B)** (non-refundable tier, AGI > $25,000) references the credit **"claimed on the resident individual's federal tax return."** The word *claimed* means the actual credit after the IRC § 26 tax liability limitation — i.e., `cdcc`, not `cdcc_potential`.

This contrasts with the refundable tier in `la_refundable_cdcc.py`, which correctly uses `cdcc_potential` because **RS 47:297.4(A)** explicitly says *"without regard to whether they claimed such federal credit"* — opting out of the IRC § 26 cap.

Closes #7680
