### PR TITLE
Correct HCE overtime salary threshold effective dates

### DIFF
--- a/changelog.d/fix-hce-overtime-threshold-date.fixed.md
+++ b/changelog.d/fix-hce-overtime-threshold-date.fixed.md
@@ -1,0 +1,1 @@
+Correct the HCE overtime salary threshold effective dates: $107,432 took effect 2020-01-01 (per 2019 DOL final rule, 84 FR 51230), not 2010-01-01; $132,964 took effect 2024-07-01, not 2024-01-01. Remove the $134,004 entry for 2016 — the 2016 rule was enjoined before it took effect.

--- a/policyengine_us/parameters/gov/irs/income/exemption/overtime/hce_salary_threshold.yaml
+++ b/policyengine_us/parameters/gov/irs/income/exemption/overtime/hce_salary_threshold.yaml
@@ -8,11 +8,14 @@ metadata:
   uprating: gov.ssa.nawi
   reference:
     - title: FLSA Exemption for Executive, Administrative, and Professional (EAP) Employees  Title 29 CFR Part 541
-      href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541  
+      href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541
+    - title: 2019 DOL final rule (84 FR 51230) setting the HCE threshold to $107,432 effective 2020-01-01
+      href: https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and
+    - title: 2024 DOL final rule raising HCE to $132,964 on 2024-07-01 and $151,164 on 2025-01-01
+      href: https://www.dol.gov/agencies/whd/overtime/salary-levels
 values:
   2004-01-01: 100_000
-  2016-01-01: 134_004
-  2010-01-01: 107_432
-  2024-01-01: 132_964
+  2020-01-01: 107_432
+  2024-07-01: 132_964
   2025-01-01: 151_164
   2026-01-01: 151_164 # To start uprating in 2027.


### PR DESCRIPTION
## Summary

Correct several wrong effective dates in the HCE overtime salary threshold parameter.

| Value | Previous date | Correct date | Source |
|---|---|---|---|
| $107,432 | `2010-01-01` | `2020-01-01` | 2019 DOL final rule, [84 FR 51230](https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and) |
| $132,964 | `2024-01-01` | `2024-07-01` | 2024 DOL final rule ([DOL salary levels page](https://www.dol.gov/agencies/whd/overtime/salary-levels)) |
| $134,004 | `2016-01-01` | *(removed)* | 2016 DOL rule was enjoined before taking effect in *Nevada v. U.S. Dept. of Labor*, E.D. Tex. Nov 2016 |

The pre-existing order in the file was also non-chronological (`2016-01-01` appeared before `2010-01-01`), which is how the typo surfaced — clearly `2010` was supposed to be `2020`.

## Impact

The HCE threshold flows into `fsla_overtime_salary_threshold` (which sets the salary cut-off above which a worker is classified as exempt from overtime). Before this fix, simulations for any year 2010–2019 used a threshold of $107,432 (the value only took effect in 2020), overstating HCE exemption eligibility. Simulations for 2024 used the $132,964 threshold from January rather than July.

## Test plan

- [x] All 3 `fsla_overtime_premium.yaml` tests pass.
- [ ] CI passes.
