### PR TITLE
Fix Delaware joint AGI floor after summing spouses

### DIFF
--- a/changelog.d/issue7869-de-joint-agi.fixed.md
+++ b/changelog.d/issue7869-de-joint-agi.fixed.md
@@ -1,0 +1,1 @@
+Fix Delaware joint AGI to floor after summing spouses' net income, preserving cross-spouse loss offsets.

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_agi_joint.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_agi_joint.yaml
@@ -69,3 +69,28 @@
         state_code: DE
   output:
     de_agi_joint: [25_000, 0]
+
+- name: Joint AGI floors to zero after combined spouse net income is negative
+  period: 2024
+  input:
+    people:
+      person1:
+        de_pre_exclusions_agi: -100_000
+        de_elderly_or_disabled_income_exclusion_joint: 0
+        is_tax_unit_dependent: false
+        is_tax_unit_head: true
+      person2:
+        de_pre_exclusions_agi: 75_000
+        de_elderly_or_disabled_income_exclusion_joint: 0
+        is_tax_unit_dependent: false
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: DE
+  output:
+    de_agi_joint: [0, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_agi_joint.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_agi_joint.yaml
@@ -43,4 +43,29 @@
         members: [person1, person2, person3]
         state_code: DE
   output:
-    de_agi_joint: [1_200, 0, 0]
+    de_agi_joint: [1_100, 0, 0]
+
+- name: Joint AGI floors after summing across spouses
+  period: 2024
+  input:
+    people:
+      person1:
+        de_pre_exclusions_agi: 100_000
+        de_elderly_or_disabled_income_exclusion_joint: 0
+        is_tax_unit_dependent: false
+        is_tax_unit_head: true
+      person2:
+        de_pre_exclusions_agi: -75_000
+        de_elderly_or_disabled_income_exclusion_joint: 0
+        is_tax_unit_dependent: false
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: DE
+  output:
+    de_agi_joint: [25_000, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
@@ -273,3 +273,38 @@
     de_deduction_indv: [5_750, 5_750, 0]
     de_deduction_joint: [11_500, 0, 0]
     de_income_tax: 6882.22
+
+- name: Tax unit with taxsimid 745 in 2024 preserves cross-spouse SE loss in joint AGI
+  absolute_error_margin: 50
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 43
+        employment_income: 2_133.02
+        self_employment_income: -104_506.57
+        taxable_interest_income: 537.23
+        taxable_private_pension_income: 953.04
+        is_tax_unit_head: true
+      person2:
+        age: 42
+        employment_income: 125_352.16
+        taxable_interest_income: 537.23
+        taxable_private_pension_income: 953.04
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        premium_tax_credit: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 10
+  output:
+    de_agi_joint: [24_043.88, 0]

--- a/policyengine_us/variables/gov/states/de/tax/income/de_agi_joint.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/de_agi_joint.py
@@ -16,7 +16,8 @@ class de_agi_joint(Variable):
         indv_exclusions = person(
             "de_elderly_or_disabled_income_exclusion_joint", period
         )
-        net_income = max_(pre_exclusions_agi - indv_exclusions, 0)
+        net_income = pre_exclusions_agi - indv_exclusions
+        joint_net_income = max_(person.tax_unit.sum(net_income), 0)
         # allocate any dependent gross income to tax unit head
         is_head = person("is_tax_unit_head", period)
-        return person.tax_unit.sum(net_income) * is_head
+        return joint_net_income * is_head


### PR DESCRIPTION
## Summary
- floor Delaware joint AGI after summing spouse net income instead of per person
- add a unit regression for cross-spouse negative AGI offsets
- add a Delaware taxsim-style integration regression from issue #7869
- add a changelog fragment

## Why
Delaware joint AGI starts from combined federal AGI. Flooring each spouse at zero before summing discards one spouse's losses instead of letting them offset the other spouse's income.

Closes #7869.

## Validation
- python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_agi_joint.yaml
- python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
- python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_files_separately.yaml policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_income_tax_before_non_refundable_credits_unit.yaml policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_agi_indiv.yaml policyengine_us/tests/policy/baseline/gov/states/de/tax/income/de_agi_joint.yaml
- uv run ruff check policyengine_us/variables/gov/states/de/tax/income/de_agi_joint.py