### PR TITLE
Optimize DC separate-combined deduction allocation

### DIFF
--- a/changelog.d/7993.fixed.md
+++ b/changelog.d/7993.fixed.md
@@ -1,0 +1,1 @@
+Optimize DC separate-combined deduction allocation using a shared two-spouse tax minimization helper, and reuse that helper for Mississippi joint deduction and exemption proration.

--- a/policyengine_us/model_api.py
+++ b/policyengine_us/model_api.py
@@ -25,6 +25,38 @@ def all_of_variables(variables: List[str]) -> Formula:
     return formula
 
 
+def allocate_joint_amount_to_minimize_combined_tax(
+    rate, head_income, spouse_income, total_allocable_amount
+):
+    best_head_allocation = total_allocable_amount
+    best_tax = rate.calc(max_(head_income - best_head_allocation, 0)) + rate.calc(
+        max_(spouse_income - (total_allocable_amount - best_head_allocation), 0)
+    )
+
+    for threshold in rate.thresholds:
+        if not np.isfinite(threshold):
+            continue
+
+        for candidate in (
+            np.clip(head_income - threshold, 0, total_allocable_amount),
+            np.clip(
+                total_allocable_amount - (spouse_income - threshold),
+                0,
+                total_allocable_amount,
+            ),
+        ):
+            candidate_tax = rate.calc(max_(head_income - candidate, 0)) + rate.calc(
+                max_(spouse_income - (total_allocable_amount - candidate), 0)
+            )
+            improves_tax = candidate_tax < (best_tax - 1e-9)
+            best_tax = where(improves_tax, candidate_tax, best_tax)
+            best_head_allocation = where(
+                improves_tax, candidate, best_head_allocation
+            )
+
+    return best_head_allocation
+
+
 STATES = [
     "AL",
     "AK",

--- a/policyengine_us/model_api.py
+++ b/policyengine_us/model_api.py
@@ -50,9 +50,7 @@ def allocate_joint_amount_to_minimize_combined_tax(
             )
             improves_tax = candidate_tax < (best_tax - 1e-9)
             best_tax = where(improves_tax, candidate_tax, best_tax)
-            best_head_allocation = where(
-                improves_tax, candidate, best_head_allocation
-            )
+            best_head_allocation = where(improves_tax, candidate, best_head_allocation)
 
     return best_head_allocation
 

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_deduction_indiv.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_deduction_indiv.yaml
@@ -1,4 +1,4 @@
-- name: dc_deduction_indiv unit test 1
+- name: dc_deduction_indiv allocates all deduction to higher earner when optimal
   absolute_error_margin: 0.01
   period: 2021
   input:
@@ -24,4 +24,30 @@
         members: [person1, person2, person3]
         state_code: DC
   output:
-    dc_deduction_indiv: [15_000, 5_000, 0]
+    dc_deduction_indiv: [20_000, 0, 0]
+
+- name: dc_deduction_indiv equalizes taxable income when that minimizes tax
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        dc_agi: 20_000
+      person2:
+        is_tax_unit_spouse: true
+        dc_agi: 25_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_itemizes: false
+        dc_deduction_joint: 25_000
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: DC
+  output:
+    dc_deduction_indiv: [10_000, 15_000]

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_income_tax_before_credits_indiv.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_income_tax_before_credits_indiv.yaml
@@ -37,3 +37,29 @@
     state_code: DC
   output:
     dc_income_tax_before_credits_indiv: 199_025
+
+- name: dc_income_tax_before_credits_indiv uses optimal separate-combined deduction allocation
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        dc_agi: 20_000
+      person2:
+        is_tax_unit_spouse: true
+        dc_agi: 25_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_itemizes: false
+        dc_deduction_joint: 25_000
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: DC
+  output:
+    dc_income_tax_before_credits_indiv: 800

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/ms_prorate_fraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/ms_prorate_fraction.yaml
@@ -97,3 +97,29 @@
         state_code: MS
   output:
     ms_prorate_fraction: [1, 0]
+
+- name: Itemized deductions above the standard deduction are used in allocation
+  period: 2025
+  absolute_error_margin: 0.001
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 40
+        ms_agi: 16_000
+      person2:
+        is_tax_unit_spouse: true
+        age: 40
+        ms_agi: 12_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        ms_itemized_deductions_unit: 8_000
+        ms_total_exemptions: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+  output:
+    ms_prorate_fraction: [0.75, 0.25]

--- a/policyengine_us/tests/policy/baseline/household/cliff_gap.yaml
+++ b/policyengine_us/tests/policy/baseline/household/cliff_gap.yaml
@@ -150,4 +150,4 @@
         members: [person1, person2]
         state_fips: 11  # DC
   output:  # as expected from above two test results
-    cliff_gap: [486.5, 470.47]
+    cliff_gap: [486.5, 461.5]

--- a/policyengine_us/variables/gov/states/dc/tax/income/deductions/dc_deduction_indiv.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/deductions/dc_deduction_indiv.py
@@ -15,12 +15,15 @@ class dc_deduction_indiv(Variable):
 
     def formula(person, period, parameters):
         tax_unit_deduction = person.tax_unit("dc_deduction_joint", period)
-        # The above references say the following:
-        # "You may allocate this [tax-unit deduction] amount as you wish."
-        # Here we allocate in proportion to head and spouse DC AGI
         person_agi = person("dc_agi", period)
-        tax_unit_agi = person.tax_unit.sum(person_agi)
-        share = np.zeros_like(tax_unit_agi)
-        mask = tax_unit_agi > 0
-        share[mask] = person_agi[mask] / tax_unit_agi[mask]
-        return share * tax_unit_deduction
+        head = person("is_tax_unit_head", period)
+        spouse = person("is_tax_unit_spouse", period)
+        tax = parameters(period).gov.states.dc.tax.income
+
+        head_agi = person.tax_unit.sum(person_agi * head)
+        spouse_agi = person.tax_unit.sum(person_agi * spouse)
+        head_allocation = allocate_joint_amount_to_minimize_combined_tax(
+            tax.rates, head_agi, spouse_agi, tax_unit_deduction
+        )
+        spouse_allocation = tax_unit_deduction - head_allocation
+        return where(head, head_allocation, where(spouse, spouse_allocation, 0))

--- a/policyengine_us/variables/gov/states/ms/tax/income/ms_prorate_fraction.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/ms_prorate_fraction.py
@@ -33,34 +33,9 @@ class ms_prorate_fraction(Variable):
             max_(standard_deduction, itemized_deductions) + total_exemptions
         )
 
-        # Mississippi lets joint filers split their combined deduction and
-        # exemption amounts between spouses however they want, so choose the
-        # split that minimizes combined liability.
-        best_head_allocation = total_allocable_deductions
-        best_tax = rate.calc(max_(head_agi - best_head_allocation, 0)) + rate.calc(
-            max_(spouse_agi - (total_allocable_deductions - best_head_allocation), 0)
+        best_head_allocation = allocate_joint_amount_to_minimize_combined_tax(
+            rate, head_agi, spouse_agi, total_allocable_deductions
         )
-
-        for threshold in rate.thresholds:
-            if not np.isfinite(threshold):
-                continue
-
-            for candidate in (
-                np.clip(head_agi - threshold, 0, total_allocable_deductions),
-                np.clip(
-                    total_allocable_deductions - (spouse_agi - threshold),
-                    0,
-                    total_allocable_deductions,
-                ),
-            ):
-                candidate_tax = rate.calc(max_(head_agi - candidate, 0)) + rate.calc(
-                    max_(spouse_agi - (total_allocable_deductions - candidate), 0)
-                )
-                improves_tax = candidate_tax < (best_tax - 1e-9)
-                best_tax = where(improves_tax, candidate_tax, best_tax)
-                best_head_allocation = where(
-                    improves_tax, candidate, best_head_allocation
-                )
 
         head_fraction = where(
             total_allocable_deductions > 0,


### PR DESCRIPTION
## Summary
- add a shared helper for splitting one joint amount across spouses to minimize combined progressive tax
- use that helper for `dc_deduction_indiv` so DC Calculation J no longer forces an AGI-proportional deduction split
- reuse the same helper in Mississippi proration logic and add DC regression coverage around the allocation rule and resulting tax

Fixes #7292
Part of #7993

## Why
DC Calculation J says each spouse's share of the D-40 deduction amount may be allocated "as you wish." The existing model split that amount in proportion to AGI, which can overstate separate-combined tax relative to the legally permitted allocation.

## Testing
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_deduction_indiv.yaml`
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_income_tax_before_credits_indiv.yaml`
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_files_separately.yaml policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_income_tax_before_credits.yaml`
- `python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/ms_prorate_fraction.yaml`
- `uv run ruff check policyengine_us/model_api.py policyengine_us/variables/gov/states/dc/tax/income/deductions/dc_deduction_indiv.py policyengine_us/variables/gov/states/ms/tax/income/ms_prorate_fraction.py`