### PR TITLE
Fix Puerto Rico EITC phase-out for non-single non-joint filers

### DIFF
--- a/changelog.d/fix-pr-eitc-filing-status-coverage.fixed.md
+++ b/changelog.d/fix-pr-eitc-filing-status-coverage.fixed.md
@@ -1,0 +1,1 @@
+Fix Puerto Rico EITC phase-out to cover all filing statuses, not only SINGLE and JOINT.

--- a/policyengine_us/tests/policy/baseline/gov/territories/pr/tax/income/credits/earned_income/pr_earned_income_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/territories/pr/tax/income/credits/earned_income/pr_earned_income_credit.yaml
@@ -120,7 +120,7 @@
   period: 2024
   input:
     people:
-      person1: 
+      person1:
         pr_gross_income_person: 50_000
         is_tax_unit_head_or_spouse: true
       person2:
@@ -148,5 +148,53 @@
       household:
         members: [person1, person2, person3, person4, person5, person6]
         state_code: PR
-  output: 
+  output:
     pr_earned_income_credit: 0
+
+- name: Eligible HEAD_OF_HOUSEHOLD filer gets the individual phase-out threshold
+  period: 2024
+  input:
+    people:
+      person1:
+        pr_gross_income_person: 17_660
+        is_tax_unit_head_or_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: HEAD_OF_HOUSEHOLD
+        eitc_child_count: 0
+        pr_earned_income_credit_eligible: true
+    households:
+      household:
+        members: [person1]
+        state_code: PR
+  # Previously, HoH fell through the `select` (only covered SINGLE and
+  # JOINT) to a default phase-out threshold of 0, which eliminated any
+  # credit. After the fix, HoH uses the `single` threshold and receives
+  # the same max credit (1,656) as a SINGLE filer with identical income.
+  output:
+    pr_earned_income_credit: 1_656
+
+- name: Eligible SURVIVING_SPOUSE filer gets the joint phase-out threshold
+  period: 2024
+  input:
+    people:
+      person1:
+        pr_gross_income_person: 19_000
+        is_tax_unit_head_or_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SURVIVING_SPOUSE
+        eitc_child_count: 0
+        pr_earned_income_credit_eligible: true
+    households:
+      household:
+        members: [person1]
+        state_code: PR
+  # SURVIVING_SPOUSE uses the joint threshold (consistent with US
+  # federal convention for two years post-bereavement). At
+  # pr_gross_income 19_000 the phase-out has not begun
+  # (joint threshold = 19_870), so the full max credit applies.
+  output:
+    pr_earned_income_credit: 1_656

--- a/policyengine_us/variables/gov/territories/pr/tax/income/credits/earned_income/pr_earned_income_credit.py
+++ b/policyengine_us/variables/gov/territories/pr/tax/income/credits/earned_income/pr_earned_income_credit.py
@@ -29,15 +29,19 @@ class pr_earned_income_credit(Variable):
         )
 
         phase_out_rate = p.phase_out.rate.calc(child_count)
-        phase_out_threshold = select(
-            [
-                filing_status == filing_status.possible_values.SINGLE,
-                filing_status == filing_status.possible_values.JOINT,
-            ],
-            [
-                p.phase_out.threshold.single.calc(child_count),
-                p.phase_out.threshold.joint.calc(child_count),
-            ],
+        # Treat SURVIVING_SPOUSE as joint (per US convention for 2 years
+        # post-bereavement); every other status uses the individual/single
+        # threshold. The previous `select` only covered SINGLE and JOINT,
+        # leaving HEAD_OF_HOUSEHOLD, SEPARATE, and SURVIVING_SPOUSE with a
+        # default threshold of 0, which caused the full credit to phase out
+        # immediately at any earned income.
+        joint_or_survivor = (filing_status == filing_status.possible_values.JOINT) | (
+            filing_status == filing_status.possible_values.SURVIVING_SPOUSE
+        )
+        phase_out_threshold = where(
+            joint_or_survivor,
+            p.phase_out.threshold.joint.calc(child_count),
+            p.phase_out.threshold.single.calc(child_count),
         )
         # could be negative if gross income not over threshold, so make the minimum value 0
         phase_out = max_(0, (gross_income - phase_out_threshold) * phase_out_rate)


### PR DESCRIPTION
## Summary

`pr_earned_income_credit` used a `select` that only covered `SINGLE` and `JOINT`:

```python
phase_out_threshold = select(
    [
        filing_status == filing_status.possible_values.SINGLE,
        filing_status == filing_status.possible_values.JOINT,
    ],
    [
        p.phase_out.threshold.single.calc(child_count),
        p.phase_out.threshold.joint.calc(child_count),
    ],
)
```

For `HEAD_OF_HOUSEHOLD`, `SEPARATE`, and `SURVIVING_SPOUSE` filers this fell through to the default `phase_out_threshold = 0`. With a threshold of zero, any positive earned income fully phases out the credit, so those filers received **0** regardless of eligibility.

## Fix

Use `where` with a JOINT-or-SURVIVING_SPOUSE partition (surviving spouse follows joint brackets for two years post-bereavement under US federal convention — Puerto Rico's Schedule CT instructions do not specify separately) and default everything else to the individual/`single` threshold:

```python
joint_or_survivor = (
    filing_status == filing_status.possible_values.JOINT
) | (filing_status == filing_status.possible_values.SURVIVING_SPOUSE)
phase_out_threshold = where(
    joint_or_survivor,
    p.phase_out.threshold.joint.calc(child_count),
    p.phase_out.threshold.single.calc(child_count),
)
```

SEPARATE eligibility remains governed by `p.eligibility.separate_filer` upstream.

## Regression tests

Two new YAML tests:
- `HEAD_OF_HOUSEHOLD` filer at $17,660 earned income with 0 children: expected $1,656 (max credit; previously **0**).
- `SURVIVING_SPOUSE` filer at $19,000 earned income with 0 children: expected $1,656 (below joint phase-out start $19,870; previously **0**).

Both tests fail on `main` and pass after the fix. All 98 tests under `gov/territories/pr` pass.

## Test plan

- [x] 98 tests under `gov/territories/pr` pass.
- [x] New regression tests fail without the fix, pass with it.
- [ ] CI passes.
