### PR TITLE
Fix Working Parents Tax Relief Act reform to be idempotent

### DIFF
--- a/changelog.d/fix-wptra-idempotent.fixed.md
+++ b/changelog.d/fix-wptra-idempotent.fixed.md
@@ -1,0 +1,1 @@
+Fixed Working Parents Tax Relief Act reform to be idempotent when applied multiple times.

--- a/policyengine_us/reforms/congress/mcdonald_rivet/working_parents_tax_relief_act/working_parents_tax_relief_act.py
+++ b/policyengine_us/reforms/congress/mcdonald_rivet/working_parents_tax_relief_act/working_parents_tax_relief_act.py
@@ -114,7 +114,7 @@ def create_working_parents_tax_relief_act() -> Reform:
 
     class reform(Reform):
         def apply(self):
-            self.add_variable(eitc_young_child_count)
+            self.update_variable(eitc_young_child_count)
             self.update_variable(eitc_phase_in_rate)
             self.update_variable(eitc_phase_out_rate)
             self.update_variable(eitc_maximum)


### PR DESCRIPTION
## Summary

Uses `update_variable()` instead of `add_variable()` for `eitc_young_child_count` to align with established reform patterns.

Closes #7941

## Problem

The WPTRA reform used `add_variable()` which fails if applied twice. Other reforms like WATCA use `update_variable()` for all variables.

## Solution

```python
# Before (WPTRA - broken pattern)
self.add_variable(eitc_young_child_count)

# After (aligns with WATCA and other reforms)
self.update_variable(eitc_young_child_count)
```

`update_variable()` is idempotent - it works whether the variable exists or not.

## Pattern Comparison

**WATCA (correct pattern):**
```python
class reform(Reform):
    def apply(self):
        self.update_variable(watca_alternative_tax_magi)
        self.update_variable(watca_surtax_magi)
        ...
```

**WPTRA (now fixed):**
```python
class reform(Reform):
    def apply(self):
        self.update_variable(eitc_young_child_count)  # was add_variable
        self.update_variable(eitc_phase_in_rate)
        self.update_variable(eitc_phase_out_rate)
        self.update_variable(eitc_maximum)
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)