### PR TITLE
Make has_tin canonical without breaking legacy has_itin inputs

### DIFF
--- a/changelog.d/codex-has-tin-canonical.fixed.md
+++ b/changelog.d/codex-has-tin-canonical.fixed.md
@@ -1,0 +1,1 @@
+Made `has_tin` the canonical TIN variable while keeping `has_itin` and `taxpayer_has_itin` as compatibility aliases during migration.

--- a/policyengine_us/tests/policy/baseline/household/demographic/person/has_itin.yaml
+++ b/policyengine_us/tests/policy/baseline/household/demographic/person/has_itin.yaml
@@ -1,0 +1,13 @@
+- name: has_itin aliases canonical has_tin input
+  period: 2024
+  input:
+    has_tin: false
+  output:
+    has_itin: false
+
+- name: has_itin stays true when canonical has_tin input is true
+  period: 2024
+  input:
+    has_tin: true
+  output:
+    has_itin: true

--- a/policyengine_us/tests/policy/baseline/household/demographic/person/has_tin.yaml
+++ b/policyengine_us/tests/policy/baseline/household/demographic/person/has_tin.yaml
@@ -1,4 +1,18 @@
-- name: has_tin follows legacy has_itin input
+- name: has_tin follows canonical has_tin input
+  period: 2024
+  input:
+    has_tin: false
+  output:
+    has_tin: false
+
+- name: has_tin stays true when canonical has_tin input is true
+  period: 2024
+  input:
+    has_tin: true
+  output:
+    has_tin: true
+
+- name: has_tin still follows legacy has_itin input during migration
   period: 2024
   input:
     has_itin: false

--- a/policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_itin.yaml
+++ b/policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_itin.yaml
@@ -1,7 +1,7 @@
 - name: taxpayer_has_itin unit test 1
   period: 2021
   input:
-    has_itin: true
+    has_tin: true
     is_tax_unit_head: true
   output:
     taxpayer_has_itin: true
@@ -9,7 +9,7 @@
 - name: taxpayer_has_itin unit test 2
   period: 2022
   input:
-    has_itin: true
+    has_tin: true
     is_tax_unit_spouse: true
   output:
     taxpayer_has_itin: true
@@ -17,7 +17,7 @@
 - name: taxpayer_has_itin unit test 3
   period: 2023
   input:
-    has_itin: false
+    has_tin: false
     is_tax_unit_head: true
   output:
     taxpayer_has_itin: false
@@ -25,8 +25,15 @@
 - name: taxpayer_has_itin unit test 4
   period: 2024
   input:
-    has_itin: false
+    has_tin: false
     is_tax_unit_spouse: true
   output:
     taxpayer_has_itin: false
 
+- name: taxpayer_has_itin still follows legacy has_itin input during migration
+  period: 2024
+  input:
+    has_itin: false
+    is_tax_unit_spouse: true
+  output:
+    taxpayer_has_itin: false

--- a/policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_tin.yaml
+++ b/policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_tin.yaml
@@ -1,7 +1,7 @@
 - name: taxpayer_has_tin unit test 1
   period: 2021
   input:
-    has_itin: true
+    has_tin: true
     is_tax_unit_head: true
   output:
     taxpayer_has_tin: true
@@ -9,7 +9,7 @@
 - name: taxpayer_has_tin unit test 2
   period: 2022
   input:
-    has_itin: true
+    has_tin: true
     is_tax_unit_spouse: true
   output:
     taxpayer_has_tin: true
@@ -17,7 +17,7 @@
 - name: taxpayer_has_tin unit test 3
   period: 2023
   input:
-    has_itin: false
+    has_tin: false
     is_tax_unit_head: true
   output:
     taxpayer_has_tin: false
@@ -25,7 +25,15 @@
 - name: taxpayer_has_tin unit test 4
   period: 2024
   input:
-    has_itin: false
+    has_tin: false
     is_tax_unit_spouse: true
+  output:
+    taxpayer_has_tin: false
+
+- name: taxpayer_has_tin still follows legacy has_itin input during migration
+  period: 2024
+  input:
+    has_itin: false
+    is_tax_unit_head: true
   output:
     taxpayer_has_tin: false

--- a/policyengine_us/variables/household/demographic/person/has_itin.py
+++ b/policyengine_us/variables/household/demographic/person/has_itin.py
@@ -4,6 +4,9 @@ from policyengine_us.model_api import *
 class has_itin(Variable):
     value_type = bool
     entity = Person
-    label = "Has ITIN or SSN (deprecated alias; use has_tin)"
+    label = "Deprecated alias for has_tin"
     definition_period = YEAR
     default_value = True
+
+    def formula(person, period, parameters):
+        return person("has_tin", period)

--- a/policyengine_us/variables/household/demographic/person/has_tin.py
+++ b/policyengine_us/variables/household/demographic/person/has_tin.py
@@ -9,5 +9,20 @@ class has_tin(Variable):
     default_value = True
 
     def formula(person, period, parameters):
-        # Temporary migration shim: legacy inputs still set `has_itin`.
-        return person("has_itin", period)
+        simulation = person.simulation
+
+        # Canonical path: allow direct `has_tin` inputs to override the formula.
+        holder = simulation.get_holder("has_tin")
+        if period in holder.get_known_periods():
+            array = holder.get_array(period)
+            if array is not None:
+                return array
+
+        # Temporary migration path: honor legacy `has_itin` inputs until callers move.
+        legacy_holder = simulation.get_holder("has_itin")
+        if period in legacy_holder.get_known_periods():
+            array = legacy_holder.get_array(period)
+            if array is not None:
+                return array
+
+        return np.full(person.count, True)

--- a/policyengine_us/variables/household/demographic/tax_unit/taxpayer_has_itin.py
+++ b/policyengine_us/variables/household/demographic/tax_unit/taxpayer_has_itin.py
@@ -5,7 +5,7 @@ class taxpayer_has_itin(Variable):
     value_type = bool
     entity = TaxUnit
     definition_period = YEAR
-    label = "Tax unit head or spouse has ITIN (deprecated alias; use taxpayer_has_tin)"
+    label = "Deprecated alias for taxpayer_has_tin"
 
     def formula(tax_unit, period, parameters):
         return tax_unit("taxpayer_has_tin", period)


### PR DESCRIPTION
## Summary
- make `has_tin` the canonical TIN variable
- make `has_itin` a true compatibility alias back to `has_tin`
- preserve legacy `has_itin` inputs during migration by having `has_tin` honor either input name
- add baseline tests for canonical inputs and legacy compatibility on both person and tax-unit variables

## Why
The merged CTC/ODC gating work now uses `has_tin`, but the naming cleanup was still incomplete. This PR aligns the public API better with the legal concept while avoiding breakage for older YAML/tests and downstream callers that still set `has_itin`.

## Verification
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/household/demographic/person/has_tin.yaml policyengine_us/tests/policy/baseline/household/demographic/person/has_itin.yaml policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_tin.yaml policyengine_us/tests/policy/baseline/household/demographic/tax_unit/taxpayer_has_itin.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_ctc_identification_requirements.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/maximum/individual/filer_meets_child_ctc_identification_requirements.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/integration.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/aca/eligibility/sbn_los_angeles.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc_post_2024_eligible.yaml policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_ctc_post_2024_base.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/household/demographic/person/has_tin.py policyengine_us/variables/household/demographic/person/has_itin.py policyengine_us/variables/household/demographic/tax_unit/taxpayer_has_itin.py`
