### PR TITLE
Switch push workflow to GitHub App token auth

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -24,10 +24,16 @@ jobs:
       && !(github.event.head_commit.message == 'Update PolicyEngine US')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Set up Python
@@ -48,7 +54,7 @@ jobs:
           committer_name: Github Actions[bot]
           author_name: Github Actions[bot]
           message: Update PolicyEngine US
-          github_token: ${{ secrets.POLICYENGINE_GITHUB }}
+          github_token: ${{ steps.app-token.outputs.token }}
           fetch: false
   NonStructural-States:
     name: Baseline States
@@ -190,19 +196,23 @@ jobs:
       (github.repository == 'PolicyEngine/policyengine-us')
       && (github.event.head_commit.message == 'Update PolicyEngine US')
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.14
       - name: Install Wheel and Pytest
         run: pip3 install wheel setuptools pytest==5.4.3
       - name: Install package
@@ -210,4 +220,4 @@ jobs:
       - name: Update API
         run: python .github/update_api.py
         env:
-          GITHUB_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog.d/use-github-app-token.changed.md
+++ b/changelog.d/use-github-app-token.changed.md
@@ -1,0 +1,1 @@
+Switch push workflow from PAT (POLICYENGINE_GITHUB) to GitHub App token for authentication.


### PR DESCRIPTION
## Summary
Replace `POLICYENGINE_GITHUB` PAT with GitHub App token (`APP_ID` + `APP_PRIVATE_KEY`) in the push workflow, matching the pattern used in `policyengine.py`.

## Changes
- **versioning** job: Generate app token and use it for checkout + add-and-commit
- **Deploy** job: Generate app token and use it for checkout + API update
- Bump Deploy job dependencies: `actions/checkout` v2→v4, `setup-python` v2→v5, Python 3.12→3.14

## Prerequisites
- The PolicyEngine GitHub App must be installed on `PolicyEngine/policyengine-us`
- `APP_ID` and `APP_PRIVATE_KEY` secrets must be available (org-level or repo-level)

## Test plan
- [ ] Verify `APP_ID` and `APP_PRIVATE_KEY` secrets are accessible to this repo
- [ ] Merge a PR and confirm the versioning job generates and uses the app token successfully
- [ ] Confirm the Deploy job authenticates and runs the API update

🤖 Generated with [Claude Code](https://claude.com/claude-code)