### PR TITLE
Add pre-commit hook for black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: "25.1.0"
+    hooks:
+      - id: black
+        args: ["-l", "79"]

--- a/changelog.d/add-pre-commit.added.md
+++ b/changelog.d/add-pre-commit.added.md
@@ -1,0 +1,1 @@
+Add pre-commit hook for black formatting.


### PR DESCRIPTION
## Summary
- Adds `.pre-commit-config.yaml` with black (line length 79) to prevent unformatted Python from being committed
- Contributors run `pre-commit install` once to enable

## Test plan
- [x] Config is valid YAML
- [x] No code changes, just tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)