### PR TITLE
Remove 2035 sunset from non-refundable SS credit

### DIFF
--- a/changelog.d/codex-fix-nonrefundable-ss-credit-2100.fixed.md
+++ b/changelog.d/codex-fix-nonrefundable-ss-credit-2100.fixed.md
@@ -1,0 +1,1 @@
+Extend the CRFB non-refundable Social Security credit reform so it continues feeding into non-refundable credits after 2035.

--- a/policyengine_us/reforms/crfb/non_refundable_ss_credit.py
+++ b/policyengine_us/reforms/crfb/non_refundable_ss_credit.py
@@ -86,7 +86,6 @@ def non_refundable_ss_credit_reform() -> Reform:
     def modify_parameters(parameters):
         parameters.gov.irs.credits.non_refundable.update(
             start=instant("2026-01-01"),
-            stop=instant("2035-12-31"),
             value=[
                 "foreign_tax_credit",
                 "cdcc",

--- a/policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml
@@ -145,3 +145,16 @@
     # Phase out = 6% * (165k - 150k) = $900
     # Credit = max(0, 600 - 900) = 0
     ss_credit: 0
+
+- name: Late-year SS credit still reduces non-refundable income tax
+  period: 2073
+  reforms: policyengine_us.reforms.crfb.non_refundable_ss_credit.non_refundable_ss_credit_reform_object
+  input:
+    gov.contrib.crfb.ss_credit.in_effect: true
+    taxable_social_security: 30_000
+    taxable_income: 1_000_000
+    filing_status: SINGLE
+  output:
+    highest_tax_rate: 0.35
+    ss_credit: 600
+    income_tax_non_refundable_credits: 600


### PR DESCRIPTION
## What changed

- remove the `2035-12-31` sunset from the `gov.irs.credits.non_refundable` rewrite in `non_refundable_ss_credit_reform`
- add a late-year policy regression showing the Social Security credit still flows through `income_tax_non_refundable_credits` in `2073`
- add the required changelog fragment

## Why

The reform-specific parameter rewrite was stopping in 2035. After that point, `ss_credit` could still be computed, but it no longer fed into the non-refundable credit stack. In downstream CRFB long-horizon scoring, that made late-year reforms collapse together incorrectly.

The CRFB deliverable is a 75-year horizon through 2100, and I do not see evidence in the CRFB thread that this custom SS credit reform was intended to sunset in 2035.

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml -c policyengine_us`
- result: `11 passed`
- direct single-household spot checks for `2026` and `2073` confirming `income_tax_non_refundable_credits` remains active in the late-year case
