### PR TITLE
Fix MA LIHEAP subsidized benefit-level breakdown range(1,6) → range(0,7)

### DIFF
--- a/changelog.d/fix-ma-liheap-subsidized-range.fixed.md
+++ b/changelog.d/fix-ma-liheap-subsidized-range.fixed.md
@@ -1,0 +1,1 @@
+Correct the benefit-level breakdown for the Massachusetts LIHEAP subsidized housing payment parameter to range(0,7), matching sibling files and the file's 0-6 value entries.

--- a/policyengine_us/parameters/gov/states/ma/doer/liheap/standard/amount/subsidized.yaml
+++ b/policyengine_us/parameters/gov/states/ma/doer/liheap/standard/amount/subsidized.yaml
@@ -104,7 +104,7 @@ metadata:
   unit: currency-USD
   label: Massachusetts LIHEAP subsidized housing payment amount 
   breakdown:
-    - range(1,6) # benefit level
+    - range(0,7) # benefit level
     - ma_liheap_utility_category
   breakdown_labels:
     - Benefit level


### PR DESCRIPTION
## Summary

`gov/states/ma/doer/liheap/standard/amount/subsidized.yaml` defines values for benefit levels **0 through 6** (7 levels), but its `breakdown` metadata said `range(1, 6)`:

```yaml
  breakdown:
    - range(1,6) # benefit level          # <-- only covers 1..5
    - ma_liheap_utility_category
```

In Python semantics, `range(1, 6)` iterates `[1, 2, 3, 4, 5]`, so benefit levels 0 and 6 are not indexable through the parameter tree.

Sibling files in the same LIHEAP module use the correct range:

- `standard/amount/non_subsidized.yaml:106`: `range(0,7)`
- `hecs/amount/non_subsidized.yaml:29`: `range(0,7)`
- `hecs/amount/subsidized.yaml:29`: `range(0,7)`

## Fix

Change the breakdown to `range(0, 7)` to match the sibling files and cover all seven benefit levels.

## Test plan

- [x] All 44 tests under `gov/states/ma/doer/liheap` pass.
- [ ] CI passes.
