### PR TITLE
Revert overtime salary thresholds after 2024 DOL rule vacated (Texas v. DOL)

### DIFF
--- a/changelog.d/fix-2024-dol-overtime-rule-vacated.fixed.md
+++ b/changelog.d/fix-2024-dol-overtime-rule-vacated.fixed.md
@@ -1,0 +1,1 @@
+Revert HCE and salary basis overtime thresholds to 2019 rule values after Texas v. U.S. Dept. of Labor (E.D. Tex. Nov 15, 2024) vacated the 2024 DOL overtime rule nationwide.

--- a/policyengine_us/parameters/gov/irs/income/exemption/overtime/hce_salary_threshold.yaml
+++ b/policyengine_us/parameters/gov/irs/income/exemption/overtime/hce_salary_threshold.yaml
@@ -11,11 +11,15 @@ metadata:
       href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541
     - title: 2019 DOL final rule (84 FR 51230) setting the HCE threshold to $107,432 effective 2020-01-01
       href: https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and
-    - title: 2024 DOL final rule raising HCE to $132,964 on 2024-07-01 and $151,164 on 2025-01-01
-      href: https://www.dol.gov/agencies/whd/overtime/salary-levels
+    - title: Texas v. U.S. Dept. of Labor (E.D. Tex. Nov 15, 2024), vacating the 2024 DOL overtime rule nationwide
+      href: https://www.sidley.com/en/insights/newsupdates/2024/12/us-district-court-vacates-dol-final-rule-on-flsa-overtime-exemptions
 values:
   2004-01-01: 100_000
+  # The 2024 DOL final rule raised this threshold to $132,964 on
+  # 2024-07-01 with a further scheduled increase to $151,164 on
+  # 2025-01-01, but the U.S. District Court for the Eastern District
+  # of Texas vacated the entire rule nationwide on 2024-11-15 in
+  # Texas v. U.S. Dept. of Labor. The threshold therefore remains at
+  # the 2019 rule's $107,432 indefinitely (subject to future DOL
+  # rulemaking).
   2020-01-01: 107_432
-  2024-07-01: 132_964
-  2025-01-01: 151_164
-  2026-01-01: 151_164 # To start uprating in 2027.

--- a/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
+++ b/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
@@ -13,14 +13,18 @@ metadata:
       href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541
     - title: 2019 DOL final rule (84 FR 51230) setting the salary basis threshold to $684/week effective 2020-01-01
       href: https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and
-    - title: 2024 DOL final rule raising the threshold to $844/week on 2024-07-01 and $1,128/week on 2025-01-01
-      href: https://www.dol.gov/agencies/whd/overtime/salary-levels
+    - title: Texas v. U.S. Dept. of Labor (E.D. Tex. Nov 15, 2024), vacating the 2024 DOL overtime rule nationwide
+      href: https://www.sidley.com/en/insights/newsupdates/2024/12/us-district-court-vacates-dol-final-rule-on-flsa-overtime-exemptions
 values:
   2004-01-01: 455
   # The 2016 DOL final rule that would have raised this threshold to
   # $913/week was enjoined nationwide before it took effect
   # (Nevada v. U.S. Dept. of Labor, E.D. Tex. Nov 2016).
+  # The 2024 DOL final rule raised this threshold to $844/week on
+  # 2024-07-01 with a further scheduled increase to $1,128/week on
+  # 2025-01-01, but the U.S. District Court for the Eastern District
+  # of Texas vacated the entire rule nationwide on 2024-11-15 in
+  # Texas v. U.S. Dept. of Labor. The threshold therefore remains at
+  # the 2019 rule's $684/week indefinitely (subject to future DOL
+  # rulemaking).
   2020-01-01: 684
-  2024-07-01: 844
-  2025-01-01: 1_128
-  2026-01-01: 1_128 # To start uprating in 2027.


### PR DESCRIPTION
## Summary

The U.S. District Court for the Eastern District of Texas vacated the 2024 DOL overtime final rule **nationwide** on 2024-11-15 in *Texas v. U.S. Dept. of Labor*. That rule had raised both the EAP salary basis threshold (to $844/week on 2024-07-01, then $1,128/week on 2025-01-01) and the HCE threshold (to $132,964 on 2024-07-01, then $151,164 on 2025-01-01).

Vacatur reverts both thresholds to the 2019 rule values (84 FR 51230):

| Threshold | Post-vacatur value |
|---|---|
| EAP salary basis | $684/week |
| HCE total compensation | $107,432/year |

This was flagged as a pre-existing follow-up during the independent review of PRs #8026 (HCE dates) and #8036 (salary basis dates).

## Changes

Both `hce_salary_threshold.yaml` and `salary_basis_threshold.yaml` in `gov/irs/income/exemption/overtime/`:

- Remove the `2024-07-01`, `2025-01-01`, and `2026-01-01` entries (all from the vacated rule).
- Add inline comment documenting the vacatur.
- Add reference to *Texas v. DOL* (via Sidley Austin legal summary).

The briefly-in-force July–November 2024 window is not modeled here: vacatur legally treats the rule as if it never existed, and tax returns are annual so mid-year changes don't materialise cleanly. NAWI-based uprating continues from the 2020 value as before, approximating future DOL rulemaking.

## Test plan

- [x] All 3 `fsla_overtime_premium.yaml` tests pass.
- [ ] CI passes.

## References

- [Sidley Austin: U.S. District Court Vacates DOL Final Rule on FLSA Overtime Exemptions (Dec 2024)](https://www.sidley.com/en/insights/newsupdates/2024/12/us-district-court-vacates-dol-final-rule-on-flsa-overtime-exemptions)
- [Epstein Becker: Not So Final — Texas Court Vacates the DOL's 2024 Final Overtime Rule](https://www.wagehourblog.com/not-so-final-texas-court-vacates-the-dols-2024-final-overtime-rule)
- [SBA: Federal Court Strikes Down Labor Department's Overtime Rule (Dec 2024)](https://advocacy.sba.gov/2024/12/17/federal-court-strikes-down-labor-departments-overtime-rule-rejecting-44k-and-59k-salary-thresholds/)
- [DOL Salary Levels page](https://www.dol.gov/agencies/whd/overtime/salary-levels) (authoritative but not yet updated post-vacatur)
