### PR TITLE
Fix NJ gross income formula that breaks API reform calculations

### DIFF
--- a/changelog.d/fix-nj-gross-income.fixed.md
+++ b/changelog.d/fix-nj-gross-income.fixed.md
@@ -1,0 +1,1 @@
+Fixed NJ gross income formula that broke API reform calculations by replacing ParameterNode iteration with explicit category references.

--- a/policyengine_us/variables/gov/states/nj/tax/income/adjusted_gross_income/nj_gross_income.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/adjusted_gross_income/nj_gross_income.py
@@ -19,6 +19,8 @@ class nj_gross_income(Variable):
         # Loss-eligible categories per N.J.S. 54A:5-1: each is
         # summed within the category then clamped to $0.
         cats = p.loss_eligible_categories
-        for cat in cats:
-            total += max_(add(person, period, cats[cat]), 0)
+        total += max_(add(person, period, cats.category_b), 0)
+        total += max_(add(person, period, cats.category_c), 0)
+        total += max_(add(person, period, cats.category_d), 0)
+        total += max_(add(person, period, cats.category_k_p), 0)
         return total


### PR DESCRIPTION
## Summary
- Replace `ParameterNode` iteration (`for cat in cats`) with explicit category references in `nj_gross_income` formula
- The iteration pattern is incompatible with the API's `clone()`-based reform path, causing all NJ tax variables to silently return `null` under any reform
- NJ was the only state affected — all other 50 states + DC work correctly

Fixes #7742

## Test plan
- [x] All 318 NJ tests pass
- [ ] Verify NJ reform calculations work on the API after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)