### PR TITLE
Cap Hawaii EITC before 2023

### DIFF
--- a/changelog.d/fix-hi-eitc-cap-8013.fixed.md
+++ b/changelog.d/fix-hi-eitc-cap-8013.fixed.md
@@ -1,0 +1,1 @@
+Cap Hawaii EITC at Hawaii income tax liability for tax years 2018 through 2022, while keeping the credit refundable for 2023 and later.

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_eitc.yaml
@@ -26,6 +26,16 @@
     hi_eitc_potential: 540
     hi_eitc: 0
 
+- name: 2023 EITC remains refundable with zero Hawaii income tax liability
+  period: 2023
+  input:
+    eitc: 2_700
+    state_code: HI
+    hi_income_tax_before_non_refundable_credits: 0
+  output:
+    hi_eitc_potential: 1_080
+    hi_eitc: 1_080
+
 - name: 40% match of fed EITC
   period: 2023
   input:

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_eitc.yaml
@@ -3,16 +3,28 @@
   input:
     eitc: 0
     state_code: HI
+    hi_income_tax_before_non_refundable_credits: 1_000_000
   output:
     hi_eitc: 0
 
-- name: 20% match of fed EITC
+- name: 20% match of fed EITC when Hawaii liability is sufficient
   period: 2022
   input:
     eitc: 1_000
     state_code: HI
+    hi_income_tax_before_non_refundable_credits: 1_000_000
   output:
     hi_eitc: 200
+
+- name: 2022 EITC is capped by Hawaii income tax liability
+  period: 2022
+  input:
+    eitc: 2_700
+    state_code: HI
+    hi_income_tax_before_non_refundable_credits: 0
+  output:
+    hi_eitc_potential: 540
+    hi_eitc: 0
 
 - name: 40% match of fed EITC
   period: 2023

--- a/policyengine_us/variables/gov/states/hi/tax/income/credits/hi_eitc.py
+++ b/policyengine_us/variables/gov/states/hi/tax/income/credits/hi_eitc.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
 
 class hi_eitc(Variable):
@@ -11,6 +14,14 @@ class hi_eitc(Variable):
     reference = "https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0235/HRS_0235-0055_0075.htm"
 
     def formula(tax_unit, period, parameters):
-        federal_eitc = tax_unit("eitc", period)
-        rate = parameters(period).gov.states.hi.tax.income.credits.eitc.match
-        return rate * federal_eitc
+        if period.start.year >= 2023:
+            return tax_unit("hi_eitc_potential", period)
+
+        return applied_state_non_refundable_credit(
+            tax_unit,
+            period,
+            ["hi_eitc"],
+            "hi_income_tax_before_non_refundable_credits",
+            "hi_eitc",
+            "hi_eitc_potential",
+        )

--- a/policyengine_us/variables/gov/states/hi/tax/income/credits/hi_eitc_potential.py
+++ b/policyengine_us/variables/gov/states/hi/tax/income/credits/hi_eitc_potential.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class hi_eitc_potential(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Hawaii earned income tax credit"
+    defined_for = StateCode.HI
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.capitol.hawaii.gov/hrscurrent/Vol04_Ch0201-0257/HRS0235/HRS_0235-0055_0075.htm"
+
+    def formula(tax_unit, period, parameters):
+        federal_eitc = tax_unit("eitc", period)
+        rate = parameters(period).gov.states.hi.tax.income.credits.eitc.match
+        return rate * federal_eitc

--- a/uv.lock
+++ b/uv.lock
@@ -1641,7 +1641,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.634.5"
+version = "1.636.3"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- split Hawaii EITC into potential and applied amounts
- cap `hi_eitc` to Hawaii income tax liability for pre-2023 tax years
- add a regression test covering the non-refundable 2022 zero-liability case

Fixes #8013

## Testing
- python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/hi_eitc.yaml -c policyengine_us
- pytest policyengine_us/tests/code_health/test_non_refundable_credit_downstream_consumers.py