### PR TITLE
Model New York inflation refund in the eligibility year

### DIFF
--- a/changelog.d/7994.fixed.md
+++ b/changelog.d/7994.fixed.md
@@ -1,0 +1,1 @@
+Move the New York inflation refund credit to tax year 2023, the eligibility year used to determine the refund amount, instead of the later payment year.

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/head_of_household.yaml
@@ -1,25 +1,25 @@
-description: New York provides the following inflation refund credit amount for head of household filers, based on adjusted gross income.
+description: New York provides the following inflation refund amount for head of household filers, modeled in tax year 2023 based on adjusted gross income.
 metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
   period: year
-  label: New York 2025 inflation refund credits head of household amount
+  label: New York inflation refund head of household amount
   reference:
     - title: New York Tax Law § 606(qqq)(3)(b) – Inflation refund credit
       href: https://www.nysenate.gov/legislation/laws/TAX/606#QQQ
-    - title: 2025 NYS inflation refund checks
+    - title: 2025 NYS inflation refund checks (eligibility based on 2023 returns)
       href: https://www.tax.ny.gov/pit/inflation-refund-checks.htm
 brackets:
   - threshold:
-      2025-01-01: -.inf
+      2023-01-01: -.inf
     amount:
-      2025-01-01: 200
+      2023-01-01: 200
   - threshold:
-      2025-01-01: 75_000
+      2023-01-01: 75_000
     amount:
-      2025-01-01: 150
+      2023-01-01: 150
   - threshold:
-      2025-01-01: 150_000
+      2023-01-01: 150_000
     amount:
-      2025-01-01: 0
+      2023-01-01: 0

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/joint.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/joint.yaml
@@ -1,25 +1,25 @@
-description: New York provides the following inflation refund credit amount for joint filers, based on adjusted gross income.
+description: New York provides the following inflation refund amount for joint filers, modeled in tax year 2023 based on adjusted gross income.
 metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
   period: year
-  label: New York 2025 inflation refund credits joint amount
+  label: New York inflation refund joint amount
   reference:
     - title: New York Tax Law § 606(qqq)(3)(a) – Inflation refund credit
       href: https://www.nysenate.gov/legislation/laws/TAX/606#QQQ
-    - title: 2025 NYS inflation refund checks
+    - title: 2025 NYS inflation refund checks (eligibility based on 2023 returns)
       href: https://www.tax.ny.gov/pit/inflation-refund-checks.htm
 brackets:
   - threshold:
-      2025-01-01: -.inf
+      2023-01-01: -.inf
     amount:
-      2025-01-01: 400
+      2023-01-01: 400
   - threshold:
-      2025-01-01: 150_000
+      2023-01-01: 150_000
     amount:
-      2025-01-01: 300
+      2023-01-01: 300
   - threshold:
-      2025-01-01: 300_000
+      2023-01-01: 300_000
     amount:
-      2025-01-01: 0
+      2023-01-01: 0

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/separate.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/separate.yaml
@@ -1,25 +1,25 @@
-description: New York provides the following inflation refund credit amount for married filing separate filers, based on adjusted gross income.
+description: New York provides the following inflation refund amount for married filing separate filers, modeled in tax year 2023 based on adjusted gross income.
 metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
   period: year
-  label: New York 2025 inflation refund credits separate amount
+  label: New York inflation refund separate amount
   reference:
     - title: New York Tax Law § 606(qqq)(3)(b) – Inflation refund credit
       href: https://www.nysenate.gov/legislation/laws/TAX/606#QQQ
-    - title: 2025 NYS inflation refund checks
+    - title: 2025 NYS inflation refund checks (eligibility based on 2023 returns)
       href: https://www.tax.ny.gov/pit/inflation-refund-checks.htm
 brackets:
   - threshold:
-      2025-01-01: -.inf
+      2023-01-01: -.inf
     amount:
-      2025-01-01: 200
+      2023-01-01: 200
   - threshold:
-      2025-01-01: 75_000
+      2023-01-01: 75_000
     amount:
-      2025-01-01: 150
+      2023-01-01: 150
   - threshold:
-      2025-01-01: 150_000
+      2023-01-01: 150_000
     amount:
-      2025-01-01: 0
+      2023-01-01: 0

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/single.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/single.yaml
@@ -1,25 +1,25 @@
-description: New York provides the following inflation refund credit amount for single filers, based on adjusted gross income.
+description: New York provides the following inflation refund amount for single filers, modeled in tax year 2023 based on adjusted gross income.
 metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
   period: year
-  label: New York 2025 inflation refund credits single amount
+  label: New York inflation refund single amount
   reference:
     - title: New York Tax Law § 606(qqq)(3)(b) – Inflation refund credit
       href: https://www.nysenate.gov/legislation/laws/TAX/606#QQQ
-    - title: 2025 NYS inflation refund checks
+    - title: 2025 NYS inflation refund checks (eligibility based on 2023 returns)
       href: https://www.tax.ny.gov/pit/inflation-refund-checks.htm
 brackets:
   - threshold:
-      2025-01-01: -.inf
+      2023-01-01: -.inf
     amount:
-      2025-01-01: 200
+      2023-01-01: 200
   - threshold:
-      2025-01-01: 75_000
+      2023-01-01: 75_000
     amount:
-      2025-01-01: 150
+      2023-01-01: 150
   - threshold:
-      2025-01-01: 150_000
+      2023-01-01: 150_000
     amount:
-      2025-01-01: 0
+      2023-01-01: 0

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/inflation_refund/surviving_spouse.yaml
@@ -1,25 +1,25 @@
-description: New York provides the following inflation refund credit amount for surviving spouses, based on adjusted gross income.
+description: New York provides the following inflation refund amount for surviving spouses, modeled in tax year 2023 based on adjusted gross income.
 metadata:
   type: single_amount
   threshold_unit: currency-USD
   amount_unit: currency-USD
   period: year
-  label: New York 2025 inflation refund credits surviving spouse amount
+  label: New York inflation refund surviving spouse amount
   reference:
     - title: New York Tax Law § 606(qqq)(3)(a) – Inflation refund credit
       href: https://www.nysenate.gov/legislation/laws/TAX/606#QQQ
-    - title: 2025 NYS inflation refund checks
+    - title: 2025 NYS inflation refund checks (eligibility based on 2023 returns)
       href: https://www.tax.ny.gov/pit/inflation-refund-checks.htm
 brackets:
   - threshold:
-      2025-01-01: -.inf
+      2023-01-01: -.inf
     amount:
-      2025-01-01: 400
+      2023-01-01: 400
   - threshold:
-      2025-01-01: 150_000
+      2023-01-01: 150_000
     amount:
-      2025-01-01: 300
+      2023-01-01: 300
   - threshold:
-      2025-01-01: 300_000
+      2023-01-01: 300_000
     amount:
-      2025-01-01: 0
+      2023-01-01: 0

--- a/policyengine_us/parameters/gov/states/ny/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/credits/refundable.yaml
@@ -33,6 +33,7 @@ values:
     - ny_real_property_tax_credit
     - ny_college_tuition_credit
     - ny_additional_ctc
+    - ny_inflation_refund_credit
 
   2024-01-01:
     - ny_eitc
@@ -49,7 +50,6 @@ values:
     - ny_cdcc
     - ny_real_property_tax_credit
     - ny_college_tuition_credit
-    - ny_inflation_refund_credit
 
   2026-01-01:
     - ny_eitc

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_inflation_refund_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_inflation_refund_credit.yaml
@@ -1,5 +1,5 @@
-- name: NY 2025 inflation refund credits - joint filer under $150k gets $400
-  period: 2025
+- name: NY 2023 inflation refund - joint filer under $150k gets $400
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -8,8 +8,8 @@
   output:
     ny_inflation_refund_credit: 400
 
-- name: NY 2025 inflation refund credits - joint filer between $150k-$300k gets $300
-  period: 2025
+- name: NY 2023 inflation refund - joint filer between $150k-$300k gets $300
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -18,8 +18,8 @@
   output:
     ny_inflation_refund_credit: 300
 
-- name: NY 2025 inflation refund credits - joint filer over $300k gets $0
-  period: 2025
+- name: NY 2023 inflation refund - joint filer over $300k gets $0
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -28,8 +28,8 @@
   output:
     ny_inflation_refund_credit: 0
 
-- name: NY 2025 inflation refund credits - surviving spouse under $150k gets $400
-  period: 2025
+- name: NY 2023 inflation refund - surviving spouse under $150k gets $400
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -38,8 +38,8 @@
   output:
     ny_inflation_refund_credit: 400
 
-- name: NY 2025 inflation refund credits - single filer under $75k gets $200
-  period: 2025
+- name: NY 2023 inflation refund - single filer under $75k gets $200
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -48,8 +48,8 @@
   output:
     ny_inflation_refund_credit: 200
 
-- name: NY 2025 inflation refund credits - single filer between $75k-$150k gets $150
-  period: 2025
+- name: NY 2023 inflation refund - single filer between $75k-$150k gets $150
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -58,8 +58,8 @@
   output:
     ny_inflation_refund_credit: 150
 
-- name: NY 2025 inflation refund credits - single filer over $150k gets $0
-  period: 2025
+- name: NY 2023 inflation refund - single filer over $150k gets $0
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -68,8 +68,8 @@
   output:
     ny_inflation_refund_credit: 0
 
-- name: NY 2025 inflation refund credits - head of household under $75k gets $200
-  period: 2025
+- name: NY 2023 inflation refund - head of household under $75k gets $200
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -78,8 +78,8 @@
   output:
     ny_inflation_refund_credit: 200
 
-- name: NY 2025 inflation refund credits - married filing separate between $75k-$150k gets $150
-  period: 2025
+- name: NY 2023 inflation refund - married filing separate between $75k-$150k gets $150
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -88,8 +88,8 @@
   output:
     ny_inflation_refund_credit: 150
 
-- name: NY 2025 inflation refund credits - not available outside of NY
-  period: 2025
+- name: NY 2023 inflation refund - not available outside of NY
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: CA
@@ -98,8 +98,7 @@
   output:
     ny_inflation_refund_credit: 0
 
-
-- name: NY 2024 inflation refund credits - not available before 2025
+- name: NY 2024 inflation refund - not available after eligibility year
   period: 2024
   absolute_error_margin: 0
   input:
@@ -109,7 +108,17 @@
   output:
     ny_inflation_refund_credit: 0
 
-- name: NY 2026 inflation refund credits - not available after 2025
+- name: NY 2025 inflation refund - payment year does not change tax-year assignment
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    state_code: NY
+    ny_agi: 50_000
+    filing_status: SINGLE
+  output:
+    ny_inflation_refund_credit: 0
+
+- name: NY 2026 inflation refund - not available after payment year
   period: 2026
   absolute_error_margin: 0
   input:
@@ -119,8 +128,8 @@
   output:
     ny_inflation_refund_credit: 0
 
-- name: NY 2025 inflation refund credits - single filer with zero AGI should get credit
-  period: 2025
+- name: NY 2023 inflation refund - single filer with zero AGI should get credit
+  period: 2023
   absolute_error_margin: 0
   input:
     state_code: NY
@@ -128,4 +137,3 @@
     filing_status: SINGLE
   output:
     ny_inflation_refund_credit: 200
-

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_inflation_refund_credit.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/ny_inflation_refund_credit.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class ny_inflation_refund_credit(Variable):
     value_type = float
     entity = TaxUnit
-    label = "New York 2025 inflation refund credits"
+    label = "New York inflation refund"
     unit = USD
     definition_period = YEAR
     reference = "https://www.nysenate.gov/legislation/laws/TAX/606#QQQ"
@@ -13,7 +13,9 @@ class ny_inflation_refund_credit(Variable):
     def formula(tax_unit, period, parameters):
         return 0
 
-    def formula_2025(tax_unit, period, parameters):
+    # This refund is based on tax year 2023 returns, even though the checks were
+    # mailed later. The tax effect belongs to the eligibility year.
+    def formula_2023(tax_unit, period, parameters):
         p = parameters(period).gov.states.ny.tax.income.credits.inflation_refund
         agi = tax_unit("ny_agi", period)
         filing_status = tax_unit("filing_status", period)
@@ -36,5 +38,5 @@ class ny_inflation_refund_credit(Variable):
             ],
         )
 
-    def formula_2026(tax_unit, period, parameters):
+    def formula_2024(tax_unit, period, parameters):
         return 0


### PR DESCRIPTION
## Summary
- move `ny_inflation_refund_credit` from the payment year to tax year 2023, the year that determines eligibility and amount
- align the refundable-credit metadata and NY inflation refund parameter schedules with the eligibility-year convention
- convert the NY fixture to 2023-positive coverage and assert zero credit in 2024, 2025, and 2026

Fixes #7994

## Testing
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_inflation_refund_credit.yaml`
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/va/tax/income/va_rebate.yaml`
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/credits/ga_surplus_tax_rebate.yaml`
- `uv run ruff check policyengine_us/variables/gov/states/ny/tax/income/credits/ny_inflation_refund_credit.py`