### PR TITLE
Make ACA marketplace enrollment create filing obligation

### DIFF
--- a/policyengine_us/variables/gov/irs/tax_unit_is_filer.py
+++ b/policyengine_us/variables/gov/irs/tax_unit_is_filer.py
@@ -26,7 +26,9 @@ class tax_unit_is_filer(Variable):
         required = tax_unit("tax_unit_is_required_to_file", period)
 
         # Would file to claim refundable credits (EITC, CTC, etc.)
-        eligible_for_credits = tax_unit("eligible_for_refundable_credits", period)
+        eligible_for_credits = tax_unit(
+            "eligible_for_refundable_credits", period
+        )
         would_file_for_credits = tax_unit(
             "would_file_if_eligible_for_refundable_credit", period
         )
@@ -35,4 +37,8 @@ class tax_unit_is_filer(Variable):
         # Would file voluntarily for other reasons
         files_voluntarily = tax_unit("would_file_taxes_voluntarily", period)
 
-        return required | files_for_credits | files_voluntarily
+        # ACA marketplace enrollment creates a filing obligation:
+        # receiving APTC requires reconciliation on a tax return.
+        files_for_aca = tax_unit("takes_up_aca_if_eligible", period)
+
+        return required | files_for_credits | files_voluntarily | files_for_aca


### PR DESCRIPTION
## Summary

- Adds `takes_up_aca_if_eligible` as an OR condition in `tax_unit_is_filer`
- Receiving APTC requires tax return reconciliation (IRC § 36B), so ACA enrollment should imply filing
- See #7781 for full discussion of the causal direction (enrollment → filing, not filing → eligibility)

## Context

This is the counterpart to #7753, which proposes gating `aca_ptc` on `is_filer`. That approach has the causation backwards — ACA enrollment creates the filing obligation, not the other way around. This PR ensures ACA enrollees are always filers, making the gate in #7753 unnecessary.

## Test plan

- [ ] Existing ACA PTC tests still pass
- [ ] Tax units with `takes_up_aca_if_eligible=True` and `would_file_taxes_voluntarily=False` should now have `tax_unit_is_filer=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)