### PR TITLE
Backdate Mississippi TANF parameters to 2017

### DIFF
--- a/changelog.d/backdate-ms-tanf.changed.md
+++ b/changelog.d/backdate-ms-tanf.changed.md
@@ -1,0 +1,1 @@
+Backdate Mississippi TANF parameters to 2017.

--- a/policyengine_us/parameters/gov/states/ms/dhs/tanf/income/gross_income_limit_rate.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dhs/tanf/income/gross_income_limit_rate.yaml
@@ -1,7 +1,7 @@
 description: Mississippi limits gross income to this share of the need standard under the Temporary Assistance for Needy Families program.
 
 values:
-  2018-07-01: 1.85
+  2017-01-01: 1.85
 
 metadata:
   unit: /1
@@ -12,3 +12,5 @@ metadata:
       href: https://www.law.cornell.edu/regulations/mississippi/Miss-Code-tit-18-pt-19
     - title: MDHS TANF Eligibility Flyer (2018) - Shows 185% Requirements
       href: https://www.mdhs.ms.gov/wp-content/uploads/2018/02/MDHS_TANF-Eligibility-Flyer.pdf
+    - title: MDHS Historic TANF Increase Announcement (confirms no change since 1999)
+      href: https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/

--- a/policyengine_us/parameters/gov/states/ms/dhs/tanf/need_standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dhs/tanf/need_standard/amount.yaml
@@ -13,36 +13,38 @@ metadata:
       href: https://www.mdhs.ms.gov/wp-content/uploads/2018/02/MDHS_TANF-Eligibility-Flyer.pdf
     - title: Mississippi Department of Human Services - Applying for TANF (Gross Income Limits, values derived by dividing by 1.85)
       href: https://www.mdhs.ms.gov/help/tanf/applying-for-tanf/
+    - title: MDHS Historic TANF Increase Announcement (confirms no change since 1999)
+      href: https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/
 # 2018 values from MDHS Eligibility Flyer (100% Requirements = Need Standard)
 # 2025 values derived from current MDHS website gross income limits / 1.85
 
 1:
-  2018-07-01: 218
+  2017-01-01: 218
   2025-07-01: 339
 2:
-  2018-07-01: 293
+  2017-01-01: 293
   2025-07-01: 460
 3:
-  2018-07-01: 368
+  2017-01-01: 368
   2025-07-01: 581
 4:
-  2018-07-01: 443
+  2017-01-01: 443
   2025-07-01: 702
 5:
-  2018-07-01: 518
+  2017-01-01: 518
   2025-07-01: 823
 6:
-  2018-07-01: 593
+  2017-01-01: 593
   2025-07-01: 944
 7:
-  2018-07-01: 668
+  2017-01-01: 668
   2025-07-01: 1_065
 8:
-  2018-07-01: 743
+  2017-01-01: 743
   2025-07-01: 1_186
 9:
-  2018-07-01: 818
+  2017-01-01: 818
   2025-07-01: 1_307
 10:
-  2018-07-01: 893
+  2017-01-01: 893
   2025-07-01: 1_428

--- a/policyengine_us/parameters/gov/states/ms/dhs/tanf/need_standard/max_table_size.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dhs/tanf/need_standard/max_table_size.yaml
@@ -1,7 +1,7 @@
 description: Mississippi caps need standard calculations at this household size under the Temporary Assistance for Needy Families program.
 
 values:
-  2018-07-01: 10
+  2017-01-01: 10
 
 metadata:
   unit: person
@@ -12,3 +12,5 @@ metadata:
       href: https://www.mdhs.ms.gov/wp-content/uploads/2018/02/MDHS_TANF-Eligibility-Flyer.pdf
     - title: Mississippi Department of Human Services - Applying for TANF (Income Limits Table shows sizes 1-10)
       href: https://www.mdhs.ms.gov/help/tanf/applying-for-tanf/
+    - title: MDHS Historic TANF Increase Announcement (confirms no change since 1999)
+      href: https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/

--- a/policyengine_us/parameters/gov/states/ms/dhs/tanf/payment_standard/additional_person.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dhs/tanf/payment_standard/additional_person.yaml
@@ -1,7 +1,7 @@
 description: Mississippi provides this amount for each additional person beyond the second under the Temporary Assistance for Needy Families program.
 
 values:
-  2018-07-01: 24
+  2017-01-01: 24
 
 metadata:
   unit: currency-USD
@@ -12,3 +12,5 @@ metadata:
       href: https://www.mdhs.ms.gov/wp-content/uploads/2018/02/MDHS_TANF-Eligibility-Flyer.pdf
     - title: Miss. Code. tit. 18, pt. 19 - TANF State Plan (Payment Standards)
       href: https://www.law.cornell.edu/regulations/mississippi/Miss-Code-tit-18-pt-19
+    - title: MDHS Historic TANF Increase Announcement (confirms no change since 1999)
+      href: https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/

--- a/policyengine_us/parameters/gov/states/ms/dhs/tanf/payment_standard/first_person.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dhs/tanf/payment_standard/first_person.yaml
@@ -1,7 +1,7 @@
 description: Mississippi provides this amount for the first person under the Temporary Assistance for Needy Families program.
 
 values:
-  2018-07-01: 110
+  2017-01-01: 110
   2021-05-01: 200
 
 metadata:
@@ -15,3 +15,5 @@ metadata:
       href: https://billstatus.ls.state.ms.us/documents/2021/html/SB/2700-2799/SB2759SG.htm
     - title: Miss. Code. tit. 18, pt. 19 - TANF State Plan (Payment Standards)
       href: https://www.law.cornell.edu/regulations/mississippi/Miss-Code-tit-18-pt-19
+    - title: MDHS Historic TANF Increase Announcement (confirms no change since 1999)
+      href: https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/

--- a/policyengine_us/parameters/gov/states/ms/dhs/tanf/payment_standard/second_person.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dhs/tanf/payment_standard/second_person.yaml
@@ -1,7 +1,7 @@
 description: Mississippi provides this amount for the second person under the Temporary Assistance for Needy Families program.
 
 values:
-  2018-07-01: 36
+  2017-01-01: 36
 
 metadata:
   unit: currency-USD
@@ -12,3 +12,5 @@ metadata:
       href: https://www.mdhs.ms.gov/wp-content/uploads/2018/02/MDHS_TANF-Eligibility-Flyer.pdf
     - title: Miss. Code. tit. 18, pt. 19 - TANF State Plan (Payment Standards)
       href: https://www.law.cornell.edu/regulations/mississippi/Miss-Code-tit-18-pt-19
+    - title: MDHS Historic TANF Increase Announcement (confirms no change since 1999)
+      href: https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/

--- a/policyengine_us/parameters/gov/states/ms/dhs/tanf/resources/limit.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dhs/tanf/resources/limit.yaml
@@ -1,7 +1,7 @@
 description: Mississippi limits resources to this amount under the Temporary Assistance for Needy Families program.
 
 values:
-  2018-07-01: 2_000
+  2017-01-01: 2_000
 
 metadata:
   unit: currency-USD
@@ -12,3 +12,5 @@ metadata:
       href: https://www.law.cornell.edu/regulations/mississippi/Miss-Code-tit-18-pt-19
     - title: Mississippi Department of Human Services - TANF
       href: https://www.mdhs.ms.gov/help/tanf/
+    - title: MDHS Historic TANF Increase Announcement (confirms no change since 1999)
+      href: https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/tanf/integration.yaml
@@ -222,7 +222,46 @@
     ms_tanf_eligible: false
     ms_tanf: 0
 
-- name: Case 7, large family of 5 with mixed income.
+- name: Case 7, 2017 family of 3 with no income receives pre-2021 benefit.
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 8
+        is_tax_unit_dependent: true
+      person3:
+        age: 3
+        is_tax_unit_dependent: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        spm_unit_assets: 500
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MS
+  output:
+    # Household size: 3
+    spm_unit_size: 3
+    # Pre-2021 payment standard: $110 + $36 + $24 = $170
+    ms_tanf_maximum_benefit: 170
+    # Resources: $500 <= $2,000
+    ms_tanf_resources_eligible: true
+    # Need standard size 3 = $368
+    # Limit: $368 * 1.85 = $680.80
+    # $0 <= $680.80
+    ms_tanf_income_eligible: true
+    ms_tanf_eligible: true
+    # Benefit: $170 - $0 = $170
+    ms_tanf: 170
+
+- name: Case 8, large family of 5 with mixed income.
   period: 2026-01
   input:
     people:

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/tanf/ms_tanf_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/tanf/ms_tanf_income_eligible.yaml
@@ -146,7 +146,63 @@
     # Income: $2,641 <= $2,641.80 = true
     ms_tanf_income_eligible: true
 
-- name: Case 13, not in Mississippi.
+- name: Case 13, single person at 2017 income limit.
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    state_code: MS
+    spm_unit_size: 1
+    tanf_gross_earned_income: 403
+    tanf_gross_unearned_income: 0
+  output:
+    # Need standard size 1 = $218
+    # Limit: $218 * 1.85 = $403.30
+    # Income: $403 <= $403.30 = true
+    ms_tanf_income_eligible: true
+
+- name: Case 14, single person above 2017 income limit.
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    state_code: MS
+    spm_unit_size: 1
+    tanf_gross_earned_income: 404
+    tanf_gross_unearned_income: 0
+  output:
+    # Need standard size 1 = $218
+    # Limit: $218 * 1.85 = $403.30
+    # Income: $404 > $403.30 = false
+    ms_tanf_income_eligible: false
+
+- name: Case 15, family of 3 below 2017 income limit.
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    state_code: MS
+    spm_unit_size: 3
+    tanf_gross_earned_income: 500
+    tanf_gross_unearned_income: 0
+  output:
+    # Need standard size 3 = $368
+    # Limit: $368 * 1.85 = $680.80
+    # Income: $500 <= $680.80 = true
+    ms_tanf_income_eligible: true
+
+- name: Case 16, family of 3 above 2017 income limit.
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    state_code: MS
+    spm_unit_size: 3
+    tanf_gross_earned_income: 681
+    tanf_gross_unearned_income: 0
+  output:
+    # Need standard size 3 = $368
+    # Limit: $368 * 1.85 = $680.80
+    # Income: $681 > $680.80 = false
+    ms_tanf_income_eligible: false
+
+- name: Case 17, not in Mississippi.
   period: 2026-01
   input:
     state_code: NY

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/tanf/ms_tanf_maximum_benefit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/tanf/ms_tanf_maximum_benefit.yaml
@@ -103,7 +103,37 @@
     # $200 + $36 + ($24 * 9) = $452
     ms_tanf_maximum_benefit: 452
 
-- name: Case 12, not in Mississippi.
+- name: Case 12, family of 1 in 2017 (pre-2021 payment standard).
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    state_code: MS
+    spm_unit_size: 1
+  output:
+    # $110 (first person only, pre-2021 rate)
+    ms_tanf_maximum_benefit: 110
+
+- name: Case 13, family of 3 in 2017 (pre-2021 payment standard).
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    state_code: MS
+    spm_unit_size: 3
+  output:
+    # $110 + $36 + $24 = $170
+    ms_tanf_maximum_benefit: 170
+
+- name: Case 14, family of 5 in 2017 (pre-2021 payment standard).
+  absolute_error_margin: 0.01
+  period: 2017-01
+  input:
+    state_code: MS
+    spm_unit_size: 5
+  output:
+    # $110 + $36 + ($24 * 3) = $218
+    ms_tanf_maximum_benefit: 218
+
+- name: Case 15, not in Mississippi.
   period: 2026-01
   input:
     state_code: NY


### PR DESCRIPTION
## Summary
Closes #6792

Backdates all Mississippi TANF parameter effective dates from 2018-07-01 to 2017-01-01. Values remain unchanged — MDHS confirmed benefits had not increased since 1999 (historic increase came in May 2021 via SB 2759).

## Changes
- 7 parameter files: effective date changed from 2018-07-01 to 2017-01-01
- Added MDHS 2021 announcement as reference (confirms no change since 1999)
- Added test cases at period 2017-01

## Regulatory Sources
- [MDHS TANF Eligibility Flyer (2018)](https://www.mdhs.ms.gov/wp-content/uploads/2018/02/MDHS_TANF-Eligibility-Flyer.pdf)
- [MDHS Historic TANF Increase Announcement](https://www.mdhs.ms.gov/post/historic-tanf-increase-delivered-to-mississippi-tanf-recipients-beginning-today/)
- [CRS Report RL32760 (2019)](https://www.everycrsreport.com/files/20191218_RL32760_15018609a062a2330f4f5d99450fe7b97fc55935.html)

## Test Plan
- [x] All existing MS TANF tests pass (66/66)
- [x] New 2017-period tests pass (payment standard, income eligibility, integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)