### PR TITLE
[codex] Add Minnesota HF4890 income tax bracket reform

### DIFF
--- a/changelog.d/8009.added.md
+++ b/changelog.d/8009.added.md
@@ -1,0 +1,1 @@
+Added a contributed Minnesota HF4890 reform with income tax rate schedules by filing status.

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/in_effect.yaml
@@ -1,12 +1,12 @@
-description: Minnesota HF4890 replaces the income tax rate schedules, if this is true.
+description: Minnesota uses this indicator to determine whether the HF4890 income tax rate schedules apply.
 
 values:
-  0000-01-01: false
+  0001-01-01: false
 
 metadata:
   unit: bool
   period: year
   label: Minnesota HF4890 income tax rate schedules in effect
   reference:
-    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c
-      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+    - title: Minnesota HF4890 (2026), Sec. 1 -- effective for taxable years after December 31, 2025
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/pdf/#page=3

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/in_effect.yaml
@@ -1,0 +1,12 @@
+description: Minnesota HF4890 replaces the income tax rate schedules, if this is true.
+
+values:
+  0000-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: Minnesota HF4890 income tax rate schedules in effect
+  reference:
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/head_of_household.yaml
@@ -1,0 +1,33 @@
+description: Minnesota HF4890 levies income taxes at these rates for head of household filers.
+
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-USD
+  rate_unit: /1
+  threshold_period: year
+  label: Minnesota HF4890 head of household income tax rates
+  reference:
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(c)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+
+brackets:
+  - threshold:
+      2026-01-01: 0
+    rate:
+      2026-01-01: 0.0535
+  - threshold:
+      2026-01-01: 41_010
+    rate:
+      2026-01-01: 0.068
+  - threshold:
+      2026-01-01: 164_800
+    rate:
+      2026-01-01: 0.0785
+  - threshold:
+      2026-01-01: 270_060
+    rate:
+      2026-01-01: 0.0985
+  - threshold:
+      2026-01-01: 800_000
+    rate:
+      2026-01-01: 0.1015

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/head_of_household.yaml
@@ -7,8 +7,8 @@ metadata:
   threshold_period: year
   label: Minnesota HF4890 head of household income tax rates
   reference:
-    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(c)
-      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(c) -- head of household rate schedule (5 brackets, 5.35%-10.15%)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/pdf/#page=2
 
 brackets:
   - threshold:

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/joint.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/joint.yaml
@@ -7,8 +7,8 @@ metadata:
   threshold_period: year
   label: Minnesota HF4890 joint income tax rates
   reference:
-    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a)
-      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a) -- joint/surviving spouse rate schedule (5 brackets, 5.35%-10.15%)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/pdf/#page=1
 
 brackets:
   - threshold:

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/joint.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/joint.yaml
@@ -1,0 +1,33 @@
+description: Minnesota HF4890 levies income taxes at these rates for joint filers.
+
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-USD
+  rate_unit: /1
+  threshold_period: year
+  label: Minnesota HF4890 joint income tax rates
+  reference:
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+
+brackets:
+  - threshold:
+      2026-01-01: 0
+    rate:
+      2026-01-01: 0.0535
+  - threshold:
+      2026-01-01: 48_700
+    rate:
+      2026-01-01: 0.068
+  - threshold:
+      2026-01-01: 193_480
+    rate:
+      2026-01-01: 0.0785
+  - threshold:
+      2026-01-01: 337_930
+    rate:
+      2026-01-01: 0.0985
+  - threshold:
+      2026-01-01: 1_000_000
+    rate:
+      2026-01-01: 0.1015

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/separate.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/separate.yaml
@@ -1,0 +1,33 @@
+description: Minnesota HF4890 levies income taxes at these rates for separate filers.
+
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-USD
+  rate_unit: /1
+  threshold_period: year
+  label: Minnesota HF4890 separate income tax rates
+  reference:
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+
+brackets:
+  - threshold:
+      2026-01-01: 0
+    rate:
+      2026-01-01: 0.0535
+  - threshold:
+      2026-01-01: 24_350
+    rate:
+      2026-01-01: 0.068
+  - threshold:
+      2026-01-01: 96_740
+    rate:
+      2026-01-01: 0.0785
+  - threshold:
+      2026-01-01: 168_965
+    rate:
+      2026-01-01: 0.0985
+  - threshold:
+      2026-01-01: 500_000
+    rate:
+      2026-01-01: 0.1015

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/separate.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/separate.yaml
@@ -7,8 +7,8 @@ metadata:
   threshold_period: year
   label: Minnesota HF4890 separate income tax rates
   reference:
-    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a)
-      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a), lines 1.18-1.20 -- married filing separate brackets are one-half of joint amounts
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/pdf/#page=1
 
 brackets:
   - threshold:

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/single.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/single.yaml
@@ -1,0 +1,33 @@
+description: Minnesota HF4890 levies income taxes at these rates for single filers.
+
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-USD
+  rate_unit: /1
+  threshold_period: year
+  label: Minnesota HF4890 single income tax rates
+  reference:
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(b)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+
+brackets:
+  - threshold:
+      2026-01-01: 0
+    rate:
+      2026-01-01: 0.0535
+  - threshold:
+      2026-01-01: 33_310
+    rate:
+      2026-01-01: 0.068
+  - threshold:
+      2026-01-01: 109_430
+    rate:
+      2026-01-01: 0.0785
+  - threshold:
+      2026-01-01: 203_150
+    rate:
+      2026-01-01: 0.0985
+  - threshold:
+      2026-01-01: 600_000
+    rate:
+      2026-01-01: 0.1015

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/single.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/single.yaml
@@ -7,8 +7,8 @@ metadata:
   threshold_period: year
   label: Minnesota HF4890 single income tax rates
   reference:
-    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(b)
-      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(b) -- single filer rate schedule (5 brackets, 5.35%-10.15%)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/pdf/#page=2
 
 brackets:
   - threshold:

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/surviving_spouse.yaml
@@ -1,0 +1,33 @@
+description: Minnesota HF4890 levies income taxes at these rates for surviving spouse filers.
+
+metadata:
+  type: marginal_rate
+  threshold_unit: currency-USD
+  rate_unit: /1
+  threshold_period: year
+  label: Minnesota HF4890 surviving spouse income tax rates
+  reference:
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+
+brackets:
+  - threshold:
+      2026-01-01: 0
+    rate:
+      2026-01-01: 0.0535
+  - threshold:
+      2026-01-01: 48_700
+    rate:
+      2026-01-01: 0.068
+  - threshold:
+      2026-01-01: 193_480
+    rate:
+      2026-01-01: 0.0785
+  - threshold:
+      2026-01-01: 337_930
+    rate:
+      2026-01-01: 0.0985
+  - threshold:
+      2026-01-01: 1_000_000
+    rate:
+      2026-01-01: 0.1015

--- a/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/mn/hf4890/rates/surviving_spouse.yaml
@@ -7,8 +7,8 @@ metadata:
   threshold_period: year
   label: Minnesota HF4890 surviving spouse income tax rates
   reference:
-    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a)
-      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
+    - title: Minnesota HF4890 (2026), Sec. 1, Subd. 2c(a) -- joint/surviving spouse rate schedule (5 brackets, 5.35%-10.15%)
+      href: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/pdf/#page=1
 
 brackets:
   - threshold:

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -45,6 +45,9 @@ from .congress.tlaib.boost import (
 from .states.mn.walz import (
     create_mn_walz_hf1938_repeal_reform,
 )
+from .states.mn.hf4890 import (
+    create_mn_hf4890_reform,
+)
 from .states.oregon.rebate import (
     create_or_rebate_state_tax_exempt_reform,
 )
@@ -306,6 +309,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         parameters, period
     )
     mn_walz_hf1938 = create_mn_walz_hf1938_repeal_reform(parameters, period)
+    mn_hf4890 = create_mn_hf4890_reform(parameters, period)
 
     or_rebate_state_tax_exempt = create_or_rebate_state_tax_exempt_reform(
         parameters, period
@@ -469,6 +473,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         edaa_end_child_poverty_act,
         boost_middle_class_tax_credit,
         mn_walz_hf1938,
+        mn_hf4890,
         or_rebate_state_tax_exempt,
         family_security_act_2024_ctc,
         family_security_act_2024_eitc,

--- a/policyengine_us/reforms/states/mn/hf4890/__init__.py
+++ b/policyengine_us/reforms/states/mn/hf4890/__init__.py
@@ -1,0 +1,4 @@
+from .mn_hf4890 import (
+    create_mn_hf4890_reform,
+    mn_hf4890,
+)

--- a/policyengine_us/reforms/states/mn/hf4890/mn_hf4890.py
+++ b/policyengine_us/reforms/states/mn/hf4890/mn_hf4890.py
@@ -1,0 +1,88 @@
+from policyengine_us.model_api import *
+from policyengine_core.periods import period as period_
+
+
+def create_mn_hf4890() -> Reform:
+    class mn_basic_tax(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "Minnesota basic tax calculated using HF4890 tax rate schedules"
+        unit = USD
+        definition_period = YEAR
+        reference = "https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/"
+        defined_for = StateCode.MN
+
+        def formula(tax_unit, period, parameters):
+            filing_status = tax_unit("filing_status", period)
+            statuses = filing_status.possible_values
+            taxable_income = tax_unit("mn_taxable_income", period)
+
+            baseline_rates = parameters(period).gov.states.mn.tax.income.rates
+            hf4890 = parameters(period).gov.contrib.states.mn.hf4890
+            hf4890_rates = hf4890.rates
+
+            baseline_tax = select(
+                [
+                    filing_status == statuses.SINGLE,
+                    filing_status == statuses.SEPARATE,
+                    filing_status == statuses.JOINT,
+                    filing_status == statuses.SURVIVING_SPOUSE,
+                    filing_status == statuses.HEAD_OF_HOUSEHOLD,
+                ],
+                [
+                    baseline_rates.single.calc(taxable_income),
+                    baseline_rates.separate.calc(taxable_income),
+                    baseline_rates.joint.calc(taxable_income),
+                    baseline_rates.surviving_spouse.calc(taxable_income),
+                    baseline_rates.head_of_household.calc(taxable_income),
+                ],
+            )
+
+            hf4890_tax = select(
+                [
+                    filing_status == statuses.SINGLE,
+                    filing_status == statuses.SEPARATE,
+                    filing_status == statuses.JOINT,
+                    filing_status == statuses.SURVIVING_SPOUSE,
+                    filing_status == statuses.HEAD_OF_HOUSEHOLD,
+                ],
+                [
+                    hf4890_rates.single.calc(taxable_income),
+                    hf4890_rates.separate.calc(taxable_income),
+                    hf4890_rates.joint.calc(taxable_income),
+                    hf4890_rates.surviving_spouse.calc(taxable_income),
+                    hf4890_rates.head_of_household.calc(taxable_income),
+                ],
+            )
+
+            return where(hf4890.in_effect, hf4890_tax, baseline_tax)
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(mn_basic_tax)
+
+    return reform
+
+
+def create_mn_hf4890_reform(parameters, period, bypass: bool = False):
+    if bypass:
+        return create_mn_hf4890()
+
+    p = parameters.gov.contrib.states.mn.hf4890
+
+    reform_active = False
+    current_period = period_(period)
+
+    for _ in range(5):
+        if p(current_period).in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
+        return create_mn_hf4890()
+    else:
+        return None
+
+
+mn_hf4890 = create_mn_hf4890_reform(None, None, bypass=True)

--- a/policyengine_us/tests/policy/contrib/states/mn/hf4890/mn_hf4890.yaml
+++ b/policyengine_us/tests/policy/contrib/states/mn/hf4890/mn_hf4890.yaml
@@ -57,3 +57,84 @@
     state_code: MN
   output:
     mn_basic_tax: 99_153.71
+
+# Test in_effect: false - baseline path
+- name: Minnesota HF4890 single filer with reform disabled uses baseline rates
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: false
+    filing_status: SINGLE
+    mn_taxable_income: 700_000
+    state_code: MN
+  output:
+    mn_basic_tax: 63_255.60
+
+# Zero income test
+- name: Minnesota HF4890 zero income produces zero tax
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: SINGLE
+    mn_taxable_income: 0
+    state_code: MN
+  output:
+    mn_basic_tax: 0
+
+# First bracket only test
+- name: Minnesota HF4890 income in first bracket only
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: SINGLE
+    mn_taxable_income: 20_000
+    state_code: MN
+  output:
+    # 20,000 * 0.0535 = 1,070.00
+    mn_basic_tax: 1_070.00
+
+# Exact bracket threshold test
+- name: Minnesota HF4890 income at exact first threshold
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: SINGLE
+    mn_taxable_income: 33_310
+    state_code: MN
+  output:
+    # 33,310 * 0.0535 = 1,782.085
+    mn_basic_tax: 1_782.09
+
+# Joint/surviving spouse equivalence test
+- name: Minnesota HF4890 joint filer matches surviving spouse at same income
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: JOINT
+    mn_taxable_income: 1_100_000
+    state_code: MN
+  output:
+    # Same as surviving spouse test above
+    mn_basic_tax: 99_153.71
+
+# Non-MN state test
+- name: Minnesota HF4890 non-MN resident has zero MN tax
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: SINGLE
+    mn_taxable_income: 700_000
+    state_code: CA
+  output:
+    mn_basic_tax: 0

--- a/policyengine_us/tests/policy/contrib/states/mn/hf4890/mn_hf4890.yaml
+++ b/policyengine_us/tests/policy/contrib/states/mn/hf4890/mn_hf4890.yaml
@@ -1,0 +1,59 @@
+- name: Minnesota HF4890 single filer reaches fifth bracket
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: SINGLE
+    mn_taxable_income: 700_000
+    state_code: MN
+  output:
+    mn_basic_tax: 63_554.99
+
+- name: Minnesota HF4890 joint filer reaches fifth bracket
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: JOINT
+    mn_taxable_income: 1_200_000
+    state_code: MN
+  output:
+    mn_basic_tax: 109_303.71
+
+- name: Minnesota HF4890 separate filer uses half of joint brackets
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: SEPARATE
+    mn_taxable_income: 600_000
+    state_code: MN
+  output:
+    mn_basic_tax: 54_651.86
+
+- name: Minnesota HF4890 head of household filer reaches fifth bracket
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: HEAD_OF_HOUSEHOLD
+    mn_taxable_income: 900_000
+    state_code: MN
+  output:
+    mn_basic_tax: 81_223.76
+
+- name: Minnesota HF4890 surviving spouse filer uses joint brackets
+  absolute_error_margin: 0.01
+  period: 2026
+  reforms: policyengine_us.reforms.states.mn.hf4890.mn_hf4890.mn_hf4890
+  input:
+    gov.contrib.states.mn.hf4890.in_effect: true
+    filing_status: SURVIVING_SPOUSE
+    mn_taxable_income: 1_100_000
+    state_code: MN
+  output:
+    mn_basic_tax: 99_153.71


### PR DESCRIPTION
## Summary

- Adds a contributed Minnesota HF4890 reform with an `in_effect` switch.
- Adds full HF4890 income tax rate schedules by filing status, including the new 10.15 percent fifth bracket.
- Registers the structural reform and adds targeted YAML tests for all filing statuses.

Closes #8008.

## Tests

- `py -3.11 -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/states/mn/hf4890/mn_hf4890.yaml -c policyengine_us`
- `py -3.11 -m ruff check policyengine_us/reforms/states/mn/hf4890/mn_hf4890.py policyengine_us/reforms/states/mn/hf4890/__init__.py policyengine_us/reforms/reforms.py`