### PR TITLE
Model brief 2024 DOL overtime window and keep DOL URL (follow-up to #8037)

### DIFF
--- a/changelog.d/fix-overtime-2024-window-and-dol-url.fixed.md
+++ b/changelog.d/fix-overtime-2024-window-and-dol-url.fixed.md
@@ -1,0 +1,1 @@
+Model the 2024-07-01 to 2024-11-15 window when the vacated 2024 DOL overtime rule was briefly in force, and restore the DOL salary-levels URL as a secondary reference.

--- a/policyengine_us/parameters/gov/irs/income/exemption/overtime/hce_salary_threshold.yaml
+++ b/policyengine_us/parameters/gov/irs/income/exemption/overtime/hce_salary_threshold.yaml
@@ -11,15 +11,19 @@ metadata:
       href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541
     - title: 2019 DOL final rule (84 FR 51230) setting the HCE threshold to $107,432 effective 2020-01-01
       href: https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and
+    - title: 2024 DOL final rule that raised HCE to $132,964 (2024-07-01) and $151,164 (2025-01-01) before being vacated
+      href: https://www.dol.gov/agencies/whd/overtime/salary-levels
     - title: Texas v. U.S. Dept. of Labor (E.D. Tex. Nov 15, 2024), vacating the 2024 DOL overtime rule nationwide
       href: https://www.sidley.com/en/insights/newsupdates/2024/12/us-district-court-vacates-dol-final-rule-on-flsa-overtime-exemptions
 values:
   2004-01-01: 100_000
-  # The 2024 DOL final rule raised this threshold to $132,964 on
-  # 2024-07-01 with a further scheduled increase to $151,164 on
-  # 2025-01-01, but the U.S. District Court for the Eastern District
-  # of Texas vacated the entire rule nationwide on 2024-11-15 in
-  # Texas v. U.S. Dept. of Labor. The threshold therefore remains at
-  # the 2019 rule's $107,432 indefinitely (subject to future DOL
-  # rulemaking).
+  # The 2020-2024-07 value is the 2019 DOL rule's threshold.
   2020-01-01: 107_432
+  # The 2024 DOL final rule raised the HCE threshold to $132,964 on
+  # 2024-07-01 and was scheduled to increase it to $151,164 on
+  # 2025-01-01. In practice the $132,964 threshold applied only from
+  # 2024-07-01 until 2024-11-15, when Texas v. U.S. Dept. of Labor
+  # (E.D. Tex.) vacated the entire 2024 rule nationwide. Vacatur
+  # reverts to the 2019 rule's $107,432.
+  2024-07-01: 132_964
+  2024-11-15: 107_432

--- a/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
+++ b/policyengine_us/parameters/gov/irs/income/exemption/overtime/salary_basis_threshold.yaml
@@ -13,6 +13,8 @@ metadata:
       href: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-V/subchapter-A/part-541
     - title: 2019 DOL final rule (84 FR 51230) setting the salary basis threshold to $684/week effective 2020-01-01
       href: https://www.federalregister.gov/documents/2019/09/27/2019-20353/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and
+    - title: 2024 DOL final rule that raised the threshold to $844/week (2024-07-01) and $1,128/week (2025-01-01) before being vacated
+      href: https://www.dol.gov/agencies/whd/overtime/salary-levels
     - title: Texas v. U.S. Dept. of Labor (E.D. Tex. Nov 15, 2024), vacating the 2024 DOL overtime rule nationwide
       href: https://www.sidley.com/en/insights/newsupdates/2024/12/us-district-court-vacates-dol-final-rule-on-flsa-overtime-exemptions
 values:
@@ -20,11 +22,12 @@ values:
   # The 2016 DOL final rule that would have raised this threshold to
   # $913/week was enjoined nationwide before it took effect
   # (Nevada v. U.S. Dept. of Labor, E.D. Tex. Nov 2016).
-  # The 2024 DOL final rule raised this threshold to $844/week on
-  # 2024-07-01 with a further scheduled increase to $1,128/week on
-  # 2025-01-01, but the U.S. District Court for the Eastern District
-  # of Texas vacated the entire rule nationwide on 2024-11-15 in
-  # Texas v. U.S. Dept. of Labor. The threshold therefore remains at
-  # the 2019 rule's $684/week indefinitely (subject to future DOL
-  # rulemaking).
   2020-01-01: 684
+  # The 2024 DOL final rule raised the threshold to $844/week on
+  # 2024-07-01 and was scheduled to increase it to $1,128/week on
+  # 2025-01-01. In practice the $844 threshold applied only from
+  # 2024-07-01 until 2024-11-15, when Texas v. U.S. Dept. of Labor
+  # (E.D. Tex.) vacated the entire 2024 rule nationwide. Vacatur
+  # reverts to the 2019 rule's $684/week.
+  2024-07-01: 844
+  2024-11-15: 684


### PR DESCRIPTION
## Summary

Two minor follow-ups to [#8037](https://github.com/PolicyEngine/policyengine-us/pull/8037) (DOL vacatur fix) surfaced by independent review:

### 1. Model the brief July–November 2024 window

The 2024 DOL final rule was actually in force from 2024-07-01 until 2024-11-15 (~4.5 months), when *Texas v. U.S. Dept. of Labor* (E.D. Tex.) vacated it nationwide. During those 4.5 months the higher thresholds applied and employers actually complied. Simulations that care about mid-2024 labor classification need those entries.

```diff
 values:
   2004-01-01: 100_000
+  # The 2020-2024-07 value is the 2019 DOL rule's threshold.
   2020-01-01: 107_432
+  # 2024 DOL final rule, in force 2024-07-01 until vacated 2024-11-15.
+  2024-07-01: 132_964
+  2024-11-15: 107_432
```

Same pattern for the EAP salary basis (`2024-07-01: 844`, `2024-11-15: 684`).

### 2. Restore DOL salary-levels URL

#8037 removed the [DOL salary-levels URL](https://www.dol.gov/agencies/whd/overtime/salary-levels) because it still listed the vacated rule. Restoring it as a secondary reference (noted as describing the vacated rule) lets auditors cross-reference the administrative values.

## Test plan

- [x] All 3 `fsla_overtime_premium.yaml` tests continue to pass.
- [ ] CI passes.

## References

Same as [#8037](https://github.com/PolicyEngine/policyengine-us/pull/8037).
