### PR TITLE
Add local employer payroll taxes

### DIFF
--- a/changelog.d/codex-local-payroll-taxes.changed.md
+++ b/changelog.d/codex-local-payroll-taxes.changed.md
@@ -1,0 +1,1 @@
+Add employer-side local payroll taxes for Seattle, St. Louis, Oregon transit districts, and Colorado occupational privilege taxes using aggregate employer inputs.

--- a/policyengine_us/parameters/gov/local/co/denver/tax/payroll/occupational_privilege/employer_amount.yaml
+++ b/policyengine_us/parameters/gov/local/co/denver/tax/payroll/occupational_privilege/employer_amount.yaml
@@ -1,0 +1,11 @@
+description: Denver business occupational privilege tax amount per taxable month.
+values:
+  0000-01-01: 4
+
+metadata:
+  period: month
+  unit: currency-USD
+  label: Denver business occupational privilege tax monthly amount
+  reference:
+    - title: Denver business tax FAQ
+      href: https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Department-of-Finance/Our-Divisions/Treasury/Business-Tax-Information/Business-Tax-FAQ

--- a/policyengine_us/parameters/gov/local/co/glendale/tax/payroll/occupational_privilege/employer_amount.yaml
+++ b/policyengine_us/parameters/gov/local/co/glendale/tax/payroll/occupational_privilege/employer_amount.yaml
@@ -1,0 +1,13 @@
+description: Glendale employer occupational privilege tax amount per taxable month.
+values:
+  0000-01-01: 5
+
+metadata:
+  period: month
+  unit: currency-USD
+  label: Glendale employer occupational privilege tax monthly amount
+  reference:
+    - title: Glendale occupational privilege tax page
+      href: https://www.glendale.co.us/355/Occupational-Privilege-Tax
+    - title: Glendale occupational privilege tax return
+      href: https://www.glendale.co.us/DocumentCenter/View/81/OPT-Tax-Return#page=1

--- a/policyengine_us/parameters/gov/local/co/greenwood_village/tax/payroll/occupational_privilege/employer_amount.yaml
+++ b/policyengine_us/parameters/gov/local/co/greenwood_village/tax/payroll/occupational_privilege/employer_amount.yaml
@@ -1,0 +1,11 @@
+description: Greenwood Village employer occupational privilege tax amount per taxable month.
+values:
+  0000-01-01: 2
+
+metadata:
+  period: month
+  unit: currency-USD
+  label: Greenwood Village employer occupational privilege tax monthly amount
+  reference:
+    - title: Greenwood Village occupational privilege tax page
+      href: https://www.greenwoodvillage.com/1220/Occupational-Privilege-Tax-OPT

--- a/policyengine_us/parameters/gov/local/co/sheridan/tax/payroll/occupational_privilege/employer_amount.yaml
+++ b/policyengine_us/parameters/gov/local/co/sheridan/tax/payroll/occupational_privilege/employer_amount.yaml
@@ -1,0 +1,11 @@
+description: Sheridan employer occupational privilege tax amount per taxable month.
+values:
+  0000-01-01: 3
+
+metadata:
+  period: month
+  unit: currency-USD
+  label: Sheridan employer occupational privilege tax monthly amount
+  reference:
+    - title: Sheridan occupational privilege tax page
+      href: https://www.ci.sheridan.co.us/288/Occupational-Privilege-Tax

--- a/policyengine_us/parameters/gov/local/mo/st_louis/tax/payroll/payroll_expense/rate.yaml
+++ b/policyengine_us/parameters/gov/local/mo/st_louis/tax/payroll/payroll_expense/rate.yaml
@@ -1,0 +1,13 @@
+description: St. Louis payroll expense tax rate.
+values:
+  0000-01-01: 0.005
+
+metadata:
+  period: year
+  unit: /1
+  label: St. Louis payroll expense tax rate
+  reference:
+    - title: St. Louis employer withholding and payroll expense tax information
+      href: https://www.stlouis-mo.gov/government/departments/collector/earnings-tax/payroll-tax-info.cfm
+    - title: St. Louis payroll expense tax code
+      href: https://library.municode.com/mo/st._louis/codes/code_of_ordinances?nodeId=TIT5REFI_CH5.23PAEXTA

--- a/policyengine_us/parameters/gov/local/or/lane_transit_district/tax/payroll/rate.yaml
+++ b/policyengine_us/parameters/gov/local/or/lane_transit_district/tax/payroll/rate.yaml
@@ -1,0 +1,13 @@
+description: Lane Transit District payroll tax rate.
+values:
+  2026-01-01: 0.008
+
+metadata:
+  period: year
+  unit: /1
+  label: Lane Transit District payroll tax rate
+  reference:
+    - title: Oregon Department of Revenue Lane Transit District payroll tax
+      href: https://www.oregon.gov/dor/programs/businesses/Pages/Lane-County-Transit-District-Payroll-tax.aspx
+    - title: 2026 Oregon combined payroll tax report instructions
+      href: https://www.oregon.gov/dor/forms/FormsPubs/combined-payroll_211-155-2_2026.pdf#page=5

--- a/policyengine_us/parameters/gov/local/or/trimet/tax/payroll/rate.yaml
+++ b/policyengine_us/parameters/gov/local/or/trimet/tax/payroll/rate.yaml
@@ -1,0 +1,13 @@
+description: TriMet transit payroll tax rate.
+values:
+  2026-01-01: 0.008237
+
+metadata:
+  period: year
+  unit: /1
+  label: TriMet transit payroll tax rate
+  reference:
+    - title: Oregon Department of Revenue TriMet transit payroll tax
+      href: https://www.oregon.gov/dor/programs/businesses/Pages/TriMet-Transit.aspx
+    - title: 2026 Oregon combined payroll tax report instructions
+      href: https://www.oregon.gov/dor/forms/FormsPubs/combined-payroll_211-155-2_2026.pdf#page=5

--- a/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/payroll_expense/prior_year_total_payroll_expense_threshold.yaml
+++ b/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/payroll_expense/prior_year_total_payroll_expense_threshold.yaml
@@ -1,0 +1,13 @@
+description: Prior-year Seattle payroll expense threshold for Seattle payroll expense tax liability.
+values:
+  2026-01-01: 9_074_409
+
+metadata:
+  period: year
+  unit: currency-USD
+  label: Seattle payroll expense tax prior-year payroll threshold
+  reference:
+    - title: Seattle payroll expense tax page
+      href: https://www.seattle.gov/city-finance/business-taxes-and-licenses/seattle-taxes/payroll-expense-tax
+    - title: Seattle Municipal Code Chapter 5.38
+      href: https://library.municode.com/wa/seattle/codes/municipal_code?nodeId=TIT5REFITA_SUBTITLE_IITA_CH5.38PAEXTA_5.38.070ADIN

--- a/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/payroll_expense/rates/lower_band.yaml
+++ b/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/payroll_expense/rates/lower_band.yaml
@@ -1,0 +1,25 @@
+description: Seattle payroll expense tax rates for the lower taxable compensation band.
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: /1
+  period: year
+  label: Seattle payroll expense tax rates for the lower taxable compensation band
+  reference:
+    - title: Seattle payroll expense tax page
+      href: https://www.seattle.gov/city-finance/business-taxes-and-licenses/seattle-taxes/payroll-expense-tax
+    - title: Seattle Municipal Code Chapter 5.38
+      href: https://library.municode.com/wa/seattle/codes/municipal_code?nodeId=TIT5REFITA_SUBTITLE_IITA_CH5.38PAEXTA_5.38.070ADIN
+brackets:
+  - threshold:
+      2026-01-01: 0
+    amount:
+      2026-01-01: 0.00746
+  - threshold:
+      2026-01-01: 129_634_413
+    amount:
+      2026-01-01: 0.00746
+  - threshold:
+      2026-01-01: 1_296_344_132
+    amount:
+      2026-01-01: 0.01492

--- a/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/payroll_expense/rates/upper_band.yaml
+++ b/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/payroll_expense/rates/upper_band.yaml
@@ -1,0 +1,25 @@
+description: Seattle payroll expense tax rates for the upper taxable compensation band.
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: /1
+  period: year
+  label: Seattle payroll expense tax rates for the upper taxable compensation band
+  reference:
+    - title: Seattle payroll expense tax page
+      href: https://www.seattle.gov/city-finance/business-taxes-and-licenses/seattle-taxes/payroll-expense-tax
+    - title: Seattle Municipal Code Chapter 5.38
+      href: https://library.municode.com/wa/seattle/codes/municipal_code?nodeId=TIT5REFITA_SUBTITLE_IITA_CH5.38PAEXTA_5.38.070ADIN
+brackets:
+  - threshold:
+      2026-01-01: 0
+    amount:
+      2026-01-01: 0.01811
+  - threshold:
+      2026-01-01: 129_634_413
+    amount:
+      2026-01-01: 0.02024
+  - threshold:
+      2026-01-01: 1_296_344_132
+    amount:
+      2026-01-01: 0.02557

--- a/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/social_housing/rate.yaml
+++ b/policyengine_us/parameters/gov/local/wa/seattle/tax/payroll/social_housing/rate.yaml
@@ -1,0 +1,13 @@
+description: Seattle Social Housing Tax rate.
+values:
+  2025-01-01: 0.05
+
+metadata:
+  period: year
+  unit: /1
+  label: Seattle social housing tax rate
+  reference:
+    - title: Seattle Social Housing Tax page
+      href: https://www.seattle.gov/city-finance/business-taxes-and-licenses/seattle-taxes/social-housing-tax
+    - title: Initiative 137 enacted text
+      href: https://www.seattle.gov/documents/departments/cityfinance/seattle%20taxes/social%20housing%20developer%20tax/res.%2032142-att.%20a%20i-137.pdf#page=1

--- a/policyengine_us/tests/core/test_payroll_contributions.py
+++ b/policyengine_us/tests/core/test_payroll_contributions.py
@@ -61,6 +61,21 @@ def make_employer_total_simulation(
     employer_total_taxable_earnings_for_state_unemployment_tax: float = 9_000,
     employer_ny_mctmt_zone_1_quarterly_payroll_expense: float = 0,
     employer_ny_mctmt_zone_2_quarterly_payroll_expense: float = 0,
+    employer_total_co_denver_occupational_privilege_tax_employee_months: int = 0,
+    employer_total_co_denver_occupational_privilege_tax_owner_months: int = 0,
+    employer_total_co_glendale_occupational_privilege_tax_employee_months: int = 0,
+    employer_total_co_glendale_occupational_privilege_tax_owner_months: int = 0,
+    employer_total_co_greenwood_village_occupational_privilege_tax_employee_months: int = 0,
+    employer_total_co_greenwood_village_occupational_privilege_tax_owner_months: int = 0,
+    employer_total_co_sheridan_occupational_privilege_tax_employee_months: int = 0,
+    employer_total_mo_st_louis_payroll_expense: float = 0,
+    employer_total_or_trimet_taxable_wages: float = 0,
+    employer_total_or_lane_transit_district_taxable_wages: float = 0,
+    employer_total_wa_seattle_social_housing_excess_compensation: float = 0,
+    employer_total_wa_seattle_payroll_expense_prior_year_total: float = 0,
+    employer_total_wa_seattle_payroll_expense_current_year_total: float = 0,
+    employer_total_wa_seattle_payroll_expense_lower_band_taxable_payroll: float = 0,
+    employer_total_wa_seattle_payroll_expense_upper_band_taxable_payroll: float = 0,
 ) -> Simulation:
     return Simulation(
         tax_benefit_system=SYSTEM,
@@ -89,6 +104,51 @@ def make_employer_total_simulation(
                     },
                     "employer_ny_mctmt_zone_2_quarterly_payroll_expense": {
                         PERIOD: employer_ny_mctmt_zone_2_quarterly_payroll_expense
+                    },
+                    "employer_total_co_denver_occupational_privilege_tax_employee_months": {
+                        PERIOD: employer_total_co_denver_occupational_privilege_tax_employee_months
+                    },
+                    "employer_total_co_denver_occupational_privilege_tax_owner_months": {
+                        PERIOD: employer_total_co_denver_occupational_privilege_tax_owner_months
+                    },
+                    "employer_total_co_glendale_occupational_privilege_tax_employee_months": {
+                        PERIOD: employer_total_co_glendale_occupational_privilege_tax_employee_months
+                    },
+                    "employer_total_co_glendale_occupational_privilege_tax_owner_months": {
+                        PERIOD: employer_total_co_glendale_occupational_privilege_tax_owner_months
+                    },
+                    "employer_total_co_greenwood_village_occupational_privilege_tax_employee_months": {
+                        PERIOD: employer_total_co_greenwood_village_occupational_privilege_tax_employee_months
+                    },
+                    "employer_total_co_greenwood_village_occupational_privilege_tax_owner_months": {
+                        PERIOD: employer_total_co_greenwood_village_occupational_privilege_tax_owner_months
+                    },
+                    "employer_total_co_sheridan_occupational_privilege_tax_employee_months": {
+                        PERIOD: employer_total_co_sheridan_occupational_privilege_tax_employee_months
+                    },
+                    "employer_total_mo_st_louis_payroll_expense": {
+                        PERIOD: employer_total_mo_st_louis_payroll_expense
+                    },
+                    "employer_total_or_trimet_taxable_wages": {
+                        PERIOD: employer_total_or_trimet_taxable_wages
+                    },
+                    "employer_total_or_lane_transit_district_taxable_wages": {
+                        PERIOD: employer_total_or_lane_transit_district_taxable_wages
+                    },
+                    "employer_total_wa_seattle_social_housing_excess_compensation": {
+                        PERIOD: employer_total_wa_seattle_social_housing_excess_compensation
+                    },
+                    "employer_total_wa_seattle_payroll_expense_prior_year_total": {
+                        PERIOD: employer_total_wa_seattle_payroll_expense_prior_year_total
+                    },
+                    "employer_total_wa_seattle_payroll_expense_current_year_total": {
+                        PERIOD: employer_total_wa_seattle_payroll_expense_current_year_total
+                    },
+                    "employer_total_wa_seattle_payroll_expense_lower_band_taxable_payroll": {
+                        PERIOD: employer_total_wa_seattle_payroll_expense_lower_band_taxable_payroll
+                    },
+                    "employer_total_wa_seattle_payroll_expense_upper_band_taxable_payroll": {
+                        PERIOD: employer_total_wa_seattle_payroll_expense_upper_band_taxable_payroll
                     },
                 }
             },
@@ -566,6 +626,142 @@ def test_ny_mctmt_total_employer_tax(
     assert calculate(sim, "employer_total_local_payroll_tax") == pytest.approx(
         expected, abs=0.01
     )
+
+
+def test_colorado_total_business_occupational_privilege_taxes():
+    sim = make_employer_total_simulation(
+        "CO",
+        employer_total_co_denver_occupational_privilege_tax_employee_months=12,
+        employer_total_co_denver_occupational_privilege_tax_owner_months=6,
+        employer_total_co_glendale_occupational_privilege_tax_employee_months=12,
+        employer_total_co_glendale_occupational_privilege_tax_owner_months=12,
+        employer_total_co_greenwood_village_occupational_privilege_tax_employee_months=12,
+        employer_total_co_greenwood_village_occupational_privilege_tax_owner_months=6,
+        employer_total_co_sheridan_occupational_privilege_tax_employee_months=12,
+    )
+
+    assert calculate(
+        sim, "co_denver_total_business_occupational_privilege_tax"
+    ) == pytest.approx(72)
+    assert calculate(
+        sim, "co_glendale_total_business_occupational_privilege_tax"
+    ) == pytest.approx(120)
+    assert calculate(
+        sim, "co_greenwood_village_total_business_occupational_privilege_tax"
+    ) == pytest.approx(36)
+    assert calculate(
+        sim, "co_sheridan_total_business_occupational_privilege_tax"
+    ) == pytest.approx(36)
+    assert calculate(sim, "employer_total_local_payroll_tax") == pytest.approx(264)
+
+
+def test_oregon_total_local_payroll_taxes():
+    sim = make_employer_total_simulation(
+        "OR",
+        employer_total_or_trimet_taxable_wages=1_000_000,
+        employer_total_or_lane_transit_district_taxable_wages=1_000_000,
+    )
+
+    assert calculate(sim, "or_trimet_total_payroll_tax") == pytest.approx(8_237)
+    assert calculate(
+        sim, "or_lane_transit_district_total_payroll_tax"
+    ) == pytest.approx(8_000)
+    assert calculate(sim, "employer_total_local_payroll_tax") == pytest.approx(16_237)
+
+
+@pytest.mark.parametrize(
+    (
+        "prior_year_total",
+        "current_year_total",
+        "lower_band_taxable_payroll",
+        "upper_band_taxable_payroll",
+        "expected",
+    ),
+    [
+        pytest.param(
+            9_000_000,
+            20_000_000,
+            1_000_000,
+            500_000,
+            0,
+            id="below-subject-threshold",
+        ),
+        pytest.param(
+            10_000_000,
+            20_000_000,
+            1_000_000,
+            500_000,
+            16_515,
+            id="lower-schedule",
+        ),
+        pytest.param(
+            10_000_000,
+            200_000_000,
+            1_000_000,
+            500_000,
+            17_580,
+            id="middle-schedule",
+        ),
+        pytest.param(
+            10_000_000,
+            2_000_000_000,
+            1_000_000,
+            500_000,
+            27_705,
+            id="top-schedule",
+        ),
+    ],
+)
+def test_seattle_total_payroll_expense_tax(
+    prior_year_total: float,
+    current_year_total: float,
+    lower_band_taxable_payroll: float,
+    upper_band_taxable_payroll: float,
+    expected: float,
+):
+    sim = make_employer_total_simulation(
+        "WA",
+        employer_total_wa_seattle_payroll_expense_prior_year_total=prior_year_total,
+        employer_total_wa_seattle_payroll_expense_current_year_total=current_year_total,
+        employer_total_wa_seattle_payroll_expense_lower_band_taxable_payroll=lower_band_taxable_payroll,
+        employer_total_wa_seattle_payroll_expense_upper_band_taxable_payroll=upper_band_taxable_payroll,
+    )
+
+    assert calculate(sim, "wa_seattle_total_payroll_expense_tax") == pytest.approx(
+        expected
+    )
+    assert calculate(sim, "employer_total_local_payroll_tax") == pytest.approx(expected)
+
+
+def test_st_louis_total_payroll_expense_tax():
+    sim = make_employer_total_simulation(
+        "MO", employer_total_mo_st_louis_payroll_expense=1_000_000
+    )
+
+    assert calculate(sim, "mo_st_louis_total_payroll_expense_tax") == pytest.approx(
+        5_000
+    )
+    assert calculate(sim, "employer_total_local_payroll_tax") == pytest.approx(5_000)
+    assert calculate(sim, "employer_total_payroll_tax") == pytest.approx(12_906.2)
+    assert calculate(sim, "employer_total_cost_of_employment") == pytest.approx(
+        112_906.2
+    )
+
+
+def test_seattle_total_social_housing_tax():
+    sim = make_employer_total_simulation(
+        "WA",
+        employer_total_wa_seattle_payroll_expense_prior_year_total=10_000_000,
+        employer_total_wa_seattle_payroll_expense_current_year_total=20_000_000,
+        employer_total_wa_seattle_payroll_expense_lower_band_taxable_payroll=1_000_000,
+        employer_total_wa_seattle_payroll_expense_upper_band_taxable_payroll=500_000,
+        employer_total_wa_seattle_social_housing_excess_compensation=500_000,
+    )
+
+    assert calculate(sim, "wa_seattle_total_social_housing_tax") == pytest.approx(
+        25_000
+    )
+    assert calculate(sim, "employer_total_local_payroll_tax") == pytest.approx(41_515)
 
 
 def test_employer_total_payroll_tax_aggregates_employer_inputs():

--- a/policyengine_us/variables/gov/local/co/denver/tax/payroll/occupational_privilege/co_denver_total_business_occupational_privilege_tax.py
+++ b/policyengine_us/variables/gov/local/co/denver/tax/payroll/occupational_privilege/co_denver_total_business_occupational_privilege_tax.py
@@ -1,0 +1,35 @@
+from policyengine_us.model_api import *
+
+
+class co_denver_total_business_occupational_privilege_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total Denver business occupational privilege tax"
+    documentation = (
+        "Employer-side Denver occupational privilege tax liability from "
+        "aggregate taxable employee-month and owner-month inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.denvergov.org/Government/Agencies-Departments-Offices/"
+        "Agencies-Departments-Offices-Directory/Department-of-Finance/"
+        "Our-Divisions/Treasury/Business-Tax-Information/Business-Tax-FAQ"
+    )
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        p = parameters(period).gov.local.co.denver.tax.payroll.occupational_privilege
+        employee_months = person(
+            "employer_total_co_denver_occupational_privilege_tax_employee_months",
+            period,
+        )
+        owner_months = person(
+            "employer_total_co_denver_occupational_privilege_tax_owner_months",
+            period,
+        )
+        return where(
+            state_code == StateCode.CO,
+            p.employer_amount * (employee_months + owner_months),
+            0,
+        )

--- a/policyengine_us/variables/gov/local/co/glendale/tax/payroll/occupational_privilege/co_glendale_total_business_occupational_privilege_tax.py
+++ b/policyengine_us/variables/gov/local/co/glendale/tax/payroll/occupational_privilege/co_glendale_total_business_occupational_privilege_tax.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class co_glendale_total_business_occupational_privilege_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total Glendale business occupational privilege tax"
+    documentation = (
+        "Employer-side Glendale occupational privilege tax liability from "
+        "aggregate taxable employee-month and owner-month inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = "https://www.glendale.co.us/355/Occupational-Privilege-Tax"
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        p = parameters(period).gov.local.co.glendale.tax.payroll.occupational_privilege
+        employee_months = person(
+            "employer_total_co_glendale_occupational_privilege_tax_employee_months",
+            period,
+        )
+        owner_months = person(
+            "employer_total_co_glendale_occupational_privilege_tax_owner_months",
+            period,
+        )
+        return where(
+            state_code == StateCode.CO,
+            p.employer_amount * (employee_months + owner_months),
+            0,
+        )

--- a/policyengine_us/variables/gov/local/co/greenwood_village/tax/payroll/occupational_privilege/co_greenwood_village_total_business_occupational_privilege_tax.py
+++ b/policyengine_us/variables/gov/local/co/greenwood_village/tax/payroll/occupational_privilege/co_greenwood_village_total_business_occupational_privilege_tax.py
@@ -1,0 +1,33 @@
+from policyengine_us.model_api import *
+
+
+class co_greenwood_village_total_business_occupational_privilege_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total Greenwood Village business occupational privilege tax"
+    documentation = (
+        "Employer-side Greenwood Village occupational privilege tax liability "
+        "from aggregate taxable employee-month and owner-month inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = "https://www.greenwoodvillage.com/1220/Occupational-Privilege-Tax-OPT"
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        p = parameters(
+            period
+        ).gov.local.co.greenwood_village.tax.payroll.occupational_privilege
+        employee_months = person(
+            "employer_total_co_greenwood_village_occupational_privilege_tax_employee_months",
+            period,
+        )
+        owner_months = person(
+            "employer_total_co_greenwood_village_occupational_privilege_tax_owner_months",
+            period,
+        )
+        return where(
+            state_code == StateCode.CO,
+            p.employer_amount * (employee_months + owner_months),
+            0,
+        )

--- a/policyengine_us/variables/gov/local/co/sheridan/tax/payroll/occupational_privilege/co_sheridan_total_business_occupational_privilege_tax.py
+++ b/policyengine_us/variables/gov/local/co/sheridan/tax/payroll/occupational_privilege/co_sheridan_total_business_occupational_privilege_tax.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class co_sheridan_total_business_occupational_privilege_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total Sheridan business occupational privilege tax"
+    documentation = (
+        "Employer-side Sheridan occupational privilege tax liability from "
+        "aggregate taxable employee-month inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = "https://www.ci.sheridan.co.us/288/Occupational-Privilege-Tax"
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        p = parameters(period).gov.local.co.sheridan.tax.payroll.occupational_privilege
+        employee_months = person(
+            "employer_total_co_sheridan_occupational_privilege_tax_employee_months",
+            period,
+        )
+        return where(
+            state_code == StateCode.CO,
+            p.employer_amount * employee_months,
+            0,
+        )

--- a/policyengine_us/variables/gov/local/mo/st_louis/tax/payroll/mo_st_louis_total_payroll_expense_tax.py
+++ b/policyengine_us/variables/gov/local/mo/st_louis/tax/payroll/mo_st_louis_total_payroll_expense_tax.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class mo_st_louis_total_payroll_expense_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total St. Louis payroll expense tax"
+    documentation = (
+        "Employer-side St. Louis payroll expense tax liability from aggregate "
+        "taxable payroll expense inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.stlouis-mo.gov/government/departments/collector/"
+        "earnings-tax/payroll-tax-info.cfm"
+    )
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        payroll_expense = person("employer_total_mo_st_louis_payroll_expense", period)
+        rate = parameters(period).gov.local.mo.st_louis.tax.payroll.payroll_expense.rate
+        return where(state_code == StateCode.MO, rate * payroll_expense, 0)

--- a/policyengine_us/variables/gov/local/or/lane_transit_district/tax/payroll/or_lane_transit_district_total_payroll_tax.py
+++ b/policyengine_us/variables/gov/local/or/lane_transit_district/tax/payroll/or_lane_transit_district_total_payroll_tax.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class or_lane_transit_district_total_payroll_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total Lane Transit District payroll tax"
+    documentation = (
+        "Employer-side Lane Transit District payroll tax liability from "
+        "aggregate district wage inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.oregon.gov/dor/programs/businesses/Pages/"
+        "Lane-County-Transit-District-Payroll-tax.aspx"
+    )
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        taxable_wages = person(
+            "employer_total_or_lane_transit_district_taxable_wages", period
+        )
+        rate = parameters(period).gov.local["or"].lane_transit_district.tax.payroll.rate
+        return where(state_code == StateCode.OR, rate * taxable_wages, 0)

--- a/policyengine_us/variables/gov/local/or/trimet/tax/payroll/or_trimet_total_payroll_tax.py
+++ b/policyengine_us/variables/gov/local/or/trimet/tax/payroll/or_trimet_total_payroll_tax.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class or_trimet_total_payroll_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total TriMet payroll tax"
+    documentation = (
+        "Employer-side TriMet transit payroll tax liability from aggregate "
+        "district wage inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.oregon.gov/dor/programs/businesses/Pages/TriMet-Transit.aspx"
+    )
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        taxable_wages = person("employer_total_or_trimet_taxable_wages", period)
+        rate = parameters(period).gov.local["or"].trimet.tax.payroll.rate
+        return where(state_code == StateCode.OR, rate * taxable_wages, 0)

--- a/policyengine_us/variables/gov/local/tax/payroll/employer_total_local_payroll_tax.py
+++ b/policyengine_us/variables/gov/local/tax/payroll/employer_total_local_payroll_tax.py
@@ -11,4 +11,15 @@ class employer_total_local_payroll_tax(Variable):
     )
     definition_period = YEAR
     unit = USD
-    adds = ["ny_mctmt_total_employer_tax"]
+    adds = [
+        "ny_mctmt_total_employer_tax",
+        "co_denver_total_business_occupational_privilege_tax",
+        "co_glendale_total_business_occupational_privilege_tax",
+        "co_greenwood_village_total_business_occupational_privilege_tax",
+        "co_sheridan_total_business_occupational_privilege_tax",
+        "mo_st_louis_total_payroll_expense_tax",
+        "or_trimet_total_payroll_tax",
+        "or_lane_transit_district_total_payroll_tax",
+        "wa_seattle_total_payroll_expense_tax",
+        "wa_seattle_total_social_housing_tax",
+    ]

--- a/policyengine_us/variables/gov/local/wa/seattle/tax/payroll/payroll_expense/wa_seattle_total_payroll_expense_tax.py
+++ b/policyengine_us/variables/gov/local/wa/seattle/tax/payroll/payroll_expense/wa_seattle_total_payroll_expense_tax.py
@@ -1,0 +1,48 @@
+from policyengine_us.model_api import *
+
+
+class wa_seattle_total_payroll_expense_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total Seattle payroll expense tax"
+    documentation = (
+        "Employer-side Seattle payroll expense tax liability from aggregate "
+        "prior-year payroll, current-year payroll, and taxable payroll-band "
+        "inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.seattle.gov/city-finance/business-taxes-and-licenses/"
+        "seattle-taxes/payroll-expense-tax"
+    )
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        p = parameters(period).gov.local.wa.seattle.tax.payroll.payroll_expense
+        prior_year_total = person(
+            "employer_total_wa_seattle_payroll_expense_prior_year_total", period
+        )
+        current_year_total = person(
+            "employer_total_wa_seattle_payroll_expense_current_year_total", period
+        )
+        lower_band_taxable_payroll = person(
+            "employer_total_wa_seattle_payroll_expense_lower_band_taxable_payroll",
+            period,
+        )
+        upper_band_taxable_payroll = person(
+            "employer_total_wa_seattle_payroll_expense_upper_band_taxable_payroll",
+            period,
+        )
+        lower_band_rate = p.rates.lower_band.calc(current_year_total)
+        upper_band_rate = p.rates.upper_band.calc(current_year_total)
+        subject = (prior_year_total >= p.prior_year_total_payroll_expense_threshold) & (
+            state_code == StateCode.WA
+        )
+
+        return where(
+            subject,
+            lower_band_rate * lower_band_taxable_payroll
+            + upper_band_rate * upper_band_taxable_payroll,
+            0,
+        )

--- a/policyengine_us/variables/gov/local/wa/seattle/tax/payroll/social_housing/wa_seattle_total_social_housing_tax.py
+++ b/policyengine_us/variables/gov/local/wa/seattle/tax/payroll/social_housing/wa_seattle_total_social_housing_tax.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class wa_seattle_total_social_housing_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Total Seattle social housing tax"
+    documentation = (
+        "Employer-side Seattle Social Housing Tax liability from aggregate "
+        "Seattle excess compensation inputs."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.seattle.gov/city-finance/business-taxes-and-licenses/"
+        "seattle-taxes/social-housing-tax"
+    )
+
+    def formula(person, period, parameters):
+        state_code = person.household("state_code", period)
+        excess_compensation = person(
+            "employer_total_wa_seattle_social_housing_excess_compensation", period
+        )
+        rate = parameters(period).gov.local.wa.seattle.tax.payroll.social_housing.rate
+        return where(state_code == StateCode.WA, rate * excess_compensation, 0)

--- a/policyengine_us/variables/input/employer_payroll.py
+++ b/policyengine_us/variables/input/employer_payroll.py
@@ -117,3 +117,194 @@ class employer_ny_mctmt_zone_2_quarterly_payroll_expense(Variable):
     unit = USD
     definition_period = YEAR
     default_value = 0
+
+
+class employer_total_co_denver_occupational_privilege_tax_employee_months(Variable):
+    value_type = int
+    entity = Person
+    label = "Employer Denver occupational privilege taxable employee-months"
+    documentation = (
+        "Annual count of taxable employee-months for Denver's business "
+        "occupational privilege tax."
+    )
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_co_denver_occupational_privilege_tax_owner_months(Variable):
+    value_type = int
+    entity = Person
+    label = "Employer Denver occupational privilege owner-months"
+    documentation = (
+        "Annual count of owner, partner, or manager months subject to "
+        "Denver's business occupational privilege tax."
+    )
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_co_glendale_occupational_privilege_tax_employee_months(Variable):
+    value_type = int
+    entity = Person
+    label = "Employer Glendale occupational privilege taxable employee-months"
+    documentation = (
+        "Annual count of taxable employee-months for Glendale's employer "
+        "occupational privilege tax."
+    )
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_co_glendale_occupational_privilege_tax_owner_months(Variable):
+    value_type = int
+    entity = Person
+    label = "Employer Glendale occupational privilege owner-months"
+    documentation = (
+        "Annual count of owner, partner, officer, or self-employed months "
+        "subject to Glendale's employer occupational privilege tax."
+    )
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_co_greenwood_village_occupational_privilege_tax_employee_months(
+    Variable
+):
+    value_type = int
+    entity = Person
+    label = "Employer Greenwood Village occupational privilege taxable employee-months"
+    documentation = (
+        "Annual count of taxable employee-months for Greenwood Village's "
+        "employer occupational privilege tax."
+    )
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_co_greenwood_village_occupational_privilege_tax_owner_months(
+    Variable
+):
+    value_type = int
+    entity = Person
+    label = "Employer Greenwood Village occupational privilege owner-months"
+    documentation = (
+        "Annual count of owner, partner, or officer months subject only to "
+        "Greenwood Village's employer occupational privilege tax."
+    )
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_co_sheridan_occupational_privilege_tax_employee_months(Variable):
+    value_type = int
+    entity = Person
+    label = "Employer Sheridan occupational privilege taxable employee-months"
+    documentation = (
+        "Annual count of taxable employee-months for Sheridan's employer "
+        "occupational privilege tax."
+    )
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_mo_st_louis_payroll_expense(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer St. Louis payroll expense"
+    documentation = (
+        "Aggregate compensation subject to the St. Louis payroll expense tax."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_or_trimet_taxable_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer TriMet taxable wages"
+    documentation = (
+        "Aggregate wages for services performed within the TriMet district "
+        "that are subject to the transit payroll tax."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_or_lane_transit_district_taxable_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer Lane Transit District taxable wages"
+    documentation = (
+        "Aggregate wages for services performed within the Lane Transit "
+        "District that are subject to the transit payroll tax."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_wa_seattle_social_housing_excess_compensation(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer Seattle social housing excess compensation"
+    documentation = (
+        "Aggregate Seattle compensation above the Social Housing Tax's "
+        "employee-level threshold."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_wa_seattle_payroll_expense_prior_year_total(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer Seattle payroll expense prior-year total payroll"
+    documentation = (
+        "Aggregate prior-year Seattle payroll expense used to determine "
+        "whether the Seattle payroll expense tax applies."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_wa_seattle_payroll_expense_current_year_total(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer Seattle payroll expense current-year total payroll"
+    documentation = (
+        "Aggregate current-year Seattle payroll expense used to determine "
+        "the Seattle payroll expense tax rate schedule."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_wa_seattle_payroll_expense_lower_band_taxable_payroll(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer Seattle payroll expense lower-band taxable payroll"
+    documentation = (
+        "Aggregate Seattle payroll expense subject to the lower taxable "
+        "compensation band of the Seattle payroll expense tax."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0
+
+
+class employer_total_wa_seattle_payroll_expense_upper_band_taxable_payroll(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer Seattle payroll expense upper-band taxable payroll"
+    documentation = (
+        "Aggregate Seattle payroll expense subject to the upper taxable "
+        "compensation band of the Seattle payroll expense tax."
+    )
+    unit = USD
+    definition_period = YEAR
+    default_value = 0


### PR DESCRIPTION
## Summary
- add employer-side local payroll taxes for Seattle, St. Louis, TriMet, Lane Transit District, and Colorado occupational privilege tax jurisdictions
- model Seattle Payroll Expense Tax and Social Housing Tax on the aggregate employer-input track with jurisdiction-specific taxable-base inputs
- roll the new local taxes into employer_total_local_payroll_tax and extend payroll contribution coverage

## Testing
- uv run pytest policyengine_us/tests/core/test_payroll_contributions.py
- uv run pytest policyengine_us/tests/code_health/variable_names.py
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/payroll -c policyengine_us
- uv run ruff check policyengine_us/variables/input/employer_payroll.py policyengine_us/variables/gov/local/tax/payroll/employer_total_local_payroll_tax.py policyengine_us/variables/gov/local/co/denver/tax/payroll/occupational_privilege/co_denver_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/co/glendale/tax/payroll/occupational_privilege/co_glendale_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/co/greenwood_village/tax/payroll/occupational_privilege/co_greenwood_village_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/co/sheridan/tax/payroll/occupational_privilege/co_sheridan_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/mo/st_louis/tax/payroll/mo_st_louis_total_payroll_expense_tax.py policyengine_us/variables/gov/local/or/trimet/tax/payroll/or_trimet_total_payroll_tax.py policyengine_us/variables/gov/local/or/lane_transit_district/tax/payroll/or_lane_transit_district_total_payroll_tax.py policyengine_us/variables/gov/local/wa/seattle/tax/payroll/payroll_expense/wa_seattle_total_payroll_expense_tax.py policyengine_us/variables/gov/local/wa/seattle/tax/payroll/social_housing/wa_seattle_total_social_housing_tax.py policyengine_us/tests/core/test_payroll_contributions.py
- uv run ruff format --check policyengine_us/variables/input/employer_payroll.py policyengine_us/variables/gov/local/tax/payroll/employer_total_local_payroll_tax.py policyengine_us/variables/gov/local/co/denver/tax/payroll/occupational_privilege/co_denver_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/co/glendale/tax/payroll/occupational_privilege/co_glendale_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/co/greenwood_village/tax/payroll/occupational_privilege/co_greenwood_village_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/co/sheridan/tax/payroll/occupational_privilege/co_sheridan_total_business_occupational_privilege_tax.py policyengine_us/variables/gov/local/mo/st_louis/tax/payroll/mo_st_louis_total_payroll_expense_tax.py policyengine_us/variables/gov/local/or/trimet/tax/payroll/or_trimet_total_payroll_tax.py policyengine_us/variables/gov/local/or/lane_transit_district/tax/payroll/or_lane_transit_district_total_payroll_tax.py policyengine_us/variables/gov/local/wa/seattle/tax/payroll/payroll_expense/wa_seattle_total_payroll_expense_tax.py policyengine_us/variables/gov/local/wa/seattle/tax/payroll/social_housing/wa_seattle_total_social_housing_tax.py policyengine_us/tests/core/test_payroll_contributions.py