### PR TITLE
[codex] Remove CRFB structural reform end dates

### DIFF
--- a/changelog.d/codex-crfb-indefinite-reforms.fixed.md
+++ b/changelog.d/codex-crfb-indefinite-reforms.fixed.md
@@ -1,0 +1,1 @@
+Remove hard-coded end dates from CRFB Social Security credit and senior deduction extension reforms.

--- a/policyengine_us/reforms/crfb/non_refundable_ss_credit.py
+++ b/policyengine_us/reforms/crfb/non_refundable_ss_credit.py
@@ -86,7 +86,6 @@ def non_refundable_ss_credit_reform() -> Reform:
     def modify_parameters(parameters):
         parameters.gov.irs.credits.non_refundable.update(
             start=instant("2026-01-01"),
-            stop=instant("2035-12-31"),
             value=[
                 "foreign_tax_credit",
                 "cdcc",

--- a/policyengine_us/reforms/crfb/senior_deduction_extension.py
+++ b/policyengine_us/reforms/crfb/senior_deduction_extension.py
@@ -8,7 +8,6 @@ def create_senior_deduction_extension() -> Reform:
         # Update deductions_if_itemizing to include additional_senior_deduction after 2028
         parameters.gov.irs.deductions.deductions_if_itemizing.update(
             start=instant("2029-01-01"),
-            stop=instant("2099-12-31"),
             value=[
                 "qualified_business_income_deduction",
                 "wagering_losses_deduction",
@@ -20,7 +19,6 @@ def create_senior_deduction_extension() -> Reform:
         # Update deductions_if_not_itemizing to include additional_senior_deduction after 2028
         parameters.gov.irs.deductions.deductions_if_not_itemizing.update(
             start=instant("2029-01-01"),
-            stop=instant("2099-12-31"),
             value=[
                 "standard_deduction",
                 "qualified_business_income_deduction",

--- a/policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml
@@ -145,3 +145,16 @@
     # Phase out = 6% * (165k - 150k) = $900
     # Credit = max(0, 600 - 900) = 0
     ss_credit: 0
+
+- name: Late-year SS credit still reduces non-refundable income tax
+  period: 2073
+  reforms: policyengine_us.reforms.crfb.non_refundable_ss_credit.non_refundable_ss_credit_reform_object
+  input:
+    gov.contrib.crfb.ss_credit.in_effect: true
+    taxable_social_security: 30_000
+    taxable_income: 1_000_000
+    filing_status: SINGLE
+  output:
+    highest_tax_rate: 0.35
+    ss_credit: 600
+    income_tax_non_refundable_credits: 600

--- a/policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml
+++ b/policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml
@@ -112,3 +112,30 @@
     # qualified_business_income_deduction: 2_000
     # additional_senior_deduction: 6_000 (from extension)
     taxable_income_deductions_if_not_itemizing: 29_800
+
+- name: Integration test - extension continues working at the 2100 modeling endpoint
+  period: 2100
+  reforms: policyengine_us.reforms.crfb.senior_deduction_extension.senior_deduction_extension
+  input:
+    gov.contrib.crfb.senior_deduction_extension.applies: true
+    people:
+      senior1:
+        age: 67
+      senior2:
+        age: 69
+    tax_units:
+      tax_unit:
+        members: [senior1, senior2]
+        filing_status: JOINT
+        adjusted_gross_income: 100_000
+        tax_unit_itemizes: true
+        itemized_taxable_income_deductions: 30_000
+        qualified_business_income_deduction: 5_000
+        wagering_losses_deduction: 0
+    households:
+      household:
+        members: [senior1, senior2]
+        state_code: CA
+  output:
+    additional_senior_deduction: 12_000
+    taxable_income_deductions_if_itemizing: 47_000


### PR DESCRIPTION
## Summary

This removes hard-coded stop dates from two CRFB structural reforms:

- `non_refundable_ss_credit`, so the credit remains in the non-refundable credit list after 2035 when the CRFB parameter is active.
- `senior_deduction_extension`, so the additional senior deduction extension continues after 2099 when the CRFB parameter is active.

The parameters already let callers specify active periods. These stop dates made late-horizon CRFB runs silently drop the structural tax-calculation changes even when the reform parameters remained true.

## Testing

- `uv run ruff check policyengine_us/reforms/crfb/non_refundable_ss_credit.py policyengine_us/reforms/crfb/senior_deduction_extension.py`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/crfb/non_refundable_ss_credit.yaml policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml -c policyengine_us`
