### PR TITLE
Gate MN M1CWFC CTC on EIC investment income eligibility

### DIFF
--- a/changelog.d/fix-mn-cwfc-investment-income-gate.fixed.md
+++ b/changelog.d/fix-mn-cwfc-investment-income-gate.fixed.md
@@ -1,0 +1,1 @@
+Gate Minnesota M1CWFC child tax credit on EIC investment income eligibility, matching form instructions.

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
@@ -361,6 +361,36 @@
   output:
     mn_child_and_working_families_credits: 3_129.2
 
+- name: 2025 Joint filers with high investment income should get zero credit
+  # Per M1CWFC form: "Do not complete Schedule M1CWFC if you are
+  # otherwise restricted from claiming the federal Earned Income Credit."
+  # Investment income ($53K) exceeds EIC limit ($11,950 in 2025),
+  # so the entire credit (CTC + WFC) should be zero.
+  # Matches TaxAct and TAXSIM (policyengine-taxsim#766).
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 10_000
+        tax_exempt_interest_income: 53_000
+      person2:
+        age: 38
+      person3:
+        age: 4
+      person4:
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: MN
+  output:
+    mn_child_and_working_families_credits: 0
+
 - name: 2025 Single filer with one CTC-eligible child, partial phase-out
   # Calculation:
   # WFC base: min($40,000, $9,480) * 0.04 = $379.20

--- a/policyengine_us/variables/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.py
+++ b/policyengine_us/variables/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.py
@@ -43,10 +43,14 @@ class mn_child_and_working_families_credits(Variable):
         )
         qualifying_older_children = tax_unit.sum(qualifying_older_child)
         additional_wfc_credit = p.wfc.additional.amount.calc(qualifying_older_children)
-        base_wfc_amount = (base_wfc_credit + additional_wfc_credit) * wfc_eligible
+        base_wfc_amount = base_wfc_credit + additional_wfc_credit
         # The credit amounts are combined and phase out together based on the number of
         # qualifying older children
-        combined_credit = base_ctc_amount + base_wfc_amount
+        # M1CWFC form: "Do not complete if you have a 2-year or 10-year
+        # IRS ban or are otherwise restricted from claiming the federal EIC."
+        # Gate the entire combined credit on WFC eligibility (which includes
+        # the federal EITC investment income check).
+        combined_credit = (base_ctc_amount + base_wfc_amount) * wfc_eligible
         # The phase out threshold is based on the larger of AGI and earnings and filing status
         agi = tax_unit("adjusted_gross_income", period)
         income = max_(earnings, agi)


### PR DESCRIPTION
## Summary
- Gate the entire MN M1CWFC combined credit (CTC + WFC) on `mn_wfc_eligible`, not just the WFC portion
- Matches M1CWFC form instruction: "Do not complete Schedule M1CWFC if you are otherwise restricted from claiming the federal Earned Income Credit"

Closes #7800.

## Change
Previously, only `base_wfc_amount` was multiplied by `wfc_eligible`. Now the entire `combined_credit` is gated, so when investment income exceeds the federal EIC limit ($11,950 in 2025), both CTC and WFC zero out.

## Test plan
- [x] Added integration test matching TAXSIM/TaxAct example from #7800: MN joint 2025, $10K wages, $53K interest, 2 children → $0 credit
- [x] All 13 existing MN CWFC tests pass
- [x] `make format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)