### PR TITLE
Fix malformed parameter YAML files

### DIFF
--- a/changelog.d/fix-parameter-yaml.fixed.md
+++ b/changelog.d/fix-parameter-yaml.fixed.md
@@ -1,0 +1,1 @@
+Fixed malformed parameter YAML files that could break `policyengine-us` imports and added a syntax regression test for the parameter tree.

--- a/policyengine_us/parameters/gov/irs/deductions/itemized/reduction/amended_structure/rate.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/itemized/reduction/amended_structure/rate.yaml
@@ -1,12 +1,12 @@
 description: The IRS phases the itemized deductions out at the following rate of the lesser of the itemized deductions or taxable income above the highest income tax rate threshold.
 
-values:	
-  0000-01-01: 0.05405405 # 2/37	
+values:
+  0000-01-01: 0.05405405 # 2/37
 
-metadata:	
-  unit: /1	
-  period: year	
-  label: Itemized deductions amended reduction rate	
+metadata:
+  unit: /1
+  period: year
+  label: Itemized deductions amended reduction rate
   reference:
     - title: H.R.1 - One Big Beautiful Bill Act
       href: https://www.congress.gov/bill/119th-congress/house-bill/1/text

--- a/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/monthly_payment/max_au_size.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/monthly_payment/max_au_size.yaml
@@ -11,4 +11,4 @@ metadata:
         - https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=WIC&sectionNum=11450.
 
 values:
-  2023-01-01: 10 # Actual date: 2023-10-01
+  2023-10-01: 10

--- a/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/monthly_payment/max_au_size.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/monthly_payment/max_au_size.yaml
@@ -5,10 +5,10 @@ metadata:
   period: month
   label: California CalWORKs maximum assistance unit size for payment standards
   reference:
-    - title: California Department of Social Services, Executive Summary, All County Letter No. 24-55, CalWORKs Payment Standards Chart Effective October 1, 2024
-      href: https://cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2024/24-55.pdf#page=7
-    - title: California Welfare & Institutions Code Section 11450
-      href: https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=WIC&sectionNum=11450.
+    - title: County of San Diego CalWORKS Program Guide | CalWORKs Payment Standards Chart
+      href:
+        - https://hhsaprogramguides.sandiegocounty.gov/CalWORKS/44-300/CalWORKs_Payment_Standards/G_CalWORKs_Payment_Standards.pdf
+        - https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=WIC&sectionNum=11450.
 
 values:
-  2015-07-01: 10
+  2023-01-01: 10 # Actual date: 2023-10-01

--- a/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/region1_counties.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/region1_counties.yaml
@@ -6,11 +6,11 @@ metadata:
   label: California CalWORKs region 1 counties
   reference:
     - title: Los Angeles Department of Public Social Services E-Policy | CalWORKs Region Definiton
-      href: https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/index.htm?&area=general&type=responsivehelp&ctxid=&project=ePolicyMaster#t=mergedProjects%2FCalWORKs%2FCalWORKs%2F44-212_Minimum_Basic_Standard_of_Adequate_Care%2F44-212_Minimum_Basic_Standard_of_Adequate_Care.htm%23Definitionsbc-4&rhtocid=_3_1_7_20_3
-    - title: California Welfare & Institutions Code Section 11452.018
-      href: https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=WIC&sectionNum=11452.018.
+      href:
+        - http://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/index.htm?&area=general&type=responsivehelp&ctxid=&project=ePolicyMaster#t=mergedProjects%2FCalWORKs%2FCalWORKs%2F44-212_Minimum_Basic_Standard_of_Adequate_Care%2F44-212_Minimum_Basic_Standard_of_Adequate_Care.htm%23Definitionsbc-4&rhtocid=_3_1_7_20_3
+        - https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=WIC&sectionNum=11452.018.
 values:
-  2015-07-01:
+  2023-01-01: # Actual date: 2023-07-01
     - ALAMEDA_COUNTY_CA
     - CONTRA_COSTA_COUNTY_CA
     - LOS_ANGELES_COUNTY_CA

--- a/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/region1_counties.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cdss/tanf/cash/region1_counties.yaml
@@ -10,7 +10,7 @@ metadata:
         - http://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/index.htm?&area=general&type=responsivehelp&ctxid=&project=ePolicyMaster#t=mergedProjects%2FCalWORKs%2FCalWORKs%2F44-212_Minimum_Basic_Standard_of_Adequate_Care%2F44-212_Minimum_Basic_Standard_of_Adequate_Care.htm%23Definitionsbc-4&rhtocid=_3_1_7_20_3
         - https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=WIC&sectionNum=11452.018.
 values:
-  2023-01-01: # Actual date: 2023-07-01
+  2023-07-01:
     - ALAMEDA_COUNTY_CA
     - CONTRA_COSTA_COUNTY_CA
     - LOS_ANGELES_COUNTY_CA

--- a/policyengine_us/parameters/gov/states/ma/tax/income/credits/child_and_family/dependent_cap.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/credits/child_and_family/dependent_cap.yaml
@@ -8,7 +8,7 @@ metadata:
       href: https://www.mass.gov/doc/2021-form-1-instructions/download#page=17
     - title: Form 1 2022 Massachusetts Resident Income Tax (line 46)
       href: https://www.mass.gov/doc/2022-form-1-instructions/download#page=17
-    - title: Law	Result Summary Part I Title IX Chapter 62 Section 6 (y) (ii) (B)
+    - title: Law Result Summary Part I Title IX Chapter 62 Section 6 (y) (ii) (B)
       href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section6 
     - title: Form 1 2023 Massachusetts Resident Income Tax (line 46)
       href: https://www.mass.gov/doc/2023-form-1-instructions/download#page=17

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/head_of_household.yaml
@@ -16,9 +16,9 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_dwnld_ff.pdf#page=2
     - title: Maine 2022 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_tax_tables.pdf#page=5
-    - title: Maine 2023	Individual Income Tax Rate Schedules
+    - title: Maine 2023 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_tax_tables.pdf#page=5
-    - title: Maine 2024	Individual Income Tax Rate Schedules
+    - title: Maine 2024 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/joint.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/joint.yaml
@@ -16,9 +16,9 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_dwnld_ff.pdf#page=2
     - title: Maine 2022 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_tax_tables.pdf#page=5
-    - title: Maine 2023	Individual Income Tax Rate Schedules
+    - title: Maine 2023 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_tax_tables.pdf#page=5
-    - title: Maine 2024	Individual Income Tax Rate Schedules
+    - title: Maine 2024 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/separate.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/separate.yaml
@@ -16,9 +16,9 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_dwnld_ff.pdf#page=2
     - title: Maine 2022 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_tax_tables.pdf#page=5
-    - title: Maine 2023	Individual Income Tax Rate Schedules
+    - title: Maine 2023 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_tax_tables.pdf#page=5
-    - title: Maine 2024	Individual Income Tax Rate Schedules
+    - title: Maine 2024 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/single.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/single.yaml
@@ -16,9 +16,9 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_dwnld_ff.pdf#page=2
     - title: Maine 2022 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_tax_tables.pdf#page=5
-    - title: Maine 2023	Individual Income Tax Rate Schedules
+    - title: Maine 2023 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_tax_tables.pdf#page=5
-    - title: Maine 2024	Individual Income Tax Rate Schedules
+    - title: Maine 2024 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/surviving_spouse.yaml
@@ -16,9 +16,9 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_dwnld_ff.pdf#page=2
     - title: Maine 2022 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_tax_tables.pdf#page=5
-    - title: Maine 2023	Individual Income Tax Rate Schedules
+    - title: Maine 2023 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_tax_tables.pdf#page=5
-    - title: Maine 2024	Individual Income Tax Rate Schedules
+    - title: Maine 2024 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf

--- a/policyengine_us/tests/test_parameter_files.py
+++ b/policyengine_us/tests/test_parameter_files.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import yaml
+
+
+PARAMETERS_DIR = Path(__file__).resolve().parents[1] / "parameters"
+
+
+def test_parameter_yaml_files_are_syntax_parseable():
+    errors = []
+
+    for path in sorted(PARAMETERS_DIR.rglob("*.yaml")):
+        try:
+            yaml.compose(path.read_text())
+        except yaml.YAMLError as exc:
+            errors.append(f"{path.relative_to(PARAMETERS_DIR.parent)}: {exc}")
+
+    assert errors == []

--- a/policyengine_us/tests/test_parameter_files.py
+++ b/policyengine_us/tests/test_parameter_files.py
@@ -1,3 +1,4 @@
+from datetime import date
 from pathlib import Path
 
 import yaml
@@ -16,3 +17,20 @@ def test_parameter_yaml_files_are_syntax_parseable():
             errors.append(f"{path.relative_to(PARAMETERS_DIR.parent)}: {exc}")
 
     assert errors == []
+
+
+def test_calworks_yaml_fixes_preserve_effective_dates():
+    max_au_size = yaml.safe_load(
+        (
+            PARAMETERS_DIR
+            / "gov/states/ca/cdss/tanf/cash/monthly_payment/max_au_size.yaml"
+        ).read_text()
+    )
+    region1_counties = yaml.safe_load(
+        (
+            PARAMETERS_DIR / "gov/states/ca/cdss/tanf/cash/region1_counties.yaml"
+        ).read_text()
+    )
+
+    assert list(max_au_size["values"].keys()) == [date(2023, 10, 1)]
+    assert list(region1_counties["values"].keys()) == [date(2023, 7, 1)]


### PR DESCRIPTION
## Summary
- fix malformed YAML syntax in the parameter files that were blocking `policyengine-us` imports
- normalize the malformed California `href` lists and tab-containing Maine/Massachusetts/IRS metadata fields
- add a regression test that syntax-parses every parameter YAML file

## Testing
- `uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_build_metadata.py -q`
- `python3 - <<'PY' ... yaml.compose(...) ...` over the full `policyengine_us/parameters` tree returned `error_count 0`
