### PR TITLE
Fix NM modified gross income to disallow losses per Admin Code 3.3.1.10

### DIFF
--- a/changelog.d/nm-modified-gross-income-fix.fixed.md
+++ b/changelog.d/nm-modified-gross-income-fix.fixed.md
@@ -1,0 +1,1 @@
+Fix NM modified gross income to disallow business losses, capital losses, and rental losses per NM Admin Code 3.3.1.10.

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_modified_gross_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_modified_gross_income.yaml
@@ -1,0 +1,66 @@
+# NM Admin Code 3.3.1.10: "zero is the lowest amount which may be reported
+# for any item in computing modified gross income"
+
+- name: NM modified gross income with positive income only
+  period: 2024
+  input:
+    state_code: NM
+    taxable_interest_income: 50_000
+    self_employment_income: 30_000
+  output:
+    nm_modified_gross_income: 80_000
+
+- name: NM business loss should not reduce modified gross income
+  period: 2024
+  input:
+    state_code: NM
+    taxable_interest_income: 100_000
+    self_employment_income: -100_000
+  output:
+    # Per PIT-RC: business loss enters as zero, not negative
+    nm_modified_gross_income: 100_000
+
+- name: NM capital losses should not reduce modified gross income
+  period: 2024
+  input:
+    state_code: NM
+    taxable_interest_income: 50_000
+    short_term_capital_gains: -20_000
+    long_term_capital_gains: -10_000
+  output:
+    # Capital gains undiminished by losses: floor to zero
+    nm_modified_gross_income: 50_000
+
+- name: NM rental loss should not reduce modified gross income
+  period: 2024
+  input:
+    state_code: NM
+    taxable_interest_income: 50_000
+    rental_income: -30_000
+  output:
+    nm_modified_gross_income: 50_000
+
+- name: NM mixed positive and negative income sources
+  period: 2024
+  input:
+    state_code: NM
+    taxable_interest_income: 100_000
+    self_employment_income: -50_000
+    rental_income: -20_000
+    short_term_capital_gains: 10_000
+    long_term_capital_gains: -15_000
+    dividend_income: 5_000
+  output:
+    # interest: max(100000, 0) = 100000
+    # self_employment: max(-50000, 0) = 0
+    # rental: max(-20000, 0) = 0
+    # capital_gains: max(10000 + -15000, 0) = max(-5000, 0) = 0
+    # dividends: max(5000, 0) = 5000
+    nm_modified_gross_income: 105_000
+
+- name: NM zero income
+  period: 2024
+  input:
+    state_code: NM
+  output:
+    nm_modified_gross_income: 0

--- a/policyengine_us/variables/gov/states/nm/tax/income/nm_modified_gross_income.py
+++ b/policyengine_us/variables/gov/states/nm/tax/income/nm_modified_gross_income.py
@@ -7,7 +7,20 @@ class nm_modified_gross_income(Variable):
     label = "New Mexico modified gross income"
     unit = USD
     definition_period = YEAR
-    reference = "https://nmonesource.com/nmos/nmsa/en/item/4340/index.do#!fragment/zoupio-_Toc140503656/BQCwhgziBcwMYgK4DsDWszIQewE4BUBTADwBdoAvbRABwEtsBaAfX2zgEYAWABgFYeAZgBsfYQEoANMmylCEAIqJCuAJ7QA5BskRCYXAiUr1WnXoMgAynlIAhdQCUAogBknANQCCAOQDCTyVIwACNoUnZxcSA"  # L
+    reference = (
+        "https://nmonesource.com/nmos/nmsa/en/item/4340/index.do#!fragment/zoupio-_Toc140503656",
+        "https://www.law.cornell.edu/regulations/new-mexico/N-M-Admin-Code-SS-3.3.1.10",
+    )
     defined_for = StateCode.NM
 
-    adds = "gov.states.nm.tax.income.modified_gross_income"
+    def formula(tax_unit, period, parameters):
+        # Per NM Admin Code 3.3.1.10:
+        # "zero is the lowest amount which may be reported for any item
+        # in computing 'modified gross income'"
+        # "The loss from one business or activity shall not reduce
+        # the income from another business or activity."
+        sources = parameters(period).gov.states.nm.tax.income.modified_gross_income
+        total = 0
+        for source in sources:
+            total += max_(add(tax_unit, period, [source]), 0)
+        return total


### PR DESCRIPTION
## Summary

Fixes NM modified gross income (`nm_modified_gross_income`) to floor each income source at zero before summing, per NM Admin Code § 3.3.1.10.

Closes #7860

## Root Cause

`nm_modified_gross_income` used a simple `adds` parameter that summed income sources including negatives. NM Admin Code § 3.3.1.10 explicitly requires:

> "zero is the lowest amount which may be reported for any item in computing 'modified gross income'"

> "The loss from one business or activity shall not reduce the income from another business or activity."

This caused business losses and capital losses to offset other income, incorrectly qualifying taxpayers for the low-income comprehensive tax rebate.

## Fix

Converted `nm_modified_gross_income` from an `adds` variable to a formula that iterates over the same parameter list but floors each source at zero with `max_(add(...), 0)`.

## Test Plan

- [x] 6 new unit tests for `nm_modified_gross_income` covering:
  - Positive income only
  - Business loss (self_employment_income < 0)
  - Capital losses (short + long term < 0)
  - Rental loss
  - Mixed positive and negative sources
  - Zero income
- [ ] CI passes
- [ ] Existing NM rebate tests unaffected (they provide `nm_modified_gross_income` directly as input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)