### PR TITLE
Fix CA state_income_tax to include AMT and mental health services tax

### DIFF
--- a/changelog.d/ca-missing-amt-mhst.fixed.md
+++ b/changelog.d/ca-missing-amt-mhst.fixed.md
@@ -1,0 +1,1 @@
+Include CA AMT and mental health services tax in state_income_tax.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/ca_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/ca_income_tax_before_refundable_credits.yaml
@@ -20,3 +20,15 @@
     ca_renter_credit: 200
   output:
     ca_income_tax_before_refundable_credits: 0
+
+- name: Includes AMT and mental health services tax
+  period: 2025
+  input:
+    state_code: CA
+    ca_income_tax_before_credits: 50_000
+    ca_non_refundable_credits: 1_000
+    ca_amt: 2_000
+    ca_mental_health_services_tax: 5_000
+  output:
+    # (50000 - 1000) + 2000 + 5000 = 56000
+    ca_income_tax_before_refundable_credits: 56_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/integration.yaml
@@ -109,3 +109,35 @@
         state_fips: 6
   output:
     ca_income_tax: 371
+
+- name: High income joint filer, state_income_tax includes behavioral health tax.
+  absolute_error_margin: 500
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        taxable_interest_income: 1_000_000
+        is_tax_unit_head: true
+      person2:
+        age: 40
+        taxable_interest_income: 1_000_000
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0
+    families:
+      family:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 6
+  output:
+    state_income_tax: 216_156

--- a/policyengine_us/variables/gov/states/ca/tax/income/ca_income_tax.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/ca_income_tax.py
@@ -12,8 +12,6 @@ class ca_income_tax(Variable):
 
     adds = [
         "ca_income_tax_before_refundable_credits",
-        "ca_amt",
-        "ca_mental_health_services_tax",
         "ca_use_tax",
     ]
     subtracts = ["ca_refundable_credits"]

--- a/policyengine_us/variables/gov/states/ca/tax/income/ca_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/ca_income_tax_before_refundable_credits.py
@@ -11,6 +11,11 @@ class ca_income_tax_before_refundable_credits(Variable):
     reference = "https://www.ftb.ca.gov/forms/Search/Home/Confirmation"
 
     def formula(tax_unit, period, parameters):
+        # Form 540 line 48: tax after nonrefundable credits
         itax = tax_unit("ca_income_tax_before_credits", period)
         nonrefundable_credits = tax_unit("ca_non_refundable_credits", period)
-        return max_(0, itax - nonrefundable_credits)
+        tax_after_credits = max_(0, itax - nonrefundable_credits)
+        # Form 540 lines 61-62: AMT and mental health services tax
+        amt = tax_unit("ca_amt", period)
+        mhst = tax_unit("ca_mental_health_services_tax", period)
+        return tax_after_credits + amt + mhst


### PR DESCRIPTION
## Summary

Includes CA AMT (Form 540 line 61) and mental health services tax (line 62) in `ca_income_tax_before_refundable_credits`, so they flow through to `state_income_tax`. Previously these only appeared in `ca_income_tax` but not in the `state_income_tax` path used by downstream consumers.

Closes #7926

## Root Cause

`ca_income_tax_before_refundable_credits` computed Form 540 line 48 (tax after nonrefundable credits) but stopped there. `ca_income_tax` then added AMT, MHST, and use tax on top. Since `state_income_tax_before_refundable_credits.yaml` references `ca_income_tax_before_refundable_credits`, the AMT and MHST were missing from `state_income_tax`.

## Fix

- `ca_income_tax_before_refundable_credits` now adds `ca_amt` and `ca_mental_health_services_tax` (matching Form 540 line 64)
- `ca_income_tax` removes these from its `adds` list to avoid double-counting
- Net effect: `ca_income_tax` produces the same result, but `state_income_tax` now correctly includes AMT and MHST

## Test Plan

- [x] Existing unit test unchanged (AMT/MHST default to 0)
- [x] New unit test: AMT + MHST included in before-refundable-credits total
- [x] Integration test: joint filer $2M income → `state_income_tax` ≈ $216,156 (matches TaxAct)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)