### PR TITLE
Fix immigration_status period access in non-TANF monthly formulas

### DIFF
--- a/changelog.d/fix-immigration-status-period-bug.fixed.md
+++ b/changelog.d/fix-immigration-status-period-bug.fixed.md
@@ -1,0 +1,1 @@
+Fix immigration_status period access in monthly eligibility formulas.

--- a/policyengine_us/variables/gov/local/ca/ala/ga/eligibility/ca_ala_general_assistance_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/ala/ga/eligibility/ca_ala_general_assistance_immigration_status_eligible.py
@@ -13,6 +13,6 @@ class ca_ala_general_assistance_immigration_status_eligible(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.local.ca.ala.general_assistance
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
         return np.isin(immigration_status_str, p.qualified_immigration_status)

--- a/policyengine_us/variables/gov/local/ca/riv/general_relief/eligibility/ca_riv_general_relief_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/riv/general_relief/eligibility/ca_riv_general_relief_immigration_status_eligible.py
@@ -10,6 +10,6 @@ class ca_riv_general_relief_immigration_status_eligible(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.local.ca.riv.general_relief
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
         return np.isin(immigration_status_str, p.qualified_immigration_status)

--- a/policyengine_us/variables/gov/states/ca/cdss/snap/eligibility/ca_snap_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/snap/eligibility/ca_snap_immigration_status_eligible.py
@@ -15,7 +15,7 @@ class ca_snap_immigration_status_eligible(Variable):
     def formula(person, period, parameters):
         # California delays OBBBA implementation to April 1, 2026 per ACL 25-92.
         p = parameters(period).gov.states.ca.cdss.snap.eligibility
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
         return np.isin(
             immigration_status_str,

--- a/policyengine_us/variables/gov/states/ca/cdss/state_supplement/ca_state_supplement_eligible_person.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/state_supplement/ca_state_supplement_eligible_person.py
@@ -13,7 +13,7 @@ class ca_state_supplement_eligible_person(Variable):
         meets_resource_test = person("meets_ssi_resource_test", period)
         aged_blind_disabled = person("is_ssi_aged_blind_disabled", period)
         is_qualified_noncitizen = person("is_ssi_qualified_noncitizen", period)
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         is_citizen = immigration_status == immigration_status.possible_values.CITIZEN
         is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
         return (

--- a/policyengine_us/variables/gov/states/dc/dhs/ccsp/eligibility/dc_ccsp_immigration_status_eligible_person.py
+++ b/policyengine_us/variables/gov/states/dc/dhs/ccsp/eligibility/dc_ccsp_immigration_status_eligible_person.py
@@ -11,7 +11,7 @@ class dc_ccsp_immigration_status_eligible_person(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.dc.dhs.ccsp
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
         return np.isin(
             immigration_status_str,

--- a/policyengine_us/variables/gov/states/il/dhs/aabd/eligibility/il_aabd_immigration_status_eligible_person.py
+++ b/policyengine_us/variables/gov/states/il/dhs/aabd/eligibility/il_aabd_immigration_status_eligible_person.py
@@ -11,7 +11,7 @@ class il_aabd_immigration_status_eligible_person(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.il.dhs.aabd
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         is_citizen = immigration_status == immigration_status.possible_values.CITIZEN
         immigration_status_str = immigration_status.decode_to_str()
         has_qualifying_status = np.isin(

--- a/policyengine_us/variables/gov/states/il/dhs/ccap/eligibility/il_ccap_immigration_status_eligible_person.py
+++ b/policyengine_us/variables/gov/states/il/dhs/ccap/eligibility/il_ccap_immigration_status_eligible_person.py
@@ -11,7 +11,7 @@ class il_ccap_immigration_status_eligible_person(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.il.dhs.ccap
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
         has_qualifying_status = np.isin(
             immigration_status_str,

--- a/policyengine_us/variables/gov/states/ma/dta/tcap/eaedc/eligibility/non_financial/ma_eaedc_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/states/ma/dta/tcap/eaedc/eligibility/non_financial/ma_eaedc_immigration_status_eligible.py
@@ -12,7 +12,7 @@ class ma_eaedc_immigration_status_eligible(Variable):
     def formula(spm_unit, period, parameters):
         person = spm_unit.members
         head_or_spouse = person("is_tax_unit_head_or_spouse", period)
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         is_undocumented = (
             immigration_status == immigration_status.possible_values.UNDOCUMENTED
         )

--- a/policyengine_us/variables/gov/states/ma/eec/ccfa/eligibility/ma_ccfa_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/states/ma/eec/ccfa/eligibility/ma_ccfa_immigration_status_eligible.py
@@ -11,7 +11,7 @@ class ma_ccfa_immigration_status_eligible(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ma.eec.ccfa
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
         return np.isin(
             immigration_status_str,

--- a/policyengine_us/variables/gov/states/nh/dhhs/ccap/eligibility/nh_ccap_immigration_status_eligible_person.py
+++ b/policyengine_us/variables/gov/states/nh/dhhs/ccap/eligibility/nh_ccap_immigration_status_eligible_person.py
@@ -11,7 +11,7 @@ class nh_ccap_immigration_status_eligible_person(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.nh.dhhs.ccap
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
         return np.isin(
             immigration_status_str,

--- a/policyengine_us/variables/gov/states/tx/twc/ccs/eligibility/tx_ccs_eligible_child.py
+++ b/policyengine_us/variables/gov/states/tx/twc/ccs/eligibility/tx_ccs_eligible_child.py
@@ -18,5 +18,7 @@ class tx_ccs_eligible_child(Variable):
         age_limit = where(is_disabled, p.disabled_child, p.child)
         age_eligible = age < age_limit
         is_dependent = person("is_tax_unit_dependent", period)
-        immigration_status_eligible = person("is_citizen_or_legal_immigrant", period)
+        immigration_status_eligible = person(
+            "is_citizen_or_legal_immigrant", period.this_year
+        )
         return age_eligible & is_dependent & immigration_status_eligible

--- a/policyengine_us/variables/gov/usda/snap/eligibility/is_snap_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/is_snap_immigration_status_eligible.py
@@ -13,7 +13,7 @@ class is_snap_immigration_status_eligible(Variable):
     )
 
     def formula(person, period, parameters):
-        immigration_status = person("immigration_status", period)
+        immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()
 
         p = parameters(period).gov.usda.snap.eligibility


### PR DESCRIPTION
## Summary
Fixes `immigration_status` (YEAR-defined Enum) being accessed with `period` instead of `period.this_year` from MONTH-defined formulas across 12 non-TANF programs. The auto-conversion divides the Enum integer encoding by 12, breaking all `==` comparisons and `np.isin()` lookups for non-citizen statuses.

Follow-up to #7989, which fixed the same bug in TANF eligibility formulas.

## What changed
All 12 files: `person("immigration_status", period)` → `person("immigration_status", period.this_year)`

**Enum bug (breaks microsim — 11 files):**
| Program | File |
|---|---|
| Federal SNAP | `gov/usda/snap/eligibility/is_snap_immigration_status_eligible.py` |
| CA SNAP | `gov/states/ca/cdss/snap/eligibility/ca_snap_immigration_status_eligible.py` |
| IL CCAP | `gov/states/il/dhs/ccap/eligibility/il_ccap_immigration_status_eligible_person.py` |
| IL AABD | `gov/states/il/dhs/aabd/eligibility/il_aabd_immigration_status_eligible_person.py` |
| NH CCAP | `gov/states/nh/dhhs/ccap/eligibility/nh_ccap_immigration_status_eligible_person.py` |
| MA CCFA | `gov/states/ma/eec/ccfa/eligibility/ma_ccfa_immigration_status_eligible.py` |
| MA EAEDC | `gov/states/ma/dta/tcap/eaedc/eligibility/non_financial/ma_eaedc_immigration_status_eligible.py` |
| DC CCSP | `gov/states/dc/dhs/ccsp/eligibility/dc_ccsp_immigration_status_eligible_person.py` |
| CA State Supplement | `gov/states/ca/cdss/state_supplement/ca_state_supplement_eligible_person.py` |
| Alameda County GA | `gov/local/ca/ala/ga/eligibility/ca_ala_general_assistance_immigration_status_eligible.py` |
| Riverside County GR | `gov/local/ca/riv/general_relief/eligibility/ca_riv_general_relief_immigration_status_eligible.py` |

**Boolean bug (correct result by accident — 1 file):**
| Program | File |
|---|---|
| TX CCS | `gov/states/tx/twc/ccs/eligibility/tx_ccs_eligible_child.py` |

## Why this matters
`immigration_status` is encoded as integers (CITIZEN=0, REFUGEE=2, etc.). Division by 12 turns REFUGEE into 0.167, which fails `== ImmigrationStatus.REFUGEE` (expects 2). This means non-citizen qualified immigrants (refugees, asylees, LPRs, etc.) are incorrectly found **ineligible** in microsimulation for all affected programs.

## Test plan
- [ ] CI passes
- [x] `make format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)