### PR TITLE
Extend AMT kiddie tax to full-time students under age 24

### DIFF
--- a/changelog.d/revive-amt-kiddie-students.fixed.md
+++ b/changelog.d/revive-amt-kiddie-students.fixed.md
@@ -1,0 +1,1 @@
+Extend the AMT kiddie tax to include full-time students under age 24, per IRC 1(g)(2)(A) which incorporates the Section 152(c)(3) age requirement. Previously only filers under age 19 were checked.

--- a/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/alternative_minimum_tax/kiddie_tax/amt_kiddie_tax_applies.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/alternative_minimum_tax/kiddie_tax/amt_kiddie_tax_applies.yaml
@@ -1,11 +1,12 @@
-- name: Kiddie tax does applies to single head
+# Non-student tests
+- name: Kiddie tax applies to single head under 19
   period: 2022
   input:
     age_head: 18
   output:
     amt_kiddie_tax_applies: true
 
-- name: Older spouse
+- name: Kiddie tax does not apply when spouse is 19+ (non-student)
   period: 2022
   input:
     age_head: 18
@@ -13,7 +14,7 @@
   output:
     amt_kiddie_tax_applies: false
 
-- name: Younger spouse
+- name: Kiddie tax applies when both head and spouse under 19
   period: 2022
   input:
     age_head: 18
@@ -21,10 +22,85 @@
   output:
     amt_kiddie_tax_applies: true
 
-- name: Older head
+- name: Kiddie tax does not apply when head is 19+ (non-student)
   period: 2022
   input:
     age_head: 19
     age_spouse: 18
+  output:
+    amt_kiddie_tax_applies: false
+
+# Full-time student tests (students under 24 are subject to kiddie tax)
+- name: Kiddie tax applies to 20-year-old full-time student head
+  period: 2022
+  input:
+    people:
+      person1:
+        age: 20
+        is_full_time_college_student: true
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    amt_kiddie_tax_applies: true
+
+- name: Kiddie tax applies to 23-year-old full-time student head
+  period: 2022
+  input:
+    people:
+      person1:
+        age: 23
+        is_full_time_college_student: true
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    amt_kiddie_tax_applies: true
+
+- name: Kiddie tax does not apply to 24-year-old student
+  period: 2022
+  input:
+    people:
+      person1:
+        age: 24
+        is_full_time_college_student: true
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    amt_kiddie_tax_applies: false
+
+- name: Kiddie tax does not apply to 20-year-old non-student
+  period: 2022
+  input:
+    people:
+      person1:
+        age: 20
+        is_full_time_college_student: false
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    amt_kiddie_tax_applies: false
+
+- name: Kiddie tax does not apply when student spouse is 24+
+  period: 2022
+  input:
+    people:
+      person1:
+        age: 20
+        is_full_time_college_student: true
+        is_tax_unit_head: true
+      person2:
+        age: 24
+        is_full_time_college_student: true
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
   output:
     amt_kiddie_tax_applies: false

--- a/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax/kiddie_tax/amt_kiddie_tax_applies.py
+++ b/policyengine_us/variables/gov/irs/tax/federal_income/alternative_minimum_tax/kiddie_tax/amt_kiddie_tax_applies.py
@@ -7,10 +7,39 @@ class amt_kiddie_tax_applies(Variable):
     definition_period = YEAR
     label = "Alternative Minimum Tax kiddie tax applies"
     documentation = "Whether the kiddie tax applies to the tax unit"
+    reference = [
+        "https://www.law.cornell.edu/uscode/text/26/1#g_2_A",
+        "https://www.irs.gov/publications/p929",
+    ]
 
     def formula(tax_unit, period, parameters):
-        age_head = tax_unit("age_head", period)
+        # The kiddie tax applies to children under 19, or under 24 if a
+        # full-time student. Per IRC 1(g)(2)(A), the age requirements
+        # reference Section 152(c)(3), same as the dependent definition.
         p = parameters(period).gov.irs.dependent.ineligible_age
-        young_head = (age_head != 0) & (age_head < p.non_student)
-        no_or_young_spouse = tax_unit("age_spouse", period) < p.non_student
+
+        # Get student status from person-level data
+        person = tax_unit.members
+        is_student = person("is_full_time_student", period)
+        is_head = person("is_tax_unit_head", period)
+        is_spouse = person("is_tax_unit_spouse", period)
+
+        # Check if head or spouse is a full-time student
+        head_is_student = tax_unit.any(is_student & is_head)
+        spouse_is_student = tax_unit.any(is_student & is_spouse)
+
+        # Get tax unit level ages
+        age_head = tax_unit("age_head", period)
+        age_spouse = tax_unit("age_spouse", period)
+
+        # Determine age limits based on student status
+        head_age_limit = where(head_is_student, p.student, p.non_student)
+        spouse_age_limit = where(spouse_is_student, p.student, p.non_student)
+
+        # Check head age: head must be young (and exist - age != 0)
+        young_head = (age_head != 0) & (age_head < head_age_limit)
+
+        # Check spouse age: spouse must be young (or not exist - age == 0)
+        no_or_young_spouse = (age_spouse == 0) | (age_spouse < spouse_age_limit)
+
         return young_head & no_or_young_spouse


### PR DESCRIPTION
Revives #6863 (closed due to stale conflicts).

## Summary
Per IRC 1(g)(2)(A), the AMT kiddie tax applies to children who meet the age requirements of Section 152(c)(3), which includes full-time students under age 24. Previously, the AMT kiddie tax only checked if the filer was under age 19.

Changes:
- Update `amt_kiddie_tax_applies` to check student status for ages 19-23
- Compute head/spouse student status inline from person-level data
- Add tests for student scenarios (all 9 pass)

Fixes #3909

## Test plan
- [x] YAML tests pass (9/9)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>