### PR TITLE
Update CLAUDE.md references from black to ruff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ make install
 pip install -e .[dev]
 
 # Format code
-make format  # Runs black with line length 79 and fixes import ordering
+make format  # Runs ruff format
 
 # Run all tests
 make test

--- a/changelog.d/update-claude-md-ruff.changed.md
+++ b/changelog.d/update-claude-md-ruff.changed.md
@@ -1,0 +1,1 @@
+Update CLAUDE.md references from black to ruff.


### PR DESCRIPTION
## Summary
- Update `make format` description in CLAUDE.md from "Runs black with line length 79 and fixes import ordering" to "Runs ruff format"
- Add changelog fragment

## Test plan
- [x] Verify CLAUDE.md accurately reflects current formatting toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)