### PR TITLE
Fix missing CTC and ODC gating follow-ups

### DIFF
--- a/changelog.d/fix-ctc-gating-followup.fixed.md
+++ b/changelog.d/fix-ctc-gating-followup.fixed.md
@@ -1,0 +1,1 @@
+Fixed federal and reform CTC gating so child CTC, ODC, and reform overrides all follow the intended child-qualification and filer-identification rules.

--- a/changelog.d/fix-ctc-gating-followup.fixed.md
+++ b/changelog.d/fix-ctc-gating-followup.fixed.md
@@ -1,1 +1,1 @@
-Fixed federal and reform CTC gating so child CTC, ODC, and reform overrides all follow the intended child-qualification and filer-identification rules.
+Fixed federal and reform CTC gating so child CTC, ODC, and reform overrides all follow the intended child-qualification and filer-identification rules, and introduced `has_tin` / `taxpayer_has_tin` compatibility variables for the TIN-side checks.

--- a/policyengine_us/parameters/gov/irs/credits/ctc/adult_ssn_requirement_applies.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/ctc/adult_ssn_requirement_applies.yaml
@@ -1,4 +1,4 @@
-description: The IRS requires a Social Security Number for at least one of the adults in the household to qualify for the Child Tax Credit, if this is true.
+description: The IRS requires at least one filer with a valid SSN, and any co-filer with an SSN or ITIN, to claim the child portion of the Child Tax Credit if this is true.
 values:
   2018-01-01: false
   2025-01-01: true

--- a/policyengine_us/reforms/aca/aca_ptc_700_fpl_cliff.py
+++ b/policyengine_us/reforms/aca/aca_ptc_700_fpl_cliff.py
@@ -53,8 +53,8 @@ def create_aca_ptc_700_fpl_cliff() -> Reform:
             immigration_eligible = person(
                 "is_aca_ptc_immigration_status_eligible", period
             )
-            taxpayer_has_itin = person.tax_unit("taxpayer_has_itin", period)
-            is_status_eligible = taxpayer_has_itin & ~separate & immigration_eligible
+            taxpayer_has_tin = person.tax_unit("taxpayer_has_tin", period)
+            is_status_eligible = taxpayer_has_tin & ~separate & immigration_eligible
 
             # determine coverage eligibility for ACA plan
             INELIGIBLE_COVERAGE = [

--- a/policyengine_us/reforms/aca/aca_ptc_additional_bracket.py
+++ b/policyengine_us/reforms/aca/aca_ptc_additional_bracket.py
@@ -50,8 +50,8 @@ def create_aca_ptc_additional_bracket() -> Reform:
             immigration_eligible = person(
                 "is_aca_ptc_immigration_status_eligible", period
             )
-            taxpayer_has_itin = person.tax_unit("taxpayer_has_itin", period)
-            is_status_eligible = taxpayer_has_itin & ~separate & immigration_eligible
+            taxpayer_has_tin = person.tax_unit("taxpayer_has_tin", period)
+            is_status_eligible = taxpayer_has_tin & ~separate & immigration_eligible
 
             # determine coverage eligibility for ACA plan
             INELIGIBLE_COVERAGE = [

--- a/policyengine_us/reforms/aca/aca_ptc_simplified_bracket.py
+++ b/policyengine_us/reforms/aca/aca_ptc_simplified_bracket.py
@@ -51,8 +51,8 @@ def create_aca_ptc_simplified_bracket() -> Reform:
             immigration_eligible = person(
                 "is_aca_ptc_immigration_status_eligible", period
             )
-            taxpayer_has_itin = person.tax_unit("taxpayer_has_itin", period)
-            is_status_eligible = taxpayer_has_itin & ~separate & immigration_eligible
+            taxpayer_has_tin = person.tax_unit("taxpayer_has_tin", period)
+            is_status_eligible = taxpayer_has_tin & ~separate & immigration_eligible
 
             # determine coverage eligibility for ACA plan
             INELIGIBLE_COVERAGE = [

--- a/policyengine_us/reforms/congress/afa/afa_other_dependent_credit.py
+++ b/policyengine_us/reforms/congress/afa/afa_other_dependent_credit.py
@@ -28,11 +28,12 @@ def create_afa_other_dependent_credit() -> Reform:
         reference = "https://www.bennet.senate.gov/wp-content/uploads/2025/04/American-Family-Act-2025.pdf"
 
         def formula(person, period, parameters):
-            p = parameters(period).gov.contrib.congress.afa.other_dependent_credit
+            p = parameters(period).gov.contrib.congress.afa
             is_dependent = person("is_tax_unit_dependent", period)
-            is_child = person("ctc_child_individual_maximum", period) > 0
+            age = person("age", period)
+            is_child = p.ctc.amount.multiplier.calc(age) > 0
             is_adult_dependent = ~is_child & is_dependent
-            return is_adult_dependent * p.amount
+            return is_adult_dependent * p.other_dependent_credit.amount
 
     class other_dependent_credit_phase_out(Variable):
         value_type = float

--- a/policyengine_us/reforms/congress/romney/family_security_act_2024/ctc/family_security_act_2024_ctc.py
+++ b/policyengine_us/reforms/congress/romney/family_security_act_2024/ctc/family_security_act_2024_ctc.py
@@ -83,10 +83,18 @@ def create_family_security_act_2024_ctc() -> Reform:
 
         def formula(person, period, parameters):
             age = person("age", period)
+            qualifying_child = person("ctc_qualifying_child", period)
+            filer_meets_child_ctc_id_requirements = person.tax_unit(
+                "filer_meets_child_ctc_identification_requirements", period
+            )
             p = parameters(
                 period
             ).gov.contrib.congress.romney.family_security_act_2_0.ctc
-            return p.base.calc(age)
+            return (
+                qualifying_child
+                * filer_meets_child_ctc_id_requirements
+                * p.base.calc(age)
+            )
 
     class ctc_qualifying_children(Variable):
         value_type = int

--- a/policyengine_us/reforms/ctc/ctc_additional_bracket.py
+++ b/policyengine_us/reforms/ctc/ctc_additional_bracket.py
@@ -14,8 +14,16 @@ def create_ctc_additional_bracket() -> Reform:
 
         def formula(person, period, parameters):
             age = person("age", period)
+            qualifying_child = person("ctc_qualifying_child", period)
+            filer_meets_child_ctc_id_requirements = person.tax_unit(
+                "filer_meets_child_ctc_identification_requirements", period
+            )
             p = parameters(period).gov.contrib.ctc.additional_bracket.amount
-            return p.base.calc(age)
+            return (
+                qualifying_child
+                * filer_meets_child_ctc_id_requirements
+                * p.base.calc(age)
+            )
 
     class ctc_refundable_maximum(Variable):
         value_type = float

--- a/policyengine_us/reforms/ctc/ctc_older_child_supplement.py
+++ b/policyengine_us/reforms/ctc/ctc_older_child_supplement.py
@@ -18,12 +18,20 @@ def create_ctc_older_child_supplement() -> Reform:
 
         def formula(person, period, parameters):
             age = person("age", period)
+            qualifying_child = person("ctc_qualifying_child", period)
+            filer_meets_child_ctc_id_requirements = person.tax_unit(
+                "filer_meets_child_ctc_identification_requirements", period
+            )
             base_amount = parameters(period).gov.irs.credits.ctc.amount.base
             base_amount = base_amount.calc(age)
             oldest_child = person("child_index", period) == 1
             p_ref = parameters(period).gov.contrib.ctc.oldest_child_supplement
             oldest_child_supplement = oldest_child * p_ref.amount
-            return base_amount + oldest_child_supplement
+            return (
+                qualifying_child
+                * filer_meets_child_ctc_id_requirements
+                * (base_amount + oldest_child_supplement)
+            )
 
     class reform(Reform):
         def apply(self):

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/integration.yaml
@@ -113,6 +113,7 @@
       dep:
         age: 60
         is_tax_unit_dependent: true
+        is_tax_unit_spouse: false
     tax_units:
       tax_unit:
         members: [head, dep]
@@ -129,6 +130,7 @@
       dep:
         age: 60
         is_tax_unit_dependent: true
+        is_tax_unit_spouse: false
     tax_units:
       tax_unit:
         members: [head, dep]
@@ -144,6 +146,7 @@
       dep:
         age: 60
         is_tax_unit_dependent: true
+        is_tax_unit_spouse: false
     tax_units:
       tax_unit:
         members: [head, dep]
@@ -160,6 +163,7 @@
       dep:
         age: 60
         is_tax_unit_dependent: true
+        is_tax_unit_spouse: false
     tax_units:
       tax_unit:
         members: [head, dep]
@@ -317,6 +321,56 @@
         income_tax_before_credits: 1_000
   output:
     ctc_qualifying_child: [false, false]
+    ctc_child_individual_maximum: [0, 0]
+    ctc_adult_individual_maximum: [0, 500]
+    refundable_ctc: 0
+    non_refundable_ctc: 500
+    ctc: 500
+
+- name: ITIN-only filer can still claim ODC for an adult dependent in 2026
+  period: 2026
+  input:
+    people:
+      head:
+        age: 40
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+      dep:
+        age: 60
+        is_tax_unit_dependent: true
+        is_tax_unit_spouse: false
+        has_itin: true
+    tax_units:
+      tax_unit:
+        members: [head, dep]
+  output:
+    filer_meets_ctc_identification_requirements: true
+    filer_meets_child_ctc_identification_requirements: false
+    ctc_adult_individual_maximum: [0, 500]
+    refundable_ctc: 0
+    non_refundable_ctc: 500
+    ctc: 500
+
+- name: Child with a valid SSN gets ODC instead of child CTC when the filer lacks the required SSN in 2026
+  period: 2026
+  input:
+    people:
+      head:
+        age: 40
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, child]
+  output:
+    filer_meets_ctc_identification_requirements: true
+    filer_meets_child_ctc_identification_requirements: false
     ctc_child_individual_maximum: [0, 0]
     ctc_adult_individual_maximum: [0, 500]
     refundable_ctc: 0

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.yaml
@@ -27,6 +27,15 @@
   output:
     ctc_adult_individual_maximum: 500
 
+- name: Adult dependents must have a TIN to qualify.
+  period: 2018
+  input:
+    is_tax_unit_dependent: true
+    ctc_child_individual_maximum: 0
+    has_itin: false
+  output:
+    ctc_adult_individual_maximum: 0
+
 - name: Extended by OBBB.
   period: 2026
   input:

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/ctc_child_individual_maximum.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/ctc_child_individual_maximum.yaml
@@ -41,3 +41,22 @@
     ssn_card_type: OTHER_NON_CITIZEN
   output:
     ctc_child_individual_maximum: 0
+
+- name: A dependent child gets ODC instead of child CTC when the filer lacks the required SSN in 2026.
+  period: 2026
+  input:
+    people:
+      head:
+        age: 40
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, child]
+  output:
+    ctc_child_individual_maximum: [0, 0]

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_child_ctc_identification_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_child_ctc_identification_requirements.yaml
@@ -1,0 +1,47 @@
+- name: One filer with a valid SSN and the other filer with an ITIN qualifies for child CTC under senate finance rules
+  period: 2026
+  absolute_error_margin: 0.9
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        ssn_card_type: CITIZEN
+      spouse:
+        is_tax_unit_spouse: true
+        ssn_card_type: NONE
+        has_itin: true
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+  output:
+    filer_meets_child_ctc_identification_requirements: true
+
+- name: An ITIN-only filer cannot claim child CTC once the stricter filer SSN rule takes effect
+  period: 2026
+  absolute_error_margin: 0.9
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+    tax_units:
+      tax_unit:
+        members: [head]
+  output:
+    filer_meets_child_ctc_identification_requirements: false
+
+- name: An ITIN-only filer could still claim child CTC before 2025
+  period: 2024
+  absolute_error_margin: 0.9
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+    tax_units:
+      tax_unit:
+        members: [head]
+  output:
+    filer_meets_child_ctc_identification_requirements: true

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.yaml
@@ -1,32 +1,93 @@
-- name: One person has a valid SSN card type, the other does not, senate finance rules
+- name: One filer with a valid SSN and the other filer with an ITIN qualifies for child CTC under senate finance rules
   period: 2026
   absolute_error_margin: 0.9
   input:
     people:
-      person1:
+      head:
+        is_tax_unit_head: true
         ssn_card_type: CITIZEN
-      person2:
+      spouse:
+        is_tax_unit_spouse: true
         ssn_card_type: NONE
+        has_itin: true
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
   output:
     meets_ctc_identification_requirements: [true, false]
     filer_meets_ctc_identification_requirements: true
+    filer_meets_child_ctc_identification_requirements: true
 
-- name: One person has a valid SSN card type, the other does not, senate finance rules, child status irrelevant
+- name: A filer with an ITIN but no valid SSN can still claim ODC under senate finance rules
   period: 2026
   absolute_error_margin: 0.9
   input:
     people:
-      person1:
-        ssn_card_type: CITIZEN
-      person2:
+      head:
+        is_tax_unit_head: true
         ssn_card_type: NONE
-      person3:
-        age: 5
-        is_tax_unit_dependent: true
-        ssn_card_type: NONE
+        has_itin: true
+    tax_units:
+      tax_unit:
+        members: [head]
   output:
-    meets_ctc_identification_requirements: [true, false, false]
+    meets_ctc_identification_requirements: [false]
     filer_meets_ctc_identification_requirements: true
+    filer_meets_child_ctc_identification_requirements: false
+
+- name: A filer without any taxpayer identification number cannot claim CTC or ODC
+  period: 2026
+  absolute_error_margin: 0.9
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: false
+    tax_units:
+      tax_unit:
+        members: [head]
+  output:
+    meets_ctc_identification_requirements: [false]
+    filer_meets_ctc_identification_requirements: false
+    filer_meets_child_ctc_identification_requirements: false
+
+- name: A joint return fails the filer identification requirement if one spouse lacks both SSN and ITIN
+  period: 2026
+  absolute_error_margin: 0.9
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        ssn_card_type: CITIZEN
+      spouse:
+        is_tax_unit_spouse: true
+        ssn_card_type: NONE
+        has_itin: false
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+  output:
+    meets_ctc_identification_requirements: [true, false]
+    filer_meets_ctc_identification_requirements: false
+    filer_meets_child_ctc_identification_requirements: false
+
+- name: An ITIN-only filer can still claim child CTC before the stricter filer SSN rule takes effect
+  period: 2024
+  absolute_error_margin: 0.9
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+    tax_units:
+      tax_unit:
+        members: [head]
+  output:
+    meets_ctc_identification_requirements: [false]
+    filer_meets_ctc_identification_requirements: true
+    filer_meets_child_ctc_identification_requirements: true
 
 - name: Single person eligible
   period: 2026
@@ -34,10 +95,15 @@
   input:
     people:
       person1:
+        is_tax_unit_head: true
         ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [person1]
   output:
     meets_ctc_identification_requirements: [true]
     filer_meets_ctc_identification_requirements: true
+    filer_meets_child_ctc_identification_requirements: true
 
 - name: Single person ineligible
   period: 2026
@@ -45,7 +111,13 @@
   input:
     people:
       person1:
+        is_tax_unit_head: true
         ssn_card_type: NONE
+        has_itin: false
+    tax_units:
+      tax_unit:
+        members: [person1]
   output:
     meets_ctc_identification_requirements: [false]
     filer_meets_ctc_identification_requirements: false
+    filer_meets_child_ctc_identification_requirements: false

--- a/policyengine_us/tests/policy/baseline/household/demographic/person/has_tin.yaml
+++ b/policyengine_us/tests/policy/baseline/household/demographic/person/has_tin.yaml
@@ -1,0 +1,13 @@
+- name: has_tin follows legacy has_itin input
+  period: 2024
+  input:
+    has_itin: false
+  output:
+    has_tin: false
+
+- name: has_tin stays true when legacy has_itin input is true
+  period: 2024
+  input:
+    has_itin: true
+  output:
+    has_tin: true

--- a/policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_tin.yaml
+++ b/policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_tin.yaml
@@ -1,0 +1,31 @@
+- name: taxpayer_has_tin unit test 1
+  period: 2021
+  input:
+    has_itin: true
+    is_tax_unit_head: true
+  output:
+    taxpayer_has_tin: true
+
+- name: taxpayer_has_tin unit test 2
+  period: 2022
+  input:
+    has_itin: true
+    is_tax_unit_spouse: true
+  output:
+    taxpayer_has_tin: true
+
+- name: taxpayer_has_tin unit test 3
+  period: 2023
+  input:
+    has_itin: false
+    is_tax_unit_head: true
+  output:
+    taxpayer_has_tin: false
+
+- name: taxpayer_has_tin unit test 4
+  period: 2024
+  input:
+    has_itin: false
+    is_tax_unit_spouse: true
+  output:
+    taxpayer_has_tin: false

--- a/policyengine_us/tests/policy/contrib/congress/afa/afa_other_dependent_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/afa/afa_other_dependent_credit.yaml
@@ -113,6 +113,32 @@
     other_dependent_credit: 0
     income_tax_non_refundable_credits: 0
 
+- name: Child is not reclassified as an adult dependent when the filer lacks the federal child-CTC SSN gate
+  period: 2026
+  reforms: policyengine_us.reforms.congress.afa.afa_other_dependent_credit.afa_other_dependent_credit
+  input:
+    gov.contrib.congress.afa.in_effect: true
+    people:
+      head:
+        age: 40
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+        employment_income: 80_000
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, child]
+  output:
+    ctc_child_individual_maximum: [0, 0]
+    ctc_child_individual_maximum_arpa: [0, 3_720]
+    other_dependent_credit_maximum: [0, 0]
+    other_dependent_credit: 0
+    ctc: 3_720
+
 - name: Integration test - CTC partially phased out
   period: 2025
   reforms: policyengine_us.reforms.congress.afa.afa_other_dependent_credit.afa_other_dependent_credit

--- a/policyengine_us/tests/policy/contrib/congress/romney/family_security_act_2024/ctc/family_security_act_2024_ctc.yaml
+++ b/policyengine_us/tests/policy/contrib/congress/romney/family_security_act_2024/ctc/family_security_act_2024_ctc.yaml
@@ -243,3 +243,31 @@
   output:
     pregnant_mothers_credit: 2_800
     income_tax_refundable_credits: 2_800
+
+- name: Child amount is blocked when the filer fails the post-2025 child CTC ID gate
+  period: 2026
+  reforms: policyengine_us.reforms.congress.romney.family_security_act_2024.ctc.family_security_act_2024_ctc.family_security_act_2024_ctc
+  input:
+    gov.contrib.congress.romney.family_security_act_2_0.ctc.apply_ctc_structure: true
+    gov.contrib.congress.romney.family_security_act_2_0.ctc.phase_in.income_phase_in_end: 20_000
+    gov.contrib.congress.romney.family_security_act_2_0.ctc.base[0].amount: 4_200
+    gov.contrib.congress.romney.family_security_act_2_0.ctc.base[1].amount: 3_000
+    gov.contrib.congress.romney.family_security_act_2_0.ctc.child_cap: 6
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+      person2:
+        age: 5
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        adjusted_gross_income: 20_000
+        ctc_phase_out: 0
+  output:
+    ctc_child_individual_maximum: [0, 0]
+    ctc_adult_individual_maximum: [0, 500]
+    ctc: 500

--- a/policyengine_us/tests/policy/contrib/ctc/ctc_additional_bracket.yaml
+++ b/policyengine_us/tests/policy/contrib/ctc/ctc_additional_bracket.yaml
@@ -112,3 +112,25 @@
   output:
     ctc_child_individual_maximum: [0, 0, 0, 3_000]
     ctc_refundable_maximum: 2_500
+
+- name: Child amount is blocked when the filer fails the post-2025 child CTC ID gate
+  period: 2026
+  reforms: policyengine_us.reforms.ctc.ctc_additional_bracket.ctc_additional_bracket
+  input:
+    gov.contrib.ctc.additional_bracket.amount.base[0].amount: 3_000
+    gov.contrib.ctc.additional_bracket.in_effect: true
+    people:
+      person1:
+        age: 38
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+      person2:
+        age: 5
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    ctc_child_individual_maximum: [0, 0]
+    ctc_refundable_maximum: 0

--- a/policyengine_us/tests/policy/contrib/ctc/ctc_older_child_supplement.yaml
+++ b/policyengine_us/tests/policy/contrib/ctc/ctc_older_child_supplement.yaml
@@ -76,3 +76,24 @@
         members: [person1, person2]
   output:
     ctc_child_individual_maximum: [0, 3_000]
+
+- name: Oldest-child supplement does not bypass the post-2025 child CTC ID gate
+  period: 2026
+  reforms: policyengine_us.reforms.ctc.ctc_older_child_supplement.ctc_older_child_supplement
+  input:
+    gov.contrib.ctc.oldest_child_supplement.amount: 1_000
+    gov.contrib.ctc.oldest_child_supplement.in_effect: true
+    people:
+      person1:
+        age: 38
+        is_tax_unit_head: true
+        ssn_card_type: NONE
+        has_itin: true
+      person2:
+        age: 5
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    ctc_child_individual_maximum: [0, 0]

--- a/policyengine_us/variables/gov/aca/eligibility/is_aca_ptc_eligible.py
+++ b/policyengine_us/variables/gov/aca/eligibility/is_aca_ptc_eligible.py
@@ -12,8 +12,8 @@ class is_aca_ptc_eligible(Variable):
         fstatus = person.tax_unit("filing_status", period)
         separate = fstatus == fstatus.possible_values.SEPARATE
         immigration_eligible = person("is_aca_ptc_immigration_status_eligible", period)
-        taxpayer_has_itin = person.tax_unit("taxpayer_has_itin", period)
-        is_status_eligible = taxpayer_has_itin & ~separate & immigration_eligible
+        taxpayer_has_tin = person.tax_unit("taxpayer_has_tin", period)
+        is_status_eligible = taxpayer_has_tin & ~separate & immigration_eligible
 
         # determine coverage eligibility for ACA plan
         INELIGIBLE_COVERAGE = [

--- a/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.py
@@ -20,7 +20,7 @@ class ctc_adult_individual_maximum(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.irs.credits.ctc
         is_adult = person("ctc_child_individual_maximum", period) == 0
-        dependent_has_tin = person("has_itin", period)
+        dependent_has_tin = person("has_tin", period)
         filer_meets_tin_requirement = person.tax_unit(
             "filer_meets_ctc_identification_requirements", period
         )

--- a/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.py
@@ -20,4 +20,13 @@ class ctc_adult_individual_maximum(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.irs.credits.ctc
         is_adult = person("ctc_child_individual_maximum", period) == 0
-        return is_adult * p.amount.adult_dependent
+        dependent_has_tin = person("has_itin", period)
+        filer_meets_tin_requirement = person.tax_unit(
+            "filer_meets_ctc_identification_requirements", period
+        )
+        return (
+            is_adult
+            * dependent_has_tin
+            * filer_meets_tin_requirement
+            * p.amount.adult_dependent
+        )

--- a/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_child_individual_maximum.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_child_individual_maximum.py
@@ -18,5 +18,10 @@ class ctc_child_individual_maximum(Variable):
     def formula(person, period, parameters):
         age = person("age", period)
         qualifying_child = person("ctc_qualifying_child", period)
+        filer_meets_child_ctc_id_requirements = person.tax_unit(
+            "filer_meets_child_ctc_identification_requirements", period
+        )
         p = parameters(period).gov.irs.credits.ctc.amount
-        return qualifying_child * p.base.calc(age)
+        return (
+            qualifying_child * filer_meets_child_ctc_id_requirements * p.base.calc(age)
+        )

--- a/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_child_ctc_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_child_ctc_identification_requirements.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class filer_meets_child_ctc_identification_requirements(Variable):
+    value_type = bool
+    entity = TaxUnit
+    definition_period = YEAR
+    label = "Filer meets child CTC identification requirements"
+    reference = "https://www.irs.gov/pub/irs-pdf/i1040s8.pdf"
+
+    def formula(tax_unit, period, parameters):
+        filer_meets_tin_requirement = tax_unit(
+            "filer_meets_ctc_identification_requirements", period
+        )
+        p = parameters(period).gov.irs.credits.ctc
+        if not p.adult_ssn_requirement_applies:
+            return filer_meets_tin_requirement
+
+        person = tax_unit.members
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        has_valid_ssn = person("meets_ctc_identification_requirements", period)
+        # For 2025+, at least one filer must have a valid SSN for child CTC.
+        return filer_meets_tin_requirement & tax_unit.any(
+            head_or_spouse & has_valid_ssn
+        )

--- a/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.py
@@ -5,16 +5,12 @@ class filer_meets_ctc_identification_requirements(Variable):
     value_type = bool
     entity = TaxUnit
     definition_period = YEAR
-    label = "Filer meets CTC identification requirements"
+    label = "Filer meets CTC or ODC identification requirements"
+    reference = "https://www.irs.gov/pub/irs-pdf/i1040s8.pdf"
 
     def formula(tax_unit, period, parameters):
-        # Both head and spouse in the tax unit must have valid SSN card type to be eligible for the CTC
-        p = parameters(period).gov.irs.credits.ctc
-        if p.adult_ssn_requirement_applies:
-            person = tax_unit.members
-            head_or_spouse = person("is_tax_unit_head_or_spouse", period)
-            eligible_ssn_card_type = person(
-                "meets_ctc_identification_requirements", period
-            )
-            return tax_unit.any(head_or_spouse & eligible_ssn_card_type)
-        return True
+        person = tax_unit.members
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        has_tin = person("has_itin", period)
+        # The combined CTC/ODC is unavailable if any filer lacks an SSN or ITIN.
+        return tax_unit.all(~head_or_spouse | has_tin)

--- a/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.py
@@ -11,6 +11,6 @@ class filer_meets_ctc_identification_requirements(Variable):
     def formula(tax_unit, period, parameters):
         person = tax_unit.members
         head_or_spouse = person("is_tax_unit_head_or_spouse", period)
-        has_tin = person("has_itin", period)
+        has_tin = person("has_tin", period)
         # The combined CTC/ODC is unavailable if any filer lacks an SSN or ITIN.
         return tax_unit.all(~head_or_spouse | has_tin)

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_escc_qualifying_child.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ctc/ny_escc_qualifying_child.py
@@ -19,7 +19,7 @@ class ny_escc_qualifying_child(Variable):
         age = person("age", period)
         # NY ESCC allows both SSN and ITIN holders
         # (decoupled from federal CTC SSN requirement)
-        has_valid_id = person("has_itin", period)  # has_itin includes SSN
+        has_valid_id = person("has_tin", period)  # has_tin includes SSN
         age_eligible = age < p.post_2024.amount.thresholds[-1]
         meets_minimum_age = age >= p.minimum_age
         return has_valid_id & age_eligible & meets_minimum_age

--- a/policyengine_us/variables/household/demographic/person/has_itin.py
+++ b/policyengine_us/variables/household/demographic/person/has_itin.py
@@ -4,6 +4,6 @@ from policyengine_us.model_api import *
 class has_itin(Variable):
     value_type = bool
     entity = Person
-    label = "Has ITIN or SSN"
+    label = "Has ITIN or SSN (deprecated alias; use has_tin)"
     definition_period = YEAR
     default_value = True

--- a/policyengine_us/variables/household/demographic/person/has_tin.py
+++ b/policyengine_us/variables/household/demographic/person/has_tin.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class has_tin(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has TIN (ITIN or SSN)"
+    definition_period = YEAR
+    default_value = True
+
+    def formula(person, period, parameters):
+        # Temporary migration shim: legacy inputs still set `has_itin`.
+        return person("has_itin", period)

--- a/policyengine_us/variables/household/demographic/tax_unit/taxpayer_has_itin.py
+++ b/policyengine_us/variables/household/demographic/tax_unit/taxpayer_has_itin.py
@@ -5,10 +5,7 @@ class taxpayer_has_itin(Variable):
     value_type = bool
     entity = TaxUnit
     definition_period = YEAR
-    label = "Tax unit head or spouse has ITIN"
+    label = "Tax unit head or spouse has ITIN (deprecated alias; use taxpayer_has_tin)"
 
     def formula(tax_unit, period, parameters):
-        person = tax_unit.members
-        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
-        has_itin = person("has_itin", period)
-        return tax_unit.any(head_or_spouse & has_itin)
+        return tax_unit("taxpayer_has_tin", period)

--- a/policyengine_us/variables/household/demographic/tax_unit/taxpayer_has_tin.py
+++ b/policyengine_us/variables/household/demographic/tax_unit/taxpayer_has_tin.py
@@ -1,0 +1,14 @@
+from policyengine_us.model_api import *
+
+
+class taxpayer_has_tin(Variable):
+    value_type = bool
+    entity = TaxUnit
+    definition_period = YEAR
+    label = "Tax unit head or spouse has TIN"
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        has_tin = person("has_tin", period)
+        return tax_unit.any(head_or_spouse & has_tin)


### PR DESCRIPTION
## Summary
- bring in the missing federal CTC and ODC identification-gating changes that did not make it into #7965
- fix the AFA dependent-classification regression under the new gating
- update the CTC reform overrides so they follow baseline child qualification and identification rules

## Testing
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_child_ctc_identification_requirements.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/ctc_child_individual_maximum.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/integration.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/contrib/congress/afa/afa_other_dependent_credit.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/contrib/ctc/ctc_additional_bracket.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/contrib/ctc/ctc_older_child_supplement.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/contrib/congress/romney/family_security_act_2024/ctc/family_security_act_2024_ctc.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/contrib/taxsim/misc/ctc.yaml -c policyengine_us
- uv run ruff check policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.py policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/filer_meets_child_ctc_identification_requirements.py policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_child_individual_maximum.py policyengine_us/variables/gov/irs/credits/ctc/maximum/individual/ctc_adult_individual_maximum.py policyengine_us/reforms/congress/afa/afa_other_dependent_credit.py policyengine_us/reforms/ctc/ctc_additional_bracket.py policyengine_us/reforms/ctc/ctc_older_child_supplement.py policyengine_us/reforms/congress/romney/family_security_act_2024/ctc/family_security_act_2024_ctc.py