### PR TITLE
Apply ordered aggregate capping to state nonrefundable credits

### DIFF
--- a/changelog.d/audit-state-nonrefundable-credit-order.fixed.md
+++ b/changelog.d/audit-state-nonrefundable-credit-order.fixed.md
@@ -1,0 +1,1 @@
+Fix state nonrefundable income tax credits to apply in statutory filing order, with state-specific regression coverage for capped credit sequencing.

--- a/policyengine_us/parameters/gov/states/ga/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/credits/non_refundable.yaml
@@ -1,5 +1,8 @@
 description: Georgia provides these non-refundable income tax credits.
 values:
+  2007-01-01:
+    - ga_cdcc
+    - ga_low_income_credit
   2021-01-01:
     - ga_cdcc
     - ga_low_income_credit

--- a/policyengine_us/parameters/gov/states/il/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/credits/non_refundable.yaml
@@ -1,8 +1,8 @@
 description: Illinois provides the following non-refundable credits.
 values:
   2021-01-01:
-    - il_k12_education_expense_credit
     - il_property_tax_credit
+    - il_k12_education_expense_credit
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/ky/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ky/tax/income/credits/non_refundable.yaml
@@ -5,7 +5,7 @@ metadata:
   period: year
 values:
   2021-01-01:
+    - ky_personal_tax_credits
     - ky_family_size_tax_credit
     - ky_tuition_tax_credit
-    - ky_personal_tax_credits
     - ky_cdcc

--- a/policyengine_us/parameters/gov/states/la/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/la/tax/income/credits/non_refundable.yaml
@@ -1,5 +1,7 @@
 description: Louisiana provides the following non-refundable tax credits.
 values:
+  2006-01-01:
+    - la_non_refundable_cdcc
   2021-01-01: 
     - la_non_refundable_cdcc
 metadata:

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/non_refundable.yaml
@@ -3,8 +3,10 @@ values:
   2007-01-01:
     - ny_household_credit
     - ny_solar_energy_systems_equipment_credit
-    - ny_geothermal_energy_system_credit
   2019-01-01:
+    - ny_household_credit
+    - ny_solar_energy_systems_equipment_credit
+  2022-01-01:
     - ny_household_credit
     - ny_solar_energy_systems_equipment_credit
     - ny_geothermal_energy_system_credit

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/non_refundable.yaml
@@ -1,5 +1,9 @@
 description: New York provides the following non-refundable tax credits.
 values:
+  2007-01-01:
+    - ny_household_credit
+    - ny_solar_energy_systems_equipment_credit
+    - ny_geothermal_energy_system_credit
   2019-01-01:
     - ny_household_credit
     - ny_solar_energy_systems_equipment_credit

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_cdcc.yaml
@@ -3,13 +3,14 @@
   input:
     cdcc: 0
     state_code: AR
-  output: 
+    ar_income_tax_before_non_refundable_credits_unit: 1000000
+  output:
     ar_cdcc: 0
-
 - name: Some cdcc, 20%
   period: 2022
   input:
-    cdcc: 1_000
+    cdcc: 1000
     state_code: AR
-  output: 
+    ar_income_tax_before_non_refundable_credits_unit: 1000000
+  output:
     ar_cdcc: 200

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_non_refundable_credit_order.yaml
@@ -1,0 +1,12 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2024
+  input:
+    state_code: AR
+    ar_income_tax_before_non_refundable_credits_unit: 100
+    ar_personal_credits_potential: 80
+    ar_cdcc_potential: 40
+    ar_additional_tax_credit_for_qualified_individuals_potential: 30
+  output:
+    ar_personal_credits: 80
+    ar_cdcc: 20
+    ar_additional_tax_credit_for_qualified_individuals: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_family_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_family_tax_credit.yaml
@@ -5,9 +5,9 @@
     filing_status: JOINT
     az_family_tax_credit_eligible: true
     tax_unit_size: 7
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_family_tax_credit: 240
-
 - name: Family tax credits for single filers without dependents ($9000 income)
   period: 2023
   input:
@@ -15,9 +15,9 @@
     filing_status: SINGLE
     az_family_tax_credit_eligible: true
     tax_unit_size: 1
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_family_tax_credit: 40
-
 - name: Family tax credits for separate couple with 2 dependents ($11000 income)
   period: 2023
   input:
@@ -25,9 +25,9 @@
     filing_status: SEPARATE
     az_family_tax_credit_eligible: false
     tax_unit_size: 4
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_family_tax_credit: 0
-
 - name: Family tax credits for head of household with 5 dependents ($26000 income)
   period: 2023
   input:
@@ -35,9 +35,9 @@
     filing_status: HEAD_OF_HOUSEHOLD
     az_family_tax_credit_eligible: true
     tax_unit_size: 6
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_family_tax_credit: 240
-
 - name: Family tax credits for surviving spouse with 3 dependents ($23000 income)
   period: 2023
   input:
@@ -45,9 +45,9 @@
     filing_status: SURVIVING_SPOUSE
     az_family_tax_credit_eligible: true
     tax_unit_size: 4
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_family_tax_credit: 160
-
 - name: Family tax credits for head of household with 5 dependents (no income)
   period: 2023
   input:
@@ -55,20 +55,9 @@
     filing_status: HEAD_OF_HOUSEHOLD
     az_family_tax_credit_eligible: true
     tax_unit_size: 6
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_family_tax_credit: 240
-
-# =============================================================================
-# 2025 Tax Year Tests
-# Family Tax Credit: $40 per person
-# Max: $240 for Joint/HOH, $120 for Single/Separate
-#
-# Income Limits (unchanged):
-# - Joint: $20,000 (0-1 deps), $23,600 (2 deps), $27,300 (3 deps), $31,000 (4+ deps)
-# - HOH: $20,000 (0-1 deps), $20,135 (2 deps), $23,800 (3 deps), $25,200 (4 deps), $26,575 (5+ deps)
-# - Single/Separate: $10,000
-# =============================================================================
-
 - name: 2025 - Joint filer with 2 dependents eligible
   period: 2025
   input:
@@ -76,10 +65,9 @@
     filing_status: JOINT
     az_family_tax_credit_eligible: true
     tax_unit_size: 4
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
-    # 4 people * $40 = $160
     az_family_tax_credit: 160
-
 - name: 2025 - Joint filer at max credit
   period: 2025
   input:
@@ -87,10 +75,9 @@
     filing_status: JOINT
     az_family_tax_credit_eligible: true
     tax_unit_size: 8
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
-    # 8 people * $40 = $320, but capped at $240 for joint
     az_family_tax_credit: 240
-
 - name: 2025 - Single filer at max credit
   period: 2025
   input:
@@ -98,10 +85,9 @@
     filing_status: SINGLE
     az_family_tax_credit_eligible: true
     tax_unit_size: 4
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
-    # 4 people * $40 = $160, but capped at $120 for single
     az_family_tax_credit: 120
-
 - name: 2025 - HOH filer eligible
   period: 2025
   input:
@@ -109,10 +95,9 @@
     filing_status: HEAD_OF_HOUSEHOLD
     az_family_tax_credit_eligible: true
     tax_unit_size: 4
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
-    # 4 people * $40 = $160
     az_family_tax_credit: 160
-
 - name: 2025 - Separate filer not eligible (over income)
   period: 2025
   input:
@@ -120,9 +105,9 @@
     filing_status: SEPARATE
     az_family_tax_credit_eligible: false
     tax_unit_size: 2
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_family_tax_credit: 0
-
 - name: 2025 - Separate filer eligible
   period: 2025
   input:
@@ -130,6 +115,6 @@
     filing_status: SEPARATE
     az_family_tax_credit_eligible: true
     tax_unit_size: 1
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
-    # 1 person * $40 = $40
     az_family_tax_credit: 40

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_non_refundable_credit_order.yaml
@@ -1,0 +1,13 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2021
+  input:
+    state_code: AZ
+    az_income_tax_before_non_refundable_credits: 100
+    az_charitable_contributions_credit_potential: 80
+    az_dependent_tax_credit_potential: 40
+    az_family_tax_credit_eligible: true
+    az_family_tax_credit_potential: 30
+  output:
+    az_charitable_contributions_credit: 80
+    az_dependent_tax_credit: 20
+    az_family_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.yaml
@@ -3,78 +3,84 @@
   input:
     state_code: AZ
     filing_status: JOINT
-    az_charitable_contributions_to_qualifying_charitable_organizations: 2_000 #841
-    az_charitable_contributions_to_qualifying_foster_care_organizations: 1_100 #1051
+    az_charitable_contributions_to_qualifying_charitable_organizations: 2000
+    az_charitable_contributions_to_qualifying_foster_care_organizations: 1100
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
-    az_charitable_contributions_credit: 1_892
-
+    az_charitable_contributions_credit: 1892
 - name: az_charitable_contributions_credit for qualifying forster (JOINT, below cap)
   period: 2023
   input:
     state_code: AZ
     filing_status: JOINT
-    az_charitable_contributions_to_qualifying_charitable_organizations: 200 
-    az_charitable_contributions_to_qualifying_foster_care_organizations: 300 
+    az_charitable_contributions_to_qualifying_charitable_organizations: 200
+    az_charitable_contributions_to_qualifying_foster_care_organizations: 300
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_charitable_contributions_credit: 500
-
-- name: az_charitable_contributions_credit for qualifying forster (JOINT, one below cap, one above cap)
+- name: az_charitable_contributions_credit for qualifying forster (JOINT, one below
+    cap, one above cap)
   period: 2023
   input:
     state_code: AZ
     filing_status: JOINT
-    az_charitable_contributions_to_qualifying_charitable_organizations: 1_000
+    az_charitable_contributions_to_qualifying_charitable_organizations: 1000
     az_charitable_contributions_to_qualifying_foster_care_organizations: 500
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
-    az_charitable_contributions_credit: 1_341
-
-- name: az_charitable_contributions_credit for qualifying forster (SINGLE, one below cap, one above cap)
+    az_charitable_contributions_credit: 1341
+- name: az_charitable_contributions_credit for qualifying forster (SINGLE, one below
+    cap, one above cap)
   period: 2023
   input:
     state_code: AZ
     filing_status: SINGLE
-    az_charitable_contributions_to_qualifying_charitable_organizations: 300 #421
-    az_charitable_contributions_to_qualifying_foster_care_organizations: 1_100 #526
+    az_charitable_contributions_to_qualifying_charitable_organizations: 300
+    az_charitable_contributions_to_qualifying_foster_care_organizations: 1100
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_charitable_contributions_credit: 826
-
-- name: az_charitable_contributions_credit for qualifying forster (SEPARATE, below cap)
+- name: az_charitable_contributions_credit for qualifying forster (SEPARATE, below
+    cap)
   period: 2023
   input:
     state_code: AZ
     filing_status: SEPARATE
-    az_charitable_contributions_to_qualifying_charitable_organizations: 200 
-    az_charitable_contributions_to_qualifying_foster_care_organizations: 300 
+    az_charitable_contributions_to_qualifying_charitable_organizations: 200
+    az_charitable_contributions_to_qualifying_foster_care_organizations: 300
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_charitable_contributions_credit: 500
-
-- name: az_charitable_contributions_credit for qualifying forster (SEPARATE, above cap)
+- name: az_charitable_contributions_credit for qualifying forster (SEPARATE, above
+    cap)
   period: 2023
   input:
     state_code: AZ
     filing_status: SEPARATE
     az_charitable_contributions_to_qualifying_charitable_organizations: 600
     az_charitable_contributions_to_qualifying_foster_care_organizations: 600
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_charitable_contributions_credit: 947
-
-
-- name: az_charitable_contributions_credit for qualifying organization (SEPARATE, one above cap, one below cap)
+- name: az_charitable_contributions_credit for qualifying organization (SEPARATE,
+    one above cap, one below cap)
   period: 2023
   input:
     state_code: AZ
     filing_status: SEPARATE
     az_charitable_contributions_to_qualifying_charitable_organizations: 300
     az_charitable_contributions_to_qualifying_foster_care_organizations: 600
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_charitable_contributions_credit: 826
-  
-- name: az_charitable_contributions_credit for qualifying organization (SEPARATE, one above cap, one below cap)
+- name: az_charitable_contributions_credit for qualifying organization (SEPARATE,
+    one above cap, one below cap)
   period: 2023
   input:
     state_code: AZ
     filing_status: SEPARATE
     az_charitable_contributions_to_qualifying_charitable_organizations: 500
     az_charitable_contributions_to_qualifying_foster_care_organizations: 400
+    az_income_tax_before_non_refundable_credits: 1000000
   output:
     az_charitable_contributions_credit: 821

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.yaml
@@ -1,16 +1,3 @@
-# Arizona Dependent Tax Credit Tests
-# Per A.R.S. 43-1073.01
-#
-# Credit Amounts:
-# - Under 17: $100
-# - Age 17+: $25
-#
-# Phase-Out Thresholds:
-# - Single/HOH/Separate: $200,000
-# - Joint: $400,000
-#
-# Phase-Out Rate: 5% per $1,000 over threshold
-
 - name: Household with no dependents
   period: 2023
   input:
@@ -20,16 +7,18 @@
         age: 25
     tax_units:
       tax_unit:
-        members: [person1]
-        adjusted_gross_income: 200_000
+        members:
+        - person1
+        adjusted_gross_income: 200000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: AZ
   output:
     az_dependent_tax_credit: 0
-
 - name: One young dependent without reduction
   period: 2023
   input:
@@ -39,16 +28,18 @@
         age: 16
     tax_units:
       tax_unit:
-        members: [person1]
-        adjusted_gross_income: 200_000
+        members:
+        - person1
+        adjusted_gross_income: 200000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: AZ
   output:
     az_dependent_tax_credit: 100
-
 - name: One young and one old dependent without reduction
   period: 2023
   input:
@@ -61,16 +52,20 @@
         age: 17
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        adjusted_gross_income: 200_000
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 200000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: AZ
   output:
     az_dependent_tax_credit: 125
-
 - name: One young and one old dependent with maximum reduction
   period: 2023
   input:
@@ -83,16 +78,20 @@
         age: 17
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        adjusted_gross_income: 220_000
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 220000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: AZ
   output:
     az_dependent_tax_credit: 0
-
 - name: One young and one old dependent with maximum reduction, capped at 0
   period: 2023
   input:
@@ -105,16 +104,20 @@
         age: 17
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        adjusted_gross_income: 300_000
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 300000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: AZ
   output:
     az_dependent_tax_credit: 0
-
 - name: One young and one old dependent without reduction, joint
   period: 2023
   input:
@@ -127,16 +130,20 @@
         age: 17
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        adjusted_gross_income: 400_000
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 400000
         filing_status: JOINT
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: AZ
   output:
     az_dependent_tax_credit: 125
-
 - name: Two old dependents with partial reduction
   period: 2023
   input:
@@ -149,22 +156,20 @@
         age: 17
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        adjusted_gross_income: 202_000
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 202000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: AZ
   output:
-    # Over threshold by $2,000 = 2 * 5% = 10% reduction
-    # 2 * $25 * (1 - 0.10) = $45
     az_dependent_tax_credit: 45
-
-# =============================================================================
-# 2025 Tax Year Tests
-# =============================================================================
-
 - name: 2025 - Single with one young dependent at threshold
   period: 2025
   input:
@@ -174,17 +179,18 @@
         age: 10
     tax_units:
       tax_unit:
-        members: [person1]
-        adjusted_gross_income: 200_000
+        members:
+        - person1
+        adjusted_gross_income: 200000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: AZ
   output:
-    # At $200,000 threshold - no reduction
     az_dependent_tax_credit: 100
-
 - name: 2025 - Single with partial phase-out
   period: 2025
   input:
@@ -194,19 +200,18 @@
         age: 10
     tax_units:
       tax_unit:
-        members: [person1]
-        adjusted_gross_income: 205_000
+        members:
+        - person1
+        adjusted_gross_income: 205000
         filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: AZ
   output:
-    # Over threshold by $5,000
-    # Reduction: ceil(5,000 / 1,000) = 5 * 5% = 25%
-    # Credit: $100 * (1 - 0.25) = $75
     az_dependent_tax_credit: 75
-
 - name: 2025 - Joint with multiple dependents at threshold
   period: 2025
   input:
@@ -222,18 +227,22 @@
         age: 18
     tax_units:
       tax_unit:
-        members: [child1, child2, child3]
-        adjusted_gross_income: 400_000
+        members:
+        - child1
+        - child2
+        - child3
+        adjusted_gross_income: 400000
         filing_status: JOINT
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [child1, child2, child3]
+        members:
+        - child1
+        - child2
+        - child3
         state_code: AZ
   output:
-    # At $400,000 joint threshold - no reduction
-    # 2 young ($100 each) + 1 older ($25) = $225
     az_dependent_tax_credit: 225
-
 - name: 2025 - Joint with partial phase-out
   period: 2025
   input:
@@ -246,19 +255,20 @@
         age: 10
     tax_units:
       tax_unit:
-        members: [child1, child2]
-        adjusted_gross_income: 410_000
+        members:
+        - child1
+        - child2
+        adjusted_gross_income: 410000
         filing_status: JOINT
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [child1, child2]
+        members:
+        - child1
+        - child2
         state_code: AZ
   output:
-    # Over threshold by $10,000
-    # Reduction: ceil(10,000 / 1,000) = 10 * 5% = 50%
-    # Credit: 2 * $100 * (1 - 0.50) = $100
     az_dependent_tax_credit: 100
-
 - name: 2025 - HOH at threshold
   period: 2025
   input:
@@ -268,17 +278,18 @@
         age: 15
     tax_units:
       tax_unit:
-        members: [child1]
-        adjusted_gross_income: 200_000
+        members:
+        - child1
+        adjusted_gross_income: 200000
         filing_status: HEAD_OF_HOUSEHOLD
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [child1]
+        members:
+        - child1
         state_code: AZ
   output:
-    # HOH has same $200,000 threshold as single
     az_dependent_tax_credit: 100
-
 - name: 2025 - Separate at threshold
   period: 2025
   input:
@@ -288,13 +299,15 @@
         age: 8
     tax_units:
       tax_unit:
-        members: [child1]
-        adjusted_gross_income: 200_000
+        members:
+        - child1
+        adjusted_gross_income: 200000
         filing_status: SEPARATE
+        az_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [child1]
+        members:
+        - child1
         state_code: AZ
   output:
-    # Separate has same $200,000 threshold as single
     az_dependent_tax_credit: 100

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.yaml
@@ -7,7 +7,7 @@
     casualty_loss_deduction: 200
     medical_out_of_pocket_expenses: 500 
     charitable_deduction: 500 
-    az_charitable_contributions_credit: 0
+    az_charitable_contributions_credit_potential: 0
     state_sales_tax: 0
   output:
     az_itemized_deductions: 1_300
@@ -21,7 +21,7 @@
     casualty_loss_deduction: 200
     medical_out_of_pocket_expenses: 700
     charitable_deduction: 500
-    az_charitable_contributions_credit: 500
+    az_charitable_contributions_credit_potential: 500
     state_sales_tax: 0
   output:
     az_itemized_deductions: 1_000
@@ -35,7 +35,7 @@
     casualty_loss_deduction: 300 
     medical_out_of_pocket_expenses: 600
     charitable_deduction: 500 
-    az_charitable_contributions_credit: 600
+    az_charitable_contributions_credit_potential: 600
     state_sales_tax: 0
   output:
     az_itemized_deductions: 1_100
@@ -50,7 +50,7 @@
     casualty_loss_deduction: 300 
     medical_out_of_pocket_expenses: 700 
     charitable_deduction: 700 
-    az_charitable_contributions_credit: 600
+    az_charitable_contributions_credit_potential: 600
     state_sales_tax: 0
   output:
     az_itemized_deductions: 1_300
@@ -65,7 +65,7 @@
     casualty_loss_deduction: 300 
     medical_out_of_pocket_expenses: 600
     charitable_deduction: 700 
-    az_charitable_contributions_credit: 600
+    az_charitable_contributions_credit_potential: 600
     state_sales_tax: 0
   output:
     az_itemized_deductions: 1_200
@@ -79,7 +79,7 @@
     casualty_loss_deduction: 300 
     medical_out_of_pocket_expenses: 600
     charitable_deduction: 700 
-    az_charitable_contributions_credit: 800
+    az_charitable_contributions_credit_potential: 800
     state_sales_tax: 0
   output:
     az_itemized_deductions: 1_100

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.yaml
@@ -3,7 +3,7 @@
   input:
     state_code: AZ
     charitable_deduction: 2_000
-    az_charitable_contributions_credit: 1_000
+    az_charitable_contributions_credit_potential: 1_000
   output:
     az_increased_standard_deduction_for_charitable_contributions: 250
 
@@ -12,7 +12,7 @@
   input:
     state_code: AZ
     charitable_deduction: 1_000
-    az_charitable_contributions_credit: 500
+    az_charitable_contributions_credit_potential: 500
   output:
     az_increased_standard_deduction_for_charitable_contributions: 135
 
@@ -21,7 +21,7 @@
   input:
     state_code: AZ
     charitable_deduction: 1_000
-    az_charitable_contributions_credit: 500
+    az_charitable_contributions_credit_potential: 500
   output:
     az_increased_standard_deduction_for_charitable_contributions: 155
 
@@ -33,7 +33,7 @@
   input:
     state_code: AZ
     charitable_deduction: 1_000
-    az_charitable_contributions_credit: 500
+    az_charitable_contributions_credit_potential: 500
   output:
     # (charitable_deduction - az_charitable_contributions_credit) * rate
     # ($1,000 - $500) * 0.34 = $170
@@ -44,7 +44,7 @@
   input:
     state_code: AZ
     charitable_deduction: 2_000
-    az_charitable_contributions_credit: 0
+    az_charitable_contributions_credit_potential: 0
   output:
     # $2,000 * 0.34 = $680
     az_increased_standard_deduction_for_charitable_contributions: 680
@@ -54,7 +54,7 @@
   input:
     state_code: AZ
     charitable_deduction: 1_000
-    az_charitable_contributions_credit: 1_000
+    az_charitable_contributions_credit_potential: 1_000
   output:
     # ($1,000 - $1,000) * 0.34 = $0
     az_increased_standard_deduction_for_charitable_contributions: 0
@@ -64,7 +64,7 @@
   input:
     state_code: AZ
     charitable_deduction: 10_000
-    az_charitable_contributions_credit: 1_500
+    az_charitable_contributions_credit_potential: 1_500
   output:
     # ($10,000 - $1,500) * 0.34 = $2,890
     az_increased_standard_deduction_for_charitable_contributions: 2_890

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/integration_2025.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/integration_2025.yaml
@@ -564,6 +564,7 @@
     tax_units:
       tax_unit:
         members: [spouse1, spouse2]
+        filing_status: JOINT
     households:
       household:
         members: [spouse1, spouse2]
@@ -573,8 +574,11 @@
     adjusted_gross_income: 17_000
     # Income $17,000 < $20,000 limit for 0-1 dependents - family credit eligible
     az_family_tax_credit_eligible: true
-    # Family tax credit: 2 people * $40 = $80 (max $240 for joint)
-    az_family_tax_credit: 80
+    az_income_tax_before_non_refundable_credits: 0
+    # Potential family tax credit: 2 people * $40 = $80 (max $240 for joint)
+    az_family_tax_credit_potential: 80
+    # Standard deduction exceeds income, so no non-refundable credit can be used.
+    az_family_tax_credit: 0
 
 - name: Joint filers 2025 with 2 dependents - family credit
   period: 2025
@@ -588,11 +592,14 @@
         employment_income: 10_000
       child1:
         age: 5
+        is_tax_unit_dependent: true
       child2:
         age: 8
+        is_tax_unit_dependent: true
     tax_units:
       tax_unit:
         members: [spouse1, spouse2, child1, child2]
+        filing_status: JOINT
     households:
       household:
         members: [spouse1, spouse2, child1, child2]
@@ -602,8 +609,11 @@
     adjusted_gross_income: 22_000
     # Income $22,000 < $23,600 limit for 2 dependents - eligible
     az_family_tax_credit_eligible: true
-    # Family tax credit: 4 people * $40 = $160
-    az_family_tax_credit: 160
+    az_income_tax_before_non_refundable_credits: 0
+    # Potential family tax credit: 4 people * $40 = $160
+    az_family_tax_credit_potential: 160
+    # Standard deduction exceeds income, so no non-refundable credit can be used.
+    az_family_tax_credit: 0
 
 - name: Joint filers 2025 over income limit - no family credit
   period: 2025
@@ -639,6 +649,7 @@
     tax_units:
       tax_unit:
         members: [person1]
+        filing_status: SINGLE
     households:
       household:
         members: [person1]
@@ -646,8 +657,11 @@
   output:
     # Income $9,500 < $10,000 limit for single filers
     az_family_tax_credit_eligible: true
-    # Single filer: 1 person * $40 = $40 (max $120)
-    az_family_tax_credit: 40
+    az_income_tax_before_non_refundable_credits: 0
+    # Potential family tax credit: 1 person * $40 = $40 (max $120)
+    az_family_tax_credit_potential: 40
+    # Standard deduction exceeds income, so no non-refundable credit can be used.
+    az_family_tax_credit: 0
 
 - name: Single filer 2025 over income limit - no family credit
   period: 2025
@@ -677,17 +691,23 @@
         employment_income: 26_000
       child1:
         age: 5
+        is_tax_unit_dependent: true
       child2:
         age: 8
+        is_tax_unit_dependent: true
       child3:
         age: 10
+        is_tax_unit_dependent: true
       child4:
         age: 12
+        is_tax_unit_dependent: true
       child5:
         age: 14
+        is_tax_unit_dependent: true
     tax_units:
       tax_unit:
         members: [parent, child1, child2, child3, child4, child5]
+        filing_status: HEAD_OF_HOUSEHOLD
     households:
       household:
         members: [parent, child1, child2, child3, child4, child5]
@@ -695,8 +715,13 @@
   output:
     # Income $26,000 < $26,575 limit for HOH with 5+ dependents
     az_family_tax_credit_eligible: true
-    # 6 people * $40 = $240, at max for HOH
-    az_family_tax_credit: 240
+    az_income_tax_before_non_refundable_credits: 59.375
+    az_dependent_tax_credit_potential: 500
+    az_dependent_tax_credit: 59.375
+    # Potential family tax credit is capped at $240 for HOH.
+    az_family_tax_credit_potential: 240
+    # Earlier non-refundable dependent credits consume the available liability first.
+    az_family_tax_credit: 0
 
 # =============================================================================
 # SECTION 6: Increased Excise Tax Credit Tests
@@ -1057,6 +1082,7 @@
       tax_unit:
         members: [spouse1, spouse2]
         charitable_deduction: 2_000
+        filing_status: JOINT
     households:
       household:
         members: [spouse1, spouse2]
@@ -1075,7 +1101,9 @@
     az_increased_excise_tax_credit: 50
     # Income under $20,000 limit for 0-1 dependents - family credit eligible
     az_family_tax_credit_eligible: true
-    az_family_tax_credit: 80
+    az_income_tax_before_non_refundable_credits: 0
+    az_family_tax_credit_potential: 80
+    az_family_tax_credit: 0
 
 - name: High income family - complete calculation
   period: 2025
@@ -1129,11 +1157,14 @@
         employment_income: 18_000
       child1:
         age: 4
+        is_tax_unit_dependent: true
       child2:
         age: 7
+        is_tax_unit_dependent: true
     tax_units:
       tax_unit:
         members: [parent, child1, child2]
+        filing_status: HEAD_OF_HOUSEHOLD
     households:
       household:
         members: [parent, child1, child2]
@@ -1143,12 +1174,16 @@
     adjusted_gross_income: 18_000
     # HOH standard deduction = $23,625
     az_base_standard_deduction: 23_625
-    # Dependent credit: 2 children under 17 * $100 = $200
-    az_dependent_tax_credit: 200
-    # Income $18,000 < $20,000 for HOH with 0-1 deps - family credit eligible
+    az_income_tax_before_non_refundable_credits: 0
+    # Potential dependent credit: 2 children under 17 * $100 = $200
+    az_dependent_tax_credit_potential: 200
+    # Standard deduction exceeds income, so the non-refundable dependent credit is unused.
+    az_dependent_tax_credit: 0
+    # Income $18,000 < $22,475 for HOH with 2 dependents - family credit eligible
     az_family_tax_credit_eligible: true
-    # 3 people * $40 = $120
-    az_family_tax_credit: 120
+    # Potential family tax credit: 3 people * $40 = $120
+    az_family_tax_credit_potential: 120
+    az_family_tax_credit: 0
     # Income $18,000 < $25,000 for HOH - excise credit eligible
     az_increased_excise_tax_credit_eligible: true
     # 3 people * $25 = $75

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/ct_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/ct_non_refundable_credit_order.yaml
@@ -1,0 +1,9 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2023
+  input:
+    state_code: CT
+    ct_income_tax_after_amt: 100
+    ct_property_tax_credit_eligible: true
+    ct_property_tax_credit_potential: 80
+  output:
+    ct_property_tax_credit: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.yaml
@@ -2,100 +2,119 @@
   period: 2021
   input:
     ct_property_tax_credit_eligible: true
-    ct_agi: 49_000
+    ct_agi: 49000
     filing_status: SINGLE
     real_estate_taxes: 100
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 100
-
-- name: SEPARATE household with $75,000  agi and  $250 property tax and eligible for property tax credit
+- name: SEPARATE household with $75,000  agi and  $250 property tax and eligible for
+    property tax credit
   period: 2021
   input:
     ct_property_tax_credit_eligible: true
-    ct_agi: 75_000
+    ct_agi: 75000
     filing_status: SEPARATE
     real_estate_taxes: 250
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 0
-
-
-- name: SEPARATE household with $45,000  agi and  $250 property tax and eligible for property tax credit - 2022
+- name: SEPARATE household with $45,000  agi and  $250 property tax and eligible for
+    property tax credit - 2022
   period: 2022
   input:
     ct_property_tax_credit_eligible: true
-    ct_agi: 45_000
+    ct_agi: 45000
     filing_status: SEPARATE
     real_estate_taxes: 250
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 175
-
-- name: SEPARATE household with $45,000  agi and  $250 property tax and eligible for property tax credit - 2021
+- name: SEPARATE household with $45,000  agi and  $250 property tax and eligible for
+    property tax credit - 2021
   period: 2021
   input:
     ct_property_tax_credit_eligible: true
-    ct_agi: 45_000
+    ct_agi: 45000
     filing_status: SEPARATE
     real_estate_taxes: 250
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 140
-
-- name: SEPARATE household with $45,000  agi and  $250 property tax but not eligible for credit
+- name: SEPARATE household with $45,000  agi and  $250 property tax but not eligible
+    for credit
   period: 2021
   input:
     ct_property_tax_credit_eligible: false
-    ct_agi: 45_000
+    ct_agi: 45000
     filing_status: SEPARATE
     real_estate_taxes: 250
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 0
-
-- name: HEAD OF HOUSEHOLD with $60,000  agi and  $400 property tax and eligible for property tax credit
+- name: HEAD OF HOUSEHOLD with $60,000  agi and  $400 property tax and eligible for
+    property tax credit
   period: 2021
   input:
     ct_property_tax_credit_eligible: true
-    ct_agi: 60_000
+    ct_agi: 60000
     filing_status: HEAD_OF_HOUSEHOLD
     real_estate_taxes: 400
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 170
-
-- name: JOINT household with $130,500  agi and  $500 property tax and eligible for property tax credit
+- name: JOINT household with $130,500  agi and  $500 property tax and eligible for
+    property tax credit
   period: 2021
   input:
     ct_property_tax_credit_eligible: true
-    ct_agi: 130_500
+    ct_agi: 130500
     filing_status: JOINT
     real_estate_taxes: 500
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 20
-
-- name: SURVIVING SPOUSE with $90,500  agi and  $320 property tax and not eligible for property tax credit
+- name: SURVIVING SPOUSE with $90,500  agi and  $320 property tax and not eligible
+    for property tax credit
   period: 2021
   input:
     ct_property_tax_credit_eligible: false
-    ct_agi: 90_500
+    ct_agi: 90500
     filing_status: SURVIVING_SPOUSE
     real_estate_taxes: 320
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 0
-
-- name: JOINT household with $130,500  agi and  $500 property tax and not eligible for property tax credit
+- name: JOINT household with $130,500  agi and  $500 property tax and not eligible
+    for property tax credit
   period: 2021
   input:
     ct_property_tax_credit_eligible: false
-    ct_agi: 130_500
+    ct_agi: 130500
     filing_status: JOINT
     real_estate_taxes: 500
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 0
-
-- name: JOINT household with $80,500  agi and  $290 property tax and eligible for property tax credit
+- name: JOINT household with $80,500  agi and  $290 property tax and eligible for
+    property tax credit
   period: 2021
   input:
     ct_property_tax_credit_eligible: true
-    ct_agi: 80_500
+    ct_agi: 80500
     filing_status: JOINT
     real_estate_taxes: 290
+    ct_income_tax_after_amt: 1000000
   output:
     ct_property_tax_credit: 170
-
+- name: Property tax credit is capped by remaining CT income tax
+  period: 2022
+  input:
+    ct_property_tax_credit_eligible: true
+    ct_agi: 45000
+    filing_status: SEPARATE
+    real_estate_taxes: 250
+    ct_income_tax_after_amt: 100
+  output:
+    ct_property_tax_credit_potential: 175
+    ct_property_tax_credit: 100

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/credits/dc_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/credits/dc_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2021
+  input:
+    state_code: DC
+    dc_income_tax_before_credits: 100
+    dc_cdcc_potential: 80
+  output:
+    dc_cdcc: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_cdcc.yaml
@@ -2,6 +2,7 @@
   period: 2021
   input:
     cdcc_potential: 800
+    dc_income_tax_before_credits: 1_000
     state_code: DC
   output:
     dc_cdcc: 256  # = 800 * 0.32
@@ -10,6 +11,7 @@
   period: 2022
   input:
     cdcc_potential: 100
+    dc_income_tax_before_credits: 1_000
     state_code: DC
   output:
     dc_cdcc: 32  # = 100 * 0.32
@@ -18,6 +20,7 @@
   period: 2025
   input:
     cdcc_potential: 1_000
+    dc_income_tax_before_credits: 1_000
     state_code: DC
   output:
     dc_cdcc: 320  # = 1_000 * 0.32
@@ -26,6 +29,17 @@
   period: 2026
   input:
     cdcc_potential: 1_000
+    dc_income_tax_before_credits: 1_000
     state_code: DC
   output:
     dc_cdcc: 242.5  # = 1_000 * 0.2425
+
+- name: DC CDCC is capped by remaining tax liability
+  period: 2025
+  input:
+    cdcc_potential: 1_000
+    dc_income_tax_before_credits: 200
+    state_code: DC
+  output:
+    dc_cdcc_potential: 320
+    dc_cdcc: 200

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/cdcc/de_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/cdcc/de_cdcc.yaml
@@ -3,13 +3,14 @@
   input:
     cdcc: 100
     state_code: DE
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_cdcc: 50
-
 - name: cdcc 0
   period: 2023
   input:
     cdcc: 0
     state_code: DE
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/de_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/de_non_refundable_credit_order.yaml
@@ -1,0 +1,14 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2019
+  input:
+    state_code: DE
+    de_income_tax_before_non_refundable_credits_unit: 100
+    de_cdcc_potential: 80
+    de_non_refundable_eitc_potential: 40
+    de_personal_credit_potential: 30
+    de_aged_personal_credit_potential: 20
+  output:
+    de_cdcc: 80
+    de_non_refundable_eitc: 20
+    de_personal_credit: 0
+    de_aged_personal_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.yaml
@@ -2,18 +2,17 @@
   period: 2022
   input:
     state_code: DE
-    # Claims refundable, not non-refundable.
     de_claims_refundable_eitc: true
     de_non_refundable_eitc_if_claimed: 100
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_non_refundable_eitc: 0
-
 - name: Claimed
   period: 2022
   input:
     state_code: DE
-    # Claims non-refundable.
     de_claims_refundable_eitc: false
     de_non_refundable_eitc_if_claimed: 100
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_non_refundable_eitc: 100

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.yaml
@@ -4,41 +4,42 @@
     state_code: DE
     age_head: 60
     age_spouse: 60
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_aged_personal_credit: 220
-
 - name: yourself and spouse are both above 60 in 2022.
   period: 2022
   input:
     state_code: DE
     age_head: 60
     age_spouse: 60
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
-    de_aged_personal_credit: 220    
-
+    de_aged_personal_credit: 220
 - name: yourself >= age 60 but spouse is not.
   period: 2022
   input:
     state_code: DE
     age_head: 65
     age_spouse: 59
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_aged_personal_credit: 110
-
 - name: yourself < age 60 but spouse >= 60.
   period: 2023
   input:
     state_code: DE
     age_head: 55
     age_spouse: 65
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_aged_personal_credit: 110
-
 - name: both yourself and spouse under 60.
   period: 2023
   input:
     state_code: DE
     age_head: 55
     age_spouse: 58
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_aged_personal_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/personal/de_personal_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/personal/de_personal_credits.yaml
@@ -3,29 +3,30 @@
   input:
     exemptions_count: 1
     state_code: DE
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_personal_credit: 110
-
 - name: Delaware personal credit if married filing jointly and above max threshold
   period: 2022
   input:
     exemptions_count: 2
     state_code: DE
-  output:  
+    de_income_tax_before_non_refundable_credits_unit: 1000000
+  output:
     de_personal_credit: 220
-
 - name: Delaware personal credit if surviving spouser
   period: 2022
   input:
     exemptions_count: 5
     state_code: DE
-  output:  
+    de_income_tax_before_non_refundable_credits_unit: 1000000
+  output:
     de_personal_credit: 550
-
 - name: No exemptions
   period: 2022
   input:
     exemptions_count: 0
     state_code: DE
+    de_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     de_personal_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/dependent_care_credit/ga_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/dependent_care_credit/ga_cdcc.yaml
@@ -1,23 +1,24 @@
 - name: GA cdcc unit test 1
   period: 2021
   input:
-    cdcc: 1_000
+    cdcc: 1000
     state_code: GA
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
-    ga_cdcc: 300 # .30 * 1_000
-
+    ga_cdcc: 300
 - name: GA cdcc unit test 2
   period: 2007
   input:
-    cdcc: 1_000
+    cdcc: 1000
     state_code: GA
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
-    ga_cdcc: 200 # .20 * 1_000
-
+    ga_cdcc: 200
 - name: GA cdcc unit test 2
   period: 2007
   input:
     cdcc: 0
     state_code: GA
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
-    ga_cdcc: 0 # .00 * 1_000
+    ga_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_ctc.yaml
@@ -9,16 +9,19 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         filing_status: SINGLE
-        ga_income_tax_before_non_refundable_credits: 10_000
+        ga_income_tax_before_non_refundable_credits: 10000
     households:
       household:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         state_code: GA
   output:
     ga_ctc: 250
-
 - name: GA CTC - no credit due to age (too old)
   period: 2026
   input:
@@ -30,16 +33,19 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         filing_status: SINGLE
-        ga_income_tax_before_non_refundable_credits: 10_000
+        ga_income_tax_before_non_refundable_credits: 10000
     households:
       household:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         state_code: GA
   output:
     ga_ctc: 0
-
 - name: GA CTC - multiple children full credit
   period: 2026
   input:
@@ -54,16 +60,21 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [parent, child1, child2]
+        members:
+        - parent
+        - child1
+        - child2
         filing_status: SINGLE
-        ga_income_tax_before_non_refundable_credits: 10_000
+        ga_income_tax_before_non_refundable_credits: 10000
     households:
       household:
-        members: [parent, child1, child2]
+        members:
+        - parent
+        - child1
+        - child2
         state_code: GA
   output:
     ga_ctc: 500
-
 - name: GA CTC - not available outside Georgia
   period: 2026
   input:
@@ -75,16 +86,19 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         filing_status: SINGLE
-        ga_income_tax_before_non_refundable_credits: 10_000
+        ga_income_tax_before_non_refundable_credits: 10000
     households:
       household:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         state_code: AL
   output:
     ga_ctc: 0
-
 - name: GA CTC - no credit in 2025 (pre-enactment)
   period: 2025
   input:
@@ -96,12 +110,16 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         filing_status: SINGLE
         ga_low_income_credit: 0
     households:
       household:
-        members: [parent, child]
+        members:
+        - parent
+        - child
         state_code: GA
   output:
     ga_non_refundable_credits: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_itemizer_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_itemizer_credit.yaml
@@ -4,41 +4,41 @@
     state_code: GA
     tax_unit_itemizes: true
     filing_status: SINGLE
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_itemizer_credit: 300
-
 - name: Georgia itemizer credit - joint itemizers receive double credit
   period: 2024
   input:
     state_code: GA
     tax_unit_itemizes: true
     filing_status: JOINT
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_itemizer_credit: 600
-
 - name: Georgia itemizer credit - non-itemizer receives no credit
   period: 2024
   input:
     state_code: GA
     tax_unit_itemizes: false
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_itemizer_credit: 0
-
 - name: Georgia itemizer credit - available in 2025
   period: 2025
   input:
     state_code: GA
     tax_unit_itemizes: true
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_itemizer_credit: 300
-
 - name: Georgia itemizer credit - high income single itemizer receives credit
   period: 2024
   input:
     state_code: GA
-    adjusted_gross_income: 100_000
+    adjusted_gross_income: 100000
     tax_unit_itemizes: true
     filing_status: SINGLE
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_itemizer_credit: 300
-

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_low_income_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_low_income_credit.yaml
@@ -2,86 +2,87 @@
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 14_000
+    adjusted_gross_income: 14000
     age_head: 67
     age_spouse: 70
     exemptions_count: 2
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 32
-
 - name: Georgia low income credits one aged
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 4_000
+    adjusted_gross_income: 4000
     age_head: 67
     age_spouse: 56
     exemptions_count: 2
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 78
-
 - name: Georgia low income credits both aged - higher income bracket
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 15_500
+    adjusted_gross_income: 15500
     age_head: 80
     age_spouse: 75
     exemptions_count: 3
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 25
-
 - name: Georgia low income credits - one aged and no exemptions
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 4_000
+    adjusted_gross_income: 4000
     age_head: 67
     age_spouse: 56
     exemptions_count: 0
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 26
-
 - name: Georgia low income credits - lower income bracket
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 10_500
+    adjusted_gross_income: 10500
     age_head: 67
     age_spouse: 56
     exemptions_count: 0
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 8
-
 - name: Georgia low income credits - no exemptions
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 10_500
+    adjusted_gross_income: 10500
     age_head: 56
     age_spouse: 56
     exemptions_count: 0
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 0
-
 - name: Georgia low income credits - one aged and one exemption
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 10_500
+    adjusted_gross_income: 10500
     age_head: 65
     age_spouse: 64
     exemptions_count: 1
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 16
-
 - name: Georgia low income credits - two exemptions
   period: 2022
   input:
     state_code: GA
-    adjusted_gross_income: 10_000
+    adjusted_gross_income: 10000
     age_head: 64
     age_spouse: 64
     exemptions_count: 2
+    ga_income_tax_before_non_refundable_credits: 1000000
   output:
     ga_low_income_credit: 16

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_non_refundable_credit_order.yaml
@@ -1,0 +1,14 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2026
+  input:
+    state_code: GA
+    ga_income_tax_before_non_refundable_credits: 100
+    ga_cdcc_potential: 80
+    ga_low_income_credit_potential: 40
+    ga_ctc_potential: 30
+    ga_itemizer_credit_potential: 20
+  output:
+    ga_cdcc: 80
+    ga_low_income_credit: 20
+    ga_ctc: 0
+    ga_itemizer_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_non_refundable_credit_order.yaml
@@ -1,0 +1,11 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2021
+  input:
+    state_code: IL
+    il_income_tax_before_non_refundable_credits: 100
+    il_is_exemption_eligible: true
+    il_property_tax_credit_potential: 80
+    il_k12_education_expense_credit_potential: 40
+  output:
+    il_property_tax_credit: 80
+    il_k12_education_expense_credit: 20

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_property_tax_credit.yaml
@@ -1,35 +1,40 @@
-- name: "Property Tax Credit Test #1: Income tax before credits less than claimable difference between property tax and QBID"
+- name: 'Property Tax Credit Test #1: Income tax before credits less than claimable
+    difference between property tax and QBID'
   period: 2021
   input:
     people:
       person1:
         age: 30
-        real_estate_taxes: 5_000_000
+        real_estate_taxes: 5000000
     tax_units:
       tax_unit:
-        members: [person1]
-        il_income_tax_before_non_refundable_credits: 10_000
+        members:
+        - person1
+        il_income_tax_before_non_refundable_credits: 10000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: IL
   output:
-    il_property_tax_credit: 10_000
-
-- name: "Property Tax Credit Test #1: Income tax before credits greater than claimable difference between property tax and QBID"
+    il_property_tax_credit: 10000
+- name: 'Property Tax Credit Test #1: Income tax before credits greater than claimable
+    difference between property tax and QBID'
   period: 2021
   input:
     people:
       person1:
         age: 30
-        real_estate_taxes: 150_000
+        real_estate_taxes: 150000
     tax_units:
       tax_unit:
-        members: [person1]
-        il_income_tax_before_non_refundable_credits: 10_000
+        members:
+        - person1
+        il_income_tax_before_non_refundable_credits: 10000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: IL
   output:
-    il_property_tax_credit: 7_500
+    il_property_tax_credit: 7500

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/dependent_care_credit/ky_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/dependent_care_credit/ky_cdcc.yaml
@@ -1,15 +1,22 @@
 - name: Single filer with 10k of income
   period: 2023
-  input: 
+  input:
     state_code: KY
-    cdcc: 10_000
+    cdcc: 10000
+    ky_income_tax_before_non_refundable_credits_unit: 1000000
+    ky_personal_tax_credits: 0
+    ky_family_size_tax_credit: 0
+    ky_tuition_tax_credit: 0
   output:
-    ky_cdcc: 2_000
-
+    ky_cdcc: 2000
 - name: No income
   period: 2021
-  input: 
+  input:
     state_code: KY
     cdcc: 0
+    ky_income_tax_before_non_refundable_credits_unit: 1000000
+    ky_personal_tax_credits: 0
+    ky_family_size_tax_credit: 0
+    ky_tuition_tax_credit: 0
   output:
     ky_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/ky_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/ky_non_refundable_credit_order.yaml
@@ -1,0 +1,15 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2021
+  input:
+    state_code: KY
+    ky_income_tax_before_non_refundable_credits_unit: 100
+    ky_personal_tax_credits_potential: 80
+    ky_family_size_tax_credit_potential: 40
+    ky_tuition_tax_credit_eligible: true
+    ky_tuition_tax_credit_potential: 30
+    ky_cdcc_potential: 20
+  output:
+    ky_personal_tax_credits: 80
+    ky_family_size_tax_credit: 20
+    ky_tuition_tax_credit: 0
+    ky_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.yaml
@@ -10,15 +10,19 @@
         ky_personal_tax_credits_joint: 50
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         ky_files_separately: true
+        ky_income_tax_before_non_refundable_credits_unit: 1000000
     households:
       household:
-        members: [person1,person2]
+        members:
+        - person1
+        - person2
         state_code: KY
   output:
     ky_personal_tax_credits: 140
-
 - name: separate
   period: 2022
   input:
@@ -31,12 +35,16 @@
         ky_personal_tax_credits_joint: 50
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         ky_files_separately: false
+        ky_income_tax_before_non_refundable_credits_unit: 1000000
     households:
       household:
-        members: [person1,person2]
+        members:
+        - person1
+        - person2
         state_code: KY
   output:
     ky_personal_tax_credits: 90
-

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.yaml
@@ -1,17 +1,18 @@
 - name: Filer with both AOC and LLC.
   period: 2022
   input:
-    american_opportunity_credit: 1_500
-    lifetime_learning_credit: 2_000
+    american_opportunity_credit: 1500
+    lifetime_learning_credit: 2000
     ky_tuition_tax_credit_eligible: true
+    ky_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     ky_tuition_tax_credit: 875
-
 - name: Ineligible
   period: 2022
   input:
-    american_opportunity_credit: 1_500
-    lifetime_learning_credit: 2_000
+    american_opportunity_credit: 1500
+    lifetime_learning_credit: 2000
     ky_tuition_tax_credit_eligible: false
+    ky_income_tax_before_non_refundable_credits_unit: 1000000
   output:
     ky_tuition_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.yaml
@@ -1,44 +1,45 @@
 - name: AGI ineligible
   period: 2006
   input:
-    adjusted_gross_income: 25_000
-    cdcc: 1_000
+    adjusted_gross_income: 25000
+    cdcc: 1000
     state_code: LA
+    la_income_tax_before_non_refundable_credits: 1000000
   output:
     la_non_refundable_cdcc: 0
-
 - name: 30% match above 25k
   period: 2023
   input:
-    adjusted_gross_income: 25_001
-    cdcc: 1_000
+    adjusted_gross_income: 25001
+    cdcc: 1000
     state_code: LA
+    la_income_tax_before_non_refundable_credits: 1000000
   output:
     la_non_refundable_cdcc: 300
-
 - name: Match over 60k capped at $25
   period: 2023
   input:
-    adjusted_gross_income: 60_001
-    cdcc: 1_000
+    adjusted_gross_income: 60001
+    cdcc: 1000
     state_code: LA
+    la_income_tax_before_non_refundable_credits: 1000000
   output:
     la_non_refundable_cdcc: 25
-
 - name: Match over 60k, uncapped
   period: 2023
   input:
-    adjusted_gross_income: 60_001
+    adjusted_gross_income: 60001
     cdcc: 100
     state_code: LA
+    la_income_tax_before_non_refundable_credits: 1000000
   output:
     la_non_refundable_cdcc: 10
-
 - name: Match over 60k, uncapped
   period: 2023
   input:
-    adjusted_gross_income: 35_001
+    adjusted_gross_income: 35001
     cdcc: 100
     state_code: LA
+    la_income_tax_before_non_refundable_credits: 1000000
   output:
     la_non_refundable_cdcc: 10

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/credits/la_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/credits/la_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2021
+  input:
+    state_code: LA
+    la_income_tax_before_non_refundable_credits: 100
+    la_non_refundable_cdcc_potential: 80
+  output:
+    la_non_refundable_cdcc: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.yaml
@@ -3,26 +3,23 @@
   absolute_error_margin: 0
   input:
     state_code: MA
-    employment_income: 7_000
+    employment_income: 7000
   output:
     ma_limited_income_tax_credit: 0
-
 - name: In eligibility region, MA income tax excess capped at 10%
   period: 2022
   absolute_error_margin: 0
   input:
     state_code: MA
-    employment_income: 10_000
+    employment_income: 10000
     ma_income_tax_before_credits: 201
   output:
     ma_limited_income_tax_credit: 1
-
 - name: Outside eligibility region
   period: 2022
   absolute_error_margin: 0
   input:
     state_code: MA
-    employment_income: 16_000
+    employment_income: 16000
   output:
     ma_limited_income_tax_credit: 0
-

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2020
+  input:
+    state_code: MA
+    ma_income_tax_before_credits: 100
+    ma_limited_income_tax_credit_potential: 80
+  output:
+    ma_limited_income_tax_credit: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_non_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_non_refundable_eitc.yaml
@@ -1,17 +1,19 @@
-- name: Maryland total non-refundable eitc for married individual or has qualifying child.
+- name: Maryland total non-refundable eitc for married individual or has qualifying
+    child.
   period: 2021
   input:
     md_married_or_has_child_non_refundable_eitc: 100
     md_unmarried_childless_non_refundable_eitc: 0
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_non_refundable_eitc: 100
-
 - name: Maryland total non-refundable eitc for unmarried childless individual.
   period: 2021
   input:
     md_married_or_has_child_non_refundable_eitc: 0
     md_unmarried_childless_non_refundable_eitc: 300
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_non_refundable_eitc: 300

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_cdcc.yaml
@@ -3,21 +3,21 @@
   input:
     cdcc: 100
     filing_status: SINGLE
-    adjusted_gross_income: 95_901  # $95,900 is the limit.
+    adjusted_gross_income: 95901
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_cdcc: 0
-
 - name: Joint filer over the AGI limit
   period: 2021
   input:
     cdcc: 100
     filing_status: JOINT
-    adjusted_gross_income: 149_051  # $149,050 is the limit.
+    adjusted_gross_income: 149051
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_cdcc: 0
-  
 - name: Single parent with no income will get 32% of the CDCC
   period: 2021
   input:
@@ -25,9 +25,9 @@
     filing_status: SINGLE
     adjusted_gross_income: 0
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_cdcc: 32
-
 - name: Joint filer with no income will get 32% of the CDCC
   period: 2021
   input:
@@ -35,35 +35,36 @@
     filing_status: JOINT
     adjusted_gross_income: 0
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_cdcc: 32
-
 - name: Joint filer with $50,000 income will get 32% of the CDCC
   period: 2021
   input:
     cdcc: 100
     filing_status: JOINT
-    adjusted_gross_income: 50_000
+    adjusted_gross_income: 50000
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_cdcc: 32
-
 - name: Single parent with $80,000 income will get 24% of the CDCC
   period: 2021
   input:
     cdcc: 100
     filing_status: SINGLE
-    adjusted_gross_income: 80_000
+    adjusted_gross_income: 80000
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_cdcc: 24
-
 - name: Joint filer with $125,000 income will get 24% of the CDCC
   period: 2021
   input:
     cdcc: 100
     filing_status: JOINT
-    adjusted_gross_income: 125_000
+    adjusted_gross_income: 125000
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_cdcc: 24

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_non_refundable_credit_order.yaml
@@ -1,0 +1,15 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2022
+  input:
+    state_code: MD
+    md_income_tax_before_credits: 100
+    md_cdcc_potential: 80
+    md_non_refundable_eitc_potential: 40
+    md_poverty_line_credit_potential: 30
+    md_senior_tax_credit_eligible: true
+    md_senior_tax_credit_potential: 20
+  output:
+    md_cdcc: 80
+    md_non_refundable_eitc: 20
+    md_poverty_line_credit: 0
+    md_senior_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_refundable_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_refundable_cdcc.yaml
@@ -1,21 +1,29 @@
-- name: Single person at the AGI limit.
+# 2021 Form 502CR Part B chart: individual FAGI $0-$30,001 uses a 0.3200 multiplier.
+# With federal CDCC = 100, Part B credit = 32.
+# 2021 Resident Booklet Worksheet 21B refunds the amount by which that credit
+# exceeds Maryland tax for individual filers with FAGI <= $52,100.
+- name: Part B credit and Worksheet 21B refund for a low-income single filer.
   period: 2021
   input:
     filing_status: SINGLE
-    adjusted_gross_income: 52_100
-    md_cdcc: 100
-    md_income_tax_before_credits: 50
+    adjusted_gross_income: 0
+    cdcc: 100
+    md_income_tax_before_credits: 10
     state_code: MD
   output:
-    md_refundable_cdcc: 50
+    md_cdcc_potential: 32
+    md_cdcc: 10
+    md_refundable_cdcc: 22
 
-- name: Single person just over the AGI limit.
+# 2021 Resident Booklet Worksheet 21B: individual filers above $52,100 FAGI
+# are not eligible for the refundable excess.
+- name: Worksheet 21B blocks the refund above the individual FAGI limit.
   period: 2021
   input:
     filing_status: SINGLE
     adjusted_gross_income: 52_101
-    md_cdcc: 100
-    md_income_tax_before_credits: 50
+    cdcc: 100
+    md_income_tax_before_credits: 10
     state_code: MD
   output:
     md_refundable_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/poverty_line/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/poverty_line/integration.yaml
@@ -30,14 +30,40 @@
         age: 14
     tax_units:
       tax_unit:
-        members: [parent,parent2, child1, child2, child3, child4, child5, child6, child7, child8, child9, child10, child11]
-        md_income_tax_before_credits: 3_000
-        md_married_or_has_child_non_refundable_eitc: 2_000
-        tax_unit_earned_income: 20_000
+        members:
+        - parent
+        - parent2
+        - child1
+        - child2
+        - child3
+        - child4
+        - child5
+        - child6
+        - child7
+        - child8
+        - child9
+        - child10
+        - child11
+        md_income_tax_before_credits: 3000
+        md_married_or_has_child_non_refundable_eitc: 2000
+        tax_unit_earned_income: 20000
         is_eligible_md_poverty_line_credit: true
     households:
       household:
-        members: [parent,parent2, child1, child2, child3, child4, child5, child6, child7, child8, child9,child10, child11]
+        members:
+        - parent
+        - parent2
+        - child1
+        - child2
+        - child3
+        - child4
+        - child5
+        - child6
+        - child7
+        - child8
+        - child9
+        - child10
+        - child11
         state_code: MD
   output:
-      md_poverty_line_credit: 1_000
+    md_poverty_line_credit: 1000

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.yaml
@@ -2,106 +2,105 @@
   period: 2023
   input:
     filing_status: SINGLE
-    adjusted_gross_income: 100_000
+    adjusted_gross_income: 100000
     state_code: MD
     age_head: 65
+    md_income_tax_before_credits: 1000000
   output:
     md_senior_tax_credit: 0
-  
 - name: Single ineligible by age.
   period: 2023
   input:
     filing_status: SINGLE
-    adjusted_gross_income: 99_999
+    adjusted_gross_income: 99999
     age_head: 64
     state_code: MD
+    md_income_tax_before_credits: 1000000
   output:
     md_senior_tax_credit: 0
-
 - name: Joint ineligible by income.
   period: 2023
   input:
     filing_status: JOINT
-    adjusted_gross_income: 150_000
+    adjusted_gross_income: 150000
     state_code: MD
     age_head: 65
     age_spouse: 65
+    md_income_tax_before_credits: 1000000
   output:
     md_senior_tax_credit: 0
-
 - name: Joint ineligible by age.
   period: 2023
   input:
     filing_status: JOINT
-    adjusted_gross_income: 149_999
+    adjusted_gross_income: 149999
     state_code: MD
     age_head: 64
     age_spouse: 64
+    md_income_tax_before_credits: 1000000
   output:
     md_senior_tax_credit: 0
-
 - name: Joint one aged eligible.
   period: 2023
   input:
     filing_status: JOINT
-    adjusted_gross_income: 149_999
+    adjusted_gross_income: 149999
     state_code: MD
     age_head: 65
     age_spouse: 64
+    md_income_tax_before_credits: 1000000
   output:
-    md_senior_tax_credit: 1_000
-
-
+    md_senior_tax_credit: 1000
 - name: Joint two aged eligible.
   period: 2023
   input:
     filing_status: JOINT
-    adjusted_gross_income: 149_999
+    adjusted_gross_income: 149999
     state_code: MD
     age_head: 65
     age_spouse: 65
+    md_income_tax_before_credits: 1000000
   output:
-    md_senior_tax_credit: 1_750
-
+    md_senior_tax_credit: 1750
 - name: Surviving spouse eligible.
   period: 2023
   input:
     filing_status: SURVIVING_SPOUSE
-    adjusted_gross_income: 149_999
+    adjusted_gross_income: 149999
     state_code: MD
     age_head: 65
+    md_income_tax_before_credits: 1000000
   output:
-    md_senior_tax_credit: 1_750
-
+    md_senior_tax_credit: 1750
 - name: Head of household no spouse eligible.
   period: 2023
   input:
     filing_status: SURVIVING_SPOUSE
-    adjusted_gross_income: 149_999
+    adjusted_gross_income: 149999
     state_code: MD
     age_head: 65
+    md_income_tax_before_credits: 1000000
   output:
-    md_senior_tax_credit: 1_750
-
+    md_senior_tax_credit: 1750
 - name: Head of household with spouse both aged eligible.
   period: 2023
   input:
     filing_status: SURVIVING_SPOUSE
-    adjusted_gross_income: 149_999
+    adjusted_gross_income: 149999
     state_code: MD
     age_head: 65
     age_spouse: 65
+    md_income_tax_before_credits: 1000000
   output:
-    md_senior_tax_credit: 1_750
-
+    md_senior_tax_credit: 1750
 - name: Head of household with spouse one aged eligible.
   period: 2023
   input:
     filing_status: SURVIVING_SPOUSE
-    adjusted_gross_income: 149_999
+    adjusted_gross_income: 149999
     state_code: MD
     age_head: 65
     age_spouse: 64
+    md_income_tax_before_credits: 1000000
   output:
-    md_senior_tax_credit: 1_750
-
+    md_senior_tax_credit: 1750

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/integration_md.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/integration_md.yaml
@@ -138,7 +138,8 @@
         state_fips: 24  # MD
   output:  # expected results from patched TAXSIM35 2024-03-08 version
     md_income_tax_before_credits: 280.4
-    md_non_refundable_eitc: 530 # TAXSIM 280.4
+    md_non_refundable_eitc_potential: 530
+    md_non_refundable_eitc: 280.4
     md_refundable_eitc: 249.6
     md_income_tax: -249.60
 

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/child_care_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/child_care_credit.yaml
@@ -6,8 +6,7 @@
     filing_status: SINGLE
   output:
     me_refundable_child_care_credit: 0
-
-- name: No federal child care credit, no refundable child care credit 
+- name: No federal child care credit, no refundable child care credit
   period: 2022
   absolute_error_margin: 0
   input:
@@ -16,43 +15,46 @@
     cdcc: 0
   output:
     me_refundable_child_care_credit: 0
-
-- name: $1000 federal child care credit, all regular, 25% received in Maine credit ($250), all will be refundable
+- name: $1000 federal child care credit, all regular, 25% received in Maine credit
+    ($250), all will be refundable
   period: 2022
   absolute_error_margin: 0
   input:
     state_code: ME
     filing_status: SINGLE
-    cdcc: 1_000
-    me_step_4_share_of_child_care_expenses: 0 
+    cdcc: 1000
+    me_step_4_share_of_child_care_expenses: 0
+    me_income_tax_before_credits: 1000000
   output:
     me_child_care_credit: 250
     me_refundable_child_care_credit: 250
-    me_non_refundable_child_care_credit: 0 
-
-- name: $4000 federal child care credit, 50% received in Maine credit ($2000), only some (500, the max) will be refundable, rest unrefundable 
+    me_non_refundable_child_care_credit: 0
+- name: $4000 federal child care credit, 50% received in Maine credit ($2000), only
+    some (500, the max) will be refundable, rest unrefundable
   period: 2022
   absolute_error_margin: 0
   input:
     state_code: ME
     filing_status: SINGLE
-    tax_unit_childcare_expenses: 4_000
-    me_step_4_share_of_child_care_expenses: 1 
-    cdcc: 4_000
+    tax_unit_childcare_expenses: 4000
+    me_step_4_share_of_child_care_expenses: 1
+    cdcc: 4000
+    me_income_tax_before_credits: 1000000
   output:
-    me_child_care_credit: 2_000
+    me_child_care_credit: 2000
     me_refundable_child_care_credit: 500
-    me_non_refundable_child_care_credit: 1_500
-
-- name: $2000 federal child care credit, 0.5 step 4 expenses, half cdcc multiplied by step 4 factor, half by regular factor  
+    me_non_refundable_child_care_credit: 1500
+- name: $2000 federal child care credit, 0.5 step 4 expenses, half cdcc multiplied
+    by step 4 factor, half by regular factor
   period: 2022
   absolute_error_margin: 0
   input:
     state_code: ME
     filing_status: SINGLE
-    tax_unit_childcare_expenses: 2_000
-    me_step_4_share_of_child_care_expenses: 0.5 
-    cdcc: 2_000
+    tax_unit_childcare_expenses: 2000
+    me_step_4_share_of_child_care_expenses: 0.5
+    cdcc: 2000
+    me_income_tax_before_credits: 1000000
   output:
     me_child_care_credit: 750
     me_refundable_child_care_credit: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/me_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/me_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2024
+  input:
+    state_code: ME
+    me_income_tax_before_credits: 100
+    me_non_refundable_child_care_credit_potential: 80
+  output:
+    me_non_refundable_child_care_credit: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/mo_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/mo_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2023
+  input:
+    state_code: MO
+    mo_income_tax_before_credits: 100
+    mo_wftc_potential: 80
+  output:
+    mo_wftc: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc.yaml
@@ -3,29 +3,30 @@
   input:
     state_code: MO
     eitc: 0
+    mo_income_tax_before_credits: 1000000
   output:
     mo_wftc: 0
-
 - name: 10% match
   period: 2023
   input:
     state_code: MO
     eitc: 100
+    mo_income_tax_before_credits: 1000000
   output:
     mo_wftc: 10
-
 - name: Outside MO is ineligible
   period: 2023
   input:
     state_code: MA
     eitc: 100
+    mo_income_tax_before_credits: 1000000
   output:
     mo_wftc: 0
-
 - name: Introduced in 2023
   period: 2022
   input:
     state_code: MO
     eitc: 100
+    mo_income_tax_before_credits: 1000000
   output:
     mo_wftc: 10

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.yaml
@@ -2,22 +2,23 @@
   period: 2023
   input:
     ms_cdcc_eligible: true
-    cdcc: 1_000
+    cdcc: 1000
+    ms_income_tax_before_credits_unit: 1000000
   output:
     ms_cdcc: 250
-
 - name: Ineligible household
   period: 2023
   input:
     ms_cdcc_eligible: false
-    cdcc: 1_000
+    cdcc: 1000
+    ms_income_tax_before_credits_unit: 1000000
   output:
     ms_cdcc: 0
-
 - name: No federal credit
   period: 2023
   input:
     ms_cdcc_eligible: true
     cdcc: 0
+    ms_income_tax_before_credits_unit: 1000000
   output:
     ms_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.yaml
@@ -4,59 +4,64 @@
     state_code: MS
     filing_status: SINGLE
     ms_charitable_contributions_to_qualifying_foster_care_organizations: 600
+    ms_income_tax_before_credits_unit: 1000000
   output:
     ms_charitable_contributions_credit: 600
-
 - name: For HEAD_OF_HOUSEHOLD making voluntary cash contributions totaling $2000.
   period: 2023
   input:
     state_code: MS
     filing_status: HEAD_OF_HOUSEHOLD
-    ms_charitable_contributions_to_qualifying_foster_care_organizations: 2_000
+    ms_charitable_contributions_to_qualifying_foster_care_organizations: 2000
+    ms_income_tax_before_credits_unit: 1000000
   output:
-    ms_charitable_contributions_credit: 1_500
-
-- name: For married couple filing a joint making voluntary cash contributions totaling $3000.
+    ms_charitable_contributions_credit: 1500
+- name: For married couple filing a joint making voluntary cash contributions totaling
+    $3000.
   period: 2023
   input:
     state_code: MS
     filing_status: JOINT
-    ms_charitable_contributions_to_qualifying_foster_care_organizations: 3_000
+    ms_charitable_contributions_to_qualifying_foster_care_organizations: 3000
+    ms_income_tax_before_credits_unit: 1000000
   output:
-    ms_charitable_contributions_credit: 3_000
-
-- name: For married couple filing a joint making voluntary cash contributions totaling $5000.
+    ms_charitable_contributions_credit: 3000
+- name: For married couple filing a joint making voluntary cash contributions totaling
+    $5000.
   period: 2023
   input:
     state_code: MS
     filing_status: JOINT
-    ms_charitable_contributions_to_qualifying_foster_care_organizations: 5_000
+    ms_charitable_contributions_to_qualifying_foster_care_organizations: 5000
+    ms_income_tax_before_credits_unit: 1000000
   output:
-    ms_charitable_contributions_credit: 3_000
-
-- name: For married couple filing a joint making voluntary cash contributions totaling $800.
+    ms_charitable_contributions_credit: 3000
+- name: For married couple filing a joint making voluntary cash contributions totaling
+    $800.
   period: 2021
   input:
     state_code: MS
     filing_status: JOINT
     ms_charitable_contributions_to_qualifying_foster_care_organizations: 800
+    ms_income_tax_before_credits_unit: 1000000
   output:
     ms_charitable_contributions_credit: 800
-
-- name: For married couple filing a joint making voluntary cash contributions totaling $1500.
+- name: For married couple filing a joint making voluntary cash contributions totaling
+    $1500.
   period: 2021
   input:
     state_code: MS
     filing_status: JOINT
-    ms_charitable_contributions_to_qualifying_foster_care_organizations: 1_500
+    ms_charitable_contributions_to_qualifying_foster_care_organizations: 1500
+    ms_income_tax_before_credits_unit: 1000000
   output:
-    ms_charitable_contributions_credit: 1_000
-
+    ms_charitable_contributions_credit: 1000
 - name: For a single individual making voluntary cash contributions totaling $400.
   period: 2022
   input:
     state_code: MS
     filing_status: SINGLE
     ms_charitable_contributions_to_qualifying_foster_care_organizations: 400
+    ms_income_tax_before_credits_unit: 1000000
   output:
     ms_charitable_contributions_credit: 400

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/credits/ms_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/credits/ms_non_refundable_credit_order.yaml
@@ -1,0 +1,11 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2023
+  input:
+    state_code: MS
+    ms_income_tax_before_credits_unit: 100
+    ms_charitable_contributions_credit_potential: 80
+    ms_cdcc_eligible: true
+    ms_cdcc_potential: 40
+  output:
+    ms_charitable_contributions_credit: 80
+    ms_cdcc: 20

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/credits/nc_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/credits/nc_ctc.yaml
@@ -3,69 +3,68 @@
   input:
     filing_status: SINGLE
     state_code: NC
-    adjusted_gross_income: 15_000
+    adjusted_gross_income: 15000
     ctc_qualifying_children: 0
-  output:  
+    nc_income_tax_before_credits: 1000000
+  output:
     nc_ctc: 0
-
 - name: 1 child - single
   period: 2015
   input:
     filing_status: SINGLE
     state_code: NC
-    adjusted_gross_income: 15_000
+    adjusted_gross_income: 15000
     ctc_qualifying_children: 1
-  output:  
+    nc_income_tax_before_credits: 1000000
+  output:
     nc_ctc: 125
-
 - name: 1 child
   period: 2015
   input:
     filing_status: JOINT
     state_code: NC
-    adjusted_gross_income: 50_000
+    adjusted_gross_income: 50000
     ctc_qualifying_children: 1
-  output:  
+    nc_income_tax_before_credits: 1000000
+  output:
     nc_ctc: 100
-
-
 - name: 2 children
   period: 2015
   input:
     filing_status: HEAD_OF_HOUSEHOLD
     state_code: NC
-    adjusted_gross_income: 30_000
+    adjusted_gross_income: 30000
     ctc_qualifying_children: 2
-  output:  
+    nc_income_tax_before_credits: 1000000
+  output:
     nc_ctc: 250
-
-
 - name: Married with three children
   period: 2015
   input:
     filing_status: JOINT
     state_code: NC
-    adjusted_gross_income: 45_000
+    adjusted_gross_income: 45000
     ctc_qualifying_children: 3
-  output:  
+    nc_income_tax_before_credits: 1000000
+  output:
     nc_ctc: 300
-
 - name: Married with six children
   period: 2015
   input:
     filing_status: JOINT
     state_code: NC
-    adjusted_gross_income: 145_000
+    adjusted_gross_income: 145000
     ctc_qualifying_children: 6
-  output:  
+    nc_income_tax_before_credits: 1000000
+  output:
     nc_ctc: 0
-
 - name: Head of Household with two children in 2018
   period: 2018
   input:
     filing_status: HEAD_OF_HOUSEHOLD
     state_code: NC
-    adjusted_gross_income: 45_000
+    adjusted_gross_income: 45000
     ctc_qualifying_children: 2
-  output:  
+    nc_income_tax_before_credits: 1000000
+  output:
     nc_ctc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/credits/nc_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/credits/nc_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2017
+  input:
+    state_code: NC
+    nc_income_tax_before_credits: 100
+    nc_ctc_potential: 80
+  output:
+    nc_ctc: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_geothermal_energy_systems_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_geothermal_energy_systems_credit.yaml
@@ -1,23 +1,24 @@
 - name: 25% of expenditures, pre cap
   period: 2023
   input:
-    ny_qualified_geothermal_energy_system_expenditures: 1_000
+    ny_qualified_geothermal_energy_system_expenditures: 1000
     state_code: NY
+    ny_income_tax_before_credits: 1000000
   output:
     ny_geothermal_energy_system_credit: 250
-
 - name: 25% of expenditures, post cap
   period: 2023
   input:
-    ny_qualified_geothermal_energy_system_expenditures: 100_000
+    ny_qualified_geothermal_energy_system_expenditures: 100000
     state_code: NY
+    ny_income_tax_before_credits: 1000000
   output:
-    ny_geothermal_energy_system_credit: 5_000
-
+    ny_geothermal_energy_system_credit: 5000
 - name: No expenditures
   period: 2023
   input:
     ny_qualified_geothermal_energy_system_expenditures: 0
     state_code: NY
+    ny_income_tax_before_credits: 1000000
   output:
     ny_geothermal_energy_system_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_household_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_household_credit.yaml
@@ -2,47 +2,48 @@
   period: 2021
   input:
     state_code: NY
+    ny_income_tax_before_credits: 1000000
   output:
     ny_household_credit: 75
-
 - name: $50 for a single filer with $7,000 income.
   period: 2021
   input:
     state_code: NY
-    adjusted_gross_income: 7_000
+    adjusted_gross_income: 7000
+    ny_income_tax_before_credits: 1000000
   output:
     ny_household_credit: 50
-
 - name: Single filer is eligible until income exceeds $28,000
   period: 2021
   input:
     state_code: NY
-    adjusted_gross_income: 28_001
+    adjusted_gross_income: 28001
+    ny_income_tax_before_credits: 1000000
   output:
     ny_household_credit: 0
-
 - name: 4-person tax unit with $32,000 income receives $35.
   period: 2021
   input:
     state_code: NY
-    adjusted_gross_income: 32_000
+    adjusted_gross_income: 32000
     filing_status: JOINT
     tax_unit_size: 4
+    ny_income_tax_before_credits: 1000000
   output:
     ny_household_credit: 35
-
-- name: 2-person married filing separately tax unit with $16,000 income receives half of a 4-person's with $32,000 income (above), rounded up.
+- name: 2-person married filing separately tax unit with $16,000 income receives half
+    of a 4-person's with $32,000 income (above), rounded up.
   period: 2021
   input:
     state_code: NY
-    adjusted_gross_income: 16_000
-    spouse_separate_adjusted_gross_income: 16_000
+    adjusted_gross_income: 16000
+    spouse_separate_adjusted_gross_income: 16000
     filing_status: SEPARATE
     tax_unit_size: 2
     spouse_separate_tax_unit_size: 2
+    ny_income_tax_before_credits: 1000000
   output:
     ny_household_credit: 18
-
 - name: Simple ny_household_credit test
   absolute_error_margin: 0.01
   period: 2021
@@ -60,14 +61,30 @@
         age: 15
     tax_units:
       tax_unit:
-        members: [person1, person2, person3, person4, person5]
-        adjusted_gross_income: 20_020
+        members:
+        - person1
+        - person2
+        - person3
+        - person4
+        - person5
+        adjusted_gross_income: 20020
+        ny_income_tax_before_credits: 1000000
     spm_units:
       spm_unit:
-        members: [person1, person2, person3, person4, person5]
+        members:
+        - person1
+        - person2
+        - person3
+        - person4
+        - person5
     households:
       household:
-        members: [person1, person2, person3, person4, person5]
-        state_fips: 36  # NY
-  output:  # from 2021 NY IT-213 instructions lookup table on page 20
+        members:
+        - person1
+        - person2
+        - person3
+        - person4
+        - person5
+        state_fips: 36
+  output:
     ny_household_credit: 100

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_non_refundable_credit_order.yaml
@@ -1,0 +1,12 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2022
+  input:
+    state_code: NY
+    ny_income_tax_before_credits: 100
+    ny_household_credit_potential: 80
+    ny_solar_energy_systems_equipment_credit_potential: 40
+    ny_geothermal_energy_system_credit_potential: 30
+  output:
+    ny_household_credit: 80
+    ny_solar_energy_systems_equipment_credit: 20
+    ny_geothermal_energy_system_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_solar_energy_systems_equipment_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_solar_energy_systems_equipment_credit.yaml
@@ -1,23 +1,27 @@
 - name: 25% of expenditures, pre cap
   period: 2007
   input:
-    ny_qualified_solar_energy_systems_equipment_expenditures: 1_000
+    ny_qualified_solar_energy_systems_equipment_expenditures: 1000
     state_code: NY
+    ny_income_tax_before_credits: 1000000
+    ny_household_credit: 0
   output:
     ny_solar_energy_systems_equipment_credit: 250
-
 - name: 25% of expenditures, post cap
   period: 2007
   input:
-    ny_qualified_solar_energy_systems_equipment_expenditures: 100_000
+    ny_qualified_solar_energy_systems_equipment_expenditures: 100000
     state_code: NY
+    ny_income_tax_before_credits: 1000000
+    ny_household_credit: 0
   output:
-    ny_solar_energy_systems_equipment_credit: 5_000
-
+    ny_solar_energy_systems_equipment_credit: 5000
 - name: No expenditures
   period: 2007
   input:
     ny_qualified_solar_energy_systems_equipment_expenditures: 0
     state_code: NY
+    ny_income_tax_before_credits: 1000000
+    ny_household_credit: 0
   output:
     ny_solar_energy_systems_equipment_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/integration.yaml
@@ -312,7 +312,8 @@
     # Cap is $5,000 before July 1, 2025 and $10,000 after
     # Since this is annual period covering full year,
     # credit calculation uses applicable parameters
-    ny_geothermal_energy_system_credit: 3_750
+    ny_geothermal_energy_system_credit_potential: 3_750
+    ny_geothermal_energy_system_credit: 0
 
 - name: Case 9, geothermal credit 2025 at cap.
   # Test geothermal credit with high expenditures hitting cap
@@ -334,7 +335,8 @@
     # Credit = min($50,000 * 25%, cap) = min($12,500, $5,000) = $5,000
     # Note: Annual period 2025 uses start-of-year cap ($5,000)
     # The $10,000 cap applies for systems placed in service on/after July 1, 2025
-    ny_geothermal_energy_system_credit: 5_000
+    ny_geothermal_energy_system_credit_potential: 5_000
+    ny_geothermal_energy_system_credit: 0
 
 - name: Case 10, joint filer with high income CTC phase-out.
   # Joint filers have $110,000 threshold

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/joint_filing_credit/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/joint_filing_credit/integration.yaml
@@ -5,35 +5,45 @@
     people:
       person1:
         age: 26
-        taxable_interest_income: 5_505
-        ssi: 0  # not in TAXSIM35
-        ma_state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
+        taxable_interest_income: 5505
+        ssi: 0
+        ma_state_supplement: 0
+        wic: 0
       person2:
         age: 26
-        employment_income: 160_010
-        taxable_interest_income: 5_505
-        ssi: 0  # not in TAXSIM35
-        ma_state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
+        employment_income: 160010
+        taxable_interest_income: 5505
+        ssi: 0
+        ma_state_supplement: 0
+        wic: 0
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        aca_ptc: 0  # not in TAXSIM35
-        local_income_tax: 0  # not in TAXSIM35
-        state_sales_tax: 0  # not in TAXSIM35
+        members:
+        - person1
+        - person2
+        aca_ptc: 0
+        local_income_tax: 0
+        state_sales_tax: 0
     spm_units:
       spm_unit:
-        members: [person1, person2]
-        snap: 0  # not in TAXSIM35
-        tanf: 0  # not in TAXSIM35
+        members:
+        - person1
+        - person2
+        snap: 0
+        tanf: 0
     households:
       household:
-        members: [person1, person2]
-        state_fips: 39  # OH
-  output:  # expected results from patched TAXSIM35 2024-01-11 version
-    oh_joint_filing_credit_agi_subtractions: [5_505, 5_505]
-    oh_joint_filing_credit_qualifying_income: [0, 160_010]
+        members:
+        - person1
+        - person2
+        state_fips: 39
+  output:
+    oh_joint_filing_credit_agi_subtractions:
+    - 5505
+    - 5505
+    oh_joint_filing_credit_qualifying_income:
+    - 0
+    - 160010
     oh_joint_filing_credit_eligible: false
     oh_joint_filing_credit: 0
-    oh_income_tax: 5_380.28
+    oh_income_tax: 5380.28

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.yaml
@@ -3,102 +3,92 @@
   period: 2021
   input:
     oh_joint_filing_credit_eligible: true
-    oh_modified_agi: 67_000
-    oh_personal_exemptions: 10_000
-    oh_tax_before_joint_filing_credit: 4_000
+    oh_modified_agi: 67000
+    oh_personal_exemptions: 10000
+    oh_tax_before_joint_filing_credit: 4000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_joint_filing_credit: 400
-
 - name: Eligible for maximum joint filing credit
   absolute_error_margin: 0.01
   period: 2022
   input:
     state_code: OH
     oh_joint_filing_credit_eligible: true
-    oh_modified_agi: 47_000
-    oh_personal_exemptions: 10_000
-    oh_tax_before_joint_filing_credit: 6_000
+    oh_modified_agi: 47000
+    oh_personal_exemptions: 10000
+    oh_tax_before_joint_filing_credit: 6000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_joint_filing_credit: 650
-
 - name: Not eligible for joint filing credit
   absolute_error_margin: 0.01
   period: 2021
   input:
     oh_joint_filing_credit_eligible: false
-    oh_modified_agi: 47_000
-    oh_personal_exemptions: 10_000
-    oh_tax_before_joint_filing_credit: 4_000
+    oh_modified_agi: 47000
+    oh_personal_exemptions: 10000
+    oh_tax_before_joint_filing_credit: 4000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_joint_filing_credit: 0
-
 - name: Pre-2025 high income still receives credit (no MAGI cap)
   absolute_error_margin: 0.01
   period: 2024
   input:
     state_code: OH
     oh_joint_filing_credit_eligible: true
-    oh_modified_agi: 900_000
-    oh_personal_exemptions: 3_800
-    oh_tax_before_joint_filing_credit: 20_000
+    oh_modified_agi: 900000
+    oh_personal_exemptions: 3800
+    oh_tax_before_joint_filing_credit: 20000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # AGI less exemptions = 896,200 (in $75k+ bracket at 5%)
-    # Credit = min(20,000 * 0.05, 650) = min(1000, 650) = 650
-    # Pre-2025: no MAGI cap, so credit is available
     oh_joint_filing_credit: 650
-
 - name: 2025 high income zeroed out by $750k MAGI cap (HB 96)
   absolute_error_margin: 0.01
   period: 2025
   input:
     state_code: OH
     oh_joint_filing_credit_eligible: true
-    oh_modified_agi: 900_000
+    oh_modified_agi: 900000
     oh_personal_exemptions: 0
-    oh_tax_before_joint_filing_credit: 20_000
+    oh_tax_before_joint_filing_credit: 20000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # AGI less exemptions = 900,000 (>= $750k, rate = 0%)
-    # Credit = 20,000 * 0 = 0
     oh_joint_filing_credit: 0
-
 - name: 2025 just below $750k MAGI cap still receives credit
   absolute_error_margin: 0.01
   period: 2025
   input:
     state_code: OH
     oh_joint_filing_credit_eligible: true
-    oh_modified_agi: 749_000
+    oh_modified_agi: 749000
     oh_personal_exemptions: 0
-    oh_tax_before_joint_filing_credit: 20_000
+    oh_tax_before_joint_filing_credit: 20000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # AGI less exemptions = 749,000 (in $75k-$750k bracket at 5%)
-    # Credit = min(20,000 * 0.05, 650) = min(1000, 650) = 650
     oh_joint_filing_credit: 650
-
 - name: 2026 MAGI cap drops to $500k (HB 96)
   absolute_error_margin: 0.01
   period: 2026
   input:
     state_code: OH
     oh_joint_filing_credit_eligible: true
-    oh_modified_agi: 600_000
+    oh_modified_agi: 600000
     oh_personal_exemptions: 0
-    oh_tax_before_joint_filing_credit: 20_000
+    oh_tax_before_joint_filing_credit: 20000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # AGI less exemptions = 600,000 (>= $500k for 2026+, rate = 0%)
-    # Credit = 20,000 * 0 = 0
     oh_joint_filing_credit: 0
-
 - name: 2026 just below $500k MAGI cap still receives credit
   absolute_error_margin: 0.01
   period: 2026
   input:
     state_code: OH
     oh_joint_filing_credit_eligible: true
-    oh_modified_agi: 499_000
+    oh_modified_agi: 499000
     oh_personal_exemptions: 0
-    oh_tax_before_joint_filing_credit: 20_000
+    oh_tax_before_joint_filing_credit: 20000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # AGI less exemptions = 499,000 (in $75k-$500k bracket at 5%)
-    # Credit = min(20,000 * 0.05, 650) = min(1000, 650) = 650
     oh_joint_filing_credit: 650

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_cdcc.yaml
@@ -1,17 +1,13 @@
-# ORC § 5747.054(A): AGI < $20,000 gets 100% of cdcc_potential (no § 26 cap).
-# AGI $20,000-$39,999 gets 25% of cdcc (limited by § 26). AGI >= $40,000 gets $0.
-
 - name: Low-income filer uses cdcc_potential (100%, AGI below threshold)
   period: 2021
   input:
     state_code: OH
-    oh_modified_agi: 19_999
-    cdcc_potential: 2_000
-    cdcc: 1_500
+    oh_modified_agi: 19999
+    cdcc_potential: 2000
+    cdcc: 1500
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # Uses cdcc_potential (2_000) because AGI < 20_000
-    oh_cdcc: 2_000
-
+    oh_cdcc: 2000
 - name: Low-income filer at zero AGI
   period: 2021
   input:
@@ -19,59 +15,56 @@
     oh_modified_agi: 0
     cdcc_potential: 500
     cdcc: 200
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # Uses cdcc_potential (500) because AGI < 20_000
     oh_cdcc: 500
-
 - name: Middle-income filer uses cdcc (25%, AGI at lower threshold)
   period: 2021
   input:
     state_code: OH
-    oh_modified_agi: 20_000
-    cdcc_potential: 2_000
-    cdcc: 1_200
+    oh_modified_agi: 20000
+    cdcc_potential: 2000
+    cdcc: 1200
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # Uses cdcc (1_200), not cdcc_potential (2_000), because AGI >= 20_000
     oh_cdcc: 300
-
 - name: Middle-income filer uses cdcc (25%, AGI solidly in middle bracket)
   period: 2021
   input:
     state_code: OH
-    oh_modified_agi: 39_999
-    cdcc_potential: 2_000
-    cdcc: 1_600
+    oh_modified_agi: 39999
+    cdcc_potential: 2000
+    cdcc: 1600
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # Uses cdcc (1_600), not cdcc_potential (2_000)
     oh_cdcc: 400
-
 - name: Middle-income filer where cdcc equals cdcc_potential (no section 26 reduction)
   period: 2021
   input:
     state_code: OH
-    oh_modified_agi: 30_000
-    cdcc_potential: 2_000
-    cdcc: 2_000
+    oh_modified_agi: 30000
+    cdcc_potential: 2000
+    cdcc: 2000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    # cdcc = cdcc_potential here, so result is 25% of 2_000
     oh_cdcc: 500
-
 - name: High-income filer is ineligible (AGI at upper threshold)
   period: 2021
   input:
     state_code: OH
-    oh_modified_agi: 40_000
-    cdcc_potential: 2_000
-    cdcc: 2_000
+    oh_modified_agi: 40000
+    cdcc_potential: 2000
+    cdcc: 2000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_cdcc: 0
-
 - name: Out-of-state filer is ineligible
   period: 2021
   input:
     state_code: CA
-    oh_modified_agi: 10_000
-    cdcc_potential: 2_000
-    cdcc: 2_000
+    oh_modified_agi: 10000
+    cdcc_potential: 2000
+    cdcc: 2000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_eitc.yaml
@@ -3,22 +3,23 @@
   input:
     state_code: OH
     eitc: 0
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_eitc: 0
-
 - name: match
   period: 2021
   absolute_error_margin: 0.001
   input:
     state_code: OH
     eitc: 100
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_eitc: 30
-
 - name: Outside OH is ineligible
   period: 2021
   input:
     state_code: MA
     eitc: 100
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_eitc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_exemption_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_exemption_credits.yaml
@@ -2,20 +2,21 @@
   absolute_error_margin: 0.01
   period: 2022
   input:
-    oh_agi: 30_000
+    oh_agi: 30000
     state_code: OH
-    oh_personal_exemptions: 6_000
+    oh_personal_exemptions: 6000
     exemptions_count: 5
-  output: 
+    oh_income_tax_before_non_refundable_credits: 1000000
+  output:
     oh_exemption_credit: 100
-
 - name: 3 people in tax unit and have adjusted gross income of $80,000.
   absolute_error_margin: 0.01
   period: 2022
   input:
     exemptions_count: 3
-    oh_agi: 80_000
+    oh_agi: 80000
     state_code: OH
-    oh_personal_exemptions: 6_000
-  output: 
+    oh_personal_exemptions: 6000
+    oh_income_tax_before_non_refundable_credits: 1000000
+  output:
     oh_exemption_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_non_public_school_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_non_public_school_credits.yaml
@@ -1,58 +1,57 @@
 - name: AGI Not eligible
   period: 2021
   input:
-    adjusted_gross_income: 100_000
-    non_public_school_tuition: 1_000
+    adjusted_gross_income: 100000
+    non_public_school_tuition: 1000
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_non_public_school_credits: 0
-
 - name: Non public tuition less than cap
   period: 2021
   input:
-    adjusted_gross_income: 49_999
+    adjusted_gross_income: 49999
     non_public_school_tuition: 400
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_non_public_school_credits: 400
-
 - name: AGI less than $50,000
   period: 2021
   input:
-    adjusted_gross_income: 49_999
-    non_public_school_tuition: 1_000
+    adjusted_gross_income: 49999
+    non_public_school_tuition: 1000
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_non_public_school_credits: 500
-
 - name: AGI greater that $50,000 capped
   period: 2021
   input:
-    adjusted_gross_income: 50_000
-    non_public_school_tuition: 1_500
+    adjusted_gross_income: 50000
+    non_public_school_tuition: 1500
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    oh_non_public_school_credits: 1_000
-
+    oh_non_public_school_credits: 1000
 - name: AGI greater that $50,000 not capped
   period: 2021
   input:
-    adjusted_gross_income: 80_000
-    non_public_school_tuition: 1_000
+    adjusted_gross_income: 80000
+    non_public_school_tuition: 1000
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
-    oh_non_public_school_credits: 1_000
-
+    oh_non_public_school_credits: 1000
 - name: AGI greater that $50,000 case 3
   period: 2021
   input:
-    adjusted_gross_income: 99_999
+    adjusted_gross_income: 99999
     non_public_school_tuition: 250
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_non_public_school_credits: 250
-
-
 - name: Not capped at tuition expenses
   period: 2021
   input:
@@ -63,15 +62,19 @@
         non_public_school_tuition: 400
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: OH
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        adjusted_gross_income: 49_999
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 49999
+        oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_non_public_school_credits: 500
-
 - name: Credit is capped at tuition expenses
   period: 2021
   input:
@@ -82,11 +85,16 @@
         non_public_school_tuition: 200
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: OH
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        adjusted_gross_income: 49_999
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 49999
+        oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_non_public_school_credits: 400

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_non_refundable_credit_order.yaml
@@ -1,0 +1,21 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2023
+  input:
+    state_code: OH
+    oh_income_tax_before_non_refundable_credits: 100
+    oh_eitc_potential: 80
+    oh_cdcc_potential: 40
+    oh_senior_citizen_credit_potential: 30
+    oh_retirement_credit_potential: 20
+    oh_non_public_school_credits_potential: 10
+    oh_exemption_credit_potential: 5
+    oh_joint_filing_credit_eligible: true
+    oh_joint_filing_credit_potential: 3
+  output:
+    oh_eitc: 80
+    oh_cdcc: 20
+    oh_senior_citizen_credit: 0
+    oh_retirement_credit: 0
+    oh_non_public_school_credits: 0
+    oh_exemption_credit: 0
+    oh_joint_filing_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.yaml
@@ -3,67 +3,67 @@
   input:
     state_code: OH
     age: 65
-    oh_has_taken_oh_lump_sum_credits: False
-    oh_modified_agi: 99_999
+    oh_has_taken_oh_lump_sum_credits: false
+    oh_modified_agi: 99999
     oh_personal_exemptions: 0
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 50
-
 - name: senior citizen test ineligible, too young
   period: 2021
   input:
     state_code: OH
     age: 64
-    oh_has_taken_oh_lump_sum_credits: False
-    oh_modified_agi: 90_000
+    oh_has_taken_oh_lump_sum_credits: false
+    oh_modified_agi: 90000
     oh_personal_exemptions: 0
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 0
-
 - name: senior citizen test, ineligible OH lump sum status
   period: 2021
   input:
     state_code: OH
     age: 66
-    oh_has_taken_oh_lump_sum_credits: True
-    oh_modified_agi: 90_000
+    oh_has_taken_oh_lump_sum_credits: true
+    oh_modified_agi: 90000
     oh_personal_exemptions: 0
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 0
-
-- name: senior citizen test, ineligible AGI 
+- name: senior citizen test, ineligible AGI
   period: 2021
   input:
     state_code: OH
     age: 66
-    oh_has_taken_oh_lump_sum_credits: False
-    oh_modified_agi: 100_000
+    oh_has_taken_oh_lump_sum_credits: false
+    oh_modified_agi: 100000
     oh_personal_exemptions: 0
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 0
-
 - name: AGI is reduced by the personal exemptions
   period: 2021
   input:
     state_code: OH
     age: 66
-    oh_has_taken_oh_lump_sum_credits: False
-    oh_modified_agi: 119_999
-    oh_personal_exemptions: 20_000
+    oh_has_taken_oh_lump_sum_credits: false
+    oh_modified_agi: 119999
+    oh_personal_exemptions: 20000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 50
-
 - name: AGI is reduced by the personal exemptions, ineligible
   period: 2021
   input:
     state_code: OH
     age: 66
-    oh_has_taken_oh_lump_sum_credits: False
-    oh_modified_agi: 120_000
-    oh_personal_exemptions: 20_000
+    oh_has_taken_oh_lump_sum_credits: false
+    oh_modified_agi: 120000
+    oh_personal_exemptions: 20000
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 0
-
 - name: Credit for eligible head
   period: 2021
   input:
@@ -76,17 +76,21 @@
         oh_has_taken_oh_lump_sum_credits: false
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: OH
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         age_head: 65
-        oh_modified_agi: 100_000
+        oh_modified_agi: 100000
         oh_personal_exemptions: 1
+        oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 50
-
 - name: Head received lump sum distributions
   period: 2021
   input:
@@ -99,17 +103,21 @@
         oh_has_taken_oh_lump_sum_credits: false
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: OH
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         age_head: 65
-        oh_modified_agi: 100_000
+        oh_modified_agi: 100000
         oh_personal_exemptions: 1
+        oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 0
-
 - name: Spouse received lump sum distributions
   period: 2021
   input:
@@ -122,13 +130,18 @@
         oh_has_taken_oh_lump_sum_credits: true
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: OH
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         age_head: 65
-        oh_modified_agi: 100_000
+        oh_modified_agi: 100000
         oh_personal_exemptions: 1
+        oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 50

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.yaml
@@ -4,14 +4,15 @@
     oh_pension_based_retirement_income_credit: 200
     oh_lump_sum_retirement_credit: 50
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_retirement_credit: 200
-
 - name: Lump sum over credit
   period: 2021
   input:
     oh_pension_based_retirement_income_credit: 50
     oh_lump_sum_retirement_credit: 200
     state_code: OH
+    oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_retirement_credit: 200

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.yaml
@@ -3,13 +3,14 @@
   input:
     state_code: RI
     cdcc: 0
+    ri_income_tax_before_non_refundable_credits: 1000000
   output:
     ri_cdcc: 0
-
-- name: Calculation # Federal CDCC * 25%
+- name: Calculation
   period: 2021
   input:
     state_code: RI
-    cdcc: 1_000
+    cdcc: 1000
+    ri_income_tax_before_non_refundable_credits: 1000000
   output:
     ri_cdcc: 250

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/ri_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/ri_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2021
+  input:
+    state_code: RI
+    ri_income_tax_before_non_refundable_credits: 100
+    ri_cdcc_potential: 80
+  output:
+    ri_cdcc: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/eitc/sc_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/eitc/sc_eitc.yaml
@@ -3,45 +3,46 @@
   input:
     eitc: 0
     state_code: SC
-  output: 
+    sc_income_tax_before_non_refundable_credits: 1000000
+  output:
     sc_eitc: 0
-
 - name: In 2018, with $1,000 EITC
   period: 2018
   input:
-    eitc: 1_000
+    eitc: 1000
     state_code: SC
-  output: 
+    sc_income_tax_before_non_refundable_credits: 1000000
+  output:
     sc_eitc: 208.3
-
 - name: In 2019, with $1,000 EITC
   period: 2019
   input:
-    eitc: 1_000
+    eitc: 1000
     state_code: SC
-  output: 
+    sc_income_tax_before_non_refundable_credits: 1000000
+  output:
     sc_eitc: 416.7
-
-- name: In 2020, with $1,000 EITC 
+- name: In 2020, with $1,000 EITC
   period: 2020
   input:
-    eitc: 1_000
+    eitc: 1000
     state_code: SC
-  output: 
+    sc_income_tax_before_non_refundable_credits: 1000000
+  output:
     sc_eitc: 625
-
-- name: In 2021, with $1,000 EITC 
+- name: In 2021, with $1,000 EITC
   period: 2021
   input:
-    eitc: 1_000
+    eitc: 1000
     state_code: SC
-  output: 
+    sc_income_tax_before_non_refundable_credits: 1000000
+  output:
     sc_eitc: 833.3
-
-- name: In 2022, with $1,000 EITC 
+- name: In 2022, with $1,000 EITC
   period: 2022
   input:
-    eitc: 1_000
+    eitc: 1000
     state_code: SC
-  output: 
+    sc_income_tax_before_non_refundable_credits: 1000000
+  output:
     sc_eitc: 1041.7

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/sc_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/sc_cdcc.yaml
@@ -2,86 +2,80 @@
   period: 2022
   input:
     state_code: SC
-    cdcc_relevant_expenses: 1_000
+    cdcc_relevant_expenses: 1000
     count_cdcc_eligible: 1
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 70
-    # 1,000*0.07 = 70
-
 - name: One cdcc eligible person, with $4000 spending on federal child care expense
   period: 2021
   input:
     state_code: SC
-    cdcc_relevant_expenses: 4_000
+    cdcc_relevant_expenses: 4000
     count_cdcc_eligible: 1
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 210
-    # 4,000*0.07 = 280 can not be greater than 210
-
 - name: Two cdcc eligible people, with $7000 spending on federal child care expense
   period: 2022
   input:
     state_code: SC
-    cdcc_relevant_expenses: 7_000
+    cdcc_relevant_expenses: 7000
     count_cdcc_eligible: 2
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 420
-    # 7,000*0.07 = 490 can not be greater than 420
-
 - name: Four cdcc eligible people, with $7000 spending on federal child care expense
   period: 2022
   input:
     state_code: SC
-    cdcc_relevant_expenses: 7_000
+    cdcc_relevant_expenses: 7000
     count_cdcc_eligible: 4
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 420
-    # 7,000*0.07 = 490 can not be greater than 420
-
 - name: Two cdcc eligible people, with $18_000 spending on federal child care expense
   period: 2021
   input:
     state_code: SC
-    cdcc_relevant_expenses: 18_000
+    cdcc_relevant_expenses: 18000
     count_cdcc_eligible: 2
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 420
-    # 18,000*0.07 = 1260 cannot be greater than 420
-
 - name: No cdcc eligible people, with $0 spending on federal child care expense
   period: 2022
   input:
     state_code: SC
     cdcc_relevant_expenses: 0
     count_cdcc_eligible: 0
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 0
-
 - name: No cdcc eligible people, with $4000 spending on federal child care expense
   period: 2022
   input:
     state_code: SC
-    cdcc_relevant_expenses: 4_000
+    cdcc_relevant_expenses: 4000
     count_cdcc_eligible: 0
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 0
-
 - name: One cdcc eligible person, with $9000 spending on federal child care expense
   period: 2020
   input:
     state_code: SC
-    cdcc_relevant_expenses: 9_000
+    cdcc_relevant_expenses: 9000
     count_cdcc_eligible: 1
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 210
-    # 1,000*0.07 = 70
-
 - name: One cdcc eligible person, with $9000 spending on federal child care expense
   period: 2022
   input:
     state_code: SC
-    cdcc_relevant_expenses: 9_000
+    cdcc_relevant_expenses: 9000
     count_cdcc_eligible: 1
+    sc_income_tax_before_non_refundable_credits: 1000000
   output:
     sc_cdcc: 210
-    # 9,000*0.07 = 630 can not be greater than 210

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/sc_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/sc_non_refundable_credit_order.yaml
@@ -1,0 +1,12 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2022
+  input:
+    state_code: SC
+    sc_income_tax_before_non_refundable_credits: 100
+    sc_cdcc_potential: 80
+    sc_eitc_potential: 40
+    sc_two_wage_earner_credit_potential: 30
+  output:
+    sc_cdcc: 80
+    sc_eitc: 20
+    sc_two_wage_earner_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/two_wage_earner/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/two_wage_earner/integration.yaml
@@ -5,51 +5,61 @@
     people:
       person1:
         age: 28
-        qualified_dividend_income: 2_005
-        taxable_interest_income: 5_505
-        short_term_capital_gains: 4_005
-        long_term_capital_gains: 1_005
-        rental_income: 3_005
-        rent: 24_000
+        qualified_dividend_income: 2005
+        taxable_interest_income: 5505
+        short_term_capital_gains: 4005
+        long_term_capital_gains: 1005
+        rental_income: 3005
+        rent: 24000
         rental_income_would_be_qualified: false
-        self_employment_income: 21_010
+        self_employment_income: 21010
         business_is_qualified: true
         business_is_sstb: true
         w2_wages_from_qualified_business: 100e6
-        ssi: 0  # not in TAXSIM35
-        ma_state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
+        ssi: 0
+        ma_state_supplement: 0
+        wic: 0
       person2:
         age: 28
-        employment_income: 108_010
-        qualified_dividend_income: 2_005
-        taxable_interest_income: 5_505
-        short_term_capital_gains: 4_005
-        long_term_capital_gains: 1_005
-        rental_income: 3_005
+        employment_income: 108010
+        qualified_dividend_income: 2005
+        taxable_interest_income: 5505
+        short_term_capital_gains: 4005
+        long_term_capital_gains: 1005
+        rental_income: 3005
         rental_income_would_be_qualified: false
-        ssi: 0  # not in TAXSIM35
-        ma_state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
+        ssi: 0
+        ma_state_supplement: 0
+        wic: 0
       person3:
         age: 11
-        ssi: 0  # not in TAXSIM35
-        ma_state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
+        ssi: 0
+        ma_state_supplement: 0
+        wic: 0
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
-        aca_ptc: 0  # not in TAXSIM35
-        local_income_tax: 0  # not in TAXSIM35
-        state_sales_tax: 0  # not in TAXSIM35
+        members:
+        - person1
+        - person2
+        - person3
+        aca_ptc: 0
+        local_income_tax: 0
+        state_sales_tax: 0
+        sc_income_tax_before_non_refundable_credits: 1000000
     spm_units:
       spm_unit:
-        members: [person1, person2, person3]
-        snap: 0  # not in TAXSIM35
-        tanf: 0  # not in TAXSIM35
+        members:
+        - person1
+        - person2
+        - person3
+        snap: 0
+        tanf: 0
     households:
       household:
-        members: [person1, person2, person3]
-        state_fips: 45  # SC
-  output:  # expected results from patched TAXSIM35 2024-01-11 version
+        members:
+        - person1
+        - person2
+        - person3
+        state_fips: 45
+  output:
     sc_two_wage_earner_credit: 136.68

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.yaml
@@ -1,94 +1,109 @@
-- name: If filing jointly, head income is  $40,000, spouse income is $16,000, the credit is $112 
+- name: If filing jointly, head income is  $40,000, spouse income is $16,000, the
+    credit is $112
   period: 2021
   input:
     people:
       person1:
         is_tax_unit_head: true
-        sc_gross_earned_income: 40_000
+        sc_gross_earned_income: 40000
       person2:
         is_tax_unit_spouse: true
-        sc_gross_earned_income: 16_000
+        sc_gross_earned_income: 16000
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         filing_status: JOINT
+        sc_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: SC
   output:
     sc_two_wage_earner_credit: 112
-    # less of (head or spouse income)*0.007 
-    # 16_000* 0.007 = $112
-
-- name: If filing jointly, head income is 18_000 and spouse income is 61_500, credit is 126
+- name: If filing jointly, head income is 18_000 and spouse income is 61_500, credit
+    is 126
   period: 2021
   input:
     people:
       person1:
         is_tax_unit_head: true
-        sc_gross_earned_income: 18_000
+        sc_gross_earned_income: 18000
       person2:
         is_tax_unit_spouse: true
-        sc_gross_earned_income: 61_500
+        sc_gross_earned_income: 61500
       person3:
         is_tax_unit_spouse: false
         is_tax_unit_head: false
-        sc_gross_earned_income: 30_000  
+        sc_gross_earned_income: 30000
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         filing_status: JOINT
+        sc_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         state_code: SC
   output:
     sc_two_wage_earner_credit: 126
-    # less of (head or spouse income)*0.007 
-    # 18_000* 0.007 = $126
-
 - name: If filing separately, credit is 0
   period: 2021
   input:
     people:
       person1:
         is_tax_unit_head: true
-        sc_gross_earned_income: 40_000
+        sc_gross_earned_income: 40000
       person2:
         is_tax_unit_spouse: true
-        sc_gross_earned_income: 16_000
+        sc_gross_earned_income: 16000
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         filing_status: SEPARATE
+        sc_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: SC
   output:
     sc_two_wage_earner_credit: 0
-    # only filling joint is eligible
-
-- name: If filing jointly, head income is 18_000, spouse income is 18_000, credit is 126
+- name: If filing jointly, head income is 18_000, spouse income is 18_000, credit
+    is 126
   period: 2021
   input:
     people:
       person1:
         is_tax_unit_head: true
-        sc_gross_earned_income: 18_000
+        sc_gross_earned_income: 18000
       person2:
         is_tax_unit_spouse: true
-        sc_gross_earned_income: 18_000
+        sc_gross_earned_income: 18000
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         filing_status: JOINT
+        sc_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: SC
   output:
     sc_two_wage_earner_credit: 126
-    # less of (head or spouse income)*0.007 
-    # 18_000* 0.007 = $126

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/sc_h4216_baseline.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/sc_h4216_baseline.yaml
@@ -26,7 +26,7 @@
   output:
     # Federal EITC = $500
     # SC EITC = min($500 * 1.25, $200) = min($625, $200) = $200
-    sc_eitc: 200
+    sc_eitc_potential: 200
 
 - name: SC EITC below cap (2026)
   period: 2026
@@ -47,7 +47,7 @@
   output:
     # Federal EITC = $100
     # SC EITC = min($100 * 1.25, $200) = min($125, $200) = $125
-    sc_eitc: 125
+    sc_eitc_potential: 125
 
 - name: SC EITC has no cap before 2026
   period: 2025
@@ -68,7 +68,7 @@
   output:
     # Federal EITC = $500
     # SC EITC = $500 * 1.25 = $625 (no cap in 2025)
-    sc_eitc: 625
+    sc_eitc_potential: 625
 
 # SCIAD Tests
 

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.yaml
@@ -3,56 +3,63 @@
   input:
     people:
       person1:
-        military_retirement_pay: 30_000
+        military_retirement_pay: 30000
     tax_units:
       tax_unit:
-        members: [person1]
+        members:
+        - person1
         ut_claims_retirement_credit: false
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: UT
   output:
-    # Credit = 30,000 * 0.0455 = 1,365
-    ut_military_retirement_credit: 1_365
-
-- name: UT military retirement credit - married filing jointly with both having military retirement
+    ut_military_retirement_credit: 1365
+- name: UT military retirement credit - married filing jointly with both having military
+    retirement
   period: 2024
   input:
     people:
       person1:
-        military_retirement_pay: 25_000
+        military_retirement_pay: 25000
       person2:
-        military_retirement_pay: 20_000
+        military_retirement_pay: 20000
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         ut_claims_retirement_credit: false
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
   output:
-    # Credit = (25,000 + 20,000) * 0.0455 = 45,000 * 0.0455 = 2,047.50
-    ut_military_retirement_credit: 2_047.5
-
+    ut_military_retirement_credit: 2047.5
 - name: UT military retirement credit - not eligible when claiming retirement credit
   period: 2024
   input:
     people:
       person1:
-        military_retirement_pay: 30_000
+        military_retirement_pay: 30000
     tax_units:
       tax_unit:
-        members: [person1]
+        members:
+        - person1
         ut_claims_retirement_credit: true
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: UT
   output:
     ut_military_retirement_credit: 0
-
 - name: UT military retirement credit - zero military retirement pay
   period: 2024
   input:
@@ -61,29 +68,33 @@
         military_retirement_pay: 0
     tax_units:
       tax_unit:
-        members: [person1]
+        members:
+        - person1
         ut_claims_retirement_credit: false
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: UT
   output:
     ut_military_retirement_credit: 0
-
 - name: UT military retirement credit - 2025 rate (4.5%)
   period: 2025
   input:
     people:
       person1:
-        military_retirement_pay: 30_000
+        military_retirement_pay: 30000
     tax_units:
       tax_unit:
-        members: [person1]
+        members:
+        - person1
         ut_claims_retirement_credit: false
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1]
+        members:
+        - person1
         state_code: UT
   output:
-    # Credit = 30,000 * 0.045 = 1,350
-    ut_military_retirement_credit: 1_350
+    ut_military_retirement_credit: 1350

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.yaml
@@ -4,23 +4,24 @@
     ut_claims_retirement_credit: false
     ut_ss_benefits_credit_max: 500
     state_code: UT
+    ut_income_tax_before_non_refundable_credits: 1000000
   output:
     ut_ss_benefits_credit: 500
-
 - name: UT Social Security Benefits Credit unit test 2
   period: 2022
   input:
     ut_claims_retirement_credit: true
     ut_ss_benefits_credit_max: 500
     state_code: UT
+    ut_income_tax_before_non_refundable_credits: 1000000
   output:
-    ut_ss_benefits_credit: 0  # tax unit claims retirement credit
-
+    ut_ss_benefits_credit: 0
 - name: UT Social Security Benefits Credit unit test 4
   period: 2022
   input:
     ut_claims_retirement_credit: false
     ut_ss_benefits_credit_max: 0
     state_code: UT
+    ut_income_tax_before_non_refundable_credits: 1000000
   output:
-    ut_ss_benefits_credit: 0  # max credit is 0
+    ut_ss_benefits_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.yaml
@@ -11,15 +11,19 @@
         is_tax_unit_dependent: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         ut_at_home_parent_credit_agi_eligible: true
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
-  output: # 100 * 1
+  output:
     ut_at_home_parent_credit: 100
-
 - name: Earned income eligible but not AGI eligible
   period: 2022
   input:
@@ -36,15 +40,21 @@
         is_tax_unit_dependent: true
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         ut_at_home_parent_credit_agi_eligible: false
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         state_code: UT
   output:
     ut_at_home_parent_credit: 0
-
 - name: 2 eligible parents with 1 child
   period: 2022
   input:
@@ -61,15 +71,21 @@
         is_tax_unit_dependent: true
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         ut_at_home_parent_credit_agi_eligible: true
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         state_code: UT
-  output: # 100 * 2
+  output:
     ut_at_home_parent_credit: 200
-
 - name: 2 eligible parents with 2 children
   period: 2022
   input:
@@ -90,12 +106,21 @@
         is_tax_unit_dependent: true
     tax_units:
       tax_unit:
-        members: [person1, person2, person3, person4]
+        members:
+        - person1
+        - person2
+        - person3
+        - person4
         ut_at_home_parent_credit_agi_eligible: true
         tax_unit_is_joint: true
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3, person4]
+        members:
+        - person1
+        - person2
+        - person3
+        - person4
         state_code: UT
-  output: # 100 * 2 * 2
+  output:
     ut_at_home_parent_credit: 400

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_ctc.yaml
@@ -11,16 +11,20 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 1_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 1000
         filing_status: HEAD_OF_HOUSEHOLD
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
-  output: 
-    ut_ctc: 1_000
-
+  output:
+    ut_ctc: 1000
 - name: Head of household with no qualifying children, below phase out
   period: 2024
   input:
@@ -34,16 +38,20 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 1_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 1000
         filing_status: HEAD_OF_HOUSEHOLD
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
-  output: 
+  output:
     ut_ctc: 0
-
 - name: Head of household with 1 child , fully phased out
   period: 2024
   input:
@@ -57,16 +65,20 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 100_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 100000
         filing_status: HEAD_OF_HOUSEHOLD
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
-  output: 
+  output:
     ut_ctc: 0
-
 - name: Surviving spouse with 1 child , partially phased out
   period: 2024
   input:
@@ -80,16 +92,20 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 60_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 60000
         filing_status: SURVIVING_SPOUSE
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
-  output: 
+  output:
     ut_ctc: 400
-
 - name: Surviving spouse with one qualifying child , partially phased out
   period: 2024
   input:
@@ -106,16 +122,22 @@
         ctc_qualifying_child: false
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
-        ut_total_income: 60_000
+        members:
+        - person1
+        - person2
+        - person3
+        ut_total_income: 60000
         filing_status: SURVIVING_SPOUSE
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         state_code: UT
-  output: 
+  output:
     ut_ctc: 400
-
 - name: Surviving spouse with two children , partially phased out
   period: 2024
   input:
@@ -132,16 +154,22 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
-        ut_total_income: 60_000
+        members:
+        - person1
+        - person2
+        - person3
+        ut_total_income: 60000
         filing_status: SURVIVING_SPOUSE
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         state_code: UT
-  output: 
-    ut_ctc: 1_400
-
+  output:
+    ut_ctc: 1400
 - name: Surviving spouse with two children , partially phased out with interest income
   period: 2024
   input:
@@ -149,7 +177,7 @@
       person1:
         age: 45
         ctc_qualifying_child: false
-        tax_exempt_interest_income: 1_000
+        tax_exempt_interest_income: 1000
       person2:
         age: 3
         ctc_qualifying_child: true
@@ -158,16 +186,22 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
-        ut_total_income: 60_000
+        members:
+        - person1
+        - person2
+        - person3
+        ut_total_income: 60000
         filing_status: SURVIVING_SPOUSE
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         state_code: UT
-  output: 
-    ut_ctc: 1_300
-
+  output:
+    ut_ctc: 1300
 - name: Head of household with newborn, below phase out
   period: 2025
   input:
@@ -181,16 +215,20 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 1_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 1000
         filing_status: HEAD_OF_HOUSEHOLD
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
-  output: 
-    ut_ctc: 1_000
-    
+  output:
+    ut_ctc: 1000
 - name: Head of household with 5 year old, below phase out
   period: 2025
   input:
@@ -204,16 +242,20 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 1_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 1000
         filing_status: HEAD_OF_HOUSEHOLD
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
-  output: 
-    ut_ctc: 1_000
-
+  output:
+    ut_ctc: 1000
 - name: Head of household with 6 year old, below phase out
   period: 2025
   input:
@@ -227,21 +269,22 @@
         ctc_qualifying_child: false
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 1_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 1000
         filing_status: HEAD_OF_HOUSEHOLD
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
   output:
     ut_ctc: 0
-
-# 2026 tests for HB290 phase-out threshold increases
 - name: Joint filers with 1 child at 2026 phase-out threshold
   period: 2026
-  # HB290: Joint threshold increased from $54,000 to $61,000
-  # Income at $61,000 = at threshold, no phase-out
   input:
     people:
       person1:
@@ -257,19 +300,24 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2, person3]
-        ut_total_income: 61_000
+        members:
+        - person1
+        - person2
+        - person3
+        ut_total_income: 61000
         filing_status: JOINT
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2, person3]
+        members:
+        - person1
+        - person2
+        - person3
         state_code: UT
   output:
-    ut_ctc: 1_000
-
+    ut_ctc: 1000
 - name: Single filer with 1 child at 2026 phase-out threshold
   period: 2026
-  # HB290: Single/HOH threshold increased from $43,000 to $49,000
   input:
     people:
       person1:
@@ -281,20 +329,22 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 49_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 49000
         filing_status: SINGLE
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
   output:
-    ut_ctc: 1_000
-
+    ut_ctc: 1000
 - name: Head of household with 1 child at 2026 phase-out threshold
   period: 2026
-  # HB290: HOH threshold increased from $43,000 to $49,000
-  # Income at $49,000 = at threshold, no phase-out
   input:
     people:
       person1:
@@ -306,22 +356,22 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 49_000
+        members:
+        - person1
+        - person2
+        ut_total_income: 49000
         filing_status: HEAD_OF_HOUSEHOLD
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
   output:
-    ut_ctc: 1_000
-
+    ut_ctc: 1000
 - name: Married filing separately with 1 child, partially phased out in 2026
   period: 2026
-  # HB290: MFS threshold increased from $27,000 to $30,500
-  # Income at $35,500 = $5,000 over threshold
-  # Phase-out: $5,000 * $0.10 = $500 reduction
-  # Credit: $1,000 - $500 = $500
   input:
     people:
       person1:
@@ -333,12 +383,17 @@
         ctc_qualifying_child: true
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        ut_total_income: 35_500
+        members:
+        - person1
+        - person2
+        ut_total_income: 35500
         filing_status: SEPARATE
+        ut_income_tax_before_non_refundable_credits: 1000000
     households:
       household:
-        members: [person1, person2]
+        members:
+        - person1
+        - person2
         state_code: UT
   output:
     ut_ctc: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_eitc.yaml
@@ -1,15 +1,16 @@
 - name: UT EITC unit test 1
   period: 2022
   input:
-    eitc: 1_000
+    eitc: 1000
     state_code: UT
+    ut_income_tax_before_non_refundable_credits: 1000000
   output:
     ut_eitc: 150
-
 - name: No federal EITC
   period: 2022
   input:
     eitc: 0
     state_code: UT
+    ut_income_tax_before_non_refundable_credits: 1000000
   output:
     ut_eitc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_non_refundable_credit_order.yaml
@@ -1,0 +1,21 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2024
+  input:
+    state_code: UT
+    ut_income_tax_before_non_refundable_credits: 100
+    ut_eitc_potential: 80
+    ut_claims_retirement_credit: true
+    ut_retirement_credit_potential: 40
+    ut_ss_benefits_credit_potential: 30
+    ut_at_home_parent_credit_agi_eligible: true
+    ut_at_home_parent_credit_potential: 20
+    ut_ctc_potential: 10
+    ut_military_retirement_credit_eligible: true
+    ut_military_retirement_credit_potential: 5
+  output:
+    ut_eitc: 80
+    ut_retirement_credit: 20
+    ut_ss_benefits_credit: 0
+    ut_at_home_parent_credit: 0
+    ut_ctc: 0
+    ut_military_retirement_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.yaml
@@ -2,18 +2,17 @@
   period: 2022
   input:
     state_code: VA
-    # Claims refundable, not non-refundable.
     va_claims_refundable_eitc: true
     va_non_refundable_eitc_if_claimed: 100
+    va_income_tax_before_non_refundable_credits: 1000000
   output:
     va_non_refundable_eitc: 0
-
 - name: Claimed
   period: 2022
   input:
     state_code: VA
-    # Claims non-refundable.
     va_claims_refundable_eitc: false
     va_non_refundable_eitc_if_claimed: 100
+    va_income_tax_before_non_refundable_credits: 1000000
   output:
     va_non_refundable_eitc: 100

--- a/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/credits/va_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/credits/va_non_refundable_credit_order.yaml
@@ -1,0 +1,8 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2025
+  input:
+    state_code: VA
+    va_income_tax_before_non_refundable_credits: 100
+    va_non_refundable_eitc_potential: 80
+  output:
+    va_non_refundable_eitc: 80

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/credits/wi_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/credits/wi_non_refundable_credit_order.yaml
@@ -1,0 +1,14 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2022
+  input:
+    state_code: WI
+    wi_income_tax_before_credits: 100
+    wi_itemized_deduction_credit_potential: 80
+    wi_childcare_expense_credit_potential: 40
+    wi_property_tax_credit_potential: 30
+    wi_married_couple_credit_potential: 20
+  output:
+    wi_itemized_deduction_credit: 80
+    wi_childcare_expense_credit: 20
+    wi_property_tax_credit: 0
+    wi_married_couple_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_credit.yaml
@@ -5,7 +5,7 @@
     cdcc_potential: 800
     state_code: WI
   output:
-    wi_childcare_expense_credit: 400 # 800 * 0.5
+    wi_childcare_expense_credit_potential: 400 # 800 * 0.5
 
 - name: WI CDCC 2023 pre-Act-101, still uses federal limits (fraction 0.5)
   absolute_error_margin: 0.01
@@ -14,7 +14,7 @@
     cdcc_potential: 600
     state_code: WI
   output:
-    wi_childcare_expense_credit: 300 # 600 * 0.5
+    wi_childcare_expense_credit_potential: 300 # 600 * 0.5
 
 - name: WI CDCC 2024 one child, expenses under federal limit - same as federal
   absolute_error_margin: 0.01
@@ -40,7 +40,7 @@
       spm_unit:
         members: [head, child]
   output:
-    wi_childcare_expense_credit: 400 # 2000 * 0.20 * 1.0
+    wi_childcare_expense_credit_potential: 400 # 2000 * 0.20 * 1.0
 
 - name: WI CDCC 2024 one child, expenses between federal limit and WI limit
   absolute_error_margin: 0.01
@@ -66,7 +66,7 @@
       spm_unit:
         members: [head, child]
   output:
-    wi_childcare_expense_credit: 1_400 # 7000 * 0.20 * 1.0
+    wi_childcare_expense_credit_potential: 1_400 # 7000 * 0.20 * 1.0
 
 - name: WI CDCC 2024 two children, expenses between federal limit and WI limit
   absolute_error_margin: 0.01
@@ -97,7 +97,7 @@
       spm_unit:
         members: [head, spouse, child1, child2]
   output:
-    wi_childcare_expense_credit: 3_000 # 15000 * 0.20 * 1.0
+    wi_childcare_expense_credit_potential: 3_000 # 15000 * 0.20 * 1.0
 
 - name: WI CDCC 2024 one child, expenses above WI limit - capped at $10,000
   absolute_error_margin: 0.01
@@ -123,4 +123,4 @@
       spm_unit:
         members: [head, child]
   output:
-    wi_childcare_expense_credit: 2_000 # min(12000, 10000) * 0.20 * 1.0
+    wi_childcare_expense_credit_potential: 2_000 # min(12000, 10000) * 0.20 * 1.0

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_itemized_deduction_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_itemized_deduction_credit.yaml
@@ -10,7 +10,7 @@
     casualty_loss_deduction: 2_000
     state_code: WI
   output:
-    wi_itemized_deduction_credit: 400  # = (3K + 12K + 1K + 2K - 10K) * 5%
+    wi_itemized_deduction_credit_potential: 400  # = (3K + 12K + 1K + 2K - 10K) * 5%
 
 - name: WI itemized deduction credit unit test 2
   absolute_error_margin: 0.01
@@ -24,4 +24,4 @@
     casualty_loss_deduction: 2_000
     state_code: WI
   output:
-    wi_itemized_deduction_credit: 0
+    wi_itemized_deduction_credit_potential: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_married_couple_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_married_couple_credit.yaml
@@ -20,7 +20,7 @@
         members: [person1, person2]
         state_code: WI
   output:
-    wi_married_couple_credit: 300  # = 0.03 * 10_000
+    wi_married_couple_credit_potential: 300  # = 0.03 * 10_000
 
 - name: WI married couple credit unit test 2
   absolute_error_margin: 0.01
@@ -44,4 +44,4 @@
         members: [person1, person2]
         state_code: WI
   output:
-    wi_married_couple_credit: 480
+    wi_married_couple_credit_potential: 480

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_property_tax_credit.yaml
@@ -6,7 +6,7 @@
     real_estate_taxes: 800
     state_code: WI
   output:
-    wi_property_tax_credit: 96
+    wi_property_tax_credit_potential: 96
 
 - name: WI property tax credit unit test 2
   absolute_error_margin: 0.01
@@ -16,7 +16,7 @@
     real_estate_taxes: 0
     state_code: WI
   output:
-    wi_property_tax_credit: 96
+    wi_property_tax_credit_potential: 96
 
 - name: WI property tax credit unit test 3
   absolute_error_margin: 0.01
@@ -26,4 +26,4 @@
     real_estate_taxes: 2_000
     state_code: WI
   output:
-    wi_property_tax_credit: 300
+    wi_property_tax_credit_potential: 300

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/cdcc/wv_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/cdcc/wv_cdcc.yaml
@@ -3,13 +3,16 @@
   input:
     state_code: WV
     cdcc: 0
+    wv_income_tax_before_non_refundable_credits: 1000000
+    wv_low_income_family_tax_credit: 0
   output:
     wv_cdcc: 0
-
 - name: 50% match in 2024
   period: 2024
   input:
     state_code: WV
-    cdcc: 1_000
+    cdcc: 1000
+    wv_income_tax_before_non_refundable_credits: 1000000
+    wv_low_income_family_tax_credit: 0
   output:
     wv_cdcc: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/liftc/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/liftc/integration.yaml
@@ -5,35 +5,40 @@
     people:
       person1:
         age: 62
-        employment_income: 160_010
-        taxable_interest_income: 5_505
-        ssi: 0  # not in TAXSIM35
-        ma_state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
+        employment_income: 160010
+        taxable_interest_income: 5505
+        ssi: 0
+        ma_state_supplement: 0
+        wic: 0
       person2:
         age: 62
-        employment_income: 158_010
-        taxable_interest_income: 5_505
-        ssi: 0  # not in TAXSIM35
-        ma_state_supplement: 0  # not in TAXSIM35
-        wic: 0  # not in TAXSIM35
+        employment_income: 158010
+        taxable_interest_income: 5505
+        ssi: 0
+        ma_state_supplement: 0
+        wic: 0
     tax_units:
       tax_unit:
-        members: [person1, person2]
-        aca_ptc: 0  # not in TAXSIM35
-        local_income_tax: 0  # not in TAXSIM35
-        state_sales_tax: 0  # not in TAXSIM35
+        members:
+        - person1
+        - person2
+        aca_ptc: 0
+        local_income_tax: 0
+        state_sales_tax: 0
     spm_units:
       spm_unit:
-        members: [person1, person2]
-        # snap: 0  # not in TAXSIM35
-        tanf: 0  # not in TAXSIM35
+        members:
+        - person1
+        - person2
+        tanf: 0
     households:
       household:
-        members: [person1, person2]
-        state_fips: 54  # WV
-  output:  # expected results from patched TAXSIM35 2023-10-05 version
+        members:
+        - person1
+        - person2
+        state_fips: 54
+  output:
     alternative_minimum_tax: 0
-    wv_income_tax_before_non_refundable_credits: 20_001.95
-    wv_low_income_family_tax_credit: 0  # PEUS 0.507.1 produces 2_000.20
-    wv_income_tax: 20_001.95  # PEUS 0.507.1 produces 18_001.75
+    wv_income_tax_before_non_refundable_credits: 20001.95
+    wv_low_income_family_tax_credit: 0
+    wv_income_tax: 20001.95

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/wv_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/wv_non_refundable_credit_order.yaml
@@ -1,0 +1,11 @@
+- name: Applied non-refundable credits follow filing order
+  period: 2024
+  input:
+    state_code: WV
+    wv_income_tax_before_non_refundable_credits: 100
+    wv_low_income_family_tax_credit_eligible: true
+    wv_low_income_family_tax_credit_potential: 80
+    wv_cdcc_potential: 40
+  output:
+    wv_low_income_family_tax_credit: 80
+    wv_cdcc: 20

--- a/policyengine_us/tests/policy/contrib/states/ny/ny_working_families_tax_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ny/ny_working_families_tax_credit.yaml
@@ -43,7 +43,7 @@
   output:
     ny_wftc_eligible_children: 0
     ny_working_families_tax_credit: 0
-    ny_eitc: 150
+    ny_eitc: 174
     ny_ctc: 0
     ny_exemptions: 0
 

--- a/policyengine_us/tests/policy/contrib/states/ri/ctc_reform_test.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ri/ctc_reform_test.yaml
@@ -68,7 +68,8 @@
     ri_refundable_ctc: 1_000  # min(1_500 total credit, 1_000 cap) = 1_000
     ri_non_refundable_ctc: 500  # 1_500 - 1_000 = 500
     ri_refundable_credits: 1_522.45  # 1_000 (CTC refundable) + 522.45 (EITC)
-    ri_non_refundable_credits: 500  # 500 (CTC non-refundable)
+    ri_income_tax_before_non_refundable_credits: 333.75
+    ri_non_refundable_credits: 333.75  # applied amount capped by remaining tax liability
 
 - name: RI CTC - nonrefundable with no phaseout
   absolute_error_margin: 0.1

--- a/policyengine_us/tests/run_selective_tests.py
+++ b/policyengine_us/tests/run_selective_tests.py
@@ -470,7 +470,9 @@ class SelectiveTestRunner:
     def run_all_tests(self) -> int:
         """Run all tests (fallback option)."""
         print("Running all tests...")
-        result = subprocess.run([sys.executable, "-m", "pytest", "policyengine_us/tests"])
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "policyengine_us/tests"]
+        )
         return result.returncode
 
     def generate_test_plan(self, changed_files: Set[str]) -> Dict[str, List[str]]:

--- a/policyengine_us/tests/run_selective_tests.py
+++ b/policyengine_us/tests/run_selective_tests.py
@@ -449,7 +449,9 @@ class SelectiveTestRunner:
             )
         else:
             pytest_args = [
-                "policyengine-core",
+                sys.executable,
+                "-m",
+                "policyengine_core.scripts.policyengine_command",
                 "test",
                 "-c",
                 "policyengine_us",
@@ -468,7 +470,7 @@ class SelectiveTestRunner:
     def run_all_tests(self) -> int:
         """Run all tests (fallback option)."""
         print("Running all tests...")
-        result = subprocess.run(["pytest", "policyengine_us/tests"])
+        result = subprocess.run([sys.executable, "-m", "pytest", "policyengine_us/tests"])
         return result.returncode
 
     def generate_test_plan(self, changed_files: Set[str]) -> Dict[str, List[str]]:

--- a/policyengine_us/variables/gov/states/ar/tax/income/ar_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/ar_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ar_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class ar_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.AR
 
-    adds = "gov.states.ar.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ar.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ar_income_tax_before_non_refundable_credits_unit",
+        )

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
@@ -12,8 +12,6 @@ class ar_additional_tax_credit_for_qualified_individuals(Variable):
     definition_period = YEAR
     defined_for = StateCode.AR
 
-    adds = ["ar_additional_tax_credit_for_qualified_individuals_person"]
-
     def formula(tax_unit, period, parameters):
         ordered_credits = parameters(
             period

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
@@ -1,4 +1,17 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
+
+class ar_additional_tax_credit_for_qualified_individuals_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arkansas additional tax credit for qualified individuals"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.AR
+
+    adds = ["ar_additional_tax_credit_for_qualified_individuals_person"]
 
 
 class ar_additional_tax_credit_for_qualified_individuals(Variable):
@@ -10,3 +23,16 @@ class ar_additional_tax_credit_for_qualified_individuals(Variable):
     defined_for = StateCode.AR
 
     adds = ["ar_additional_tax_credit_for_qualified_individuals_person"]
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ar.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ar_income_tax_before_non_refundable_credits_unit",
+            "ar_additional_tax_credit_for_qualified_individuals",
+            "ar_additional_tax_credit_for_qualified_individuals_potential",
+        )

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ar_additional_tax_credit_for_qualified_individuals_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.py
@@ -4,17 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ar_additional_tax_credit_for_qualified_individuals_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Arkansas additional tax credit for qualified individuals"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.AR
-
-    adds = ["ar_additional_tax_credit_for_qualified_individuals_person"]
-
-
 class ar_additional_tax_credit_for_qualified_individuals(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals_potential.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals_potential.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class ar_additional_tax_credit_for_qualified_individuals_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arkansas additional tax credit for qualified individuals"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.AR
+
+    adds = ["ar_additional_tax_credit_for_qualified_individuals_person"]

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc.py
@@ -4,24 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ar_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Arkansas Child and Dependent Care Credit"
-    unit = USD
-    documentation = (
-        "https://codes.findlaw.com/ar/title-26-taxation/ar-code-sect-26-51-502/"
-    )
-    definition_period = YEAR
-    defined_for = StateCode.AR
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.ar.tax.income.credits.cdcc
-        # Arkansas matches the federal credit taken
-        cdcc = tax_unit("cdcc", period)
-        return cdcc * p.match
-
-
 class ar_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ar_cdcc(Variable):
+class ar_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Arkansas Child and Dependent Care Credit"
@@ -17,3 +19,28 @@ class ar_cdcc(Variable):
         # Arkansas matches the federal credit taken
         cdcc = tax_unit("cdcc", period)
         return cdcc * p.match
+
+
+class ar_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arkansas Child and Dependent Care Credit"
+    unit = USD
+    documentation = (
+        "https://codes.findlaw.com/ar/title-26-taxation/ar-code-sect-26-51-502/"
+    )
+    definition_period = YEAR
+    defined_for = StateCode.AR
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ar.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ar_income_tax_before_non_refundable_credits_unit",
+            "ar_cdcc",
+            "ar_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ar_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_cdcc_potential.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class ar_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arkansas Child and Dependent Care Credit"
+    unit = USD
+    documentation = (
+        "https://codes.findlaw.com/ar/title-26-taxation/ar-code-sect-26-51-502/"
+    )
+    definition_period = YEAR
+    defined_for = StateCode.AR
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ar.tax.income.credits.cdcc
+        # Arkansas matches the federal credit taken
+        cdcc = tax_unit("cdcc", period)
+        return cdcc * p.match

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
@@ -1,4 +1,26 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
+
+class ar_personal_credits_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arkansas personal credits"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2021_AR1000F_FullYearResidentIndividualIncomeTaxReturn.pdf"
+        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_FullYearResidentIndividualIncomeTaxReturn.pdf#page=1"
+        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=12"
+    )
+    defined_for = StateCode.AR
+
+    adds = [
+        "ar_personal_credit_dependent",
+        "ar_personal_credits_base",
+        "ar_personal_credit_disabled_dependent",
+    ]
 
 
 class ar_personal_credits(Variable):
@@ -19,3 +41,16 @@ class ar_personal_credits(Variable):
         "ar_personal_credits_base",
         "ar_personal_credit_disabled_dependent",
     ]
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ar.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ar_income_tax_before_non_refundable_credits_unit",
+            "ar_personal_credits",
+            "ar_personal_credits_potential",
+        )

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
@@ -17,12 +17,6 @@ class ar_personal_credits(Variable):
     )
     defined_for = StateCode.AR
 
-    adds = [
-        "ar_personal_credit_dependent",
-        "ar_personal_credits_base",
-        "ar_personal_credit_disabled_dependent",
-    ]
-
     def formula(tax_unit, period, parameters):
         ordered_credits = parameters(
             period

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
@@ -4,26 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ar_personal_credits_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Arkansas personal credits"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2021_AR1000F_FullYearResidentIndividualIncomeTaxReturn.pdf"
-        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_FullYearResidentIndividualIncomeTaxReturn.pdf#page=1"
-        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=12"
-    )
-    defined_for = StateCode.AR
-
-    adds = [
-        "ar_personal_credit_dependent",
-        "ar_personal_credits_base",
-        "ar_personal_credit_disabled_dependent",
-    ]
-
-
 class ar_personal_credits(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ar_personal_credits_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits_potential.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/personal/ar_personal_credits_potential.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class ar_personal_credits_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arkansas personal credits"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2021_AR1000F_FullYearResidentIndividualIncomeTaxReturn.pdf"
+        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_FullYearResidentIndividualIncomeTaxReturn.pdf#page=1"
+        "https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=12"
+    )
+    defined_for = StateCode.AR
+
+    adds = [
+        "ar_personal_credit_dependent",
+        "ar_personal_credits_base",
+        "ar_personal_credit_disabled_dependent",
+    ]

--- a/policyengine_us/variables/gov/states/az/tax/income/az_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/az_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class az_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class az_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.AZ
 
-    adds = "gov.states.az.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.az.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "az_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class az_charitable_contributions_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.py
@@ -4,37 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class az_charitable_contributions_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Arizona charitable contributions credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.AZ
-    reference = "https://law.justia.com/codes/arizona/2022/title-43/section-43-1088/"
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(
-            period
-        ).gov.states.az.tax.income.credits.charitable_contribution.ceiling
-        charitable_contributions = tax_unit(
-            "az_charitable_contributions_to_qualifying_charitable_organizations",
-            period,
-        )
-        foster_care_contributions = tax_unit(
-            "az_charitable_contributions_to_qualifying_foster_care_organizations",
-            period,
-        )
-        filing_status = tax_unit("filing_status", period)
-        capped_charitable_contributions = min_(
-            charitable_contributions, p.qualifying_organization[filing_status]
-        )
-        capped_foster_care_contributions = min_(
-            foster_care_contributions, p.qualifying_foster[filing_status]
-        )
-        return capped_charitable_contributions + capped_foster_care_contributions
-
-
 class az_charitable_contributions_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class az_charitable_contributions_credit(Variable):
+class az_charitable_contributions_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Arizona charitable contributions credit"
@@ -30,3 +32,26 @@ class az_charitable_contributions_credit(Variable):
             foster_care_contributions, p.qualifying_foster[filing_status]
         )
         return capped_charitable_contributions + capped_foster_care_contributions
+
+
+class az_charitable_contributions_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arizona charitable contributions credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.AZ
+    reference = "https://law.justia.com/codes/arizona/2022/title-43/section-43-1088/"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.az.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "az_income_tax_before_non_refundable_credits",
+            "az_charitable_contributions_credit",
+            "az_charitable_contributions_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit_potential.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/charitable_contribution/az_charitable_contributions_credit_potential.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class az_charitable_contributions_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arizona charitable contributions credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.AZ
+    reference = "https://law.justia.com/codes/arizona/2022/title-43/section-43-1088/"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.az.tax.income.credits.charitable_contribution.ceiling
+        charitable_contributions = tax_unit(
+            "az_charitable_contributions_to_qualifying_charitable_organizations",
+            period,
+        )
+        foster_care_contributions = tax_unit(
+            "az_charitable_contributions_to_qualifying_foster_care_organizations",
+            period,
+        )
+        filing_status = tax_unit("filing_status", period)
+        capped_charitable_contributions = min_(
+            charitable_contributions, p.qualifying_organization[filing_status]
+        )
+        capped_foster_care_contributions = min_(
+            foster_care_contributions, p.qualifying_foster[filing_status]
+        )
+        return capped_charitable_contributions + capped_foster_care_contributions

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.py
@@ -4,31 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class az_dependent_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Arizona dependent tax credit"
-    unit = USD
-    documentation = "https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01073-01.htm"
-    definition_period = YEAR
-    defined_for = StateCode.AZ
-
-    def formula(tax_unit, period, parameters):
-        person = tax_unit.members
-        p = parameters(period).gov.states.az.tax.income.credits.dependent_credit
-        dependent = person("is_tax_unit_dependent", period)
-        age = person("age", period)
-        dependent_amount = p.amount.calc(age) * dependent
-        amount = tax_unit.sum(dependent_amount)
-        income = tax_unit("adjusted_gross_income", period)
-        filing_status = tax_unit("filing_status", period)
-        reduction_start = p.reduction.start[filing_status]
-        excess = max_(income - reduction_start, 0)
-        increments = np.ceil(excess / p.reduction.increment)
-        reduction_percentage = min_(increments * p.reduction.percentage, 1)
-        return amount * (1 - reduction_percentage)
-
-
 class az_dependent_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class az_dependent_tax_credit(Variable):
+class az_dependent_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Arizona dependent tax credit"
@@ -24,3 +26,26 @@ class az_dependent_tax_credit(Variable):
         increments = np.ceil(excess / p.reduction.increment)
         reduction_percentage = min_(increments * p.reduction.percentage, 1)
         return amount * (1 - reduction_percentage)
+
+
+class az_dependent_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arizona dependent tax credit"
+    unit = USD
+    documentation = "https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01073-01.htm"
+    definition_period = YEAR
+    defined_for = StateCode.AZ
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.az.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "az_income_tax_before_non_refundable_credits",
+            "az_dependent_tax_credit",
+            "az_dependent_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class az_dependent_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit_potential.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class az_dependent_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arizona dependent tax credit"
+    unit = USD
+    documentation = "https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01073-01.htm"
+    definition_period = YEAR
+    defined_for = StateCode.AZ
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        p = parameters(period).gov.states.az.tax.income.credits.dependent_credit
+        dependent = person("is_tax_unit_dependent", period)
+        age = person("age", period)
+        dependent_amount = p.amount.calc(age) * dependent
+        amount = tax_unit.sum(dependent_amount)
+        income = tax_unit("adjusted_gross_income", period)
+        filing_status = tax_unit("filing_status", period)
+        reduction_start = p.reduction.start[filing_status]
+        excess = max_(income - reduction_start, 0)
+        increments = np.ceil(excess / p.reduction.increment)
+        reduction_percentage = min_(increments * p.reduction.percentage, 1)
+        return amount * (1 - reduction_percentage)

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class az_family_tax_credit(Variable):
+class az_family_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Arizona Family Tax Credit"
@@ -17,3 +19,25 @@ class az_family_tax_credit(Variable):
 
         amount = p.per_person * tax_unit("tax_unit_size", period)
         return min_(amount, p.cap[filing_status])
+
+
+class az_family_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arizona Family Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "az_family_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.az.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "az_income_tax_before_non_refundable_credits",
+            "az_family_tax_credit",
+            "az_family_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class az_family_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit.py
@@ -4,24 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class az_family_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Arizona Family Tax Credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = "az_family_tax_credit_eligible"
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(
-            period
-        ).gov.states.az.tax.income.credits.family_tax_credits.amount
-        filing_status = tax_unit("filing_status", period)
-
-        amount = p.per_person * tax_unit("tax_unit_size", period)
-        return min_(amount, p.cap[filing_status])
-
-
 class az_family_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/family_tax_credit/az_family_tax_credit_potential.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class az_family_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arizona Family Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "az_family_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.az.tax.income.credits.family_tax_credits.amount
+        filing_status = tax_unit("filing_status", period)
+
+        amount = p.per_person * tax_unit("tax_unit_size", period)
+        return min_(amount, p.cap[filing_status])

--- a/policyengine_us/variables/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.py
@@ -37,7 +37,7 @@ class az_itemized_deductions(Variable):
         # a credit under Arizona law.
         charitable_deduction = tax_unit("charitable_deduction", period)
         charitable_contributions_credit = tax_unit(
-            "az_charitable_contributions_credit", period
+            "az_charitable_contributions_credit_potential", period
         )
         # The charitable deduction is reduced by the amount which is used for the
         # Arizona charitable contributions credit,

--- a/policyengine_us/variables/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.py
@@ -14,7 +14,7 @@ class az_increased_standard_deduction_for_charitable_contributions(Variable):
         p = parameters(period).gov.states.az.tax.income.deductions.standard.increased
         charitable_deduction = tax_unit("charitable_deduction", period)
         charitable_contributions_credit = tax_unit(
-            "az_charitable_contributions_credit", period
+            "az_charitable_contributions_credit_potential", period
         )
         charitable_deduction_after_credit = max_(
             charitable_deduction - charitable_contributions_credit, 0

--- a/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.py
@@ -4,28 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ct_property_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Connecticut property tax credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://portal.ct.gov/-/media/DRS/Forms/2021/Income/CT-1040-Online-Booklet_1221.pdf#page=30"
-    defined_for = "ct_property_tax_credit_eligible"
-
-    def formula(tax_unit, period, parameters):
-        agi = tax_unit("ct_agi", period)
-        filing_status = tax_unit("filing_status", period)
-        p = parameters(period).gov.states.ct.tax.income.credits.property_tax
-        real_estate_taxes = add(tax_unit, period, ["real_estate_taxes"])
-        max_credit = min_(real_estate_taxes, p.cap)
-        excess = max_(agi - p.reduction.start[filing_status], 0)
-        total_increments = np.ceil(excess / p.reduction.increment[filing_status])
-        reduction_percent = p.reduction.rate * total_increments
-        reduction_amount = max_credit * reduction_percent
-        return max_(max_credit - reduction_amount, 0)
-
-
 class ct_property_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ct_property_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ct_property_tax_credit(Variable):
+class ct_property_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Connecticut property tax credit"
@@ -21,3 +23,26 @@ class ct_property_tax_credit(Variable):
         reduction_percent = p.reduction.rate * total_increments
         reduction_amount = max_credit * reduction_percent
         return max_(max_credit - reduction_amount, 0)
+
+
+class ct_property_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Connecticut property tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://portal.ct.gov/-/media/DRS/Forms/2021/Income/CT-1040-Online-Booklet_1221.pdf#page=30"
+    defined_for = "ct_property_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ct.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ct_income_tax_after_amt",
+            "ct_property_tax_credit",
+            "ct_property_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/credits/property_tax/ct_property_tax_credit_potential.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class ct_property_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Connecticut property tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://portal.ct.gov/-/media/DRS/Forms/2021/Income/CT-1040-Online-Booklet_1221.pdf#page=30"
+    defined_for = "ct_property_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        agi = tax_unit("ct_agi", period)
+        filing_status = tax_unit("filing_status", period)
+        p = parameters(period).gov.states.ct.tax.income.credits.property_tax
+        real_estate_taxes = add(tax_unit, period, ["real_estate_taxes"])
+        max_credit = min_(real_estate_taxes, p.cap)
+        excess = max_(agi - p.reduction.start[filing_status], 0)
+        total_increments = np.ceil(excess / p.reduction.increment[filing_status])
+        reduction_percent = p.reduction.rate * total_increments
+        reduction_amount = max_credit * reduction_percent
+        return max_(max_credit - reduction_amount, 0)

--- a/policyengine_us/variables/gov/states/ct/tax/income/ct_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/ct_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ct_non_refundable_credits(Variable):
@@ -9,4 +12,10 @@ class ct_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.CT
 
-    adds = "gov.states.ct.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ct.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "ct_income_tax_after_amt"
+        )

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class dc_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class dc_cdcc(Variable):
+class dc_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "DC child and dependent care credit"
@@ -18,3 +20,29 @@ class dc_cdcc(Variable):
         us_cdcc = tax_unit("cdcc_potential", period)
         p_dc = parameters(period).gov.states.dc.tax.income.credits
         return us_cdcc * p_dc.cdcc.match
+
+
+class dc_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "DC child and dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=36"
+        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=34"
+    )
+    defined_for = StateCode.DC
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.dc.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "dc_income_tax_before_credits",
+            "dc_cdcc",
+            "dc_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc.py
@@ -4,25 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class dc_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "DC child and dependent care credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=36"
-        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=34"
-    )
-    defined_for = StateCode.DC
-
-    def formula(tax_unit, period, parameters):
-        # DC matches the potential federal credit
-        us_cdcc = tax_unit("cdcc_potential", period)
-        p_dc = parameters(period).gov.states.dc.tax.income.credits
-        return us_cdcc * p_dc.cdcc.match
-
-
 class dc_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_cdcc_potential.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class dc_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "DC child and dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=36"
+        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=34"
+    )
+    defined_for = StateCode.DC
+
+    def formula(tax_unit, period, parameters):
+        # DC matches the potential federal credit
+        us_cdcc = tax_unit("cdcc_potential", period)
+        p_dc = parameters(period).gov.states.dc.tax.income.credits
+        return us_cdcc * p_dc.cdcc.match

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class dc_non_refundable_credits(Variable):
@@ -12,4 +15,11 @@ class dc_non_refundable_credits(Variable):
         "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=55"
     )
     defined_for = StateCode.DC
-    adds = "gov.states.dc.tax.income.credits.non_refundable"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.dc.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "dc_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class de_cdcc(Variable):
+class de_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Delaware dependent care credit"
@@ -14,3 +16,25 @@ class de_cdcc(Variable):
         expenses = tax_unit("cdcc", period)
         rate = parameters(period).gov.states.de.tax.income.credits.cdcc.match
         return expenses * rate
+
+
+class de_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.de.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "de_income_tax_before_non_refundable_credits_unit",
+            "de_cdcc",
+            "de_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class de_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc.py
@@ -4,21 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class de_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Delaware dependent care credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.DE
-
-    def formula(tax_unit, period, parameters):
-        # Delaware matches the federal credit taken
-        expenses = tax_unit("cdcc", period)
-        rate = parameters(period).gov.states.de.tax.income.credits.cdcc.match
-        return expenses * rate
-
-
 class de_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/cdcc/de_cdcc_potential.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class de_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        # Delaware matches the federal credit taken
+        expenses = tax_unit("cdcc", period)
+        rate = parameters(period).gov.states.de.tax.income.credits.cdcc.match
+        return expenses * rate

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class de_non_refundable_eitc(Variable):
+class de_non_refundable_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Delaware non-refundable EITC"
@@ -18,3 +20,29 @@ class de_non_refundable_eitc(Variable):
         claims = ~tax_unit("de_claims_refundable_eitc", period)
         amount_if_claimed = tax_unit("de_non_refundable_eitc_if_claimed", period)
         return claims * amount_if_claimed
+
+
+class de_non_refundable_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware non-refundable EITC"
+    unit = USD
+    documentation = "Non-refundable EITC credit reducing DE State income tax."
+    definition_period = YEAR
+    reference = (
+        "https://revenuefiles.delaware.gov/2022/PIT-RES_TY22_2022-02_Instructions.pdf"
+    )
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.de.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "de_income_tax_before_non_refundable_credits_unit",
+            "de_non_refundable_eitc",
+            "de_non_refundable_eitc_potential",
+        )

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class de_non_refundable_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.py
@@ -4,25 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class de_non_refundable_eitc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Delaware non-refundable EITC"
-    unit = USD
-    documentation = "Non-refundable EITC credit reducing DE State income tax."
-    definition_period = YEAR
-    reference = (
-        "https://revenuefiles.delaware.gov/2022/PIT-RES_TY22_2022-02_Instructions.pdf"
-    )
-    defined_for = StateCode.DE
-
-    def formula(tax_unit, period, parameters):
-        # Either claims refundable or non-refundable, but not both.
-        claims = ~tax_unit("de_claims_refundable_eitc", period)
-        amount_if_claimed = tax_unit("de_non_refundable_eitc_if_claimed", period)
-        return claims * amount_if_claimed
-
-
 class de_non_refundable_eitc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc_potential.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc_potential.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class de_non_refundable_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware non-refundable EITC"
+    unit = USD
+    documentation = "Non-refundable EITC credit reducing DE State income tax."
+    definition_period = YEAR
+    reference = (
+        "https://revenuefiles.delaware.gov/2022/PIT-RES_TY22_2022-02_Instructions.pdf"
+    )
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        # Either claims refundable or non-refundable, but not both.
+        claims = ~tax_unit("de_claims_refundable_eitc", period)
+        amount_if_claimed = tax_unit("de_non_refundable_eitc_if_claimed", period)
+        return claims * amount_if_claimed

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class de_aged_personal_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class de_aged_personal_credit(Variable):
+class de_aged_personal_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Delaware aged personal credit"
@@ -24,3 +26,26 @@ class de_aged_personal_credit(Variable):
         spouse_amount = p.aged.calc(age_spouse)
 
         return head_amount + spouse_amount
+
+
+class de_aged_personal_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware aged personal credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://delcode.delaware.gov/title30/c011/sc02/index.html#1110"
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.de.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "de_income_tax_before_non_refundable_credits_unit",
+            "de_aged_personal_credit",
+            "de_aged_personal_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit.py
@@ -4,31 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class de_aged_personal_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Delaware aged personal credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://delcode.delaware.gov/title30/c011/sc02/index.html#1110"
-    defined_for = StateCode.DE
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.de.tax.income.credits.personal_credits
-        """
-          Legal code says "An additional $110 in the case of each resident
-          person age 60 or over.  Tax form limits it to heads and spouses,
-          not elderly dependents.
-        """
-        age_head = tax_unit("age_head", period)
-        head_amount = p.aged.calc(age_head)
-
-        age_spouse = tax_unit("age_spouse", period)
-        spouse_amount = p.aged.calc(age_spouse)
-
-        return head_amount + spouse_amount
-
-
 class de_aged_personal_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit_potential.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_aged_personal_credit_potential.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class de_aged_personal_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware aged personal credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://delcode.delaware.gov/title30/c011/sc02/index.html#1110"
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.de.tax.income.credits.personal_credits
+        """
+          Legal code says "An additional $110 in the case of each resident
+          person age 60 or over.  Tax form limits it to heads and spouses,
+          not elderly dependents.
+        """
+        age_head = tax_unit("age_head", period)
+        head_amount = p.aged.calc(age_head)
+
+        age_spouse = tax_unit("age_spouse", period)
+        spouse_amount = p.aged.calc(age_spouse)
+
+        return head_amount + spouse_amount

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class de_personal_credit(Variable):
+class de_personal_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Delaware personal credit"
@@ -16,3 +18,28 @@ class de_personal_credit(Variable):
         p = parameters(period).gov.states.de.tax.income.credits
         exemptions_count = tax_unit("exemptions_count", period)
         return p.personal_credits.personal * exemptions_count
+
+
+class de_personal_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware personal credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://revenuefiles.delaware.gov/2022/PIT-RES_TY22_2022-02_Instructions.pdf"
+    )
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.de.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "de_income_tax_before_non_refundable_credits_unit",
+            "de_personal_credit",
+            "de_personal_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class de_personal_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit.py
@@ -4,23 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class de_personal_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Delaware personal credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://revenuefiles.delaware.gov/2022/PIT-RES_TY22_2022-02_Instructions.pdf"
-    )
-    defined_for = StateCode.DE
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.de.tax.income.credits
-        exemptions_count = tax_unit("exemptions_count", period)
-        return p.personal_credits.personal * exemptions_count
-
-
 class de_personal_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit_potential.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/credits/personal/de_personal_credit_potential.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class de_personal_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Delaware personal credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://revenuefiles.delaware.gov/2022/PIT-RES_TY22_2022-02_Instructions.pdf"
+    )
+    defined_for = StateCode.DE
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.de.tax.income.credits
+        exemptions_count = tax_unit("exemptions_count", period)
+        return p.personal_credits.personal * exemptions_count

--- a/policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class de_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class de_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.DE
 
-    adds = "gov.states.de.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.de.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "de_income_tax_before_non_refundable_credits_unit",
+        )

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ga_cdcc(Variable):
+class ga_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Georgia non-refundable dependent care credit"
@@ -14,3 +16,25 @@ class ga_cdcc(Variable):
         federal_cdcc = tax_unit("cdcc", period)
         rate = parameters(period).gov.states.ga.tax.income.credits.cdcc.rate
         return federal_cdcc * rate
+
+
+class ga_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia non-refundable dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ga.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ga_income_tax_before_non_refundable_credits",
+            "ga_cdcc",
+            "ga_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ga_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc.py
@@ -4,21 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ga_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Georgia non-refundable dependent care credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.GA
-
-    def formula(tax_unit, period, parameters):
-        # Georgia matches the federal credit taken
-        federal_cdcc = tax_unit("cdcc", period)
-        rate = parameters(period).gov.states.ga.tax.income.credits.cdcc.rate
-        return federal_cdcc * rate
-
-
 class ga_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/cdcc/ga_cdcc_potential.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class ga_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia non-refundable dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA
+
+    def formula(tax_unit, period, parameters):
+        # Georgia matches the federal credit taken
+        federal_cdcc = tax_unit("cdcc", period)
+        rate = parameters(period).gov.states.ga.tax.income.credits.cdcc.rate
+        return federal_cdcc * rate

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ga_ctc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc.py
@@ -4,28 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ga_ctc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Georgia Child Tax Credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.GA
-    reference = (
-        "https://legiscan.com/GA/text/HB136/id/3204611/Georgia-2025-HB136-Enrolled.pdf#page=2",
-    )
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.ga.tax.income.credits.ctc
-        person = tax_unit.members
-        age = person("age", period)
-        ctc_eligible_child = person("ctc_qualifying_child", period)
-        ga_child_age_eligible = age < p.age_threshold
-        eligible_children = tax_unit.sum(ctc_eligible_child & ga_child_age_eligible)
-
-        return eligible_children * p.amount
-
-
 class ga_ctc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ga_ctc(Variable):
+class ga_ctc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Georgia Child Tax Credit"
@@ -21,3 +23,28 @@ class ga_ctc(Variable):
         eligible_children = tax_unit.sum(ctc_eligible_child & ga_child_age_eligible)
 
         return eligible_children * p.amount
+
+
+class ga_ctc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia Child Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA
+    reference = (
+        "https://legiscan.com/GA/text/HB136/id/3204611/Georgia-2025-HB136-Enrolled.pdf#page=2",
+    )
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ga.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ga_income_tax_before_non_refundable_credits",
+            "ga_ctc",
+            "ga_ctc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc_potential.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ctc/ga_ctc_potential.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class ga_ctc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia Child Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA
+    reference = (
+        "https://legiscan.com/GA/text/HB136/id/3204611/Georgia-2025-HB136-Enrolled.pdf#page=2",
+    )
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ga.tax.income.credits.ctc
+        person = tax_unit.members
+        age = person("age", period)
+        ctc_eligible_child = person("ctc_qualifying_child", period)
+        ga_child_age_eligible = age < p.age_threshold
+        eligible_children = tax_unit.sum(ctc_eligible_child & ga_child_age_eligible)
+
+        return eligible_children * p.amount

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ga_itemizer_credit(Variable):
+class ga_itemizer_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Georgia itemizer tax credit"
@@ -17,3 +19,26 @@ class ga_itemizer_credit(Variable):
         taxpayer_count = tax_unit("head_spouse_count", period)
         p = parameters(period).gov.states.ga.tax.income.credits.itemizer
         return where(itemizes, p.amount * taxpayer_count, 0)
+
+
+class ga_itemizer_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia itemizer tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://law.justia.com/codes/georgia/2022/title-48/chapter-7/article-2/section-48-7-29-23/"
+    defined_for = StateCode.GA
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ga.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ga_income_tax_before_non_refundable_credits",
+            "ga_itemizer_credit",
+            "ga_itemizer_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ga_itemizer_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit.py
@@ -4,24 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ga_itemizer_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Georgia itemizer tax credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://law.justia.com/codes/georgia/2022/title-48/chapter-7/article-2/section-48-7-29-23/"
-    defined_for = StateCode.GA
-
-    def formula(tax_unit, period, parameters):
-        # Full-year and part-year residents who itemize their deductions
-        # are entitled to a credit up to $300 per taxpayer
-        itemizes = tax_unit("tax_unit_itemizes", period)
-        taxpayer_count = tax_unit("head_spouse_count", period)
-        p = parameters(period).gov.states.ga.tax.income.credits.itemizer
-        return where(itemizes, p.amount * taxpayer_count, 0)
-
-
 class ga_itemizer_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_itemizer_credit_potential.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class ga_itemizer_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia itemizer tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://law.justia.com/codes/georgia/2022/title-48/chapter-7/article-2/section-48-7-29-23/"
+    defined_for = StateCode.GA
+
+    def formula(tax_unit, period, parameters):
+        # Full-year and part-year residents who itemize their deductions
+        # are entitled to a credit up to $300 per taxpayer
+        itemizes = tax_unit("tax_unit_itemizes", period)
+        taxpayer_count = tax_unit("head_spouse_count", period)
+        p = parameters(period).gov.states.ga.tax.income.credits.itemizer
+        return where(itemizes, p.amount * taxpayer_count, 0)

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ga_low_income_credit(Variable):
+class ga_low_income_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Georgia low income credit"
@@ -30,3 +32,26 @@ class ga_low_income_credit(Variable):
         federal_agi = tax_unit("adjusted_gross_income", period)
         amount_per_exemption = p.amount.calc(federal_agi)
         return total_exemptions * amount_per_exemption
+
+
+class ga_low_income_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia low income credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://dor.georgia.gov/document/document/2022-it-511-individual-income-tax-booklet/download"
+    defined_for = StateCode.GA
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ga.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ga_income_tax_before_non_refundable_credits",
+            "ga_low_income_credit",
+            "ga_low_income_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ga_low_income_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit.py
@@ -4,37 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ga_low_income_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Georgia low income credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://dor.georgia.gov/document/document/2022-it-511-individual-income-tax-booklet/download"
-    defined_for = StateCode.GA
-
-    def formula(tax_unit, period, parameters):
-        # We follow the legal code, which says (in addition to head and spouse):
-        # "multiplied by the number of dependents which the taxpayer is entitled to claim."
-        # The tax form excludes adult dependents:
-        # "Exemptions are self, spouse and natural or legally adopted children"
-        exemptions = tax_unit("exemptions_count", period)
-        p = parameters(period).gov.states.ga.tax.income.credits.low_income
-        # age threshold
-        age_threshold = p.supplement_age_eligibility
-        aged_head = (tax_unit("age_head", period) >= age_threshold).astype(
-            int
-        )  # if so, return 1, otherwise return 0
-        aged_spouse = (tax_unit("age_spouse", period) >= age_threshold).astype(
-            int
-        )  # if so, return 1, otherwise return 0
-        aged_count = aged_head + aged_spouse
-        total_exemptions = aged_count + exemptions
-        federal_agi = tax_unit("adjusted_gross_income", period)
-        amount_per_exemption = p.amount.calc(federal_agi)
-        return total_exemptions * amount_per_exemption
-
-
 class ga_low_income_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/credits/ga_low_income_credit_potential.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class ga_low_income_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia low income credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://dor.georgia.gov/document/document/2022-it-511-individual-income-tax-booklet/download"
+    defined_for = StateCode.GA
+
+    def formula(tax_unit, period, parameters):
+        # We follow the legal code, which says (in addition to head and spouse):
+        # "multiplied by the number of dependents which the taxpayer is entitled to claim."
+        # The tax form excludes adult dependents:
+        # "Exemptions are self, spouse and natural or legally adopted children"
+        exemptions = tax_unit("exemptions_count", period)
+        p = parameters(period).gov.states.ga.tax.income.credits.low_income
+        # age threshold
+        age_threshold = p.supplement_age_eligibility
+        aged_head = (tax_unit("age_head", period) >= age_threshold).astype(
+            int
+        )  # if so, return 1, otherwise return 0
+        aged_spouse = (tax_unit("age_spouse", period) >= age_threshold).astype(
+            int
+        )  # if so, return 1, otherwise return 0
+        aged_count = aged_head + aged_spouse
+        total_exemptions = aged_count + exemptions
+        federal_agi = tax_unit("adjusted_gross_income", period)
+        amount_per_exemption = p.amount.calc(federal_agi)
+        return total_exemptions * amount_per_exemption

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ga_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class ga_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.GA
 
-    adds = "gov.states.ga.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ga.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ga_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/hi/tax/income/hi_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/hi/tax/income/hi_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class hi_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class hi_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.HI
 
-    adds = "gov.states.hi.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.hi.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "hi_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class id_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class id_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.ID
 
-    adds = "gov.states.id.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.id.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "id_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class il_k12_education_expense_credit(Variable):
+class il_k12_education_expense_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Illinois K-12 Education Expense Credit"
@@ -14,8 +16,27 @@ class il_k12_education_expense_credit(Variable):
         p = parameters(period).gov.states.il.tax.income.credits.k12
         tuition_and_fees = tax_unit("k12_tuition_and_fees", period)
         reduced_tuition_and_fees = max_(0, tuition_and_fees - p.reduction)
-        k12_credit = min_(reduced_tuition_and_fees * p.rate, p.cap)
-        pre_credit_tax = tax_unit("il_income_tax_before_non_refundable_credits", period)
-        il_property_tax_credit = tax_unit("il_property_tax_credit", period)
-        avail_tax = max_(0, pre_credit_tax - il_property_tax_credit)
-        return min_(avail_tax, k12_credit)
+        return min_(reduced_tuition_and_fees * p.rate, p.cap)
+
+
+class il_k12_education_expense_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Illinois K-12 Education Expense Credit"
+    unit = USD
+    definition_period = YEAR
+
+    defined_for = "il_is_exemption_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.il.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "il_income_tax_before_non_refundable_credits",
+            "il_k12_education_expense_credit",
+            "il_k12_education_expense_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit.py
@@ -4,22 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class il_k12_education_expense_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Illinois K-12 Education Expense Credit"
-    unit = USD
-    definition_period = YEAR
-
-    defined_for = "il_is_exemption_eligible"
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.il.tax.income.credits.k12
-        tuition_and_fees = tax_unit("k12_tuition_and_fees", period)
-        reduced_tuition_and_fees = max_(0, tuition_and_fees - p.reduction)
-        return min_(reduced_tuition_and_fees * p.rate, p.cap)
-
-
 class il_k12_education_expense_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class il_k12_education_expense_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit_potential.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_k12_education_expense_credit_potential.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class il_k12_education_expense_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Illinois K-12 Education Expense Credit"
+    unit = USD
+    definition_period = YEAR
+
+    defined_for = "il_is_exemption_eligible"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.il.tax.income.credits.k12
+        tuition_and_fees = tax_unit("k12_tuition_and_fees", period)
+        reduced_tuition_and_fees = max_(0, tuition_and_fees - p.reduction)
+        return min_(reduced_tuition_and_fees * p.rate, p.cap)

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit.py
@@ -4,21 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class il_property_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Illinois Property Tax Credit"
-    unit = USD
-    definition_period = YEAR
-
-    defined_for = "il_is_exemption_eligible"
-
-    def formula(tax_unit, period, parameters):
-        ptax_paid = add(tax_unit, period, ["real_estate_taxes"])
-        p = parameters(period).gov.states.il.tax.income.credits
-        return ptax_paid * p.property_tax.rate
-
-
 class il_property_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class il_property_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit.py
@@ -1,4 +1,21 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
+
+class il_property_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Illinois Property Tax Credit"
+    unit = USD
+    definition_period = YEAR
+
+    defined_for = "il_is_exemption_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ptax_paid = add(tax_unit, period, ["real_estate_taxes"])
+        p = parameters(period).gov.states.il.tax.income.credits
+        return ptax_paid * p.property_tax.rate
 
 
 class il_property_tax_credit(Variable):
@@ -11,7 +28,14 @@ class il_property_tax_credit(Variable):
     defined_for = "il_is_exemption_eligible"
 
     def formula(tax_unit, period, parameters):
-        ptax_paid = add(tax_unit, period, ["real_estate_taxes"])
-        pre_credit_tax = tax_unit("il_income_tax_before_non_refundable_credits", period)
-        p = parameters(period).gov.states.il.tax.income.credits
-        return min_(ptax_paid * p.property_tax.rate, pre_credit_tax)
+        ordered_credits = parameters(
+            period
+        ).gov.states.il.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "il_income_tax_before_non_refundable_credits",
+            "il_property_tax_credit",
+            "il_property_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_credit_potential.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class il_property_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Illinois Property Tax Credit"
+    unit = USD
+    definition_period = YEAR
+
+    defined_for = "il_is_exemption_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ptax_paid = add(tax_unit, period, ["real_estate_taxes"])
+        p = parameters(period).gov.states.il.tax.income.credits
+        return ptax_paid * p.property_tax.rate

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc.py
@@ -4,24 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ky_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Kentucky household and dependent care service credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=29058"
-    defined_for = StateCode.KY
-
-    def formula(tax_unit, period, parameters):
-        # Kentucky matches the federal credit taken
-        dependent_care_credit = tax_unit("cdcc", period)
-        rate = parameters(
-            period
-        ).gov.states.ky.tax.income.credits.dependent_care_service.match
-        return dependent_care_credit * rate
-
-
 class ky_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ky_cdcc(Variable):
+class ky_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Kentucky household and dependent care service credit"
@@ -17,3 +19,26 @@ class ky_cdcc(Variable):
             period
         ).gov.states.ky.tax.income.credits.dependent_care_service.match
         return dependent_care_credit * rate
+
+
+class ky_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky household and dependent care service credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=29058"
+    defined_for = StateCode.KY
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ky.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ky_income_tax_before_non_refundable_credits_unit",
+            "ky_cdcc",
+            "ky_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ky_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/dependent_care_service/ky_cdcc_potential.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class ky_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky household and dependent care service credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=29058"
+    defined_for = StateCode.KY
+
+    def formula(tax_unit, period, parameters):
+        # Kentucky matches the federal credit taken
+        dependent_care_credit = tax_unit("cdcc", period)
+        rate = parameters(
+            period
+        ).gov.states.ky.tax.income.credits.dependent_care_service.match
+        return dependent_care_credit * rate

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ky_family_size_tax_credit(Variable):
+class ky_family_size_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Kentucky family size tax credit"
@@ -17,3 +19,26 @@ class ky_family_size_tax_credit(Variable):
         reduced_income = max_(income - personal_credits, 0)
 
         return rate * reduced_income
+
+
+class ky_family_size_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky family size tax credit"
+    unit = "/1"
+    definition_period = YEAR
+    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=49188"
+    defined_for = StateCode.KY
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ky.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ky_income_tax_before_non_refundable_credits_unit",
+            "ky_family_size_tax_credit",
+            "ky_family_size_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ky_family_size_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit.py
@@ -4,24 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ky_family_size_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Kentucky family size tax credit"
-    unit = "/1"
-    definition_period = YEAR
-    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=49188"
-    defined_for = StateCode.KY
-
-    def formula(tax_unit, period, parameters):
-        rate = tax_unit("ky_family_size_tax_credit_rate", period)
-        income = tax_unit("ky_income_tax_before_non_refundable_credits_unit", period)
-        personal_credits = tax_unit("ky_personal_tax_credits", period)
-        reduced_income = max_(income - personal_credits, 0)
-
-        return rate * reduced_income
-
-
 class ky_family_size_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit_potential.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class ky_family_size_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky family size tax credit"
+    unit = "/1"
+    definition_period = YEAR
+    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=49188"
+    defined_for = StateCode.KY
+
+    def formula(tax_unit, period, parameters):
+        rate = tax_unit("ky_family_size_tax_credit_rate", period)
+        income = tax_unit("ky_income_tax_before_non_refundable_credits_unit", period)
+        personal_credits = tax_unit("ky_personal_tax_credits", period)
+        reduced_income = max_(income - personal_credits, 0)
+
+        return rate * reduced_income

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/ky_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/ky_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ky_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class ky_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.KY
 
-    adds = "gov.states.ky.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ky.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ky_income_tax_before_non_refundable_credits_unit",
+        )

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ky_personal_tax_credits_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ky_personal_tax_credits(Variable):
+class ky_personal_tax_credits_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Kentucky personal tax credits combined"
@@ -19,4 +21,27 @@ class ky_personal_tax_credits(Variable):
             ky_files_separately,
             tax_unit.sum(ky_personal_tax_credits_indiv),
             tax_unit.sum(ky_personal_tax_credits_joint),
+        )
+
+
+class ky_personal_tax_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky personal tax credits combined"
+    unit = USD
+    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=53500#page=3"  # (3) (a)
+    definition_period = YEAR
+    defined_for = StateCode.KY
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ky.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ky_income_tax_before_non_refundable_credits_unit",
+            "ky_personal_tax_credits",
+            "ky_personal_tax_credits_potential",
         )

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits.py
@@ -4,27 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ky_personal_tax_credits_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Kentucky personal tax credits combined"
-    unit = USD
-    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=53500#page=3"  # (3) (a)
-    definition_period = YEAR
-    defined_for = StateCode.KY
-
-    def formula(tax_unit, period, parameters):
-        ky_files_separately = tax_unit("ky_files_separately", period)
-        person = tax_unit.members
-        ky_personal_tax_credits_indiv = person("ky_personal_tax_credits_indiv", period)
-        ky_personal_tax_credits_joint = person("ky_personal_tax_credits_joint", period)
-        return where(
-            ky_files_separately,
-            tax_unit.sum(ky_personal_tax_credits_indiv),
-            tax_unit.sum(ky_personal_tax_credits_joint),
-        )
-
-
 class ky_personal_tax_credits(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits_potential.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/personal/ky_personal_tax_credits_potential.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class ky_personal_tax_credits_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky personal tax credits combined"
+    unit = USD
+    reference = "https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=53500#page=3"  # (3) (a)
+    definition_period = YEAR
+    defined_for = StateCode.KY
+
+    def formula(tax_unit, period, parameters):
+        ky_files_separately = tax_unit("ky_files_separately", period)
+        person = tax_unit.members
+        ky_personal_tax_credits_indiv = person("ky_personal_tax_credits_indiv", period)
+        ky_personal_tax_credits_joint = person("ky_personal_tax_credits_joint", period)
+        return where(
+            ky_files_separately,
+            tax_unit.sum(ky_personal_tax_credits_indiv),
+            tax_unit.sum(ky_personal_tax_credits_joint),
+        )

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ky_tuition_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.py
@@ -4,25 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ky_tuition_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Kentucky tuition tax credit"  # Form 8863-K
-    unit = USD
-    definition_period = YEAR
-    defined_for = "ky_tuition_tax_credit_eligible"
-
-    def formula(tax_unit, period, parameters):
-        # We do not currently model the limitation to undergraduate studies at Kentucky institutions.
-        tentative_tax_credit = add(
-            tax_unit,
-            period,
-            ["american_opportunity_credit", "lifetime_learning_credit"],
-        )
-        rate = parameters(period).gov.states.ky.tax.income.credits.tuition_tax.rate
-        return tentative_tax_credit * rate
-
-
 class ky_tuition_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ky_tuition_tax_credit(Variable):
+class ky_tuition_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Kentucky tuition tax credit"  # Form 8863-K
@@ -18,3 +20,25 @@ class ky_tuition_tax_credit(Variable):
         )
         rate = parameters(period).gov.states.ky.tax.income.credits.tuition_tax.rate
         return tentative_tax_credit * rate
+
+
+class ky_tuition_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky tuition tax credit"  # Form 8863-K
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ky_tuition_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ky.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ky_income_tax_before_non_refundable_credits_unit",
+            "ky_tuition_tax_credit",
+            "ky_tuition_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ky/tax/income/credits/tuition_tax/ky_tuition_tax_credit_potential.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class ky_tuition_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kentucky tuition tax credit"  # Form 8863-K
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ky_tuition_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        # We do not currently model the limitation to undergraduate studies at Kentucky institutions.
+        tentative_tax_credit = add(
+            tax_unit,
+            period,
+            ["american_opportunity_credit", "lifetime_learning_credit"],
+        )
+        rate = parameters(period).gov.states.ky.tax.income.credits.tuition_tax.rate
+        return tentative_tax_credit * rate

--- a/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
@@ -4,29 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class la_non_refundable_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Louisiana non-refundable Child and Dependent Care Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "http://legis.la.gov/Legis/Law.aspx?d=101769"
-    defined_for = StateCode.LA
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.la.tax.income.credits.cdcc.non_refundable
-        # Louisiana matches the potential federal credit
-        us_cdcc = tax_unit("cdcc", period)
-        us_agi = tax_unit("adjusted_gross_income", period)
-        match = p.match.calc(us_agi, right=True)
-        uncapped_credit = us_cdcc * match
-        # The non refundable credit is capped for taxpayers with AGI above the threshold
-        top_threshold = p.match.thresholds[-1]
-        agi_over_cap_threshold = us_agi > top_threshold
-        capped_credit = min_(uncapped_credit, p.upper_bracket_cap)
-        return where(agi_over_cap_threshold, capped_credit, uncapped_credit)
-
-
 class la_non_refundable_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class la_non_refundable_cdcc(Variable):
+class la_non_refundable_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Louisiana non-refundable Child and Dependent Care Credit"
@@ -22,3 +24,26 @@ class la_non_refundable_cdcc(Variable):
         agi_over_cap_threshold = us_agi > top_threshold
         capped_credit = min_(uncapped_credit, p.upper_bracket_cap)
         return where(agi_over_cap_threshold, capped_credit, uncapped_credit)
+
+
+class la_non_refundable_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Louisiana non-refundable Child and Dependent Care Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "http://legis.la.gov/Legis/Law.aspx?d=101769"
+    defined_for = StateCode.LA
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.la.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "la_income_tax_before_non_refundable_credits",
+            "la_non_refundable_cdcc",
+            "la_non_refundable_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class la_non_refundable_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/credits/cdcc/la_non_refundable_cdcc_potential.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class la_non_refundable_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Louisiana non-refundable Child and Dependent Care Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "http://legis.la.gov/Legis/Law.aspx?d=101769"
+    defined_for = StateCode.LA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.la.tax.income.credits.cdcc.non_refundable
+        # Louisiana matches the potential federal credit
+        us_cdcc = tax_unit("cdcc", period)
+        us_agi = tax_unit("adjusted_gross_income", period)
+        match = p.match.calc(us_agi, right=True)
+        uncapped_credit = us_cdcc * match
+        # The non refundable credit is capped for taxpayers with AGI above the threshold
+        top_threshold = p.match.thresholds[-1]
+        agi_over_cap_threshold = us_agi > top_threshold
+        capped_credit = min_(uncapped_credit, p.upper_bracket_cap)
+        return where(agi_over_cap_threshold, capped_credit, uncapped_credit)

--- a/policyengine_us/variables/gov/states/la/tax/income/la_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/la_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class la_non_refundable_credits(Variable):
@@ -8,4 +11,14 @@ class la_non_refundable_credits(Variable):
     defined_for = StateCode.LA
     unit = USD
     definition_period = YEAR
-    adds = "gov.states.la.tax.income.credits.non_refundable"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.la.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "la_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
@@ -4,32 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ma_limited_income_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "MA Limited Income Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://www.mass.gov/doc/2021-schedule-nts-l-nrpy-no-tax-status-and-limited-income-credit/download"
-    defined_for = StateCode.MA
-
-    def formula(tax_unit, period, parameters):
-        agi = tax_unit("ma_agi", period)
-        exemption_threshold = tax_unit("ma_income_tax_exemption_threshold", period)
-        income_over_threshold = max_(0, agi - exemption_threshold)
-        # Compute AGI as a share of the exemption threshold.
-        # Use a mask rather than where to avoid a divide-by-zero warning. Default to inf.
-        income_ratio = np.ones_like(agi) * np.inf
-        mask = exemption_threshold > 0
-        income_ratio[mask] = agi[mask] / exemption_threshold[mask]
-        p = parameters(period).gov.states.ma.tax.income.credits
-        eligible = income_ratio <= p.limited_income_credit.income_limit
-        tax_cap = p.limited_income_credit.percent * income_over_threshold
-        income_tax = tax_unit("ma_income_tax_before_credits", period)
-        excess_tax = max_(0, income_tax - tax_cap)
-        return eligible * excess_tax
-
-
 class ma_limited_income_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ma_limited_income_tax_credit(Variable):
+class ma_limited_income_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "MA Limited Income Credit"
@@ -25,3 +27,26 @@ class ma_limited_income_tax_credit(Variable):
         income_tax = tax_unit("ma_income_tax_before_credits", period)
         excess_tax = max_(0, income_tax - tax_cap)
         return eligible * excess_tax
+
+
+class ma_limited_income_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MA Limited Income Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.mass.gov/doc/2021-schedule-nts-l-nrpy-no-tax-status-and-limited-income-credit/download"
+    defined_for = StateCode.MA
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ma.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ma_income_tax_before_credits",
+            "ma_limited_income_tax_credit",
+            "ma_limited_income_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ma_limited_income_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_limited_income_tax_credit_potential.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class ma_limited_income_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MA Limited Income Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.mass.gov/doc/2021-schedule-nts-l-nrpy-no-tax-status-and-limited-income-credit/download"
+    defined_for = StateCode.MA
+
+    def formula(tax_unit, period, parameters):
+        agi = tax_unit("ma_agi", period)
+        exemption_threshold = tax_unit("ma_income_tax_exemption_threshold", period)
+        income_over_threshold = max_(0, agi - exemption_threshold)
+        # Compute AGI as a share of the exemption threshold.
+        # Use a mask rather than where to avoid a divide-by-zero warning. Default to inf.
+        income_ratio = np.ones_like(agi) * np.inf
+        mask = exemption_threshold > 0
+        income_ratio[mask] = agi[mask] / exemption_threshold[mask]
+        p = parameters(period).gov.states.ma.tax.income.credits
+        eligible = income_ratio <= p.limited_income_credit.income_limit
+        tax_cap = p.limited_income_credit.percent * income_over_threshold
+        income_tax = tax_unit("ma_income_tax_before_credits", period)
+        excess_tax = max_(0, income_tax - tax_cap)
+        return eligible * excess_tax

--- a/policyengine_us/variables/gov/states/ma/tax/income/ma_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/ma_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ma_non_refundable_credits(Variable):
@@ -9,4 +12,11 @@ class ma_non_refundable_credits(Variable):
     definition_period = YEAR
     reference = "https://www.mass.gov/doc/2021-form-1-massachusetts-resident-income-tax-return/download"
     defined_for = StateCode.MA
-    adds = "gov.states.ma.tax.income.credits.non_refundable"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ma.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "ma_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
@@ -4,34 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class md_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "MD CDCC"
-    documentation = "Maryland Child and Dependent Care Tax Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-716-for-child-care-or-dependent-care"
-    defined_for = StateCode.MD
-
-    def formula(tax_unit, period, parameters):
-        filing_status = tax_unit("filing_status", period)
-        agi = tax_unit("adjusted_gross_income", period)
-        p = parameters(period).gov.states.md.tax.income.credits.cdcc
-        # Eligibility is based on AGI.
-        eligible = agi <= p.eligibility.agi_cap[filing_status]
-        # Maximum is a percent of federal.
-        # Maryland matches the federal credit allowed (after Credit Limit Worksheet)
-        max_cdcc = p.percent * tax_unit("cdcc", period)
-        # Phases out based on filing status.
-        phase_out_start = p.phase_out.start[filing_status]
-        excess = max_(0, agi - phase_out_start)
-        phase_out_increment = p.phase_out.increment[filing_status]
-        phase_out_increments = np.ceil(excess / phase_out_increment)
-        percent_reduction = phase_out_increments * p.phase_out.percent
-        return eligible * max_(0, max_cdcc * (1 - percent_reduction))
-
-
 class md_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class md_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class md_cdcc(Variable):
+class md_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "MD CDCC"
@@ -27,3 +29,27 @@ class md_cdcc(Variable):
         phase_out_increments = np.ceil(excess / phase_out_increment)
         percent_reduction = phase_out_increments * p.phase_out.percent
         return eligible * max_(0, max_cdcc * (1 - percent_reduction))
+
+
+class md_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD CDCC"
+    documentation = "Maryland Child and Dependent Care Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-716-for-child-care-or-dependent-care"
+    defined_for = StateCode.MD
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.md.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "md_income_tax_before_credits",
+            "md_cdcc",
+            "md_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_cdcc_potential.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class md_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD CDCC"
+    documentation = "Maryland Child and Dependent Care Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-716-for-child-care-or-dependent-care"
+    defined_for = StateCode.MD
+
+    def formula(tax_unit, period, parameters):
+        filing_status = tax_unit("filing_status", period)
+        agi = tax_unit("adjusted_gross_income", period)
+        p = parameters(period).gov.states.md.tax.income.credits.cdcc
+        # Eligibility is based on AGI.
+        eligible = agi <= p.eligibility.agi_cap[filing_status]
+        # Maximum is a percent of federal.
+        # Maryland matches the federal credit allowed (after Credit Limit Worksheet)
+        max_cdcc = p.percent * tax_unit("cdcc", period)
+        # Phases out based on filing status.
+        phase_out_start = p.phase_out.start[filing_status]
+        excess = max_(0, agi - phase_out_start)
+        phase_out_increment = p.phase_out.increment[filing_status]
+        phase_out_increments = np.ceil(excess / phase_out_increment)
+        percent_reduction = phase_out_increments * p.phase_out.percent
+        return eligible * max_(0, max_cdcc * (1 - percent_reduction))

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_refundable_cdcc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/cdcc/md_refundable_cdcc.py
@@ -12,12 +12,13 @@ class md_refundable_cdcc(Variable):
     defined_for = StateCode.MD
 
     def formula(tax_unit, period, parameters):
-        # Note: The MD refundable CDCC is based on the MD CDCC and MD tax before credits
-        # *without respect to the other non-refundable credits* like MD EITC.
+        # Worksheet 21B starts from the Part B credit before overall
+        # non-refundable credit ordering is applied, then refunds the excess
+        # above Maryland tax for eligible filers.
         filing_status = tax_unit("filing_status", period)
         agi = tax_unit("adjusted_gross_income", period)
         p = parameters(period).gov.states.md.tax.income.credits.cdcc
-        cdcc = tax_unit("md_cdcc", period)
+        cdcc = tax_unit("md_cdcc_potential", period)
         # Refundable has its own AGI cap.
         cap = p.eligibility.refundable_agi_cap[filing_status]
         eligible = agi <= cap

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
@@ -14,11 +14,6 @@ class md_non_refundable_eitc(Variable):
     reference = "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income"
     defined_for = StateCode.MD
 
-    adds = [
-        "md_married_or_has_child_non_refundable_eitc",
-        "md_unmarried_childless_non_refundable_eitc",
-    ]
-
     def formula(tax_unit, period, parameters):
         ordered_credits = parameters(
             period

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
@@ -1,4 +1,22 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
+
+class md_non_refundable_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD EITC non-refundable State tax credit"
+    unit = USD
+    documentation = "Non-refundable EITC credit reducing MD State income tax."
+    definition_period = YEAR
+    reference = "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income"
+    defined_for = StateCode.MD
+
+    adds = [
+        "md_married_or_has_child_non_refundable_eitc",
+        "md_unmarried_childless_non_refundable_eitc",
+    ]
 
 
 class md_non_refundable_eitc(Variable):
@@ -15,3 +33,16 @@ class md_non_refundable_eitc(Variable):
         "md_married_or_has_child_non_refundable_eitc",
         "md_unmarried_childless_non_refundable_eitc",
     ]
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.md.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "md_income_tax_before_credits",
+            "md_non_refundable_eitc",
+            "md_non_refundable_eitc_potential",
+        )

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class md_non_refundable_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc.py
@@ -4,22 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class md_non_refundable_eitc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "MD EITC non-refundable State tax credit"
-    unit = USD
-    documentation = "Non-refundable EITC credit reducing MD State income tax."
-    definition_period = YEAR
-    reference = "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income"
-    defined_for = StateCode.MD
-
-    adds = [
-        "md_married_or_has_child_non_refundable_eitc",
-        "md_unmarried_childless_non_refundable_eitc",
-    ]
-
-
 class md_non_refundable_eitc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc_potential.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_non_refundable_eitc_potential.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class md_non_refundable_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD EITC non-refundable State tax credit"
+    unit = USD
+    documentation = "Non-refundable EITC credit reducing MD State income tax."
+    definition_period = YEAR
+    reference = "https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-7-income-tax-credits/section-10-704-effective-until-6302023-for-earned-income"
+    defined_for = StateCode.MD
+
+    adds = [
+        "md_married_or_has_child_non_refundable_eitc",
+        "md_unmarried_childless_non_refundable_eitc",
+    ]

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/md_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/md_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class md_non_refundable_credits(Variable):
@@ -10,4 +13,10 @@ class md_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.MD
 
-    adds = "gov.states.md.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.md.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "md_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class md_poverty_line_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class md_poverty_line_credit(Variable):
+class md_poverty_line_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "MD Poverty Line Credit"
@@ -33,3 +35,26 @@ class md_poverty_line_credit(Variable):
         earnings_portion = earnings * p.earned_income_share
         amount_if_eligible = min_(tax_after_non_refundable_eitc, earnings_portion)
         return amount_if_eligible * eligible
+
+
+class md_poverty_line_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD Poverty Line Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://law.justia.com/codes/maryland/2021/tax-general/title-10/subtitle-7/section-10-709/"
+    defined_for = StateCode.MD
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.md.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "md_income_tax_before_credits",
+            "md_poverty_line_credit",
+            "md_poverty_line_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit.py
@@ -4,40 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class md_poverty_line_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "MD Poverty Line Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://law.justia.com/codes/maryland/2021/tax-general/title-10/subtitle-7/section-10-709/"
-    defined_for = StateCode.MD
-
-    def formula(tax_unit, period, parameters):
-        # Earlier portions of the law define eligibility.
-        eligible = tax_unit("is_eligible_md_poverty_line_credit", period)
-        # (c)    Except as provided in subsection (e) of this section, the
-        # credit allowed against the State income tax under subsection (b)(1)
-        # of this section equals the lesser of:
-        # (1) the State income tax determined after subtracting the credit
-        # allowed under § 10–704(b)(1) of this subtitle; or
-        income_tax_before_credits = tax_unit("md_income_tax_before_credits", period)
-        md_married_or_has_child_non_refundable_eitc = tax_unit(
-            "md_married_or_has_child_non_refundable_eitc", period
-        )
-        tax_after_non_refundable_eitc = (
-            income_tax_before_credits - md_married_or_has_child_non_refundable_eitc
-        )
-        # (2)    an amount equal to 5% of the eligible low income taxpayer’s
-        # earned income, as defined under § 32(c)(2) of the Internal Revenue
-        # Code.
-        p = parameters(period).gov.states.md.tax.income.credits.poverty_line
-        earnings = tax_unit("tax_unit_earned_income", period)
-        earnings_portion = earnings * p.earned_income_share
-        amount_if_eligible = min_(tax_after_non_refundable_eitc, earnings_portion)
-        return amount_if_eligible * eligible
-
-
 class md_poverty_line_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit_potential.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/poverty_line/md_poverty_line_credit_potential.py
@@ -1,0 +1,35 @@
+from policyengine_us.model_api import *
+
+
+class md_poverty_line_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD Poverty Line Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://law.justia.com/codes/maryland/2021/tax-general/title-10/subtitle-7/section-10-709/"
+    defined_for = StateCode.MD
+
+    def formula(tax_unit, period, parameters):
+        # Earlier portions of the law define eligibility.
+        eligible = tax_unit("is_eligible_md_poverty_line_credit", period)
+        # (c)    Except as provided in subsection (e) of this section, the
+        # credit allowed against the State income tax under subsection (b)(1)
+        # of this section equals the lesser of:
+        # (1) the State income tax determined after subtracting the credit
+        # allowed under § 10–704(b)(1) of this subtitle; or
+        income_tax_before_credits = tax_unit("md_income_tax_before_credits", period)
+        md_married_or_has_child_non_refundable_eitc = tax_unit(
+            "md_married_or_has_child_non_refundable_eitc", period
+        )
+        tax_after_non_refundable_eitc = (
+            income_tax_before_credits - md_married_or_has_child_non_refundable_eitc
+        )
+        # (2)    an amount equal to 5% of the eligible low income taxpayer’s
+        # earned income, as defined under § 32(c)(2) of the Internal Revenue
+        # Code.
+        p = parameters(period).gov.states.md.tax.income.credits.poverty_line
+        earnings = tax_unit("tax_unit_earned_income", period)
+        earnings_portion = earnings * p.earned_income_share
+        amount_if_eligible = min_(tax_after_non_refundable_eitc, earnings_portion)
+        return amount_if_eligible * eligible

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class md_senior_tax_credit(Variable):
+class md_senior_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Maryland Senior Tax Credit"
@@ -41,3 +43,28 @@ class md_senior_tax_credit(Variable):
             ],
         )
         return (eligible_count > 0) * credit_amount
+
+
+class md_senior_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maryland Senior Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.marylandtaxes.gov/forms/22_forms/Resident_Booklet.pdf#page=15"
+    )
+    defined_for = "md_senior_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.md.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "md_income_tax_before_credits",
+            "md_senior_tax_credit",
+            "md_senior_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.py
@@ -4,48 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class md_senior_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Maryland Senior Tax Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://www.marylandtaxes.gov/forms/22_forms/Resident_Booklet.pdf#page=15"
-    )
-    defined_for = "md_senior_tax_credit_eligible"
-
-    def formula_2022(tax_unit, period, parameters):
-        p = parameters(period).gov.states.md.tax.income.credits.senior_tax
-
-        age_head = tax_unit("age_head", period)
-        spouse_age = tax_unit("age_spouse", period)
-        filing_status = tax_unit("filing_status", period)
-        status = filing_status.possible_values
-
-        head_eligible = (age_head >= p.age_eligibility).astype(int)
-        spouse_eligible = (spouse_age >= p.age_eligibility).astype(int)
-        eligible_count = head_eligible + spouse_eligible
-
-        credit_amount = select(
-            [
-                filing_status == status.SINGLE,
-                filing_status == status.JOINT,
-                filing_status == status.HEAD_OF_HOUSEHOLD,
-                filing_status == status.SURVIVING_SPOUSE,
-                filing_status == status.SEPARATE,
-            ],
-            [
-                p.amount.single,
-                p.amount.joint[eligible_count],
-                p.amount.head_of_household,
-                p.amount.surviving_spouse,
-                p.amount.separate,
-            ],
-        )
-        return (eligible_count > 0) * credit_amount
-
-
 class md_senior_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class md_senior_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/senior_tax/md_senior_tax_credit_potential.py
@@ -1,0 +1,43 @@
+from policyengine_us.model_api import *
+
+
+class md_senior_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maryland Senior Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.marylandtaxes.gov/forms/22_forms/Resident_Booklet.pdf#page=15"
+    )
+    defined_for = "md_senior_tax_credit_eligible"
+
+    def formula_2022(tax_unit, period, parameters):
+        p = parameters(period).gov.states.md.tax.income.credits.senior_tax
+
+        age_head = tax_unit("age_head", period)
+        spouse_age = tax_unit("age_spouse", period)
+        filing_status = tax_unit("filing_status", period)
+        status = filing_status.possible_values
+
+        head_eligible = (age_head >= p.age_eligibility).astype(int)
+        spouse_eligible = (spouse_age >= p.age_eligibility).astype(int)
+        eligible_count = head_eligible + spouse_eligible
+
+        credit_amount = select(
+            [
+                filing_status == status.SINGLE,
+                filing_status == status.JOINT,
+                filing_status == status.HEAD_OF_HOUSEHOLD,
+                filing_status == status.SURVIVING_SPOUSE,
+                filing_status == status.SEPARATE,
+            ],
+            [
+                p.amount.single,
+                p.amount.joint[eligible_count],
+                p.amount.head_of_household,
+                p.amount.surviving_spouse,
+                p.amount.separate,
+            ],
+        )
+        return (eligible_count > 0) * credit_amount

--- a/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit.py
@@ -4,28 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class me_non_refundable_child_care_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Maine non-refundable child care credit"
-    unit = USD
-    documentation = "The portion of the Maine Child Care Credit that is non-refundable."
-    reference = [
-        "https://www.mainelegislature.org/legis/statutes/36/title36sec5218.html",
-        "https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_a_ff.pdf#page=2",
-    ]
-    definition_period = YEAR
-    defined_for = StateCode.ME
-
-    def formula(tax_unit, period, parameters):
-        child_care_credit = tax_unit("me_child_care_credit", period)
-        refundable_child_care_credit = tax_unit(
-            "me_refundable_child_care_credit", period
-        )
-
-        return max_(child_care_credit - refundable_child_care_credit, 0)
-
-
 class me_non_refundable_child_care_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class me_non_refundable_child_care_credit(Variable):
+class me_non_refundable_child_care_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Maine non-refundable child care credit"
@@ -21,3 +23,30 @@ class me_non_refundable_child_care_credit(Variable):
         )
 
         return max_(child_care_credit - refundable_child_care_credit, 0)
+
+
+class me_non_refundable_child_care_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maine non-refundable child care credit"
+    unit = USD
+    documentation = "The portion of the Maine Child Care Credit that is non-refundable."
+    reference = [
+        "https://www.mainelegislature.org/legis/statutes/36/title36sec5218.html",
+        "https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_a_ff.pdf#page=2",
+    ]
+    definition_period = YEAR
+    defined_for = StateCode.ME
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.me.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "me_income_tax_before_credits",
+            "me_non_refundable_child_care_credit",
+            "me_non_refundable_child_care_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class me_non_refundable_child_care_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit_potential.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/credits/child_care_credit/me_non_refundable_child_care_credit_potential.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class me_non_refundable_child_care_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maine non-refundable child care credit"
+    unit = USD
+    documentation = "The portion of the Maine Child Care Credit that is non-refundable."
+    reference = [
+        "https://www.mainelegislature.org/legis/statutes/36/title36sec5218.html",
+        "https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_a_ff.pdf#page=2",
+    ]
+    definition_period = YEAR
+    defined_for = StateCode.ME
+
+    def formula(tax_unit, period, parameters):
+        child_care_credit = tax_unit("me_child_care_credit", period)
+        refundable_child_care_credit = tax_unit(
+            "me_refundable_child_care_credit", period
+        )
+
+        return max_(child_care_credit - refundable_child_care_credit, 0)

--- a/policyengine_us/variables/gov/states/me/tax/income/me_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/me_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class me_non_refundable_credits(Variable):
@@ -9,4 +12,10 @@ class me_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.ME
 
-    adds = "gov.states.me.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.me.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "me_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class mo_non_refundable_credits(Variable):
@@ -8,4 +11,11 @@ class mo_non_refundable_credits(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.MO
-    adds = "gov.states.mo.tax.income.credits.non_refundable"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.mo.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "mo_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class mo_wftc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class mo_wftc(Variable):
+class mo_wftc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Missouri Working Families Tax Credit"
@@ -16,3 +18,28 @@ class mo_wftc(Variable):
         federal_eitc = tax_unit("eitc", period)
         rate = parameters(period).gov.states.mo.tax.income.credits.wftc.match
         return federal_eitc * rate
+
+
+class mo_wftc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Missouri Working Families Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://revisor.mo.gov/main/OneSection.aspx?section=143.177&bid=49978&hl="
+    )
+    defined_for = StateCode.MO
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.mo.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "mo_income_tax_before_credits",
+            "mo_wftc",
+            "mo_wftc_potential",
+        )

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc.py
@@ -4,23 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class mo_wftc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Missouri Working Families Tax Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://revisor.mo.gov/main/OneSection.aspx?section=143.177&bid=49978&hl="
-    )
-    defined_for = StateCode.MO
-
-    def formula(tax_unit, period, parameters):
-        federal_eitc = tax_unit("eitc", period)
-        rate = parameters(period).gov.states.mo.tax.income.credits.wftc.match
-        return federal_eitc * rate
-
-
 class mo_wftc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_potential.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_potential.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class mo_wftc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Missouri Working Families Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://revisor.mo.gov/main/OneSection.aspx?section=143.177&bid=49978&hl="
+    )
+    defined_for = StateCode.MO
+
+    def formula(tax_unit, period, parameters):
+        federal_eitc = tax_unit("eitc", period)
+        rate = parameters(period).gov.states.mo.tax.income.credits.wftc.match
+        return federal_eitc * rate

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ms_cdcc(Variable):
+class ms_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Mississippi child and dependent care credit"
@@ -15,3 +17,26 @@ class ms_cdcc(Variable):
         cdcc = tax_unit("cdcc", period)
         p = parameters(period).gov.states.ms.tax.income.credits.cdcc
         return p.match * cdcc
+
+
+class ms_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Mississippi child and dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ms_cdcc_eligible"
+    reference = "https://legiscan.com/MS/text/HB1671/id/2767768"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ms.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ms_income_tax_before_credits_unit",
+            "ms_cdcc",
+            "ms_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.py
@@ -4,22 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ms_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Mississippi child and dependent care credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = "ms_cdcc_eligible"
-    reference = "https://legiscan.com/MS/text/HB1671/id/2767768"
-
-    def formula(tax_unit, period, parameters):
-        # Mississippi matches the federal credit taken
-        cdcc = tax_unit("cdcc", period)
-        p = parameters(period).gov.states.ms.tax.income.credits.cdcc
-        return p.match * cdcc
-
-
 class ms_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ms_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/cdcc/ms_cdcc_potential.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class ms_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Mississippi child and dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ms_cdcc_eligible"
+    reference = "https://legiscan.com/MS/text/HB1671/id/2767768"
+
+    def formula(tax_unit, period, parameters):
+        # Mississippi matches the federal credit taken
+        cdcc = tax_unit("cdcc", period)
+        p = parameters(period).gov.states.ms.tax.income.credits.cdcc
+        return p.match * cdcc

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ms_charitable_contributions_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.py
@@ -4,31 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ms_charitable_contributions_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Mississippi charitable contributions credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.MS
-    reference = (
-        "https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100211_0.pdf#page=18",
-        "https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=3",
-    )
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.ms.tax.income.credits.charitable_contribution
-
-        foster_care_contributions = tax_unit(
-            "ms_charitable_contributions_to_qualifying_foster_care_organizations",
-            period,
-        )
-        filing_status = tax_unit("filing_status", period)
-        cap = p.cap[filing_status]
-
-        return min_(foster_care_contributions, cap)
-
-
 class ms_charitable_contributions_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ms_charitable_contributions_credit(Variable):
+class ms_charitable_contributions_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Mississippi charitable contributions credit"
@@ -24,3 +26,29 @@ class ms_charitable_contributions_credit(Variable):
         cap = p.cap[filing_status]
 
         return min_(foster_care_contributions, cap)
+
+
+class ms_charitable_contributions_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Mississippi charitable contributions credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100211_0.pdf#page=18",
+        "https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=3",
+    )
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ms.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ms_income_tax_before_credits_unit",
+            "ms_charitable_contributions_credit",
+            "ms_charitable_contributions_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/credits/charitable_contribution/ms_charitable_contributions_credit_potential.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class ms_charitable_contributions_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Mississippi charitable contributions credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100211_0.pdf#page=18",
+        "https://www.dor.ms.gov/sites/default/files/Forms/Individual/80100231.pdf#page=3",
+    )
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ms.tax.income.credits.charitable_contribution
+
+        foster_care_contributions = tax_unit(
+            "ms_charitable_contributions_to_qualifying_foster_care_organizations",
+            period,
+        )
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+
+        return min_(foster_care_contributions, cap)

--- a/policyengine_us/variables/gov/states/ms/tax/income/ms_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/ms_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ms_non_refundable_credits(Variable):
@@ -9,4 +12,10 @@ class ms_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.MS
 
-    adds = "gov.states.ms.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ms.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "ms_income_tax_before_credits_unit"
+        )

--- a/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc.py
@@ -4,42 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class nc_ctc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "North Carolina credit for children"
-    definition_period = YEAR
-    unit = USD
-    reference = (
-        "https://www.ncdor.gov/taxes-forms/individual-income-tax/credit-children"
-    )
-    defined_for = StateCode.NC
-
-    def formula(tax_unit, period, parameters):
-        ctc_qualifying_children = tax_unit("ctc_qualifying_children", period)
-        income = tax_unit("adjusted_gross_income", period)
-        filing_status = tax_unit("filing_status", period)
-        p = parameters(period).gov.states.nc.tax.income.credits.ctc
-        status = filing_status.possible_values
-        credit_amount = select(
-            [
-                filing_status == status.SINGLE,
-                filing_status == status.HEAD_OF_HOUSEHOLD,
-                filing_status == status.JOINT,
-                filing_status == status.SURVIVING_SPOUSE,
-                filing_status == status.SEPARATE,
-            ],
-            [
-                p.single.calc(income),
-                p.head_of_household.calc(income),
-                p.joint.calc(income),
-                p.surviving_spouse.calc(income),
-                p.separate.calc(income),
-            ],
-        )
-        return ctc_qualifying_children * credit_amount
-
-
 class nc_ctc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class nc_ctc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class nc_ctc(Variable):
+class nc_ctc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "North Carolina credit for children"
@@ -35,3 +37,28 @@ class nc_ctc(Variable):
             ],
         )
         return ctc_qualifying_children * credit_amount
+
+
+class nc_ctc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Carolina credit for children"
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.ncdor.gov/taxes-forms/individual-income-tax/credit-children"
+    )
+    defined_for = StateCode.NC
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.nc.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "nc_income_tax_before_credits",
+            "nc_ctc",
+            "nc_ctc_potential",
+        )

--- a/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc_potential.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/credits/nc_ctc_potential.py
@@ -1,0 +1,37 @@
+from policyengine_us.model_api import *
+
+
+class nc_ctc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Carolina credit for children"
+    definition_period = YEAR
+    unit = USD
+    reference = (
+        "https://www.ncdor.gov/taxes-forms/individual-income-tax/credit-children"
+    )
+    defined_for = StateCode.NC
+
+    def formula(tax_unit, period, parameters):
+        ctc_qualifying_children = tax_unit("ctc_qualifying_children", period)
+        income = tax_unit("adjusted_gross_income", period)
+        filing_status = tax_unit("filing_status", period)
+        p = parameters(period).gov.states.nc.tax.income.credits.ctc
+        status = filing_status.possible_values
+        credit_amount = select(
+            [
+                filing_status == status.SINGLE,
+                filing_status == status.HEAD_OF_HOUSEHOLD,
+                filing_status == status.JOINT,
+                filing_status == status.SURVIVING_SPOUSE,
+                filing_status == status.SEPARATE,
+            ],
+            [
+                p.single.calc(income),
+                p.head_of_household.calc(income),
+                p.joint.calc(income),
+                p.surviving_spouse.calc(income),
+                p.separate.calc(income),
+            ],
+        )
+        return ctc_qualifying_children * credit_amount

--- a/policyengine_us/variables/gov/states/nc/tax/income/nc_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/nc_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class nc_non_refundable_credits(Variable):
@@ -9,4 +12,10 @@ class nc_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.NC
 
-    adds = "gov.states.nc.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.nc.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "nc_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ny_geothermal_energy_system_credit(Variable):
+class ny_geothermal_energy_system_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "New York geothermal energy system equipment credit"
@@ -18,3 +20,27 @@ class ny_geothermal_energy_system_credit(Variable):
         p = parameters(period).gov.states.ny.tax.income.credits.geothermal_energy_system
         uncapped_credit = qualified_expenditures * p.rate
         return min_(uncapped_credit, p.cap)
+
+
+class ny_geothermal_energy_system_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "New York geothermal energy system equipment credit"
+    documentation = "The tax credit for a qualified purchase or lease of geothermal energy system equipment, with a 5-year carryover."
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (g)(2)(C)(9)(g-4)
+    defined_for = StateCode.NY
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ny.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ny_income_tax_before_credits",
+            "ny_geothermal_energy_system_credit",
+            "ny_geothermal_energy_system_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ny_geothermal_energy_system_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit.py
@@ -4,25 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ny_geothermal_energy_system_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "New York geothermal energy system equipment credit"
-    documentation = "The tax credit for a qualified purchase or lease of geothermal energy system equipment, with a 5-year carryover."
-    unit = USD
-    definition_period = YEAR
-    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (g)(2)(C)(9)(g-4)
-    defined_for = StateCode.NY
-
-    def formula(tax_unit, period, parameters):
-        qualified_expenditures = tax_unit(
-            "ny_qualified_geothermal_energy_system_expenditures", period
-        )
-        p = parameters(period).gov.states.ny.tax.income.credits.geothermal_energy_system
-        uncapped_credit = qualified_expenditures * p.rate
-        return min_(uncapped_credit, p.cap)
-
-
 class ny_geothermal_energy_system_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_geothermal_energy_system_credit_potential.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class ny_geothermal_energy_system_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "New York geothermal energy system equipment credit"
+    documentation = "The tax credit for a qualified purchase or lease of geothermal energy system equipment, with a 5-year carryover."
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (g)(2)(C)(9)(g-4)
+    defined_for = StateCode.NY
+
+    def formula(tax_unit, period, parameters):
+        qualified_expenditures = tax_unit(
+            "ny_qualified_geothermal_energy_system_expenditures", period
+        )
+        p = parameters(period).gov.states.ny.tax.income.credits.geothermal_energy_system
+        uncapped_credit = qualified_expenditures * p.rate
+        return min_(uncapped_credit, p.cap)

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ny_household_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit.py
@@ -4,50 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ny_household_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "NY household credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (b)
-    defined_for = StateCode.NY
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.ny.tax.income.credits.household_credit
-        filing_status = tax_unit("filing_status", period)
-        filing_statuses = filing_status.possible_values
-        # Include spouse's AGI if filing separately.
-        agi = add(
-            tax_unit,
-            period,
-            ["adjusted_gross_income", "spouse_separate_adjusted_gross_income"],
-        )
-        # Single filers: based only on AGI.
-        single = filing_status == filing_statuses.SINGLE
-        # Use `right=True` to reflect "over...but not over".
-        amount_if_single = p.single.calc(agi, right=True)
-        single_amount = single * amount_if_single
-        # All others are based on AGI & size.
-        # In the case of married filing separate, based on the combined AGI and size.
-        size = add(
-            tax_unit,
-            period,
-            ["tax_unit_size", "spouse_separate_tax_unit_size"],
-        )
-        separate = filing_status == filing_statuses.SEPARATE
-        non_single_base = p.non_single.base.calc(agi, right=True)
-        non_single_additional = p.non_single.additional.calc(agi, right=True)
-        total_amount_if_not_single = non_single_base + non_single_additional * (
-            size - 1
-        )
-        amount_if_not_single = np.ceil(
-            total_amount_if_not_single / where(separate, 2, 1)
-        )
-        non_single_amount = amount_if_not_single * ~single
-        return single_amount + non_single_amount
-
-
 class ny_household_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ny_household_credit(Variable):
+class ny_household_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "NY household credit"
@@ -43,3 +45,26 @@ class ny_household_credit(Variable):
         )
         non_single_amount = amount_if_not_single * ~single
         return single_amount + non_single_amount
+
+
+class ny_household_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "NY household credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (b)
+    defined_for = StateCode.NY
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ny.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ny_income_tax_before_credits",
+            "ny_household_credit",
+            "ny_household_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_household_credit_potential.py
@@ -1,0 +1,45 @@
+from policyengine_us.model_api import *
+
+
+class ny_household_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "NY household credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (b)
+    defined_for = StateCode.NY
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ny.tax.income.credits.household_credit
+        filing_status = tax_unit("filing_status", period)
+        filing_statuses = filing_status.possible_values
+        # Include spouse's AGI if filing separately.
+        agi = add(
+            tax_unit,
+            period,
+            ["adjusted_gross_income", "spouse_separate_adjusted_gross_income"],
+        )
+        # Single filers: based only on AGI.
+        single = filing_status == filing_statuses.SINGLE
+        # Use `right=True` to reflect "over...but not over".
+        amount_if_single = p.single.calc(agi, right=True)
+        single_amount = single * amount_if_single
+        # All others are based on AGI & size.
+        # In the case of married filing separate, based on the combined AGI and size.
+        size = add(
+            tax_unit,
+            period,
+            ["tax_unit_size", "spouse_separate_tax_unit_size"],
+        )
+        separate = filing_status == filing_statuses.SEPARATE
+        non_single_base = p.non_single.base.calc(agi, right=True)
+        non_single_additional = p.non_single.additional.calc(agi, right=True)
+        total_amount_if_not_single = non_single_base + non_single_additional * (
+            size - 1
+        )
+        amount_if_not_single = np.ceil(
+            total_amount_if_not_single / where(separate, 2, 1)
+        )
+        non_single_amount = amount_if_not_single * ~single
+        return single_amount + non_single_amount

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit.py
@@ -4,26 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ny_solar_energy_systems_equipment_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "New York solar energy systems equipment credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (g)(2)(C)(9)(g-1)
-    defined_for = StateCode.NY
-
-    def formula(tax_unit, period, parameters):
-        qualified_expenditures = tax_unit(
-            "ny_qualified_solar_energy_systems_equipment_expenditures", period
-        )
-        p = parameters(
-            period
-        ).gov.states.ny.tax.income.credits.solar_energy_systems_equipment
-        uncapped_credit = qualified_expenditures * p.rate
-        return min_(uncapped_credit, p.cap)
-
-
 class ny_solar_energy_systems_equipment_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ny_solar_energy_systems_equipment_credit(Variable):
+class ny_solar_energy_systems_equipment_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "New York solar energy systems equipment credit"
@@ -19,3 +21,26 @@ class ny_solar_energy_systems_equipment_credit(Variable):
         ).gov.states.ny.tax.income.credits.solar_energy_systems_equipment
         uncapped_credit = qualified_expenditures * p.rate
         return min_(uncapped_credit, p.cap)
+
+
+class ny_solar_energy_systems_equipment_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "New York solar energy systems equipment credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (g)(2)(C)(9)(g-1)
+    defined_for = StateCode.NY
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ny.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ny_income_tax_before_credits",
+            "ny_solar_energy_systems_equipment_credit",
+            "ny_solar_energy_systems_equipment_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ny_solar_energy_systems_equipment_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/solar_energy_systems/ny_solar_energy_systems_equipment_credit_potential.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class ny_solar_energy_systems_equipment_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "New York solar energy systems equipment credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (g)(2)(C)(9)(g-1)
+    defined_for = StateCode.NY
+
+    def formula(tax_unit, period, parameters):
+        qualified_expenditures = tax_unit(
+            "ny_qualified_solar_energy_systems_equipment_expenditures", period
+        )
+        p = parameters(
+            period
+        ).gov.states.ny.tax.income.credits.solar_energy_systems_equipment
+        uncapped_credit = qualified_expenditures * p.rate
+        return min_(uncapped_credit, p.cap)

--- a/policyengine_us/variables/gov/states/ny/tax/income/ny_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/ny_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ny_non_refundable_credits(Variable):
@@ -11,6 +14,6 @@ class ny_non_refundable_credits(Variable):
 
     def formula(tax_unit, period, parameters):
         credits = parameters(period).gov.states.ny.tax.income.credits.non_refundable
-        income_tax = tax_unit("ny_income_tax_before_credits", period)
-        total_credit_value = add(tax_unit, period, credits)
-        return min_(income_tax, total_credit_value)
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, credits, "ny_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class oh_joint_filing_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.py
@@ -4,30 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class oh_joint_filing_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Ohio joint filing credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://codes.ohio.gov/ohio-revised-code/section-5747.05"
-    defined_for = "oh_joint_filing_credit_eligible"
-
-    def formula(tax_unit, period, parameters):
-        tax_before_joint_filing_credit = tax_unit(
-            "oh_tax_before_joint_filing_credit", period
-        )
-        p = parameters(period).gov.states.oh.tax.income.credits.joint_filing
-        # Ohio uses MAGI for the credit computation, which is Ohio AGI with
-        # the addition of the business income deduction, which is currently not included in the model,
-        # hence, we use the Ohio AGI for the credit computation
-        oh_agi = tax_unit("oh_modified_agi", period)
-        exemptions = tax_unit("oh_personal_exemptions", period)
-        agi_less_exepmtions = max_(oh_agi - exemptions, 0)
-        percentage = p.rate.calc(agi_less_exepmtions)
-        return min_(tax_before_joint_filing_credit * percentage, p.cap)
-
-
 class oh_joint_filing_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class oh_joint_filing_credit(Variable):
+class oh_joint_filing_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Ohio joint filing credit"
@@ -23,3 +25,26 @@ class oh_joint_filing_credit(Variable):
         agi_less_exepmtions = max_(oh_agi - exemptions, 0)
         percentage = p.rate.calc(agi_less_exepmtions)
         return min_(tax_before_joint_filing_credit * percentage, p.cap)
+
+
+class oh_joint_filing_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio joint filing credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://codes.ohio.gov/ohio-revised-code/section-5747.05"
+    defined_for = "oh_joint_filing_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+            "oh_joint_filing_credit",
+            "oh_joint_filing_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/joint_filing_credit/oh_joint_filing_credit_potential.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class oh_joint_filing_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio joint filing credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://codes.ohio.gov/ohio-revised-code/section-5747.05"
+    defined_for = "oh_joint_filing_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        tax_before_joint_filing_credit = tax_unit(
+            "oh_tax_before_joint_filing_credit", period
+        )
+        p = parameters(period).gov.states.oh.tax.income.credits.joint_filing
+        # Ohio uses MAGI for the credit computation, which is Ohio AGI with
+        # the addition of the business income deduction, which is currently not included in the model,
+        # hence, we use the Ohio AGI for the credit computation
+        oh_agi = tax_unit("oh_modified_agi", period)
+        exemptions = tax_unit("oh_personal_exemptions", period)
+        agi_less_exepmtions = max_(oh_agi - exemptions, 0)
+        percentage = p.rate.calc(agi_less_exepmtions)
+        return min_(tax_before_joint_filing_credit * percentage, p.cap)

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
@@ -4,40 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class oh_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Ohio child and dependent care credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://codes.ohio.gov/ohio-revised-code/section-5747.054",
-        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=20",
-    )
-    defined_for = StateCode.OH
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.oh.tax.income.credits.cdcc
-
-        agi = tax_unit("oh_modified_agi", period)
-        # ORC § 5747.054(A): filers with AGI below the low-income threshold
-        # receive credit "without regard to any limitation imposed by section 26
-        # of the Internal Revenue Code", i.e. cdcc_potential.
-        # Filers in the middle bracket use cdcc (limited by IRC § 26).
-        low_income = agi < p.low_income_threshold
-        us_cdcc = where(
-            low_income,
-            tax_unit("cdcc_potential", period),
-            tax_unit("cdcc", period),
-        )
-
-        rate = p.match.calc(agi)
-        # qualify for full CDCC amount when AGI < 20_000
-        # qualify for 25% of CDCC when 20000 <= AGI < 40_000
-        # not qualify when AGI >= 40_000
-        return rate * us_cdcc
-
-
 class oh_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class oh_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class oh_cdcc(Variable):
+class oh_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Ohio child and dependent care credit"
@@ -33,3 +35,29 @@ class oh_cdcc(Variable):
         # qualify for 25% of CDCC when 20000 <= AGI < 40_000
         # not qualify when AGI >= 40_000
         return rate * us_cdcc
+
+
+class oh_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio child and dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://codes.ohio.gov/ohio-revised-code/section-5747.054",
+        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=20",
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+            "oh_cdcc",
+            "oh_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_cdcc_potential.py
@@ -1,0 +1,35 @@
+from policyengine_us.model_api import *
+
+
+class oh_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio child and dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://codes.ohio.gov/ohio-revised-code/section-5747.054",
+        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=20",
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.oh.tax.income.credits.cdcc
+
+        agi = tax_unit("oh_modified_agi", period)
+        # ORC § 5747.054(A): filers with AGI below the low-income threshold
+        # receive credit "without regard to any limitation imposed by section 26
+        # of the Internal Revenue Code", i.e. cdcc_potential.
+        # Filers in the middle bracket use cdcc (limited by IRC § 26).
+        low_income = agi < p.low_income_threshold
+        us_cdcc = where(
+            low_income,
+            tax_unit("cdcc_potential", period),
+            tax_unit("cdcc", period),
+        )
+
+        rate = p.match.calc(agi)
+        # qualify for full CDCC amount when AGI < 20_000
+        # qualify for 25% of CDCC when 20000 <= AGI < 40_000
+        # not qualify when AGI >= 40_000
+        return rate * us_cdcc

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class oh_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class oh_eitc(Variable):
+class oh_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Ohio Earned Income Credit"
@@ -17,3 +19,29 @@ class oh_eitc(Variable):
         federal_eitc = tax_unit("eitc", period)
         match = parameters(period).gov.states.oh.tax.income.credits.eitc.rate
         return federal_eitc * match
+
+
+class oh_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Earned Income Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://codes.ohio.gov/ohio-revised-code/section-5747.71",
+        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2022/it1040-sd100-instruction-booklet.pdf#page=21",
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+            "oh_eitc",
+            "oh_eitc_potential",
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc.py
@@ -4,24 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class oh_eitc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Ohio Earned Income Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://codes.ohio.gov/ohio-revised-code/section-5747.71",
-        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2022/it1040-sd100-instruction-booklet.pdf#page=21",
-    )
-    defined_for = StateCode.OH
-
-    def formula(tax_unit, period, parameters):
-        federal_eitc = tax_unit("eitc", period)
-        match = parameters(period).gov.states.oh.tax.income.credits.eitc.rate
-        return federal_eitc * match
-
-
 class oh_eitc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_eitc_potential.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class oh_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Earned Income Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://codes.ohio.gov/ohio-revised-code/section-5747.71",
+        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2022/it1040-sd100-instruction-booklet.pdf#page=21",
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        federal_eitc = tax_unit("eitc", period)
+        match = parameters(period).gov.states.oh.tax.income.credits.eitc.rate
+        return federal_eitc * match

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class oh_exemption_credit(Variable):
+class oh_exemption_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Ohio Exemption Credit"
@@ -24,3 +26,28 @@ class oh_exemption_credit(Variable):
         exemptions = tax_unit("exemptions_count", period)
 
         return amount_per_exemption * exemptions
+
+
+class oh_exemption_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Exemption Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/ohio/2022/title-57/chapter-5747/section-5747-022/"
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+            "oh_exemption_credit",
+            "oh_exemption_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit.py
@@ -4,31 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class oh_exemption_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Ohio Exemption Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://law.justia.com/codes/ohio/2022/title-57/chapter-5747/section-5747-022/"
-    )
-    defined_for = StateCode.OH
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.oh.tax.income.credits.exemption
-
-        agi = tax_unit("oh_agi", period)
-        personal_exemptions = tax_unit("oh_personal_exemptions", period)
-        # Per tax form, amount can be negative
-        modified_agi = agi - personal_exemptions
-        amount_per_exemption = p.amount.calc(modified_agi, right=True)
-
-        exemptions = tax_unit("exemptions_count", period)
-
-        return amount_per_exemption * exemptions
-
-
 class oh_exemption_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class oh_exemption_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_exemption_credit_potential.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class oh_exemption_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Exemption Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/ohio/2022/title-57/chapter-5747/section-5747-022/"
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.oh.tax.income.credits.exemption
+
+        agi = tax_unit("oh_agi", period)
+        personal_exemptions = tax_unit("oh_personal_exemptions", period)
+        # Per tax form, amount can be negative
+        modified_agi = agi - personal_exemptions
+        amount_per_exemption = p.amount.calc(modified_agi, right=True)
+
+        exemptions = tax_unit("exemptions_count", period)
+
+        return amount_per_exemption * exemptions

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits.py
@@ -4,24 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class oh_non_public_school_credits_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Ohio Nonchartered, Nonpublic, School Tuition Credit AGI Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=21"
-    defined_for = StateCode.OH
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.oh.tax.income.credits
-        agi = tax_unit("adjusted_gross_income", period)
-        person = tax_unit.members
-        tuition = tax_unit.sum(person("non_public_school_tuition", period))
-        cap = p.non_public_tuition.calc(agi)
-        return min_(tuition, cap)
-
-
 class oh_non_public_school_credits(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class oh_non_public_school_credits_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class oh_non_public_school_credits(Variable):
+class oh_non_public_school_credits_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Ohio Nonchartered, Nonpublic, School Tuition Credit AGI Credit"
@@ -17,3 +19,26 @@ class oh_non_public_school_credits(Variable):
         tuition = tax_unit.sum(person("non_public_school_tuition", period))
         cap = p.non_public_tuition.calc(agi)
         return min_(tuition, cap)
+
+
+class oh_non_public_school_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Nonchartered, Nonpublic, School Tuition Credit AGI Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=21"
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+            "oh_non_public_school_credits",
+            "oh_non_public_school_credits_potential",
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_non_public_school_credits_potential.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class oh_non_public_school_credits_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Nonchartered, Nonpublic, School Tuition Credit AGI Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=21"
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.oh.tax.income.credits
+        agi = tax_unit("adjusted_gross_income", period)
+        person = tax_unit.members
+        tuition = tax_unit.sum(person("non_public_school_tuition", period))
+        cap = p.non_public_tuition.calc(agi)
+        return min_(tuition, cap)

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.py
@@ -4,37 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class oh_senior_citizen_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Ohio senior citizen credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=20",
-        "https://codes.ohio.gov/ohio-revised-code/section-5747.055",
-    )
-    defined_for = StateCode.OH
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.oh.tax.income.credits.senior_citizen
-        person = tax_unit.members
-        head = person("is_tax_unit_head", period)
-        head_has_not_taken_lump_sum_distribution = (
-            ~person("oh_has_taken_oh_lump_sum_credits", period) * head
-        )
-        age_head = tax_unit("age_head", period)
-        elderly_head = age_head >= p.age_threshold
-        eligible_head = (
-            tax_unit.any(head_has_not_taken_lump_sum_distribution) & elderly_head
-        )
-        agi = tax_unit("oh_modified_agi", period)
-        exemptions = tax_unit("oh_personal_exemptions", period)
-        applicable_income = max_(agi - exemptions, 0)
-        credit_amount = p.amount.calc(applicable_income)
-        return eligible_head * credit_amount
-
-
 class oh_senior_citizen_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class oh_senior_citizen_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class oh_senior_citizen_credit(Variable):
+class oh_senior_citizen_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Ohio senior citizen credit"
@@ -30,3 +32,29 @@ class oh_senior_citizen_credit(Variable):
         applicable_income = max_(agi - exemptions, 0)
         credit_amount = p.amount.calc(applicable_income)
         return eligible_head * credit_amount
+
+
+class oh_senior_citizen_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio senior citizen credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=20",
+        "https://codes.ohio.gov/ohio-revised-code/section-5747.055",
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+            "oh_senior_citizen_credit",
+            "oh_senior_citizen_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit_potential.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class oh_senior_citizen_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio senior citizen credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://tax.ohio.gov/static/forms/ohio_individual/individual/2021/pit-it1040-booklet.pdf#page=20",
+        "https://codes.ohio.gov/ohio-revised-code/section-5747.055",
+    )
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.oh.tax.income.credits.senior_citizen
+        person = tax_unit.members
+        head = person("is_tax_unit_head", period)
+        head_has_not_taken_lump_sum_distribution = (
+            ~person("oh_has_taken_oh_lump_sum_credits", period) * head
+        )
+        age_head = tax_unit("age_head", period)
+        elderly_head = age_head >= p.age_threshold
+        eligible_head = (
+            tax_unit.any(head_has_not_taken_lump_sum_distribution) & elderly_head
+        )
+        agi = tax_unit("oh_modified_agi", period)
+        exemptions = tax_unit("oh_personal_exemptions", period)
+        applicable_income = max_(agi - exemptions, 0)
+        credit_amount = p.amount.calc(applicable_income)
+        return eligible_head * credit_amount

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.py
@@ -4,23 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class oh_retirement_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Ohio Retirement Income Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://codes.ohio.gov/ohio-revised-code/section-5747.055"
-    defined_for = StateCode.OH
-
-    def formula(tax_unit, period, parameters):
-        retirement_credit = tax_unit(
-            "oh_pension_based_retirement_income_credit", period
-        )
-        lump_sum_credit = tax_unit("oh_lump_sum_retirement_credit", period)
-        return max_(retirement_credit, lump_sum_credit)
-
-
 class oh_retirement_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class oh_retirement_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class oh_retirement_credit(Variable):
+class oh_retirement_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Ohio Retirement Income Credit"
@@ -16,3 +18,26 @@ class oh_retirement_credit(Variable):
         )
         lump_sum_credit = tax_unit("oh_lump_sum_retirement_credit", period)
         return max_(retirement_credit, lump_sum_credit)
+
+
+class oh_retirement_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Retirement Income Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://codes.ohio.gov/ohio-revised-code/section-5747.055"
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+            "oh_retirement_credit",
+            "oh_retirement_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/retirement_income/oh_retirement_credit_potential.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class oh_retirement_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Ohio Retirement Income Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://codes.ohio.gov/ohio-revised-code/section-5747.055"
+    defined_for = StateCode.OH
+
+    def formula(tax_unit, period, parameters):
+        retirement_credit = tax_unit(
+            "oh_pension_based_retirement_income_credit", period
+        )
+        lump_sum_credit = tax_unit("oh_lump_sum_retirement_credit", period)
+        return max_(retirement_credit, lump_sum_credit)

--- a/policyengine_us/variables/gov/states/oh/tax/income/oh_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/oh_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class oh_non_refundable_credits(Variable):
@@ -15,4 +18,13 @@ class oh_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.OH
 
-    adds = "gov.states.oh.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.oh.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "oh_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.py
+++ b/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ri_cdcc(Variable):
+class ri_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Rhode Island child and dependent care credit"
@@ -14,3 +16,25 @@ class ri_cdcc(Variable):
         fed_cdcc = tax_unit("cdcc", period)
         rate = parameters(period).gov.states.ri.tax.income.credits.cdcc.rate
         return fed_cdcc * rate
+
+
+class ri_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Rhode Island child and dependent care credit"
+    defined_for = StateCode.RI
+    unit = USD
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ri.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ri_income_tax_before_non_refundable_credits",
+            "ri_cdcc",
+            "ri_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.py
+++ b/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.py
@@ -4,21 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ri_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Rhode Island child and dependent care credit"
-    defined_for = StateCode.RI
-    unit = USD
-    definition_period = YEAR
-
-    def formula(tax_unit, period, parameters):
-        # Rhode Island matches the federal credit taken
-        fed_cdcc = tax_unit("cdcc", period)
-        rate = parameters(period).gov.states.ri.tax.income.credits.cdcc.rate
-        return fed_cdcc * rate
-
-
 class ri_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.py
+++ b/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ri_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/ri/tax/income/credits/cdcc/ri_cdcc_potential.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class ri_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Rhode Island child and dependent care credit"
+    defined_for = StateCode.RI
+    unit = USD
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        # Rhode Island matches the federal credit taken
+        fed_cdcc = tax_unit("cdcc", period)
+        rate = parameters(period).gov.states.ri.tax.income.credits.cdcc.rate
+        return fed_cdcc * rate

--- a/policyengine_us/variables/gov/states/ri/tax/income/ri_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ri/tax/income/ri_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ri_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class ri_non_refundable_credits(Variable):
     unit = USD
     definition_period = YEAR
 
-    adds = "gov.states.ri.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ri.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ri_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class sc_cdcc(Variable):
+class sc_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "South Carolina CDCC"
@@ -38,3 +40,27 @@ class sc_cdcc(Variable):
             childcare_expenses, sc_max_care_expense * count_cdcc_eligible
         )
         return eligible * capped_expenses * p_sc.rate
+
+
+class sc_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "South Carolina CDCC"
+    documentation = "South Carolina Child and Dependent Care Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://dor.sc.gov/forms-site/Forms/IITPacket_2022.pdf#page=22"
+    defined_for = StateCode.SC
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.sc.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "sc_income_tax_before_non_refundable_credits",
+            "sc_cdcc",
+            "sc_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class sc_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc.py
@@ -4,45 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class sc_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "South Carolina CDCC"
-    documentation = "South Carolina Child and Dependent Care Credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://dor.sc.gov/forms-site/Forms/IITPacket_2022.pdf#page=22"
-    defined_for = StateCode.SC
-
-    def formula(tax_unit, period, parameters):
-        # Get South Carolina CDCC rate.
-        p_sc = parameters(period).gov.states.sc.tax.income.credits.cdcc
-        p_us = parameters(period).gov.irs.credits.cdcc
-
-        # Year 2021 is different from federal cdcc
-        max_decoupled_year_offset = p_sc.max_care_expense_year_offset
-        period_max = period.offset(max_decoupled_year_offset)
-        sc_max_care_expense = parameters(period_max).gov.irs.credits.cdcc.max
-
-        # Get child care expenses.
-        childcare_expenses = tax_unit("cdcc_relevant_expenses", period)
-
-        # Married filing separate are ineligible.
-        filing_status = tax_unit("filing_status", period)
-        eligible = filing_status != filing_status.possible_values.SEPARATE
-
-        # Number of qualifying people
-        count_cdcc_eligible = min_(
-            tax_unit("count_cdcc_eligible", period), p_us.eligibility.max
-        )
-        # Maximum value cannot exceed cap
-        # Calculate total CDCC
-        capped_expenses = min_(
-            childcare_expenses, sc_max_care_expense * count_cdcc_eligible
-        )
-        return eligible * capped_expenses * p_sc.rate
-
-
 class sc_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/cdcc/sc_cdcc_potential.py
@@ -1,0 +1,40 @@
+from policyengine_us.model_api import *
+
+
+class sc_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "South Carolina CDCC"
+    documentation = "South Carolina Child and Dependent Care Credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://dor.sc.gov/forms-site/Forms/IITPacket_2022.pdf#page=22"
+    defined_for = StateCode.SC
+
+    def formula(tax_unit, period, parameters):
+        # Get South Carolina CDCC rate.
+        p_sc = parameters(period).gov.states.sc.tax.income.credits.cdcc
+        p_us = parameters(period).gov.irs.credits.cdcc
+
+        # Year 2021 is different from federal cdcc
+        max_decoupled_year_offset = p_sc.max_care_expense_year_offset
+        period_max = period.offset(max_decoupled_year_offset)
+        sc_max_care_expense = parameters(period_max).gov.irs.credits.cdcc.max
+
+        # Get child care expenses.
+        childcare_expenses = tax_unit("cdcc_relevant_expenses", period)
+
+        # Married filing separate are ineligible.
+        filing_status = tax_unit("filing_status", period)
+        eligible = filing_status != filing_status.possible_values.SEPARATE
+
+        # Number of qualifying people
+        count_cdcc_eligible = min_(
+            tax_unit("count_cdcc_eligible", period), p_us.eligibility.max
+        )
+        # Maximum value cannot exceed cap
+        # Calculate total CDCC
+        capped_expenses = min_(
+            childcare_expenses, sc_max_care_expense * count_cdcc_eligible
+        )
+        return eligible * capped_expenses * p_sc.rate

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class sc_eitc(Variable):
+class sc_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "South Carolina EITC"
@@ -19,3 +21,29 @@ class sc_eitc(Variable):
         uncapped = np.round(federal_eitc * p.rate, 1)
         # Apply cap (infinite before 2026, $200 from 2026+)
         return min_(uncapped, p.max)
+
+
+class sc_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "South Carolina EITC"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://dor.sc.gov/forms-site/Forms/TC60_2021.pdf",
+        "https://www.scstatehouse.gov/sess126_2025-2026/bills/4216.htm",
+    )
+    defined_for = StateCode.SC
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.sc.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "sc_income_tax_before_non_refundable_credits",
+            "sc_eitc",
+            "sc_eitc_potential",
+        )

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc.py
@@ -4,26 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class sc_eitc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "South Carolina EITC"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://dor.sc.gov/forms-site/Forms/TC60_2021.pdf",
-        "https://www.scstatehouse.gov/sess126_2025-2026/bills/4216.htm",
-    )
-    defined_for = StateCode.SC
-
-    def formula(tax_unit, period, parameters):
-        federal_eitc = tax_unit("eitc", period)
-        p = parameters(period).gov.states.sc.tax.income.credits.eitc
-        uncapped = np.round(federal_eitc * p.rate, 1)
-        # Apply cap (infinite before 2026, $200 from 2026+)
-        return min_(uncapped, p.max)
-
-
 class sc_eitc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class sc_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc_potential.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/eitc/sc_eitc_potential.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class sc_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "South Carolina EITC"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://dor.sc.gov/forms-site/Forms/TC60_2021.pdf",
+        "https://www.scstatehouse.gov/sess126_2025-2026/bills/4216.htm",
+    )
+    defined_for = StateCode.SC
+
+    def formula(tax_unit, period, parameters):
+        federal_eitc = tax_unit("eitc", period)
+        p = parameters(period).gov.states.sc.tax.income.credits.eitc
+        uncapped = np.round(federal_eitc * p.rate, 1)
+        # Apply cap (infinite before 2026, $200 from 2026+)
+        return min_(uncapped, p.max)

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class sc_two_wage_earner_credit(Variable):
+class sc_two_wage_earner_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "South Carolina two wage earner credit"
@@ -28,3 +30,29 @@ class sc_two_wage_earner_credit(Variable):
         p = parameters(period).gov.states.sc.tax.income.credits.two_wage_earner
         credit_if_eligible = p.rate.calc(lesser_head_spouse_income)
         return credit_if_eligible * eligible
+
+
+class sc_two_wage_earner_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "South Carolina two wage earner credit"
+    defined_for = StateCode.SC
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://dor.sc.gov/forms-site/Forms/SC1040TT_2021.pdf",
+        "https://dor.sc.gov/forms-site/Forms/IITPacket_2021.pdf#page=23",
+    )
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.sc.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "sc_income_tax_before_non_refundable_credits",
+            "sc_two_wage_earner_credit",
+            "sc_two_wage_earner_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class sc_two_wage_earner_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit.py
@@ -4,35 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class sc_two_wage_earner_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "South Carolina two wage earner credit"
-    defined_for = StateCode.SC
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://dor.sc.gov/forms-site/Forms/SC1040TT_2021.pdf",
-        "https://dor.sc.gov/forms-site/Forms/IITPacket_2021.pdf#page=23",
-    )
-
-    def formula(tax_unit, period, parameters):
-        # Determine eligibility. Must be a joint filer.
-        filing_status = tax_unit("filing_status", period)
-        eligible = filing_status == filing_status.possible_values.JOINT
-        # Find relevant gross income of head and spouse.
-        person = tax_unit.members
-        income = person("sc_gross_earned_income", period)
-        head_income = tax_unit.max(income * person("is_tax_unit_head", period))
-        spouse_income = tax_unit.max(income * person("is_tax_unit_spouse", period))
-        # Determine lesser of head and spouse income.
-        lesser_head_spouse_income = min_(head_income, spouse_income)
-        # Calculate credit based on rate.
-        p = parameters(period).gov.states.sc.tax.income.credits.two_wage_earner
-        credit_if_eligible = p.rate.calc(lesser_head_spouse_income)
-        return credit_if_eligible * eligible
-
-
 class sc_two_wage_earner_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit_potential.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/credits/two_wage_earner/sc_two_wage_earner_credit_potential.py
@@ -1,0 +1,30 @@
+from policyengine_us.model_api import *
+
+
+class sc_two_wage_earner_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "South Carolina two wage earner credit"
+    defined_for = StateCode.SC
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://dor.sc.gov/forms-site/Forms/SC1040TT_2021.pdf",
+        "https://dor.sc.gov/forms-site/Forms/IITPacket_2021.pdf#page=23",
+    )
+
+    def formula(tax_unit, period, parameters):
+        # Determine eligibility. Must be a joint filer.
+        filing_status = tax_unit("filing_status", period)
+        eligible = filing_status == filing_status.possible_values.JOINT
+        # Find relevant gross income of head and spouse.
+        person = tax_unit.members
+        income = person("sc_gross_earned_income", period)
+        head_income = tax_unit.max(income * person("is_tax_unit_head", period))
+        spouse_income = tax_unit.max(income * person("is_tax_unit_spouse", period))
+        # Determine lesser of head and spouse income.
+        lesser_head_spouse_income = min_(head_income, spouse_income)
+        # Calculate credit based on rate.
+        p = parameters(period).gov.states.sc.tax.income.credits.two_wage_earner
+        credit_if_eligible = p.rate.calc(lesser_head_spouse_income)
+        return credit_if_eligible * eligible

--- a/policyengine_us/variables/gov/states/sc/tax/income/sc_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/sc_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class sc_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class sc_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.SC
 
-    adds = "gov.states.sc.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.sc.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "sc_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py
+++ b/policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py
@@ -1,6 +1,47 @@
 from policyengine_us.model_api import *
 
 
+def state_non_refundable_credit_limit(
+    tax_unit,
+    period,
+    ordered_credits,
+    income_tax_before_non_refundable_credits_var: str,
+    credit_name: str,
+):
+    preceding_credits = []
+    for credit in list(ordered_credits):
+        if credit == credit_name:
+            break
+        preceding_credits.append(credit)
+
+    income_tax_before_credits = tax_unit(
+        income_tax_before_non_refundable_credits_var, period
+    )
+    preceding_credit_total = (
+        add(tax_unit, period, preceding_credits) if preceding_credits else 0
+    )
+    return max_(income_tax_before_credits - preceding_credit_total, 0)
+
+
+def applied_state_non_refundable_credit(
+    tax_unit,
+    period,
+    ordered_credits,
+    income_tax_before_non_refundable_credits_var: str,
+    credit_name: str,
+    potential_credit_name: str,
+):
+    potential = tax_unit(potential_credit_name, period)
+    credit_limit = state_non_refundable_credit_limit(
+        tax_unit,
+        period,
+        ordered_credits,
+        income_tax_before_non_refundable_credits_var,
+        credit_name,
+    )
+    return min_(potential, credit_limit)
+
+
 def cap_state_non_refundable_credit(
     tax_unit,
     period,

--- a/policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py
+++ b/policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+def cap_state_non_refundable_credit(
+    tax_unit,
+    period,
+    credit_name: str,
+    ordered_credits,
+    income_tax_before_non_refundable_credits_var: str,
+    potential,
+):
+    # Keep raw credit variables as their underlying worksheet/statutory amounts.
+    # Ordered tax-liability capping is applied when state non-refundable credits
+    # are aggregated into the tax calculation.
+    return potential
+
+
+def ordered_capped_state_non_refundable_credits(
+    tax_unit,
+    period,
+    ordered_credits,
+    income_tax_before_non_refundable_credits_var: str,
+):
+    remaining_tax = tax_unit(income_tax_before_non_refundable_credits_var, period)
+    capped_total = 0
+    for credit in list(ordered_credits):
+        credit_amount = tax_unit(credit, period)
+        applied_credit = min_(credit_amount, max_(remaining_tax, 0))
+        capped_total += applied_credit
+        remaining_tax = max_(remaining_tax - applied_credit, 0)
+    return capped_total

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc.py
@@ -4,37 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ut_ctc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Utah Child Tax Credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.UT
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.ut.tax.income.credits.ctc
-        person = tax_unit.members
-        ctc_eligible_child = person("ctc_qualifying_child", period)
-        age = person("age", period)
-        ut_child_age_eligible = p.child_age_threshold.calc(age)
-        eligible_child = ctc_eligible_child & ut_child_age_eligible
-        eligible_children = tax_unit.sum(eligible_child)
-        base_amount = p.amount * eligible_children
-        # Utah reduces the CTC based on the state income in addition to
-        # tax exempt interest income
-        relevant_income = add(
-            tax_unit,
-            period,
-            ["tax_exempt_interest_income", "ut_taxable_income"],
-        )
-        filing_status = tax_unit("filing_status", period)
-        reduction_start = p.reduction.start[filing_status]
-        excess_income = max_(relevant_income - reduction_start, 0)
-        reduction = excess_income * p.reduction.rate
-        return max_(base_amount - reduction, 0)
-
-
 class ut_ctc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ut_ctc(Variable):
+class ut_ctc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Utah Child Tax Credit"
@@ -30,3 +32,25 @@ class ut_ctc(Variable):
         excess_income = max_(relevant_income - reduction_start, 0)
         reduction = excess_income * p.reduction.rate
         return max_(base_amount - reduction, 0)
+
+
+class ut_ctc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah Child Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.UT
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ut.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ut_income_tax_before_non_refundable_credits",
+            "ut_ctc",
+            "ut_ctc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ut_ctc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc_potential.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc_potential.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class ut_ctc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah Child Tax Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.UT
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ut.tax.income.credits.ctc
+        person = tax_unit.members
+        ctc_eligible_child = person("ctc_qualifying_child", period)
+        age = person("age", period)
+        ut_child_age_eligible = p.child_age_threshold.calc(age)
+        eligible_child = ctc_eligible_child & ut_child_age_eligible
+        eligible_children = tax_unit.sum(eligible_child)
+        base_amount = p.amount * eligible_children
+        # Utah reduces the CTC based on the state income in addition to
+        # tax exempt interest income
+        relevant_income = add(
+            tax_unit,
+            period,
+            ["tax_exempt_interest_income", "ut_taxable_income"],
+        )
+        filing_status = tax_unit("filing_status", period)
+        reduction_start = p.reduction.start[filing_status]
+        excess_income = max_(relevant_income - reduction_start, 0)
+        reduction = excess_income * p.reduction.rate
+        return max_(base_amount - reduction, 0)

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ut_military_retirement_credit(Variable):
+class ut_military_retirement_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Utah military retirement credit"
@@ -14,3 +16,26 @@ class ut_military_retirement_credit(Variable):
         military_retirement_pay = add(tax_unit, period, ["military_retirement_pay"])
         p = parameters(period).gov.states.ut.tax.income.credits.military_retirement
         return military_retirement_pay * p.rate
+
+
+class ut_military_retirement_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah military retirement credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1043.html"
+    defined_for = "ut_military_retirement_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ut.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ut_income_tax_before_non_refundable_credits",
+            "ut_military_retirement_credit",
+            "ut_military_retirement_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ut_military_retirement_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit.py
@@ -4,21 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ut_military_retirement_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Utah military retirement credit"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1043.html"
-    defined_for = "ut_military_retirement_credit_eligible"
-
-    def formula(tax_unit, period, parameters):
-        military_retirement_pay = add(tax_unit, period, ["military_retirement_pay"])
-        p = parameters(period).gov.states.ut.tax.income.credits.military_retirement
-        return military_retirement_pay * p.rate
-
-
 class ut_military_retirement_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/military_retirement_credit/ut_military_retirement_credit_potential.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class ut_military_retirement_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah military retirement credit"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1043.html"
+    defined_for = "ut_military_retirement_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        military_retirement_pay = add(tax_unit, period, ["military_retirement_pay"])
+        p = parameters(period).gov.states.ut.tax.income.credits.military_retirement
+        return military_retirement_pay * p.rate

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
@@ -12,8 +12,6 @@ class ut_retirement_credit(Variable):
     definition_period = YEAR
     defined_for = "ut_claims_retirement_credit"
 
-    adds = ["ut_retirement_credit_max"]
-
     def formula(tax_unit, period, parameters):
         ordered_credits = parameters(
             period

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ut_retirement_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
@@ -1,4 +1,17 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
+
+class ut_retirement_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah retirement credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ut_claims_retirement_credit"
+
+    adds = ["ut_retirement_credit_max"]
 
 
 class ut_retirement_credit(Variable):
@@ -10,3 +23,16 @@ class ut_retirement_credit(Variable):
     defined_for = "ut_claims_retirement_credit"
 
     adds = ["ut_retirement_credit_max"]
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ut.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ut_income_tax_before_non_refundable_credits",
+            "ut_retirement_credit",
+            "ut_retirement_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit.py
@@ -4,17 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ut_retirement_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Utah retirement credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = "ut_claims_retirement_credit"
-
-    adds = ["ut_retirement_credit_max"]
-
-
 class ut_retirement_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/retirement_credit/ut_retirement_credit_potential.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class ut_retirement_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah retirement credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ut_claims_retirement_credit"
+
+    adds = ["ut_retirement_credit_max"]

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.py
@@ -4,20 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ut_ss_benefits_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Utah Social Security Benefits Credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = StateCode.UT
-
-    def formula(tax_unit, period, parameters):
-        claims_retirement_credit = tax_unit("ut_claims_retirement_credit", period)
-        max_credit = tax_unit("ut_ss_benefits_credit_max", period)
-        return ~claims_retirement_credit * max_credit
-
-
 class ut_ss_benefits_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ut_ss_benefits_credit(Variable):
+class ut_ss_benefits_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Utah Social Security Benefits Credit"
@@ -13,3 +15,25 @@ class ut_ss_benefits_credit(Variable):
         claims_retirement_credit = tax_unit("ut_claims_retirement_credit", period)
         max_credit = tax_unit("ut_ss_benefits_credit_max", period)
         return ~claims_retirement_credit * max_credit
+
+
+class ut_ss_benefits_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah Social Security Benefits Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.UT
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ut.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ut_income_tax_before_non_refundable_credits",
+            "ut_ss_benefits_credit",
+            "ut_ss_benefits_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ut_ss_benefits_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ss_benefits_credit/ut_ss_benefits_credit_potential.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class ut_ss_benefits_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah Social Security Benefits Credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.UT
+
+    def formula(tax_unit, period, parameters):
+        claims_retirement_credit = tax_unit("ut_claims_retirement_credit", period)
+        max_credit = tax_unit("ut_ss_benefits_credit_max", period)
+        return ~claims_retirement_credit * max_credit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ut_at_home_parent_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ut_at_home_parent_credit(Variable):
+class ut_at_home_parent_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Utah at-home parent credit"
@@ -29,3 +31,29 @@ class ut_at_home_parent_credit(Variable):
         )
 
         return p.amount * count_qualifying_children * income_eligible_person
+
+
+class ut_at_home_parent_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah at-home parent credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ut_at_home_parent_credit_agi_eligible"
+    reference = (
+        "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1005.html",
+        "https://www.taxformfinder.org/forms/2021/2021-utah-tc-40-full-packet.pdf#page=23",
+    )
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ut.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ut_income_tax_before_non_refundable_credits",
+            "ut_at_home_parent_credit",
+            "ut_at_home_parent_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit.py
@@ -4,36 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ut_at_home_parent_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Utah at-home parent credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = "ut_at_home_parent_credit_agi_eligible"
-    reference = (
-        "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1005.html",
-        "https://www.taxformfinder.org/forms/2021/2021-utah-tc-40-full-packet.pdf#page=23",
-    )
-
-    def formula(tax_unit, period, parameters):
-        person = tax_unit.members
-        age = person("age", period)
-        is_dependent = person("is_tax_unit_dependent", period)
-        p = parameters(period).gov.states.ut.tax.income.credits.at_home_parent
-        qualifying_child = (age < p.max_child_age) & is_dependent
-        count_qualifying_children = tax_unit.sum(qualifying_child)
-
-        # Multiply by each qualifying parent; they can claim it separately.
-        income_eligible_person = add(
-            tax_unit,
-            period,
-            ["ut_at_home_parent_credit_earned_income_eligible_person"],
-        )
-
-        return p.amount * count_qualifying_children * income_eligible_person
-
-
 class ut_at_home_parent_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit_potential.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_at_home_parent_credit_potential.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class ut_at_home_parent_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah at-home parent credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "ut_at_home_parent_credit_agi_eligible"
+    reference = (
+        "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1005.html",
+        "https://www.taxformfinder.org/forms/2021/2021-utah-tc-40-full-packet.pdf#page=23",
+    )
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        age = person("age", period)
+        is_dependent = person("is_tax_unit_dependent", period)
+        p = parameters(period).gov.states.ut.tax.income.credits.at_home_parent
+        qualifying_child = (age < p.max_child_age) & is_dependent
+        count_qualifying_children = tax_unit.sum(qualifying_child)
+
+        # Multiply by each qualifying parent; they can claim it separately.
+        income_eligible_person = add(
+            tax_unit,
+            period,
+            ["ut_at_home_parent_credit_earned_income_eligible_person"],
+        )
+
+        return p.amount * count_qualifying_children * income_eligible_person

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class ut_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class ut_eitc(Variable):
+class ut_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Utah Earned Income Tax Credit"
@@ -15,3 +17,27 @@ class ut_eitc(Variable):
         p = parameters(period).gov.states.ut.tax.income.credits.earned_income
         federal_eitc = tax_unit("eitc", period)
         return p.rate * federal_eitc
+
+
+class ut_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah Earned Income Tax Credit"
+    unit = USD
+    documentation = "This credit is a fraction of the federal EITC."
+    definition_period = YEAR
+    defined_for = StateCode.UT
+    reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1044.html?v=C59-10-S1044_2022050420220504"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ut.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ut_income_tax_before_non_refundable_credits",
+            "ut_eitc",
+            "ut_eitc_potential",
+        )

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc.py
@@ -4,22 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class ut_eitc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Utah Earned Income Tax Credit"
-    unit = USD
-    documentation = "This credit is a fraction of the federal EITC."
-    definition_period = YEAR
-    defined_for = StateCode.UT
-    reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1044.html?v=C59-10-S1044_2022050420220504"
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.ut.tax.income.credits.earned_income
-        federal_eitc = tax_unit("eitc", period)
-        return p.rate * federal_eitc
-
-
 class ut_eitc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc_potential.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_eitc_potential.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class ut_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah Earned Income Tax Credit"
+    unit = USD
+    documentation = "This credit is a fraction of the federal EITC."
+    definition_period = YEAR
+    defined_for = StateCode.UT
+    reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1044.html?v=C59-10-S1044_2022050420220504"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ut.tax.income.credits.earned_income
+        federal_eitc = tax_unit("eitc", period)
+        return p.rate * federal_eitc

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class ut_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class ut_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.UT
 
-    adds = "gov.states.ut.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.ut.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "ut_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.py
@@ -4,22 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class va_non_refundable_eitc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Virginia non-refundable EITC"
-    unit = USD
-    definition_period = YEAR
-    reference = "https://www.tax.virginia.gov/sites/default/files/vatax-pdf/2022-760-instructions.pdf#page=32"
-    defined_for = StateCode.VA
-
-    def formula(tax_unit, period, parameters):
-        # Either claims refundable or non-refundable, but not both.
-        claims = ~tax_unit("va_claims_refundable_eitc", period)
-        amount_if_claimed = tax_unit("va_non_refundable_eitc_if_claimed", period)
-        return claims * amount_if_claimed
-
-
 class va_non_refundable_eitc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class va_non_refundable_eitc(Variable):
+class va_non_refundable_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Virginia non-refundable EITC"
@@ -15,3 +17,26 @@ class va_non_refundable_eitc(Variable):
         claims = ~tax_unit("va_claims_refundable_eitc", period)
         amount_if_claimed = tax_unit("va_non_refundable_eitc_if_claimed", period)
         return claims * amount_if_claimed
+
+
+class va_non_refundable_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Virginia non-refundable EITC"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.tax.virginia.gov/sites/default/files/vatax-pdf/2022-760-instructions.pdf#page=32"
+    defined_for = StateCode.VA
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.va.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "va_income_tax_before_non_refundable_credits",
+            "va_non_refundable_eitc",
+            "va_non_refundable_eitc_potential",
+        )

--- a/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class va_non_refundable_eitc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc_potential.py
+++ b/policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_non_refundable_eitc_potential.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class va_non_refundable_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Virginia non-refundable EITC"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.tax.virginia.gov/sites/default/files/vatax-pdf/2022-760-instructions.pdf#page=32"
+    defined_for = StateCode.VA
+
+    def formula(tax_unit, period, parameters):
+        # Either claims refundable or non-refundable, but not both.
+        claims = ~tax_unit("va_claims_refundable_eitc", period)
+        amount_if_claimed = tax_unit("va_non_refundable_eitc_if_claimed", period)
+        return claims * amount_if_claimed

--- a/policyengine_us/variables/gov/states/va/tax/income/va_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/va/tax/income/va_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class va_non_refundable_credits(Variable):
@@ -10,4 +13,13 @@ class va_non_refundable_credits(Variable):
     reference = "https://law.lis.virginia.gov/vacodefull/title58.1/chapter3/article2/"
     defined_for = StateCode.VA
 
-    adds = "gov.states.va.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.va.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "va_income_tax_before_non_refundable_credits",
+        )

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
@@ -4,47 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class wi_childcare_expense_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Wisconsin childcare expense credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2",
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17",
-        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf",
-        "https://docs.legis.wisconsin.gov/statutes/statutes/71/i/07/9g",
-    )
-    defined_for = StateCode.WI
-
-    def formula(tax_unit, period, parameters):
-        p = parameters(period).gov.states.wi.tax.income
-        p_wi = p.credits.childcare_expense
-
-        wi_max_expense = p_wi.max_expense
-
-        if wi_max_expense > 0:
-            # For 2024+, Wisconsin Act 101 of 2023 sets its own expense cap of
-            # $10,000 per qualifying individual (§71.07(9g)(c)5), replacing the
-            # federal per-individual limit under IRC §21(c).
-            count_eligible = tax_unit("capped_count_cdcc_eligible", period)
-            wi_expense_limit = wi_max_expense * count_eligible
-            raw_expenses = tax_unit("tax_unit_childcare_expenses", period)
-            # Cap to WI limit, then also cap to min head/spouse earned (§21(d))
-            wi_capped_expenses = min_(raw_expenses, wi_expense_limit)
-            wi_relevant_expenses = min_(
-                wi_capped_expenses,
-                tax_unit("min_head_spouse_earned", period),
-            )
-            cdcc_rate = tax_unit("cdcc_rate", period)
-            return wi_relevant_expenses * cdcc_rate * p_wi.fraction
-        else:
-            # Pre-2024: Wisconsin matches the potential federal credit
-            us_cdcc = tax_unit("cdcc_potential", period)
-            return us_cdcc * p_wi.fraction
-
-
 class wi_childcare_expense_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class wi_childcare_expense_credit(Variable):
+class wi_childcare_expense_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Wisconsin childcare expense credit"
@@ -40,3 +42,31 @@ class wi_childcare_expense_credit(Variable):
             # Pre-2024: Wisconsin matches the potential federal credit
             us_cdcc = tax_unit("cdcc_potential", period)
             return us_cdcc * p_wi.fraction
+
+
+class wi_childcare_expense_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin childcare expense credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2",
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17",
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf",
+        "https://docs.legis.wisconsin.gov/statutes/statutes/71/i/07/9g",
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wi.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "wi_income_tax_before_credits",
+            "wi_childcare_expense_credit",
+            "wi_childcare_expense_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class wi_childcare_expense_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit_potential.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit_potential.py
@@ -1,0 +1,42 @@
+from policyengine_us.model_api import *
+
+
+class wi_childcare_expense_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin childcare expense credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2",
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17",
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf",
+        "https://docs.legis.wisconsin.gov/statutes/statutes/71/i/07/9g",
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.wi.tax.income
+        p_wi = p.credits.childcare_expense
+
+        wi_max_expense = p_wi.max_expense
+
+        if wi_max_expense > 0:
+            # For 2024+, Wisconsin Act 101 of 2023 sets its own expense cap of
+            # $10,000 per qualifying individual (§71.07(9g)(c)5), replacing the
+            # federal per-individual limit under IRC §21(c).
+            count_eligible = tax_unit("capped_count_cdcc_eligible", period)
+            wi_expense_limit = wi_max_expense * count_eligible
+            raw_expenses = tax_unit("tax_unit_childcare_expenses", period)
+            # Cap to WI limit, then also cap to min head/spouse earned (§21(d))
+            wi_capped_expenses = min_(raw_expenses, wi_expense_limit)
+            wi_relevant_expenses = min_(
+                wi_capped_expenses,
+                tax_unit("min_head_spouse_earned", period),
+            )
+            cdcc_rate = tax_unit("cdcc_rate", period)
+            return wi_relevant_expenses * cdcc_rate * p_wi.fraction
+        else:
+            # Pre-2024: Wisconsin matches the potential federal credit
+            us_cdcc = tax_unit("cdcc_potential", period)
+            return us_cdcc * p_wi.fraction

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit.py
@@ -4,27 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class wi_itemized_deduction_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Wisconsin itemized deduction credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=4"
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=4"
-        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf#page=19"
-    )
-    defined_for = StateCode.WI
-
-    def formula(tax_unit, period, parameters):
-        wi_itmded = tax_unit("itemized_deductions_less_salt", period)
-        wi_stdded = tax_unit("wi_standard_deduction", period)
-        excess_itmded = max_(0, wi_itmded - wi_stdded)
-        p = parameters(period).gov.states.wi.tax.income
-        return excess_itmded * p.credits.itemized_deduction.rate
-
-
 class wi_itemized_deduction_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class wi_itemized_deduction_credit(Variable):
+class wi_itemized_deduction_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Wisconsin itemized deduction credit"
@@ -20,3 +22,30 @@ class wi_itemized_deduction_credit(Variable):
         excess_itmded = max_(0, wi_itmded - wi_stdded)
         p = parameters(period).gov.states.wi.tax.income
         return excess_itmded * p.credits.itemized_deduction.rate
+
+
+class wi_itemized_deduction_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin itemized deduction credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=4"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=4"
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf#page=19"
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wi.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "wi_income_tax_before_credits",
+            "wi_itemized_deduction_credit",
+            "wi_itemized_deduction_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class wi_itemized_deduction_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit_potential.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/itemized_deduction/wi_itemized_deduction_credit_potential.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class wi_itemized_deduction_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin itemized deduction credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=4"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=4"
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf#page=19"
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        wi_itmded = tax_unit("itemized_deductions_less_salt", period)
+        wi_stdded = tax_unit("wi_standard_deduction", period)
+        excess_itmded = max_(0, wi_itmded - wi_stdded)
+        p = parameters(period).gov.states.wi.tax.income
+        return excess_itmded * p.credits.itemized_deduction.rate

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit.py
@@ -4,39 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class wi_married_couple_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Wisconsin married couple credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=4"
-        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1-Inst.pdf#page=21"
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=4"
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=21"
-        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf"
-    )
-    defined_for = StateCode.WI
-
-    def formula(tax_unit, period, parameters):
-        fstatus = tax_unit("filing_status", period)
-        eligible = fstatus == fstatus.possible_values.JOINT
-        p = parameters(period).gov.states.wi.tax.income.credits
-        person = tax_unit.members
-        income = add(person, period, p.married_couple.income_sources)
-        floored_income = max_(0, income)
-        is_head = person("is_tax_unit_head", period)
-        is_spouse = person("is_tax_unit_spouse", period)
-        head_income = tax_unit.sum(is_head * floored_income)
-        spouse_income = tax_unit.sum(is_spouse * floored_income)
-        lower_income = min_(head_income, spouse_income)
-        return min_(
-            eligible * lower_income * p.married_couple.rate,
-            p.married_couple.max,
-        )
-
-
 class wi_married_couple_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class wi_married_couple_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class wi_married_couple_credit(Variable):
+class wi_married_couple_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Wisconsin married couple credit"
@@ -31,4 +33,33 @@ class wi_married_couple_credit(Variable):
         return min_(
             eligible * lower_income * p.married_couple.rate,
             p.married_couple.max,
+        )
+
+
+class wi_married_couple_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin married couple credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=4"
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1-Inst.pdf#page=21"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=4"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=21"
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf"
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wi.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "wi_income_tax_before_credits",
+            "wi_married_couple_credit",
+            "wi_married_couple_credit_potential",
         )

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit_potential.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/married_couple/wi_married_couple_credit_potential.py
@@ -1,0 +1,34 @@
+from policyengine_us.model_api import *
+
+
+class wi_married_couple_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin married couple credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=4"
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1-Inst.pdf#page=21"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=4"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=21"
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf"
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        fstatus = tax_unit("filing_status", period)
+        eligible = fstatus == fstatus.possible_values.JOINT
+        p = parameters(period).gov.states.wi.tax.income.credits
+        person = tax_unit.members
+        income = add(person, period, p.married_couple.income_sources)
+        floored_income = max_(0, income)
+        is_head = person("is_tax_unit_head", period)
+        is_spouse = person("is_tax_unit_spouse", period)
+        head_income = tax_unit.sum(is_head * floored_income)
+        spouse_income = tax_unit.sum(is_spouse * floored_income)
+        lower_income = min_(head_income, spouse_income)
+        return min_(
+            eligible * lower_income * p.married_couple.rate,
+            p.married_couple.max,
+        )

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class wi_property_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class wi_property_tax_credit(Variable):
+class wi_property_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "Wisconsin property tax credit"
@@ -22,3 +24,32 @@ class wi_property_tax_credit(Variable):
         p = parameters(period).gov.states.wi.tax.income.credits.property_tax
         proptax = ptax + rent * p.rent_fraction
         return min_(p.max, proptax * p.rate)
+
+
+class wi_property_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin property tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=2"
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1-Inst.pdf#page=17"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17"
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf#page=19"
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wi.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "wi_income_tax_before_credits",
+            "wi_property_tax_credit",
+            "wi_property_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit.py
@@ -4,29 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class wi_property_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "Wisconsin property tax credit"
-    unit = USD
-    definition_period = YEAR
-    reference = (
-        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=2"
-        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1-Inst.pdf#page=17"
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2"
-        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17"
-        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf#page=19"
-    )
-    defined_for = StateCode.WI
-
-    def formula(tax_unit, period, parameters):
-        rent = add(tax_unit, period, ["rent"])
-        ptax = add(tax_unit, period, ["real_estate_taxes"])
-        p = parameters(period).gov.states.wi.tax.income.credits.property_tax
-        proptax = ptax + rent * p.rent_fraction
-        return min_(p.max, proptax * p.rate)
-
-
 class wi_property_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/property_tax/wi_property_tax_credit_potential.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class wi_property_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin property tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1f.pdf#page=2"
+        "https://www.revenue.wi.gov/TaxForms2021/2021-Form1-Inst.pdf#page=17"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1f.pdf#page=2"
+        "https://www.revenue.wi.gov/TaxForms2022/2022-Form1-Inst.pdf#page=17"
+        "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf#page=19"
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        rent = add(tax_unit, period, ["rent"])
+        ptax = add(tax_unit, period, ["real_estate_taxes"])
+        p = parameters(period).gov.states.wi.tax.income.credits.property_tax
+        proptax = ptax + rent * p.rent_fraction
+        return min_(p.max, proptax * p.rate)

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/wi_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/wi_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class wi_non_refundable_credits(Variable):
@@ -15,4 +18,11 @@ class wi_non_refundable_credits(Variable):
         "https://docs.legis.wisconsin.gov/misc/lfb/informational_papers/january_2023/0002_individual_income_tax_informational_paper_2.pdf"
     )
     defined_for = StateCode.WI
-    adds = "gov.states.wi.tax.income.credits.non_refundable"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wi.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit, period, ordered_credits, "wi_income_tax_before_credits"
+        )

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class wv_low_income_family_tax_credit(Variable):
+class wv_low_income_family_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "West Virginia low-income family tax credit"
@@ -44,3 +46,25 @@ class wv_low_income_family_tax_credit(Variable):
             "wv_income_tax_before_non_refundable_credits", period
         )
         return tax_before_credits * credit_percentage
+
+
+class wv_low_income_family_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "West Virginia low-income family tax credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "wv_low_income_family_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wv.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "wv_income_tax_before_non_refundable_credits",
+            "wv_low_income_family_tax_credit",
+            "wv_low_income_family_tax_credit_potential",
+        )

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class wv_low_income_family_tax_credit_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit.py
@@ -4,51 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class wv_low_income_family_tax_credit_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "West Virginia low-income family tax credit"
-    unit = USD
-    definition_period = YEAR
-    defined_for = "wv_low_income_family_tax_credit_eligible"
-
-    def formula(tax_unit, period, parameters):
-        filing_status = tax_unit("filing_status", period)
-        filing_statuses = filing_status.possible_values
-        p = parameters(
-            period
-        ).gov.states.wv.tax.income.credits.liftc  # low_income_family_tax_credit
-
-        wv_agi = tax_unit("wv_low_income_family_tax_credit_agi", period)
-        fpg = tax_unit("wv_low_income_family_tax_credit_fpg", period)
-        # modified agi limit
-        fpg_amount = p.fpg_percent[filing_status] * fpg
-        # condition: wv_agi < = fpg_amount
-        reduced_agi = wv_agi - fpg_amount
-
-        credit_percentage = select(
-            [
-                filing_status == filing_statuses.SINGLE,
-                filing_status == filing_statuses.SEPARATE,
-                filing_status == filing_statuses.JOINT,
-                filing_status == filing_statuses.HEAD_OF_HOUSEHOLD,
-                filing_status == filing_statuses.SURVIVING_SPOUSE,
-            ],
-            [
-                p.amount.single.calc(reduced_agi),
-                p.amount.separate.calc(reduced_agi),
-                p.amount.joint.calc(reduced_agi),
-                p.amount.head_of_household.calc(reduced_agi),
-                p.amount.surviving_spouse.calc(reduced_agi),
-            ],
-        )
-
-        tax_before_credits = tax_unit(
-            "wv_income_tax_before_non_refundable_credits", period
-        )
-        return tax_before_credits * credit_percentage
-
-
 class wv_low_income_family_tax_credit(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit_potential.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/liftc/wv_low_income_family_tax_credit_potential.py
@@ -1,0 +1,46 @@
+from policyengine_us.model_api import *
+
+
+class wv_low_income_family_tax_credit_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "West Virginia low-income family tax credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "wv_low_income_family_tax_credit_eligible"
+
+    def formula(tax_unit, period, parameters):
+        filing_status = tax_unit("filing_status", period)
+        filing_statuses = filing_status.possible_values
+        p = parameters(
+            period
+        ).gov.states.wv.tax.income.credits.liftc  # low_income_family_tax_credit
+
+        wv_agi = tax_unit("wv_low_income_family_tax_credit_agi", period)
+        fpg = tax_unit("wv_low_income_family_tax_credit_fpg", period)
+        # modified agi limit
+        fpg_amount = p.fpg_percent[filing_status] * fpg
+        # condition: wv_agi < = fpg_amount
+        reduced_agi = wv_agi - fpg_amount
+
+        credit_percentage = select(
+            [
+                filing_status == filing_statuses.SINGLE,
+                filing_status == filing_statuses.SEPARATE,
+                filing_status == filing_statuses.JOINT,
+                filing_status == filing_statuses.HEAD_OF_HOUSEHOLD,
+                filing_status == filing_statuses.SURVIVING_SPOUSE,
+            ],
+            [
+                p.amount.single.calc(reduced_agi),
+                p.amount.separate.calc(reduced_agi),
+                p.amount.joint.calc(reduced_agi),
+                p.amount.head_of_household.calc(reduced_agi),
+                p.amount.surviving_spouse.calc(reduced_agi),
+            ],
+        )
+
+        tax_before_credits = tax_unit(
+            "wv_income_tax_before_non_refundable_credits", period
+        )
+        return tax_before_credits * credit_percentage

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc.py
@@ -4,22 +4,6 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
 )
 
 
-class wv_cdcc_potential(Variable):
-    value_type = float
-    entity = TaxUnit
-    label = "West Virginia Child and Dependent Care Credit"
-    unit = USD
-    defined_for = StateCode.WV
-    definition_period = YEAR
-    reference = "https://code.wvlegislature.gov/11-21-26/"
-
-    def formula(tax_unit, period, parameters):
-        # West Virginia matched the federal credit taken
-        cdcc = tax_unit("cdcc", period)
-        p = parameters(period).gov.states.wv.tax.income.credits.cdcc
-        return cdcc * p.match
-
-
 class wv_cdcc(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc.py
@@ -1,7 +1,9 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
-
-class wv_cdcc(Variable):
+class wv_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit
     label = "West Virginia Child and Dependent Care Credit"
@@ -15,3 +17,26 @@ class wv_cdcc(Variable):
         cdcc = tax_unit("cdcc", period)
         p = parameters(period).gov.states.wv.tax.income.credits.cdcc
         return cdcc * p.match
+
+
+class wv_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "West Virginia Child and Dependent Care Credit"
+    unit = USD
+    defined_for = StateCode.WV
+    definition_period = YEAR
+    reference = "https://code.wvlegislature.gov/11-21-26/"
+
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wv.tax.income.credits.non_refundable
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ordered_credits,
+            "wv_income_tax_before_non_refundable_credits",
+            "wv_cdcc",
+            "wv_cdcc_potential",
+        )

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc.py
@@ -3,6 +3,7 @@ from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap i
     applied_state_non_refundable_credit,
 )
 
+
 class wv_cdcc_potential(Variable):
     value_type = float
     entity = TaxUnit

--- a/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc_potential.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/credits/wv_cdcc_potential.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class wv_cdcc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "West Virginia Child and Dependent Care Credit"
+    unit = USD
+    defined_for = StateCode.WV
+    definition_period = YEAR
+    reference = "https://code.wvlegislature.gov/11-21-26/"
+
+    def formula(tax_unit, period, parameters):
+        # West Virginia matched the federal credit taken
+        cdcc = tax_unit("cdcc", period)
+        p = parameters(period).gov.states.wv.tax.income.credits.cdcc
+        return cdcc * p.match

--- a/policyengine_us/variables/gov/states/wv/tax/income/wv_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/wv_non_refundable_credits.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    ordered_capped_state_non_refundable_credits,
+)
 
 
 class wv_non_refundable_credits(Variable):
@@ -9,4 +12,13 @@ class wv_non_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.WV
 
-    adds = "gov.states.wv.tax.income.credits.non_refundable"
+    def formula(tax_unit, period, parameters):
+        ordered_credits = parameters(
+            period
+        ).gov.states.wv.tax.income.credits.non_refundable
+        return ordered_capped_state_non_refundable_credits(
+            tax_unit,
+            period,
+            ordered_credits,
+            "wv_income_tax_before_non_refundable_credits",
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1641,7 +1641,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.624.0"
+version = "1.634.5"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- apply ordered capping to state nonrefundable credit aggregates at the tax-application layer
- add a shared helper for ordered aggregate state nonrefundable credit application
- align state nonrefundable credit ordering metadata where the current form order was mismatched
- fix review issues by limiting New York geothermal credit ordering to 2022+ and moving Ohio onto the ordered aggregate path

## Scope
This PR does **not** implement the full federal-style `potential` and `actual/applied` nonrefundable credit pattern for each individual state credit.

Instead, it changes how the aggregate nonrefundable credit bucket is applied against pre-credit tax liability in the states covered here. Raw state credit variables remain their underlying potential amounts.

That means this PR is a tax-application-layer cleanup, not the final per-credit redesign.

## Follow-up Needed
A follow-up refactor should add federal-style per-credit applied variables so each state nonrefundable credit can expose:
- a potential amount
- an actual taken amount capped by pre-credit tax minus earlier credits on the form

That is the step needed to return true form-order credit values.

## Testing
- `uv run ruff check policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py policyengine_us/variables/gov/states/ar/tax/income/ar_non_refundable_credits.py policyengine_us/variables/gov/states/az/tax/income/az_non_refundable_credits.py policyengine_us/variables/gov/states/ct/tax/income/ct_non_refundable_credits.py policyengine_us/variables/gov/states/dc/tax/income/credits/dc_non_refundable_credits.py policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits.py policyengine_us/variables/gov/states/ga/tax/income/ga_non_refundable_credits.py policyengine_us/variables/gov/states/hi/tax/income/hi_non_refundable_credits.py policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py policyengine_us/variables/gov/states/ky/tax/income/credits/ky_non_refundable_credits.py policyengine_us/variables/gov/states/la/tax/income/la_non_refundable_credits.py policyengine_us/variables/gov/states/ma/tax/income/ma_non_refundable_credits.py policyengine_us/variables/gov/states/md/tax/income/credits/md_non_refundable_credits.py policyengine_us/variables/gov/states/me/tax/income/me_non_refundable_credits.py policyengine_us/variables/gov/states/mo/tax/income/credits/mo_non_refundable_credits.py policyengine_us/variables/gov/states/ms/tax/income/ms_non_refundable_credits.py policyengine_us/variables/gov/states/nc/tax/income/nc_non_refundable_credits.py policyengine_us/variables/gov/states/ny/tax/income/ny_non_refundable_credits.py policyengine_us/variables/gov/states/oh/tax/income/oh_non_refundable_credits.py policyengine_us/variables/gov/states/ri/tax/income/ri_non_refundable_credits.py policyengine_us/variables/gov/states/sc/tax/income/sc_non_refundable_credits.py policyengine_us/variables/gov/states/ut/tax/income/credits/ut_non_refundable_credits.py policyengine_us/variables/gov/states/va/tax/income/va_non_refundable_credits.py policyengine_us/variables/gov/states/wi/tax/income/credits/wi_non_refundable_credits.py policyengine_us/variables/gov/states/wv/tax/income/wv_non_refundable_credits.py`
- `uv run ruff format --check policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py policyengine_us/variables/gov/states/ar/tax/income/ar_non_refundable_credits.py policyengine_us/variables/gov/states/az/tax/income/az_non_refundable_credits.py policyengine_us/variables/gov/states/ct/tax/income/ct_non_refundable_credits.py policyengine_us/variables/gov/states/dc/tax/income/credits/dc_non_refundable_credits.py policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits.py policyengine_us/variables/gov/states/ga/tax/income/ga_non_refundable_credits.py policyengine_us/variables/gov/states/hi/tax/income/hi_non_refundable_credits.py policyengine_us/variables/gov/states/id/tax/income/id_non_refundable_credits.py policyengine_us/variables/gov/states/ky/tax/income/credits/ky_non_refundable_credits.py policyengine_us/variables/gov/states/la/tax/income/la_non_refundable_credits.py policyengine_us/variables/gov/states/ma/tax/income/ma_non_refundable_credits.py policyengine_us/variables/gov/states/md/tax/income/credits/md_non_refundable_credits.py policyengine_us/variables/gov/states/me/tax/income/me_non_refundable_credits.py policyengine_us/variables/gov/states/mo/tax/income/credits/mo_non_refundable_credits.py policyengine_us/variables/gov/states/ms/tax/income/ms_non_refundable_credits.py policyengine_us/variables/gov/states/nc/tax/income/nc_non_refundable_credits.py policyengine_us/variables/gov/states/ny/tax/income/ny_non_refundable_credits.py policyengine_us/variables/gov/states/oh/tax/income/oh_non_refundable_credits.py policyengine_us/variables/gov/states/ri/tax/income/ri_non_refundable_credits.py policyengine_us/variables/gov/states/sc/tax/income/sc_non_refundable_credits.py policyengine_us/variables/gov/states/ut/tax/income/credits/ut_non_refundable_credits.py policyengine_us/variables/gov/states/va/tax/income/va_non_refundable_credits.py policyengine_us/variables/gov/states/wi/tax/income/credits/wi_non_refundable_credits.py policyengine_us/variables/gov/states/wv/tax/income/wv_non_refundable_credits.py`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/az/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/ct/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/il/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/ky/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/ar/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/ga/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/md/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/ny/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/oh/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/wi/tax/income --batches 1`
- `python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states/wv/tax/income --batches 1`