### PR TITLE
Update CSFP per-slot cost parameters for FY 2019-2025

### DIFF
--- a/changelog.d/update-csfp-amount.changed.md
+++ b/changelog.d/update-csfp-amount.changed.md
@@ -1,0 +1,1 @@
+Update CSFP per-slot cost parameters for FY 2019-2025.

--- a/policyengine_us/parameters/gov/usda/csfp/amount.yaml
+++ b/policyengine_us/parameters/gov/usda/csfp/amount.yaml
@@ -1,11 +1,29 @@
-description: The following food value amount is provided under the Commodity Supplemental Food Program to each eligible person.
+description: The United States provides this amount per slot under the Commodity Supplemental Food Program.
 
 values:
-  2024-01-01: 330 # cost / participation => 222,891,000 / 676,000
+  2019-01-01: 330 # cost / participation => 222,891,000 / 676,000
+  2020-01-01: 333 # cost / participation => 245,000,000 / 736,110
+  2021-01-01: 476 # cost / participation => 362,000,000 / 760,634
+  2022-01-01: 437 # cost / participation => 332,000,000 / 760,547
+  2023-01-01: 445 # cost / participation => 338,640,000 / 760,547
+  2024-01-01: 531 # cost / participation => 389,000,000 / 731,933
+  2025-01-01: 601 # cost / participation => 425,000,000 / 707,000
 metadata:
   unit: currency-USD
   period: year
   label: Commodity Supplemental Food Program amount
   reference:
-    - title: Commodity Supplemental Food Program
+    - title: Commodity Supplemental Food Program Fact Sheet (2019)
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/csfp-program-fact-sheet-2019.pdf
+    - title: CSFP Final Caseload Assignments for the 2020 Caseload Cycle
+      href: https://www.fns.usda.gov/csfp/final-caseload-assignments-2020-caseload-cycle
+    - title: CSFP Additional Caseload Assignments for the 2021 Caseload Cycle
+      href: https://www.fns.usda.gov/csfp/additional-caseload-assignments-2021-caseload-cycle
+    - title: CSFP Caseload Assignments for the 2022 Caseload Cycle and Administrative Grants
+      href: https://www.fns.usda.gov/csfp/caseload-assignments-2022-caseload-cycle-and-administrative-grants
+    - title: CSFP Caseload Assignments for the 2023 Caseload Cycle and Administrative Grants
+      href: https://www.fns.usda.gov/csfp/caseload-assignments-2023-caseload-cycle-and-administrative-grants
+    - title: CSFP Caseload Assignments for the 2024 Caseload Cycle
+      href: https://www.fns.usda.gov/csfp/caseload-assignments-2024
+    - title: CSFP Caseload Assignments for the 2025 Caseload Cycle
+      href: https://www.fns.usda.gov/csfp/caseload-assignments-2025

--- a/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program.yaml
@@ -1,5 +1,5 @@
 - name: Age ineligible
-  period: 2024
+  period: 2019
   input:
     school_meal_fpg_ratio: 1.3
     age: 59
@@ -7,7 +7,7 @@
     commodity_supplemental_food_program: 0
 
 - name: Income ineligible
-  period: 2024
+  period: 2019
   input:
     school_meal_fpg_ratio: 1.31
     age: 60
@@ -15,9 +15,25 @@
     commodity_supplemental_food_program: 0
 
 - name: Eligible
-  period: 2024
+  period: 2019
   input:
     school_meal_fpg_ratio: 1.30
     age: 60
   output:
     commodity_supplemental_food_program: 330
+
+- name: Case 4, eligible in 2024.
+  period: 2024
+  input:
+    school_meal_fpg_ratio: 1.30
+    age: 60
+  output:
+    commodity_supplemental_food_program: 531
+
+- name: Case 5, eligible in 2025 with updated amount.
+  period: 2025
+  input:
+    school_meal_fpg_ratio: 1.50
+    age: 60
+  output:
+    commodity_supplemental_food_program: 601

--- a/policyengine_us/tests/policy/baseline/gov/usda/csfp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/csfp/integration.yaml
@@ -1,24 +1,23 @@
 - name: Income integration test ineligible
-  period: 2024
+  period: 2019
   input:
-    employment_income: 3916
-    self_employment_income: 3916
-    rental_income: 3916
-    pension_income: 3916
-    social_security: 3916
+    employment_income: 3_248
+    self_employment_income: 3_248
+    rental_income: 3_248
+    pension_income: 3_248
+    social_security: 3_248
     age: 100
   output:
     commodity_supplemental_food_program: 0
 
 - name: Income integration test eligible
-  period: 2024
+  period: 2019
   input:
-    employment_income: 3915
-    self_employment_income: 3915
-    rental_income: 3915
-    pension_income: 3915
-    social_security: 3915
+    employment_income: 3_247
+    self_employment_income: 3_247
+    rental_income: 3_247
+    pension_income: 3_247
+    social_security: 3_247
     age: 100
   output:
     commodity_supplemental_food_program: 330
-


### PR DESCRIPTION
## Summary

Closes #7789

The CSFP `amount` parameter previously had a single value of $330 incorrectly dated as `2024-01-01` (derived from 2019 data). This PR updates the parameter with verified per-slot costs for all fiscal years from 2019-2025.

## Per-Slot Cost = Total Appropriation / Total Caseload Slots

| FY | Appropriation | Caseload Slots | Per-Slot Cost | Source |
|----|--------------|----------------|---------------|--------|
| 2019 | $222,891,000 | 676,000 | **$330** | [CSFP Fact Sheet 2019](https://fns-prod.azureedge.us/sites/default/files/resource-files/csfp-program-fact-sheet-2019.pdf) |
| 2020 | $245,000,000 | 736,110 | **$333** | [FY 2020 Caseload Assignments](https://www.fns.usda.gov/csfp/final-caseload-assignments-2020-caseload-cycle) |
| 2021 | $362,000,000 | 760,634 | **$476** | [FY 2021 Caseload Assignments (incl. ARPA)](https://www.fns.usda.gov/csfp/additional-caseload-assignments-2021-caseload-cycle) |
| 2022 | $332,000,000 | 760,547 | **$437** | [FY 2022 Caseload Assignments](https://www.fns.usda.gov/csfp/caseload-assignments-2022-caseload-cycle-and-administrative-grants) |
| 2023 | $338,640,000 | 760,547 | **$445** | [FY 2023 Caseload Assignments](https://www.fns.usda.gov/csfp/caseload-assignments-2023-caseload-cycle-and-administrative-grants) |
| 2024 | $389,000,000 | 731,933 | **$531** | [FY 2024 Caseload Assignments](https://www.fns.usda.gov/csfp/caseload-assignments-2024) |
| 2025 | $425,000,000 | 707,000 | **$601** | [FY 2025 Caseload Assignments](https://www.fns.usda.gov/csfp/caseload-assignments-2025) |

**Note:** FY 2021 includes ARPA supplemental funding ($37M additional, P.L. 117-2). FY 2022 drops because that supplemental expired.

## Changes

- **`amount.yaml`**: Fixed effective date from `2024-01-01` → `2019-01-01` for the $330 value; added FY 2020-2025 values with computation comments; added references for each year's FNS caseload assignment document
- **Tests**: Adjusted test periods to match the corrected parameter dates; added 2024 and 2025 test cases; recalibrated integration test income values for 2019 FPG thresholds

## Test plan

- [x] All 19 CSFP tests pass (`policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/csfp -c policyengine_us`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)