### PR TITLE
[codex] Fix microsim self-employment smoke test

### DIFF
--- a/changelog.d/fix-microsim-self-employment.fixed.md
+++ b/changelog.d/fix-microsim-self-employment.fixed.md
@@ -1,0 +1,1 @@
+Fix the microsimulation smoke test for self-employment income when weighted business losses exceed profits.

--- a/policyengine_us/tests/microsimulation/test_microsim.py
+++ b/policyengine_us/tests/microsimulation/test_microsim.py
@@ -30,11 +30,16 @@ def test_microsim_runs(dataset: str, year: int):
             f"{decile_var} out of bounds."
         )
 
-    # Check that the microsim calculates important variables as nonzero in current year.
-    # Self-employment is net business income, so weighted totals can be negative
-    # when losses outweigh profits in the sampled records.
-    for var in ["employment_income", "self_employment_income"]:
-        assert sim.calc(var, period=2024).abs().sum() > 0, f"{var} is zero in 2024."
+    # Employment income should aggregate positive in the sample.
+    assert sim.calc("employment_income", period=2024).sum() > 0, (
+        "employment_income is zero in 2024."
+    )
+
+    # Self-employment is net business income, so weighted totals can be
+    # negative when losses outweigh profits in the sampled records.
+    assert sim.calc("self_employment_income", period=2024).abs().sum() > 0, (
+        "self_employment_income is zero in 2024."
+    )
 
 
 def test_county_persists_across_periods():

--- a/policyengine_us/tests/microsimulation/test_microsim.py
+++ b/policyengine_us/tests/microsimulation/test_microsim.py
@@ -31,8 +31,10 @@ def test_microsim_runs(dataset: str, year: int):
         )
 
     # Check that the microsim calculates important variables as nonzero in current year.
+    # Self-employment is net business income, so weighted totals can be negative
+    # when losses outweigh profits in the sampled records.
     for var in ["employment_income", "self_employment_income"]:
-        assert sim.calc(var, period=2024).sum() > 0, f"{var} is zero in 2024."
+        assert sim.calc(var, period=2024).abs().sum() > 0, f"{var} is zero in 2024."
 
 
 def test_county_persists_across_periods():


### PR DESCRIPTION
## Summary
- update the microsimulation smoke test to treat self-employment income as nonzero when its aggregate magnitude is nonzero
- document why a weighted self-employment total can be negative
- add a changelog fragment

## Why
The failing GitHub Actions job on PR #7977 was not caused by the Texas Medicaid change. It failed in `policyengine_us/tests/microsimulation/test_microsim.py` because the test assumed `self_employment_income.sum() > 0`.

That assumption is too strict: `self_employment_income` is modeled as net business income, so weighted losses can outweigh weighted profits in a sampled dataset and produce a negative aggregate total even when the variable is present and working.

## Root cause
The smoke test was using a positivity check where it really needed a nonzero-magnitude check.

## Validation
- `make format`
- `python -m py_compile policyengine_us/tests/microsimulation/test_microsim.py`
- confirmed locally that `MicroSeries.sum()` can be negative while `MicroSeries.abs().sum()` remains nonzero

## Notes
I could not run the full dataset-backed microsimulation test locally in this sandbox because the Hugging Face datasets are not reachable here, so CI should be the source of truth for the full repro and verification.