### PR TITLE
Turn off Pease limitation permanently (OBBBA § 70111)

### DIFF
--- a/changelog.d/fix-obbba-pease-permanence.fixed.md
+++ b/changelog.d/fix-obbba-pease-permanence.fixed.md
@@ -1,0 +1,1 @@
+Set Pease itemized deductions reduction to permanently inactive per OBBBA H.R.1 § 70111.

--- a/policyengine_us/parameters/gov/irs/deductions/itemized/reduction/applies.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/itemized/reduction/applies.yaml
@@ -1,16 +1,17 @@
-description: The itemized deductions reduction applies if this is true.
+description: The itemized deductions reduction applies if this is true. OBBBA § 70111 permanently terminated the Pease limitation; a new 2/37 cap for top-bracket filers (IRC § 68(f)) applies beginning in 2026 and is modeled separately.
 
 values:
   2009-01-01: true
   2010-01-01: false
   2013-01-01: true
   2018-01-01: false
-  2026-01-01: true
 
 metadata:
   unit: bool
   period: year
   label: Itemized deductions reduction applies
   reference:
-    - title: 26 U.S. Code § 68 - Overall limitation on itemized deductions, (a)(2) 
+    - title: 26 U.S. Code § 68 - Overall limitation on itemized deductions (as amended by OBBBA § 70111)
       href: https://www.law.cornell.edu/uscode/text/26/68
+    - title: H.R.1 - One Big Beautiful Bill Act, § 70111
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1/text

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/itemizing/itemized_taxable_income_deductions_reduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/itemizing/itemized_taxable_income_deductions_reduction.yaml
@@ -7,22 +7,27 @@
   output: 
     itemized_taxable_income_deductions_reduction: 0
 
-- name: Reduction in 2026, due to AGI
+- name: No Pease reduction in 2026 - OBBBA permanently repealed IRC section 68(a)
   period: 2026
   absolute_error_margin: 1
   input:
     adjusted_gross_income: 900_000
     filing_status: SINGLE
     total_itemized_taxable_income_deductions: 200_000
-  output: 
-    itemized_taxable_income_deductions_reduction: 10_811
+  # Old Pease previously reactivated in 2026 at the $339,850 SINGLE
+  # CBO-forecast threshold, reducing deductions by $10,811 in this
+  # scenario. OBBBA section 70111 permanently terminated that
+  # limitation. A new 2/37 cap for top-bracket filers applies
+  # starting 2026 and is modeled separately, not through this variable.
+  output:
+    itemized_taxable_income_deductions_reduction: 0
 
-- name: Reduction in 2026, due to total deductions reduction
+- name: No Pease reduction in 2026 at total-deductions margin - OBBBA permanence
   period: 2026
   absolute_error_margin: 1
   input:
     adjusted_gross_income: 650_000
     filing_status: SINGLE
     total_itemized_taxable_income_deductions: 1_000
-  output: 
-    itemized_taxable_income_deductions_reduction: 54
+  output:
+    itemized_taxable_income_deductions_reduction: 0


### PR DESCRIPTION
## Summary

The parameter `gov.irs.deductions.itemized.reduction.applies` had `2026-01-01: true`, reactivating the pre-TCJA Pease limitation on itemized deductions in 2026 alongside CBO-forecast AGI thresholds (in `agi_threshold.yaml`, `applicable_amount.yaml`, etc.).

**OBBBA § 70111 permanently terminated the Pease limitation under IRC § 68(a).** A replacement — the 2/37 cap on itemized deductions for filers in the top (37%) bracket under new IRC § 68(f) — is a distinct mechanism that operates on different inputs (the 37% bracket threshold, not a fixed AGI threshold) and is modeled separately, not through this variable.

## Fix

Remove the `2026-01-01: true` entry from `reduction/applies.yaml`:

```diff
 values:
   2009-01-01: true
   2010-01-01: false
   2013-01-01: true
   2018-01-01: false
-  2026-01-01: true
```

Update the description and references to cite OBBBA.

The associated threshold and rate parameters (`agi_threshold.yaml`, `applicable_amount.yaml`, `agi_rate.yaml`, `itemized_deduction_rate.yaml`) are unused when `applies` is false and remain unchanged in this PR to avoid a larger refactor. The new 2/37 OBBBA limitation should be implemented as a separate variable using the top-bracket threshold as input.

**Personal exemption permanence** (OBBBA § 70102) is already represented correctly via `gov.irs.income.exemption.suspended` (`2018-01-01: true`, no reversal), with comments explicitly noting "OBBB made the suspension permanent." No change needed there.

## Test updates

Two 2026-dated tests in `itemized_taxable_income_deductions_reduction.yaml` were codifying the buggy Pease reactivation (expected $10,811 and $54 of reduction). Updated to expect 0 with a note that the new 2/37 limitation is tracked separately:

```yaml
- name: No Pease reduction in 2026 - OBBBA permanently repealed IRC section 68(a)
  period: 2026
  input:
    adjusted_gross_income: 900_000
    filing_status: SINGLE
    total_itemized_taxable_income_deductions: 200_000
  output:
    itemized_taxable_income_deductions_reduction: 0
```

## Test plan

- [x] All 751 tests under `gov/irs/` pass (full IRS suite).
- [x] 2 previously-failing 2026 tests in `itemized_taxable_income_deductions_reduction.yaml` now pass with correct expected values.
- [ ] CI passes.

## References

- [OBBBA H.R.1 § 70111](https://www.congress.gov/bill/119th-congress/house-bill/1/text)
- [IRC § 68 (as amended by OBBBA)](https://www.law.cornell.edu/uscode/text/26/68)
- [Kitces: OBBBA itemized deductions](https://www.kitces.com/blog/obbba-one-big-beautiful-bill-act-tax-planning-salt-cap-senior-deduction-qbi-deduction-tax-cut-and-jobs-act-tcja-amt-trump-accounts/)
- [PKF O'Connor Davies: Preparing for 2026 — How OBBBA Reshapes Itemized Deductions](https://www.pkfod.com/insights/preparing-for-2026-how-obbba-reshapes-itemized-deductions/)
