### PR TITLE
Fix Delaware non-refundable credit order

### DIFF
--- a/changelog.d/fix-de-credit-order-8014.fixed.md
+++ b/changelog.d/fix-de-credit-order-8014.fixed.md
@@ -1,0 +1,1 @@
+Reorder Delaware non-refundable income tax credits so personal credits and aged personal credits apply before the non-refundable EITC, matching the PIT-RES filing order.

--- a/policyengine_us/parameters/gov/states/de/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/credits/non_refundable.yaml
@@ -9,3 +9,16 @@ metadata:
   unit: list
   period: year
   label: Delaware non-refundable tax credits
+  reference:
+    - title: 2021 Delaware Form PIT-RES, Lines 26a-34 non-refundable credit order
+      href: https://revenuefiles.delaware.gov/2021/PIT-RES_TY21_2021-01_PaperBase.pdf#page=2
+    - title: 2021 Delaware Individual Income Tax Return Instructions, Lines 26a-33 credit order
+      href: https://revenuefiles.delaware.gov/2021/PIT-RES_TY21_2021-01_Instructions.pdf#page=8
+    - title: 2022 Delaware Individual Income Tax Return Instructions, Lines 26a-33 credit order
+      href: https://revenuefiles.delaware.gov/2022/PIT-RES_TY22_2022-02_Instructions.pdf#page=8
+    - title: 2023 Delaware Individual Income Tax Return Instructions, Lines 26a-33 credit order
+      href: https://revenuefiles.delaware.gov/2023/PIT-RES_TY23_2023-01_Instructions.pdf#page=8
+    - title: 2024 Delaware Individual Income Tax Return Instructions, Lines 27a-34 credit order
+      href: https://revenuefiles.delaware.gov/2024/PIT_2024_Forms/PIT_Instructions/PIT-RES_TY24_2024-01_Instructions.pdf#page=8
+    - title: 2025 Delaware Individual Income Tax Return Instructions, non-refundable credit order
+      href: https://revenuefiles.delaware.gov/2025/PITForms_Instructions/Instructions/PIT-RES_Instructions_2025-01.pdf#page=8

--- a/policyengine_us/parameters/gov/states/de/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/credits/non_refundable.yaml
@@ -1,10 +1,10 @@
 description: Delaware non-refundable tax credits.
 values:
   2019-01-01:
-    - de_cdcc
-    - de_non_refundable_eitc
     - de_personal_credit
     - de_aged_personal_credit
+    - de_cdcc
+    - de_non_refundable_eitc
 metadata:
   unit: list
   period: year

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/de_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/de_non_refundable_credit_order.yaml
@@ -12,3 +12,33 @@
     de_aged_personal_credit: 0
     de_cdcc: 0
     de_non_refundable_eitc: 502
+
+- name: Delaware applies all four non-refundable credits in PIT-RES order with middle-slot cascade.
+  period: 2021
+  input:
+    state_code: DE
+    de_income_tax_before_non_refundable_credits_unit: 500
+    de_personal_credit_potential: 100
+    de_aged_personal_credit_potential: 300
+    de_cdcc_potential: 200
+    de_non_refundable_eitc_potential: 200
+  output:
+    de_personal_credit: 100
+    de_aged_personal_credit: 300
+    de_cdcc: 100
+    de_non_refundable_eitc: 0
+
+- name: Delaware first credit consumes entire liability, later credits zero out.
+  period: 2021
+  input:
+    state_code: DE
+    de_income_tax_before_non_refundable_credits_unit: 100
+    de_personal_credit_potential: 300
+    de_aged_personal_credit_potential: 100
+    de_cdcc_potential: 200
+    de_non_refundable_eitc_potential: 500
+  output:
+    de_personal_credit: 100
+    de_aged_personal_credit: 0
+    de_cdcc: 0
+    de_non_refundable_eitc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/de_non_refundable_credit_order.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/de_non_refundable_credit_order.yaml
@@ -1,14 +1,14 @@
-- name: Applied non-refundable credits follow filing order
-  period: 2019
+- name: Delaware personal credits apply before non-refundable EITC
+  period: 2021
   input:
     state_code: DE
-    de_income_tax_before_non_refundable_credits_unit: 100
-    de_cdcc_potential: 80
-    de_non_refundable_eitc_potential: 40
-    de_personal_credit_potential: 30
-    de_aged_personal_credit_potential: 20
+    de_income_tax_before_non_refundable_credits_unit: 832
+    de_personal_credit_potential: 330
+    de_aged_personal_credit_potential: 0
+    de_cdcc_potential: 0
+    de_non_refundable_eitc_potential: 965.2
   output:
-    de_cdcc: 80
-    de_non_refundable_eitc: 20
-    de_personal_credit: 0
+    de_personal_credit: 330
     de_aged_personal_credit: 0
+    de_cdcc: 0
+    de_non_refundable_eitc: 502


### PR DESCRIPTION
## Summary
- reorder Delaware non-refundable credits so personal credits apply before the non-refundable EITC
- align the Delaware ordered-credit parameter with the PIT-RES filing order
- update the Delaware ordering regression to cover the issue example behavior

Fixes #8014

## Testing
- python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/de_non_refundable_credit_order.yaml -c policyengine_us
- python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/eitc/de_non_refundable_eitc.yaml -c policyengine_us
- python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/de/tax/income/credits/personal/de_personal_credits.yaml -c policyengine_us