### PR TITLE
Gate aca_ptc on tax_unit_is_filer for non-filers

### DIFF
--- a/changelog.d/fix-aca-ptc-non-filers.fixed.md
+++ b/changelog.d/fix-aca-ptc-non-filers.fixed.md
@@ -1,0 +1,1 @@
+Gate aca_ptc on tax_unit_is_filer to prevent non-filers from receiving PTC.

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
@@ -17,6 +17,7 @@
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
+    tax_unit_is_filer: true
   output:
     aca_ptc: 200  # 1200 - 0.04 * 25000 = 200
 
@@ -28,6 +29,7 @@
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.05
+    tax_unit_is_filer: true
   output:
     aca_ptc: 0  # 1200 - 0.05 * 25000 = -50, floored to 0
 
@@ -39,5 +41,19 @@
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
+    tax_unit_is_filer: true
   output:
     aca_ptc: 0
+
+- name: ACA PTC zero for non-filers
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    is_aca_ptc_eligible: true
+    slcsp: 1_200
+    aca_magi: 25_000
+    aca_required_contribution_percentage: 0.04
+    takes_up_aca_if_eligible: true
+    tax_unit_is_filer: false
+  output:
+    aca_ptc: 0  # Non-filers cannot claim PTC per 26 USC § 36B

--- a/policyengine_us/variables/gov/aca/ptc/aca_ptc.py
+++ b/policyengine_us/variables/gov/aca/ptc/aca_ptc.py
@@ -18,6 +18,9 @@ class aca_ptc(Variable):
         income = tax_unit("aca_magi", period)
         applicable_figure = tax_unit("aca_required_contribution_percentage", period)
         takes_up_aca_if_eligible = tax_unit("takes_up_aca_if_eligible", period)
+        is_filer = tax_unit("tax_unit_is_filer", period)
         return (
-            max_(0, plan_cost - income * applicable_figure) * takes_up_aca_if_eligible
+            max_(0, plan_cost - income * applicable_figure)
+            * takes_up_aca_if_eligible
+            * is_filer
         )


### PR DESCRIPTION
## Summary
- Gates `aca_ptc.formula_2024` on `tax_unit_is_filer` so non-filers correctly receive $0 PTC
- Fixes ~5x overestimate in calibrated microsimulation datasets (non-filer tax units were computing PTC that was never constrained by IRS SOI calibration targets)
- ACA PTC legally requires filing Form 8962 with a federal return ([26 USC § 36B](https://www.law.cornell.edu/uscode/text/26/36B))

Closes #7748

## Test plan
- [x] Added test case verifying non-filers get $0 PTC
- [x] Updated existing tests to explicitly set `tax_unit_is_filer: true` so each test validates its intended logic path
- [x] All 5 YAML tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)