### PR TITLE
Correct salary basis threshold effective dates (mirror of #8026)

### DIFF
--- a/changelog.d/fix-salary-basis-threshold-date.fixed.md
+++ b/changelog.d/fix-salary-basis-threshold-date.fixed.md
@@ -1,0 +1,1 @@
+Correct salary basis threshold effective dates: $684 took effect 2020-01-01 (per 2019 DOL rule), $844 took effect 2024-07-01; remove the enjoined 2016 $913 entry.

--- a/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
+++ b/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
@@ -8,13 +8,19 @@ metadata:
   uprating: gov.ssa.nawi
   reference:
     - title: 29 CFR § 541.600
-      href: https://www.law.cornell.edu/cfr/text/29/541.600 
+      href: https://www.law.cornell.edu/cfr/text/29/541.600
     - title: FLSA Exemption for Executive, Administrative, and Professional (EAP) Employees  Title 29 CFR Part 541
-      href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541  
+      href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541
+    - title: 2019 DOL final rule (84 FR 51230) setting the salary basis threshold to $684/week effective 2020-01-01
+      href: https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and
+    - title: 2024 DOL final rule raising the threshold to $844/week on 2024-07-01 and $1,128/week on 2025-01-01
+      href: https://www.dol.gov/agencies/whd/overtime/salary-levels
 values:
   2004-01-01: 455
-  2016-01-01: 913
-  2019-01-01: 684
-  2024-01-01: 844
+  # The 2016 DOL final rule that would have raised this threshold to
+  # $913/week was enjoined nationwide before it took effect
+  # (Nevada v. U.S. Dept. of Labor, E.D. Tex. Nov 2016).
+  2020-01-01: 684
+  2024-07-01: 844
   2025-01-01: 1_128
   2026-01-01: 1_128 # To start uprating in 2027.


### PR DESCRIPTION
## Summary

Mirror-image of [#8026](https://github.com/PolicyEngine/policyengine-us/pull/8026) (HCE overtime threshold) for the `salary_basis_threshold.yaml` file in the same overtime directory. Flagged by an independent review of #8026 as an unaddressed but analogous bug.

| Value | Previous date | Correct date | Source |
|---|---|---|---|
| $684/week | `2019-01-01` | `2020-01-01` | 2019 DOL final rule ([84 FR 51230](https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and)) |
| $844/week | `2024-01-01` | `2024-07-01` | 2024 DOL final rule ([DOL salary levels](https://www.dol.gov/agencies/whd/overtime/salary-levels)) |
| $913/week | `2016-01-01` | *(removed)* | 2016 DOL rule was enjoined nationwide before taking effect in *Nevada v. U.S. Dept. of Labor*, E.D. Tex. Nov 2016 |

## Impact

The salary basis threshold is the cutoff above which a worker paid on a salary basis can be classified as exempt (executive/administrative/professional). Before this fix, simulations for 2019 used $684 (the value only took effect in 2020), and 2024 used $844 starting in January rather than July.

## Test plan

- [x] All 3 `fsla_overtime_premium.yaml` tests pass.
- [ ] CI passes.
