### PR TITLE
Record explicit refundable CTC individual_max for 2025 and 2026

### DIFF
--- a/changelog.d/fix-ctc-refundable-explicit-2025-2026.fixed.md
+++ b/changelog.d/fix-ctc-refundable-explicit-2025-2026.fixed.md
@@ -1,0 +1,1 @@
+Record explicit refundable CTC individual_max values for 2025 and 2026 ($1,700 per IRS Rev. Proc. 24-40 and 25-32).

--- a/policyengine_us/parameters/gov/irs/credits/ctc/refundable/individual_max.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/ctc/refundable/individual_max.yaml
@@ -6,6 +6,11 @@ values:
   2022-01-01: 1_500
   2023-01-01: 1_600
   2024-01-01: 1_700
+  # IRS Rev. Proc. 24-40 (TY 2025) p.8 and Rev. Proc. 25-32 (TY 2026)
+  # p.13 both hold the refundable CTC amount at $1,700 under current
+  # law (the statutory cap has not been indexed high enough to round up).
+  2025-01-01: 1_700
+  2026-01-01: 1_700
   # CBO forecast.
   2027-01-01: 1_800
   2029-01-01: 1_900


### PR DESCRIPTION
## Summary

The refundable CTC individual_max parameter jumped from 2024 ($1,700) directly to the 2027 CBO forecast ($1,800), leaving 2025 and 2026 to silently inherit 2024.

```yaml
values:
  2024-01-01: 1_700
  # CBO forecast.            # <-- 2025 and 2026 inherited 2024
  2027-01-01: 1_800
```

The IRS has officially published both values — they remain $1,700 under current law (IRC §24 indexing doesn't round up the $1,400 statutory base high enough for a $100 tick):

- TY 2025: [IRS Rev. Proc. 24-40 p.8](https://www.irs.gov/pub/irs-drop/rp-24-40.pdf#page=8)
- TY 2026: [IRS Rev. Proc. 25-32 p.13](https://www.irs.gov/pub/irs-drop/rp-25-32.pdf#page=13)

## Fix

Record the published values explicitly, so a future change to the uprating factor can't silently drift a statutory value:

```yaml
  2024-01-01: 1_700
+ 2025-01-01: 1_700
+ 2026-01-01: 1_700
  # CBO forecast.
  2027-01-01: 1_800
```

## Test plan

- [x] All 90 tests under `gov/irs/credits/ctc/` pass.
- [ ] CI passes.
