### PR TITLE
Fix Arkansas inflation relief credit to exclude dependents

### DIFF
--- a/changelog.d/fix-ar-inflation-credit-dependents.fixed.md
+++ b/changelog.d/fix-ar-inflation-credit-dependents.fixed.md
@@ -1,0 +1,1 @@
+Fix Arkansas inflation relief credit to only apply to the head and spouse, not dependents.

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
@@ -123,3 +123,31 @@
         state_code: AR
   output:
     ar_inflation_relief_credit_person: 150
+
+- name: Joint household with a dependent child does not credit the dependent
+  period: 2022
+  input:
+    people:
+      person1:
+        age: 40
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 60_000
+      person2:
+        age: 38
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 0
+      person3:
+        age: 8
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        ar_files_separately: false
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: AR
+  output:
+    ar_inflation_relief_credit_person: [150, 150, 0]

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.py
@@ -32,4 +32,7 @@ class ar_inflation_relief_credit_person(Variable):
         # Attribute the maximum amount to each spouse equally when married filing jointly
         joint = filing_status == filing_status.possible_values.JOINT
         divisor = where(joint, 2, 1)
-        return max_(max_amount - total_reduction_amount, 0) / divisor
+        credit = max_(max_amount - total_reduction_amount, 0) / divisor
+        # The credit is only allocated to the head and spouse, not dependents.
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        return credit * head_or_spouse


### PR DESCRIPTION
## Summary

`ar_inflation_relief_credit_person` computes the Arkansas inflation-relief credit for each individual. Its parent TaxUnit-level variable `ar_inflation_relief_credit` has `adds = ["ar_inflation_relief_credit_person"]`, which sums across every person in the tax unit.

The person-level formula was missing the `is_tax_unit_head_or_spouse` filter, so dependents also contributed their own full (undivided) credit to the tax-unit total. A joint couple with one dependent child received 3× the statutory credit.

```python
# before
return max_(max_amount - total_reduction_amount, 0) / divisor

# after
credit = max_(max_amount - total_reduction_amount, 0) / divisor
head_or_spouse = person("is_tax_unit_head_or_spouse", period)
return credit * head_or_spouse
```

The sibling file `ar_additional_tax_credit_for_qualified_individuals_person.py:42-43` has the correct pattern (`return total_credit * head_or_spouse`). This just mirrors it.

## Changes

- `ar_inflation_relief_credit_person.py`: multiply the return value by `is_tax_unit_head_or_spouse`.
- `ar_inflation_relief_credit_person.yaml`: add a regression test with a joint household containing a dependent child. Expected output: `[150, 150, 0]` (head, spouse, child). Verified the test fails on `main` (actual `[150, 150, 150]`) and passes after the fix.

## Test plan

- [x] Existing 6 tests still pass.
- [x] New regression test fails without the fix, passes with it.
- [ ] CI passes.
