### PR TITLE
Fix Indiana EITC eligibility enum-as-bool bug

### DIFF
--- a/changelog.d/fix-in-eitc-married-enum-bug.fixed.md
+++ b/changelog.d/fix-in-eitc-married-enum-bug.fixed.md
@@ -1,0 +1,1 @@
+Fix Indiana EITC eligibility to only use the spouse's age when filing jointly.

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_eitc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_eitc_eligible.yaml
@@ -75,3 +75,17 @@
     dividend_income: 3_801
   output:
     in_eitc_eligible: true
+
+- name: in_eitc_eligible head-of-household ineligible when head over max age, spouse age should not be used
+  period: 2021
+  input:
+    gov.states.in.tax.income.credits.earned_income.decoupled: true
+    state_code: IN
+    eitc: 999
+    filing_status: HEAD_OF_HOUSEHOLD
+    eitc_child_count: 0
+    age_head: 65
+    age_spouse: 40
+    dividend_income: 3_600
+  output:
+    in_eitc_eligible: false

--- a/policyengine_us/variables/gov/states/in/tax/income/credits/earned_income_credit/in_eitc_eligible.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/credits/earned_income_credit/in_eitc_eligible.py
@@ -28,7 +28,7 @@ class in_eitc_eligible(Variable):
         age_spouse = tax_unit("age_spouse", period)
         head_age_eligible = (age_head >= min_age) & (age_head <= max_age)
         spouse_age_eligible = (age_spouse >= min_age) & (age_spouse <= max_age)
-        married = filing_status.possible_values.JOINT
+        married = filing_status == filing_status.possible_values.JOINT
         age_eligible = where(
             married, head_age_eligible | spouse_age_eligible, head_age_eligible
         )


### PR DESCRIPTION
## Summary

Fixes a bug in `in_eitc_eligible` where `married = filing_status.possible_values.JOINT` was assigning the enum member itself (always truthy) rather than comparing filing status against it.

```python
# before
married = filing_status.possible_values.JOINT            # enum, always truthy
age_eligible = where(married, head | spouse, head)       # always picks spouse-inclusive

# after
married = filing_status == filing_status.possible_values.JOINT   # boolean
age_eligible = where(married, head | spouse, head)               # correct
```

The sibling line two rows above uses the correct form (`separate = filing_status == filing_status.possible_values.SEPARATE`). Indiana's decoupled EITC eligibility was therefore using the spouse's age for non-JOINT filers whenever one was provided, which is not how the federal EITC rule works.

The effect is muted when `age_spouse` defaults to 0 for non-joint filers (the OR with a False `spouse_age_eligible` preserves the head-only outcome), but the code is still incorrect and became observable the moment `age_spouse` was non-zero (e.g. via a reform, a constructed household, or future code changes that widen spouse visibility).

## Changes

- `in_eitc_eligible.py`: add the `==` comparison.
- `in_eitc_eligible.yaml`: add a regression test — HEAD_OF_HOUSEHOLD filer, head age 65 (above max), spouse age 40 (within range). Expected `in_eitc_eligible: false`. Verified the test fails on `main` and passes after the fix.

## Test plan

- [x] Existing 6 tests still pass.
- [x] New regression test fails without the fix, passes with it.
- [ ] CI passes.
