### PR TITLE
Harden state nonrefundable credit guardrails

### DIFF
--- a/changelog.d/7991.fixed.md
+++ b/changelog.d/7991.fixed.md
@@ -1,0 +1,1 @@
+Added shared invariant coverage and reviewed-consumer guards for ordered state nonrefundable credit variables.

--- a/policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py
+++ b/policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py
@@ -1,0 +1,93 @@
+import re
+
+from policyengine_us.model_api import REPO
+
+
+REVIEWED_APPLIED_CREDIT_EXTERNAL_REFERENCES = {
+    "de_non_refundable_eitc": {
+        "policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_eitc.py",
+        "policyengine_us/variables/gov/states/de/tax/income/credits/eitc/refundability_calculation/de_income_tax_if_claiming_non_refundable_eitc.py",
+    },
+    "ky_personal_tax_credits": {
+        "policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit_potential.py",
+    },
+    "la_non_refundable_cdcc": {
+        "policyengine_us/variables/gov/states/la/tax/income/credits/school_readiness/la_school_readiness_tax_credit.py",
+    },
+    "md_non_refundable_eitc": {
+        "policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_eitc.py",
+    },
+    "ny_household_credit": {
+        "policyengine_us/variables/gov/states/ny/tax/income/credits/ny_eitc.py",
+    },
+    "va_non_refundable_eitc": {
+        "policyengine_us/variables/gov/states/va/tax/income/credits/eitc/refundability_calculation/va_income_tax_if_claiming_non_refundable_eitc.py",
+        "policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_eitc.py",
+        "policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_eitc_person.py",
+    },
+}
+
+
+def applied_credit_variable_definitions() -> dict[str, str]:
+    definitions = {}
+
+    for file_name in (REPO / "policyengine_us" / "variables" / "gov" / "states").glob(
+        "**/*.py"
+    ):
+        source = file_name.read_text()
+        if "applied_state_non_refundable_credit(" not in source:
+            continue
+
+        class_match = re.search(r"class\\s+([a-z0-9_]+)\\(Variable\\):", source)
+        assert class_match is not None, (
+            f"Could not identify applied credit variable in "
+            f"{file_name.relative_to(REPO)}"
+        )
+        definitions[class_match.group(1)] = file_name.relative_to(REPO).as_posix()
+
+    return definitions
+
+
+def string_literal_references(variable_name: str) -> set[str]:
+    pattern = re.compile(rf"[\"']{re.escape(variable_name)}[\"']")
+    references = set()
+
+    for file_name in (REPO / "policyengine_us" / "variables" / "gov" / "states").glob(
+        "**/*.py"
+    ):
+        if pattern.search(file_name.read_text()):
+            references.add(file_name.relative_to(REPO).as_posix())
+
+    return references
+
+
+def test_applied_credit_downstream_consumers_are_reviewed():
+    mismatches = []
+
+    for variable_name, defining_file in sorted(
+        applied_credit_variable_definitions().items()
+    ):
+        actual_external_references = string_literal_references(variable_name) - {
+            defining_file
+        }
+        expected_external_references = REVIEWED_APPLIED_CREDIT_EXTERNAL_REFERENCES.get(
+            variable_name, set()
+        )
+
+        if actual_external_references != expected_external_references:
+            mismatches.append(
+                "\n".join(
+                    [
+                        f"{variable_name}:",
+                        f"  expected: {sorted(expected_external_references)}",
+                        f"  actual:   {sorted(actual_external_references)}",
+                    ]
+                )
+            )
+
+    assert not mismatches, (
+        "Applied state nonrefundable credit variables gained new downstream "
+        "consumers or no longer match the reviewed set. If a form or statute "
+        "needs the pre-ordering amount, add a *_potential variable consumer "
+        "instead of reading the applied credit. Details:\n\n" + "\n\n".join(mismatches)
+    )

--- a/policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py
+++ b/policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py
@@ -4,6 +4,7 @@ from policyengine_us.model_api import REPO
 
 
 STATE_VARIABLES_ROOT = REPO / "variables" / "gov" / "states"
+REFORMS_ROOT = REPO / "reforms"
 
 
 REVIEWED_APPLIED_CREDIT_EXTERNAL_REFERENCES = {
@@ -20,8 +21,36 @@ REVIEWED_APPLIED_CREDIT_EXTERNAL_REFERENCES = {
     "md_non_refundable_eitc": {
         "variables/gov/states/md/tax/income/credits/eitc/md_eitc.py",
     },
+    "mo_wftc": {
+        "reforms/states/mo/eitc/mo_refundable_eitc_reform.py",
+    },
     "ny_household_credit": {
+        "reforms/states/ny/wftc/ny_working_families_tax_credit.py",
         "variables/gov/states/ny/tax/income/credits/ny_eitc.py",
+    },
+    "oh_eitc": {
+        "reforms/states/oh/eitc/oh_refundable_eitc_reform.py",
+    },
+    "sc_cdcc": {
+        "reforms/states/sc/h3492/sc_h3492_eitc_refundable.py",
+    },
+    "sc_two_wage_earner_credit": {
+        "reforms/states/sc/h3492/sc_h3492_eitc_refundable.py",
+    },
+    "ut_at_home_parent_credit": {
+        "reforms/states/ut/ut_refundable_eitc.py",
+    },
+    "ut_ctc": {
+        "reforms/states/ut/ut_refundable_eitc.py",
+    },
+    "ut_eitc": {
+        "reforms/states/ut/child_poverty_eitc/ut_fully_refundable_eitc_reform.py",
+    },
+    "ut_retirement_credit": {
+        "reforms/states/ut/ut_refundable_eitc.py",
+    },
+    "ut_ss_benefits_credit": {
+        "reforms/states/ut/ut_refundable_eitc.py",
     },
     "va_non_refundable_eitc": {
         "variables/gov/states/va/tax/income/credits/eitc/refundability_calculation/va_income_tax_if_claiming_non_refundable_eitc.py",
@@ -52,12 +81,32 @@ def applied_credit_variable_definitions() -> dict[str, str]:
     return definitions
 
 
+def is_internal_reform_reference(file_name, variable_name: str) -> bool:
+    source = file_name.read_text()
+    return (
+        re.search(rf"class\s+{re.escape(variable_name)}\(Variable\):", source)
+        is not None
+        or re.search(
+            rf"neutralize_variable\([\"']{re.escape(variable_name)}[\"']\)",
+            source,
+        )
+        is not None
+    )
+
+
 def string_literal_references(variable_name: str) -> set[str]:
     pattern = re.compile(rf"[\"']{re.escape(variable_name)}[\"']")
     references = set()
 
-    for file_name in STATE_VARIABLES_ROOT.glob("**/*.py"):
-        if pattern.search(file_name.read_text()):
+    for root in (STATE_VARIABLES_ROOT, REFORMS_ROOT):
+        for file_name in root.glob("**/*.py"):
+            source = file_name.read_text()
+            if not pattern.search(source):
+                continue
+            if root == REFORMS_ROOT and is_internal_reform_reference(
+                file_name, variable_name
+            ):
+                continue
             references.add(file_name.relative_to(REPO).as_posix())
 
     return references

--- a/policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py
+++ b/policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py
@@ -3,27 +3,30 @@ import re
 from policyengine_us.model_api import REPO
 
 
+STATE_VARIABLES_ROOT = REPO / "variables" / "gov" / "states"
+
+
 REVIEWED_APPLIED_CREDIT_EXTERNAL_REFERENCES = {
     "de_non_refundable_eitc": {
-        "policyengine_us/variables/gov/states/de/tax/income/credits/eitc/de_eitc.py",
-        "policyengine_us/variables/gov/states/de/tax/income/credits/eitc/refundability_calculation/de_income_tax_if_claiming_non_refundable_eitc.py",
+        "variables/gov/states/de/tax/income/credits/eitc/de_eitc.py",
+        "variables/gov/states/de/tax/income/credits/eitc/refundability_calculation/de_income_tax_if_claiming_non_refundable_eitc.py",
     },
     "ky_personal_tax_credits": {
-        "policyengine_us/variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit_potential.py",
+        "variables/gov/states/ky/tax/income/credits/family_size_credit/ky_family_size_tax_credit_potential.py",
     },
     "la_non_refundable_cdcc": {
-        "policyengine_us/variables/gov/states/la/tax/income/credits/school_readiness/la_school_readiness_tax_credit.py",
+        "variables/gov/states/la/tax/income/credits/school_readiness/la_school_readiness_tax_credit.py",
     },
     "md_non_refundable_eitc": {
-        "policyengine_us/variables/gov/states/md/tax/income/credits/eitc/md_eitc.py",
+        "variables/gov/states/md/tax/income/credits/eitc/md_eitc.py",
     },
     "ny_household_credit": {
-        "policyengine_us/variables/gov/states/ny/tax/income/credits/ny_eitc.py",
+        "variables/gov/states/ny/tax/income/credits/ny_eitc.py",
     },
     "va_non_refundable_eitc": {
-        "policyengine_us/variables/gov/states/va/tax/income/credits/eitc/refundability_calculation/va_income_tax_if_claiming_non_refundable_eitc.py",
-        "policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_eitc.py",
-        "policyengine_us/variables/gov/states/va/tax/income/credits/eitc/va_eitc_person.py",
+        "variables/gov/states/va/tax/income/credits/eitc/refundability_calculation/va_income_tax_if_claiming_non_refundable_eitc.py",
+        "variables/gov/states/va/tax/income/credits/eitc/va_eitc.py",
+        "variables/gov/states/va/tax/income/credits/eitc/va_eitc_person.py",
     },
 }
 
@@ -31,20 +34,21 @@ REVIEWED_APPLIED_CREDIT_EXTERNAL_REFERENCES = {
 def applied_credit_variable_definitions() -> dict[str, str]:
     definitions = {}
 
-    for file_name in (REPO / "policyengine_us" / "variables" / "gov" / "states").glob(
-        "**/*.py"
-    ):
+    assert STATE_VARIABLES_ROOT.exists(), (
+        f"Expected state variables root to exist: {STATE_VARIABLES_ROOT}"
+    )
+
+    for file_name in STATE_VARIABLES_ROOT.glob("**/*.py"):
         source = file_name.read_text()
         if "applied_state_non_refundable_credit(" not in source:
             continue
 
-        class_match = re.search(r"class\\s+([a-z0-9_]+)\\(Variable\\):", source)
-        assert class_match is not None, (
-            f"Could not identify applied credit variable in "
-            f"{file_name.relative_to(REPO)}"
-        )
+        class_match = re.search(r"class\s+([a-z0-9_]+)\(Variable\):", source)
+        if class_match is None:
+            continue
         definitions[class_match.group(1)] = file_name.relative_to(REPO).as_posix()
 
+    assert definitions, "Expected to discover at least one applied credit variable"
     return definitions
 
 
@@ -52,9 +56,7 @@ def string_literal_references(variable_name: str) -> set[str]:
     pattern = re.compile(rf"[\"']{re.escape(variable_name)}[\"']")
     references = set()
 
-    for file_name in (REPO / "policyengine_us" / "variables" / "gov" / "states").glob(
-        "**/*.py"
-    ):
+    for file_name in STATE_VARIABLES_ROOT.glob("**/*.py"):
         if pattern.search(file_name.read_text()):
             references.add(file_name.relative_to(REPO).as_posix())
 

--- a/policyengine_us/tests/core/test_non_refundable_credit_cap.py
+++ b/policyengine_us/tests/core/test_non_refundable_credit_cap.py
@@ -1,0 +1,109 @@
+import policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap as credit_cap_module
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+    cap_state_non_refundable_credit,
+    ordered_capped_state_non_refundable_credits,
+    state_non_refundable_credit_limit,
+)
+
+
+class FakeTaxUnit:
+    def __init__(self, values):
+        self.values = values
+
+    def __call__(self, variable, period):
+        return self.values[variable]
+
+
+def test_state_non_refundable_credit_limit_only_counts_preceding_credits(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        credit_cap_module,
+        "add",
+        lambda tax_unit, period, variables: sum(
+            tax_unit(variable, period) for variable in variables
+        ),
+    )
+    tax_unit = FakeTaxUnit(
+        {
+            "income_tax_before_credits": 50,
+            "first_credit": 20,
+            "target_credit": 40,
+            "later_credit": 999,
+        }
+    )
+
+    limit = state_non_refundable_credit_limit(
+        tax_unit=tax_unit,
+        period=2024,
+        ordered_credits=["first_credit", "target_credit", "later_credit"],
+        income_tax_before_non_refundable_credits_var="income_tax_before_credits",
+        credit_name="target_credit",
+    )
+
+    assert limit == 30
+
+
+def test_applied_state_non_refundable_credit_caps_to_remaining_liability(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        credit_cap_module,
+        "add",
+        lambda tax_unit, period, variables: sum(
+            tax_unit(variable, period) for variable in variables
+        ),
+    )
+    tax_unit = FakeTaxUnit(
+        {
+            "income_tax_before_credits": 50,
+            "first_credit": 20,
+            "target_credit_potential": 40,
+        }
+    )
+
+    applied = applied_state_non_refundable_credit(
+        tax_unit=tax_unit,
+        period=2024,
+        ordered_credits=["first_credit", "target_credit"],
+        income_tax_before_non_refundable_credits_var="income_tax_before_credits",
+        credit_name="target_credit",
+        potential_credit_name="target_credit_potential",
+    )
+
+    assert applied == 30
+
+
+def test_cap_state_non_refundable_credit_keeps_raw_variable_as_potential():
+    assert (
+        cap_state_non_refundable_credit(
+            tax_unit=None,
+            period=2024,
+            credit_name="target_credit",
+            ordered_credits=["first_credit", "target_credit"],
+            income_tax_before_non_refundable_credits_var="income_tax_before_credits",
+            potential=123,
+        )
+        == 123
+    )
+
+
+def test_ordered_capped_state_non_refundable_credits_never_exceed_tax():
+    tax_unit = FakeTaxUnit(
+        {
+            "income_tax_before_credits": 50,
+            "first_credit": 40,
+            "second_credit": 40,
+            "third_credit": 10,
+        }
+    )
+
+    capped_total = ordered_capped_state_non_refundable_credits(
+        tax_unit=tax_unit,
+        period=2024,
+        ordered_credits=["first_credit", "second_credit", "third_credit"],
+        income_tax_before_non_refundable_credits_var="income_tax_before_credits",
+    )
+
+    assert capped_total == 50

--- a/policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py
+++ b/policyengine_us/variables/gov/states/tax/income/non_refundable_credit_cap.py
@@ -1,3 +1,18 @@
+"""Shared helpers for ordered state nonrefundable credits.
+
+These helpers distinguish between:
+
+- potential credit amounts: the worksheet or statutory amount before applying
+  overall nonrefundable ordering and tax-liability limits
+- applied credit amounts: the amount actually allowed on the return after
+  accounting for earlier credits and remaining liability
+
+Downstream formulas should only read applied credit variables when the form or
+statute refers to the post-ordering amount that lands on the return. If a
+downstream formula refers to the underlying worksheet amount, it should read
+the corresponding ``*_potential`` variable instead.
+"""
+
 from policyengine_us.model_api import *
 
 
@@ -8,6 +23,11 @@ def state_non_refundable_credit_limit(
     income_tax_before_non_refundable_credits_var: str,
     credit_name: str,
 ):
+    """Return the remaining liability available to ``credit_name``.
+
+    Only credits that appear earlier in ``ordered_credits`` reduce the amount
+    available to this credit. Later credits must not affect this limit.
+    """
     preceding_credits = []
     for credit in list(ordered_credits):
         if credit == credit_name:
@@ -31,6 +51,7 @@ def applied_state_non_refundable_credit(
     credit_name: str,
     potential_credit_name: str,
 ):
+    """Cap a potential state credit to the liability remaining at its turn."""
     potential = tax_unit(potential_credit_name, period)
     credit_limit = state_non_refundable_credit_limit(
         tax_unit,
@@ -50,9 +71,13 @@ def cap_state_non_refundable_credit(
     income_tax_before_non_refundable_credits_var: str,
     potential,
 ):
-    # Keep raw credit variables as their underlying worksheet/statutory amounts.
-    # Ordered tax-liability capping is applied when state non-refundable credits
-    # are aggregated into the tax calculation.
+    """Preserve the pre-ordering credit amount on the raw credit variable.
+
+    This helper exists for compatibility with older variable formulas that used
+    a generic "cap" helper. The raw credit variable should still represent the
+    underlying worksheet/statutory amount; the ordered application happens only
+    when nonrefundable credits are aggregated into tax.
+    """
     return potential
 
 
@@ -62,6 +87,7 @@ def ordered_capped_state_non_refundable_credits(
     ordered_credits,
     income_tax_before_non_refundable_credits_var: str,
 ):
+    """Apply ordered nonrefundable credits without exceeding tax liability."""
     remaining_tax = tax_unit(income_tax_before_non_refundable_credits_var, period)
     capped_total = 0
     for credit in list(ordered_credits):


### PR DESCRIPTION
## Summary
- document the shared `*_potential` vs applied-credit convention for ordered state nonrefundable credits
- add helper-level invariant tests for remaining-liability calculation and ordered capping
- add a code-health guard that flags new downstream consumers of applied credit variables unless they have been reviewed intentionally

## Why
PR #7984 split several state credits into potential and applied forms. The Maryland refundable CDCC regression showed that downstream formulas can silently read the applied amount when a form or worksheet really refers to the pre-ordering amount. This PR makes that distinction explicit and adds tests around the specific bug class.

## Impact
This does not change any state credit amounts directly. It hardens the shared helper semantics and adds regression coverage so future split-credit refactors are less likely to reintroduce Maryland-style downstream-consumer bugs.

## Validation
- `pytest policyengine_us/tests/core/test_non_refundable_credit_cap.py policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py -q`
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/md_refundable_cdcc.yaml policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/eitc/de_eitc.yaml policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/eitc/refundability_calculation/de_income_tax_if_claiming_non_refundable_eitc.yaml policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/credits/family_size_tax_credit/ky_family_size_tax_credit.yaml policyengine_us/tests/policy/baseline/gov/states/la/tax/income/credits/child_care_expense_credit/la_school_readiness_tax_credit.yaml policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_eitc.yaml policyengine_us/tests/policy/baseline/gov/states/va/tax/income/credits/eitc/va_eitc.yaml policyengine_us/tests/policy/baseline/gov/states/va/tax/income/credits/eitc/va_eitc_person.yaml policyengine_us/tests/policy/baseline/gov/states/va/tax/income/credits/eitc/refundability_calculation/va_income_tax_if_claiming_non-refundable_eitc.yaml`

Closes #7991.
