### PR TITLE
Revive state SSI supplements for NM, SC, TX

### DIFF
--- a/changelog.d/revive-state-ssi-supplements.added.md
+++ b/changelog.d/revive-state-ssi-supplements.added.md
@@ -1,0 +1,1 @@
+Add SSI state supplements for New Mexico, South Carolina, and Texas.

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -32,6 +32,8 @@ values:
     - nm_ssi_state_supplement
     # South Carolina benefits
     - sc_ssi_state_supplement
+    # Texas benefits
+    - tx_ssi_state_supplement
     # Massachusetts benefits
     - ma_eaedc
     - ma_tafdc
@@ -69,6 +71,8 @@ values:
     - nm_ssi_state_supplement
     # South Carolina benefits
     - sc_ssi_state_supplement
+    # Texas benefits
+    - tx_ssi_state_supplement
     # North Carolina benefits
     - nc_scca
     # Massachusetts benefits

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -30,6 +30,8 @@ values:
     - ne_child_care_subsidies
     # New Mexico benefits
     - nm_ssi_state_supplement
+    # South Carolina benefits
+    - sc_ssi_state_supplement
     # Massachusetts benefits
     - ma_eaedc
     - ma_tafdc
@@ -65,6 +67,8 @@ values:
     - ne_child_care_subsidies
     # New Mexico benefits
     - nm_ssi_state_supplement
+    # South Carolina benefits
+    - sc_ssi_state_supplement
     # North Carolina benefits
     - nc_scca
     # Massachusetts benefits

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -28,6 +28,8 @@ values:
     - ak_ssp
     # Nebraska benefits
     - ne_child_care_subsidies
+    # New Mexico benefits
+    - nm_ssi_state_supplement
     # Massachusetts benefits
     - ma_eaedc
     - ma_tafdc
@@ -61,6 +63,8 @@ values:
     - ak_ssp
     # Nebraska benefits
     - ne_child_care_subsidies
+    # New Mexico benefits
+    - nm_ssi_state_supplement
     # North Carolina benefits
     - nc_scca
     # Massachusetts benefits

--- a/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/couple.yaml
+++ b/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/couple.yaml
@@ -1,0 +1,14 @@
+description: The Social Security Administration provides this reduced Supplemental Security Income amount for an eligible couple both residing in a Medicaid-funded institution.
+
+values:
+  1988-07-01: 60
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Federal SSI reduced institutional payment for couples
+  reference:
+    - title: 42 USC 1382(e)(1)(B)
+      href: https://www.law.cornell.edu/uscode/text/42/1382
+    - title: HHSC MEPD Handbook Section H-6000 - Co-Payment for SSI Cases
+      href: https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases

--- a/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/individual.yaml
+++ b/policyengine_us/parameters/gov/ssa/ssi/amount/institutional/individual.yaml
@@ -1,0 +1,14 @@
+description: The Social Security Administration provides this reduced Supplemental Security Income amount for an eligible individual residing in a Medicaid-funded institution.
+
+values:
+  1988-07-01: 30
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Federal SSI reduced institutional payment for individuals
+  reference:
+    - title: 42 USC 1382(e)(1)(B)
+      href: https://www.law.cornell.edu/uscode/text/42/1382
+    - title: HHSC MEPD Handbook Section H-6000 - Co-Payment for SSI Cases
+      href: https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases

--- a/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/amount.yaml
@@ -1,0 +1,14 @@
+description: New Mexico provides this amount as the monthly supplement under the Supplemental Security Income state supplement program.
+
+values:
+  2004-07-01: 100
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: New Mexico SSI state supplement amount
+  reference:
+    - title: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+      href: https://srca.nm.gov/parts/title08/08.106.0500.html
+    - title: SSA State Assistance Programs for SSI Recipients - New Mexico (2011)
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/nm.html

--- a/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/min_age.yaml
+++ b/policyengine_us/parameters/gov/states/nm/hca/ssi_supplement/min_age.yaml
@@ -1,0 +1,12 @@
+description: New Mexico limits the Supplemental Security Income state supplement program to individuals at or above this age.
+
+values:
+  2004-07-01: 18
+
+metadata:
+  unit: year
+  period: year
+  label: New Mexico SSI state supplement minimum age
+  reference:
+    - title: SSA State Assistance Programs for SSI Recipients - New Mexico (2011)
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/nm.html

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/maximum_facility_payment.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/maximum_facility_payment.yaml
@@ -1,0 +1,27 @@
+description: South Carolina provides this amount as the maximum facility payment under the Optional State Supplementation program.
+
+values:
+  2022-07-01: 1_620
+  2023-01-01: 1_620
+  2023-07-01: 1_645
+  2024-01-01: 1_672
+  2025-01-01: 1_694
+  2026-01-01: 1_719
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement maximum facility payment
+  reference:
+    - title: S.C. Code Regs. 126-910(B)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/net_income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/net_income_limit.yaml
@@ -1,0 +1,27 @@
+description: South Carolina limits net income to this amount under the Optional State Supplementation program.
+
+values:
+  2022-07-01: 1_626
+  2023-01-01: 1_699
+  2023-07-01: 1_724
+  2024-01-01: 1_753
+  2025-01-01: 1_777
+  2026-01-01: 1_804
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement net income limit
+  reference:
+    - title: S.C. Code Regs. 126-910(D)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/other_income.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/other_income.yaml
@@ -1,0 +1,27 @@
+description: South Carolina provides this amount as a personal needs allowance under the Optional State Supplementation program for recipients with income beyond Supplemental Security Income.
+
+values:
+  2022-07-01: 97
+  2023-01-01: 99
+  2023-07-01: 99
+  2024-01-01: 101
+  2025-01-01: 103
+  2026-01-01: 105
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement personal needs allowance (other income)
+  reference:
+    - title: S.C. Code Regs. 126-910(G)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/ssi_only.yaml
+++ b/policyengine_us/parameters/gov/states/sc/scdhhs/ssi_state_supplement/personal_needs_allowance/ssi_only.yaml
@@ -1,0 +1,27 @@
+description: South Carolina provides this amount as a personal needs allowance under the Optional State Supplementation program for recipients with only Supplemental Security Income.
+
+values:
+  2022-07-01: 77
+  2023-01-01: 79
+  2023-07-01: 79
+  2024-01-01: 81
+  2025-01-01: 83
+  2026-01-01: 85
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: South Carolina SSI State Supplement personal needs allowance (SSI-only income)
+  reference:
+    - title: S.C. Code Regs. 126-910(G)
+      href: https://www.law.cornell.edu/regulations/south-carolina/R-126-910
+    - title: SCDHHS MB# 26-001 - 2026 COLA Adjustments
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0
+    - title: SCDHHS 2025 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases
+    - title: SCDHHS 2024 COLA Bulletin
+      href: https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-ssi-cost-living-adjustment-cola
+    - title: SCDHHS MB# 23-009 - OSS Rate Increases effective July 2023
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases-0
+    - title: SCDHHS MB# 22-013 - OSS Rate Increases effective July 2022
+      href: https://www.scdhhs.gov/communications/optional-state-supplementation-oss-rate-increases

--- a/policyengine_us/parameters/gov/states/tx/hhsc/ssi_state_supplement/personal_needs_allowance.yaml
+++ b/policyengine_us/parameters/gov/states/tx/hhsc/ssi_state_supplement/personal_needs_allowance.yaml
@@ -1,0 +1,18 @@
+description: Texas provides this amount as the personal needs allowance for Supplemental Security Income recipients in Medicaid-funded long-term care facilities under the Optional State Supplement program.
+
+values:
+  1999-09-01: 45
+  2001-09-01: 60
+  2003-09-01: 45
+  2006-01-01: 60
+  2024-01-01: 75
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Texas SSI State Supplement personal needs allowance
+  reference:
+    - title: Texas Human Resources Code Section 32.024(w)
+      href: https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm
+    - title: HHSC MEPD Handbook Section H-1500 - Personal Needs Allowance
+      href: https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-1500-personal-needs-allowance

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/integration.yaml
@@ -1,0 +1,166 @@
+# New Mexico SSI State Supplement Integration Tests
+# Tests the full eligibility and benefit calculation pipeline
+# Source: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+# Program: $100/month flat payment for SSI recipients in licensed ARSCH facilities
+
+- name: Case 1, elderly SSI recipient in ARSCH facility receives supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Eligibility: SSI-eligible (true) AND age >= 18 (70 >= 18) AND in ARSCH (true)
+        nm_ssi_state_supplement_eligible: true
+        # Benefit: $100/month * 12 = $1,200/year (flat payment)
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 2, disabled adult SSI recipient in ARSCH facility receives supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 35
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Eligibility: SSI-eligible (true) AND age >= 18 (35 >= 18) AND in ARSCH (true)
+        nm_ssi_state_supplement_eligible: true
+        # Benefit: $100/month * 12 = $1,200/year
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 3, SSI couple both in ARSCH facility each receive supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 68
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+      person2:
+        age: 66
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Person 1: SSI-eligible, age 68 >= 18, in ARSCH
+        nm_ssi_state_supplement_eligible: true
+        # $100/month * 12 = $1,200/year per person
+        nm_ssi_state_supplement: 1_200
+      person2:
+        # Person 2: SSI-eligible, age 66 >= 18, in ARSCH
+        # Per 8.106.400.10 NMAC: couples in ARSCH are two separate benefit groups
+        nm_ssi_state_supplement_eligible: true
+        # $100/month * 12 = $1,200/year per person
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 4, NM resident not in ARSCH facility receives no supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 72
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: false
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Not in ARSCH facility: ineligible regardless of SSI status
+        nm_ssi_state_supplement_eligible: false
+        nm_ssi_state_supplement: 0
+
+- name: Case 5, age 18 boundary in ARSCH facility is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 18
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Age exactly 18: meets the 18+ requirement
+        nm_ssi_state_supplement_eligible: true
+        # $100/month * 12 = $1,200/year
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 6, household with one eligible and one ineligible person.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 60
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+      person2:
+        age: 45
+        is_ssi_eligible_individual: false
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # Person 1: SSI-eligible, age 60 >= 18, in ARSCH = eligible
+        nm_ssi_state_supplement_eligible: true
+        nm_ssi_state_supplement: 1_200
+      person2:
+        # Person 2: NOT SSI-eligible = ineligible even though in ARSCH
+        nm_ssi_state_supplement_eligible: false
+        nm_ssi_state_supplement: 0
+
+- name: Case 7, SSI recipient in ARSCH facility but outside NM receives nothing.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    people:
+      person1:
+        # Wrong state: defined_for = StateCode.NM excludes non-NM residents
+        nm_ssi_state_supplement_eligible: false
+        nm_ssi_state_supplement: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.yaml
@@ -1,0 +1,76 @@
+# New Mexico SSI State Supplement Benefit Amount Unit Tests
+# Tests the flat $100/month ($1,200/year) payment for eligible individuals
+# Source: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+
+- name: Case 1, eligible person receives full annual supplement.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        # $100/month * 12 months = $1,200/year
+        nm_ssi_state_supplement: 1_200
+
+- name: Case 2, not SSI-eligible receives zero.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: false
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement: 0
+
+- name: Case 3, not in ARSCH facility receives zero.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: false
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement: 0
+
+- name: Case 4, underage person receives zero.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 17
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.yaml
@@ -1,0 +1,129 @@
+# New Mexico SSI State Supplement Eligibility Unit Tests
+# Tests eligibility for the ARSCH shelter care supplement
+# Source: 8.106.500.10 NMAC - Payments to Adults in Residential Care
+
+- name: Case 1, elderly SSI recipient in ARSCH facility in NM is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: true
+
+- name: Case 2, younger adult SSI recipient in ARSCH facility in NM is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: true
+
+- name: Case 3, not SSI-eligible person in ARSCH facility in NM is ineligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: false
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false
+
+- name: Case 4, underage person is ineligible even if SSI-eligible and in ARSCH.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 17
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false
+
+- name: Case 5, exactly age 18 boundary is eligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 18
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: true
+
+- name: Case 6, SSI-eligible adult NOT in ARSCH facility is ineligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: false
+    households:
+      household:
+        members: [person1]
+        state_code: NM
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false
+
+- name: Case 7, SSI-eligible adult in ARSCH but wrong state is ineligible.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        is_ssi_eligible_individual: true
+        is_in_adult_residential_care: true
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    people:
+      person1:
+        nm_ssi_state_supplement_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/integration.yaml
@@ -1,0 +1,201 @@
+- name: Case 1, aged SSI recipient in CRCF with SSI only.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 0
+        ssi: 11_928
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Eligibility: aged (70 >= 65) + in CRCF + SC + income < NIL
+    sc_ssi_state_supplement_eligible: [true]
+
+    # PNA: SSI-only (no non-SSI income) = $85/month * 12 = $1,020/year
+    sc_ssi_state_supplement_pna: [1_020]
+
+    # OSS amount:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $0 + $11,928 = $11,928
+    # OSS = $21,648 - $11,928 = $9,720
+    sc_ssi_state_supplement: [9_720]
+
+- name: Case 2, disabled person in CRCF with SSI and Social Security.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_blind: false
+        is_ssi_disabled: true
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 2_400
+        ssi: 11_928
+        ssi_unearned_income: 2_400
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Eligibility: disabled + in CRCF + SC + income < NIL
+    # Total countable = $2,400 + $11,928 = $14,328 < $21,648 NIL
+    sc_ssi_state_supplement_eligible: [true]
+
+    # PNA: has non-SSI income ($2,400 unearned) = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: [1_260]
+
+    # OSS amount:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $2,400 + $11,928 = $14,328
+    # OSS = $21,648 - $14,328 = $7,320
+    sc_ssi_state_supplement: [7_320]
+
+- name: Case 3, blind person in CRCF, no SSI, income below NIL.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 50
+        is_blind: true
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 15_000
+        ssi: 0
+        ssi_unearned_income: 15_000
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Eligibility: blind + in CRCF + SC + income < NIL
+    # Total countable = $15,000 + $0 = $15,000 < $21,648 NIL
+    sc_ssi_state_supplement_eligible: [true]
+
+    # PNA: has non-SSI income ($15,000 unearned) = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: [1_260]
+
+    # OSS amount:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $15,000 + $0 = $15,000
+    # OSS = $21,648 - $15,000 = $6,648
+    sc_ssi_state_supplement: [6_648]
+
+- name: Case 4, aged person NOT in CRCF is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: false
+        ssi_countable_income: 0
+        ssi: 11_928
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Not in CRCF so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]
+
+- name: Case 5, non-disabled non-aged person in CRCF is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: false
+        is_in_residential_care_facility: true
+        ssi_countable_income: 0
+        ssi: 0
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Not aged/blind/disabled so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]
+
+- name: Case 6, income above NIL makes person ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 12_000
+        ssi: 11_928
+        ssi_unearned_income: 12_000
+    households:
+      household:
+        members: [person1]
+        state_code: SC
+  output:
+    # Income check: total countable = $12,000 + $11,928 = $23,928
+    # NIL annual = $1,804 * 12 = $21,648
+    # $23,928 > $21,648 so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]
+
+- name: Case 7, person in wrong state is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+        is_blind: false
+        is_ssi_disabled: false
+        is_ssi_aged_blind_disabled: true
+        is_in_residential_care_facility: true
+        ssi_countable_income: 0
+        ssi: 11_928
+        ssi_unearned_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: GA
+  output:
+    # Wrong state (GA, not SC) so not eligible
+    sc_ssi_state_supplement_eligible: [false]
+
+    # Not eligible so PNA = $0
+    sc_ssi_state_supplement_pna: [0]
+
+    # Not eligible so OSS = $0
+    sc_ssi_state_supplement: [0]

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.yaml
@@ -1,0 +1,95 @@
+- name: Case 1, SSI-only recipient.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $0 + $11,928 = $11,928
+    # OSS = $21,648 - $11,928 = $9,720
+    sc_ssi_state_supplement: 9_720
+
+- name: Case 2, SSI plus Social Security income.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 2_400
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $2,400 + $11,928 = $14,328
+    # OSS = $21,648 - $14,328 = $7,320
+    sc_ssi_state_supplement: 7_320
+
+- name: Case 3, income above NIL.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 12_000
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $12,000 + $11,928 = $23,928
+    # OSS = max(0, $21,648 - $23,928) = $0
+    sc_ssi_state_supplement: 0
+
+- name: Case 4, not eligible.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: false
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    # Not eligible so OSS = $0 (defined_for gates this)
+    sc_ssi_state_supplement: 0
+
+- name: Case 5, non-SSI recipient with countable income below NIL.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 15_000
+    ssi: 0
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $15,000 + $0 = $15,000
+    # OSS = $21,648 - $15,000 = $6,648
+    sc_ssi_state_supplement: 6_648
+
+- name: Case 6, income exactly at NIL.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 9_720
+    ssi: 11_928
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $9,720 + $11,928 = $21,648
+    # OSS = max(0, $21,648 - $21,648) = $0
+    sc_ssi_state_supplement: 0
+
+# Edge case tests
+
+- name: Edge case - zero income, maximum OSS.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $0 + $0 = $0
+    # OSS = $21,648 - $0 = $21,648 (maximum possible supplement)
+    sc_ssi_state_supplement: 21_648
+
+- name: Edge case - very small countable income with no SSI.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 1
+    ssi: 0
+  output:
+    # NIL annual = $1,804 * 12 = $21,648
+    # Total countable = $1 + $0 = $1
+    # OSS = $21,648 - $1 = $21,647
+    sc_ssi_state_supplement: 21_647

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.yaml
@@ -1,0 +1,146 @@
+- name: Case 1, aged person in CRCF in SC with low income.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Case 2, aged person NOT in CRCF.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: false
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: false
+
+- name: Case 3, non-disabled person under 65 in CRCF.
+  period: 2026
+  input:
+    age: 30
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: false
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    sc_ssi_state_supplement_eligible: false
+
+- name: Case 4, person in wrong state.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: GA
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: false
+
+- name: Case 5, disabled person under 65 in CRCF.
+  period: 2026
+  input:
+    age: 45
+    is_ssi_disabled: true
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Case 6, blind person in CRCF.
+  period: 2026
+  input:
+    age: 50
+    is_blind: true
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Case 7, income above net income limit.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 12_000
+    ssi: 11_928
+  output:
+    # Total countable = 12_000 + 11_928 = 23_928
+    # NIL annual = 1_804 * 12 = 21_648
+    # 23_928 > 21_648 so not eligible
+    sc_ssi_state_supplement_eligible: false
+
+# Edge case tests
+
+- name: Edge case - income exactly at NIL boundary (strict less-than).
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 9_720
+    ssi: 11_928
+  output:
+    # Total = 9_720 + 11_928 = 21_648
+    # NIL annual = 1_804 * 12 = 21_648
+    # Uses strict < so 21_648 < 21_648 is false
+    sc_ssi_state_supplement_eligible: false
+
+- name: Edge case - income one dollar below NIL boundary.
+  period: 2026
+  input:
+    age: 70
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 9_719
+    ssi: 11_928
+  output:
+    # Total = 9_719 + 11_928 = 21_647
+    # NIL annual = 21_648
+    # 21_647 < 21_648 is true
+    sc_ssi_state_supplement_eligible: true
+
+- name: Edge case - person aged exactly 65 in CRCF (meets SSI aged threshold).
+  period: 2026
+  input:
+    age: 65
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: true
+    ssi_countable_income: 0
+    ssi: 11_928
+  output:
+    sc_ssi_state_supplement_eligible: true
+
+- name: Edge case - person aged 64, not disabled or blind, in CRCF.
+  period: 2026
+  input:
+    age: 64
+    is_in_residential_care_facility: true
+    state_code: SC
+    is_ssi_aged_blind_disabled: false
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    # Age 64 does not meet SSI aged threshold (65+)
+    # Not disabled or blind, so is_ssi_aged_blind_disabled = false
+    sc_ssi_state_supplement_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.yaml
@@ -1,0 +1,52 @@
+- name: Case 1, SSI-only recipient gets lower PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    state_code: SC
+  output:
+    # PNA for SSI-only = $85/month * 12 = $1,020/year
+    sc_ssi_state_supplement_pna: 1_020
+
+- name: Case 2, recipient with other income gets higher PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 2_400
+    state_code: SC
+  output:
+    # PNA for other income = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: 1_260
+
+- name: Case 3, not eligible gets zero PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: false
+    ssi_countable_income: 0
+    state_code: SC
+  output:
+    sc_ssi_state_supplement_pna: 0
+
+# Edge case tests
+
+- name: Edge case - countable income exactly zero, SSI-only PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 0
+    state_code: SC
+  output:
+    # ssi_countable_income == 0 triggers SSI-only PNA
+    # PNA = $85/month * 12 = $1,020/year
+    sc_ssi_state_supplement_pna: 1_020
+
+- name: Edge case - countable income of one dollar, triggers other-income PNA.
+  period: 2026
+  input:
+    sc_ssi_state_supplement_eligible: true
+    ssi_countable_income: 1
+    state_code: SC
+  output:
+    # ssi_countable_income == 1 != 0, so other-income PNA applies
+    # PNA = $105/month * 12 = $1,260/year
+    sc_ssi_state_supplement_pna: 1_260

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/integration.yaml
@@ -1,0 +1,213 @@
+# Integration tests for Texas SSI State Supplement
+# Tests realistic scenarios with full eligibility and benefit calculations
+#
+# Key Texas SSI State Supplement rules:
+# - Only for SSI recipients in Medicaid-funded nursing facilities or ICF/IID
+# - Supplement = PNA - Federal reduced SSI benefit
+# - 2024 PNA: $75/month, Federal reduced SSI: $30/month individual
+# - Individual supplement: $45/month = $540/year
+# - No additional state income rules beyond federal SSI
+#
+# Reference: Texas Human Resources Code Section 32.024(w)
+# Reference: SSA State Assistance Programs for SSI Recipients - Texas
+
+- name: Scenario 1, SSI-eligible elderly individual in Texas Medicaid facility.
+  # 70-year-old SSI recipient in a nursing facility receives state supplement
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Eligibility: SSI eligible + in Medicaid facility + TX = eligible
+    tx_ssi_state_supplement_eligible: true
+    # Supplement: ($75 PNA - $30 federal reduced SSI) * 12 = $540/year
+    tx_ssi_state_supplement: 540
+
+- name: Scenario 2, SSI-eligible disabled individual in Texas Medicaid facility.
+  # 45-year-old disabled SSI recipient in ICF/IID
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 45
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Eligibility: SSI eligible + in Medicaid facility + TX = eligible
+    tx_ssi_state_supplement_eligible: true
+    # Supplement: ($75 - $30) * 12 = $540/year
+    tx_ssi_state_supplement: 540
+
+- name: Scenario 3, SSI-eligible individual NOT in Medicaid facility.
+  # SSI recipient living in community - no supplement
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Not in Medicaid facility = not eligible
+    tx_ssi_state_supplement_eligible: false
+    tx_ssi_state_supplement: 0
+
+- name: Scenario 4, person in Medicaid facility but NOT SSI eligible.
+  # Non-SSI recipient in nursing facility - no supplement
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 50
+        is_ssi_eligible_individual: false
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Not SSI eligible = not eligible for supplement
+    tx_ssi_state_supplement_eligible: false
+    tx_ssi_state_supplement: 0
+
+- name: Scenario 5, SSI-eligible individual in Medicaid facility in another state.
+  # SSI recipient in facility but not in Texas
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 68
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    # Not in Texas = TX supplement does not apply (defined_for TX)
+    tx_ssi_state_supplement_eligible: false
+    tx_ssi_state_supplement: 0
+
+- name: Scenario 6, couple both SSI-eligible in Texas Medicaid facility.
+  # Both members of a couple in a nursing facility
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 72
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+      person2:
+        age: 70
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    # Both persons are eligible
+    tx_ssi_state_supplement_eligible: [true, true]
+    # Each person: ($75 - $30) * 12 = $540/year
+    tx_ssi_state_supplement: [540, 540]
+
+- name: Scenario 7, historical 2023 period with lower PNA.
+  # Tests pre-2024 PNA of $60/month
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 75
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: true
+    # 2023 PNA: $60/month, Federal reduced SSI: $30/month
+    # Supplement: ($60 - $30) * 12 = $360/year
+    tx_ssi_state_supplement: 360
+
+- name: Scenario 8, historical 2005 period with $45 PNA.
+  # Tests 2003-2005 PNA of $45/month (PNA dropped back from $60)
+  period: 2005
+  input:
+    people:
+      person1:
+        age: 80
+        is_ssi_eligible_individual: true
+        is_in_medicaid_facility: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: true
+    # 2005 PNA: $45/month (set 2003-09-01), Federal reduced SSI: $30/month
+    # Supplement: ($45 - $30) * 12 = $180/year
+    tx_ssi_state_supplement: 180

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.yaml
@@ -1,0 +1,29 @@
+# Unit tests for Texas SSI State Supplement benefit amount
+# Supplement = max(0, (PNA - Federal institutional SSI rate) * 12)
+# For 2024: ($75 - $30) * 12 = $45/month * 12 = $540/year
+# Reference: Texas Human Resources Code Section 32.024(w)
+
+- name: Case 1, eligible individual receives full supplement.
+  period: 2024
+  input:
+    tx_ssi_state_supplement_eligible: true
+  output:
+    # PNA = $75/month, Federal reduced SSI = $30/month
+    # Supplement = ($75 - $30) * 12 = $540/year
+    tx_ssi_state_supplement: 540
+
+- name: Case 2, not eligible receives zero.
+  period: 2024
+  input:
+    tx_ssi_state_supplement_eligible: false
+  output:
+    tx_ssi_state_supplement: 0
+
+- name: Case 3, eligible individual in 2023 with lower PNA.
+  period: 2023
+  input:
+    tx_ssi_state_supplement_eligible: true
+  output:
+    # PNA = $60/month (2006-2023), Federal reduced SSI = $30/month
+    # Supplement = ($60 - $30) * 12 = $360/year
+    tx_ssi_state_supplement: 360

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.yaml
@@ -1,0 +1,40 @@
+# Unit tests for Texas SSI State Supplement eligibility
+# Eligible if: SSI eligible individual AND residing in a Medicaid-funded facility
+# AND in Texas
+# Reference: Texas Human Resources Code Section 32.024(w)
+
+- name: Case 1, SSI eligible and in Medicaid facility in Texas.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: true
+    is_in_medicaid_facility: true
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: true
+
+- name: Case 2, SSI eligible but not in Medicaid facility.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: true
+    is_in_medicaid_facility: false
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: false
+
+- name: Case 3, not SSI eligible but in Medicaid facility.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: false
+    is_in_medicaid_facility: true
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: false
+
+- name: Case 4, neither SSI eligible nor in Medicaid facility.
+  period: 2024
+  input:
+    is_ssi_eligible_individual: false
+    is_in_medicaid_facility: false
+    state_code: TX
+  output:
+    tx_ssi_state_supplement_eligible: false

--- a/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
+++ b/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
@@ -1,0 +1,9 @@
+from policyengine_us.model_api import *
+
+
+class is_in_medicaid_facility(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether the person resides in a Medicaid-funded nursing facility or ICF/IID"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/42/1382"

--- a/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
+++ b/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
@@ -4,6 +4,8 @@ from policyengine_us.model_api import *
 class is_in_medicaid_facility(Variable):
     value_type = bool
     entity = Person
-    label = "Whether the person resides in a Medicaid-funded nursing facility or ICF/IID"
+    label = (
+        "Whether the person resides in a Medicaid-funded nursing facility or ICF/IID"
+    )
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/uscode/text/42/1382"

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/is_in_adult_residential_care.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/is_in_adult_residential_care.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class is_in_adult_residential_care(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether the person lives in a licensed adult residential shelter care home"
+    definition_period = YEAR
+    default_value = False
+    reference = "https://srca.nm.gov/parts/title08/08.106.0100.html"

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class nm_ssi_state_supplement(Variable):
+    value_type = float
+    entity = Person
+    label = "New Mexico SSI state supplement"
+    definition_period = YEAR
+    defined_for = "nm_ssi_state_supplement_eligible"
+    unit = USD
+    reference = "https://srca.nm.gov/parts/title08/08.106.0500.html"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.nm.hca.ssi_supplement
+        return p.amount * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class nm_ssi_state_supplement_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "New Mexico SSI state supplement eligible"
+    definition_period = YEAR
+    defined_for = StateCode.NM
+    reference = (
+        "https://srca.nm.gov/parts/title08/08.106.0500.html",
+        "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/nm.html",
+    )
+
+    def formula(person, period, parameters):
+        ssi_eligible = person("is_ssi_eligible_individual", period)
+        age = person("age", period)
+        p = parameters(period).gov.states.nm.hca.ssi_supplement
+        meets_age = age >= p.min_age
+        in_residential_care = person("is_in_adult_residential_care", period)
+        return ssi_eligible & meets_age & in_residential_care

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class sc_ssi_state_supplement(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "South Carolina SSI State Supplement"
+    unit = USD
+    reference = (
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-910",
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-920",
+    )
+    defined_for = "sc_ssi_state_supplement_eligible"
+
+    def formula(person, period, parameters):
+        # Per S.C. Code Regs. 126-910: OSS = max(0, NIL - countable income)
+        p = parameters(period).gov.states.sc.scdhhs.ssi_state_supplement
+        nil = p.net_income_limit * MONTHS_IN_YEAR
+        countable_income = person("ssi_countable_income", period)
+        ssi = person("ssi", period)
+        return max_(0, nil - countable_income - ssi)

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class sc_ssi_state_supplement_eligible(Variable):
+    value_type = bool
+    entity = Person
+    definition_period = YEAR
+    label = "South Carolina SSI State Supplement eligible"
+    reference = (
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-920",
+        "https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0",
+    )
+    defined_for = StateCode.SC
+
+    def formula(person, period, parameters):
+        # Per S.C. Code Regs. 126-920: aged/blind/disabled + CRCF + income < NIL
+        is_aged_blind_disabled = person("is_ssi_aged_blind_disabled", period)
+        in_facility = person("is_in_residential_care_facility", period)
+        p = parameters(period).gov.states.sc.scdhhs.ssi_state_supplement
+        nil = p.net_income_limit * MONTHS_IN_YEAR
+        countable_income = person("ssi_countable_income", period)
+        ssi = person("ssi", period)
+        income_eligible = (countable_income + ssi) < nil
+        return is_aged_blind_disabled & in_facility & income_eligible

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class sc_ssi_state_supplement_pna(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    label = "South Carolina SSI State Supplement personal needs allowance"
+    unit = USD
+    reference = (
+        "https://www.law.cornell.edu/regulations/south-carolina/R-126-910",
+        "https://www.scdhhs.gov/communications/social-security-and-supplemental-security-income-cost-living-adjustment-increases-0",
+    )
+    defined_for = "sc_ssi_state_supplement_eligible"
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.sc.scdhhs.ssi_state_supplement.personal_needs_allowance
+        # Per S.C. Code Regs. 126-910(G): SSI-only PNA if no other
+        # countable income; higher PNA if other income sources exist
+        ssi_only = person("ssi_countable_income", period) == 0
+        return where(ssi_only, p.ssi_only, p.other_income) * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class tx_ssi_state_supplement(Variable):
+    value_type = float
+    entity = Person
+    label = "Texas SSI State Supplement"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "tx_ssi_state_supplement_eligible"
+    reference = (
+        "https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm",
+        "https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases",
+    )
+
+    def formula(person, period, parameters):
+        # Per 42 USC 1382(e)(1)(B) and Texas HR Code 32.024(w)
+        p = parameters(period).gov.states.tx.hhsc.ssi_state_supplement
+        pna = p.personal_needs_allowance
+        federal_reduced = parameters(
+            period
+        ).gov.ssa.ssi.amount.institutional.individual
+        return max_(pna - federal_reduced, 0) * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
@@ -17,7 +17,5 @@ class tx_ssi_state_supplement(Variable):
         # Per 42 USC 1382(e)(1)(B) and Texas HR Code 32.024(w)
         p = parameters(period).gov.states.tx.hhsc.ssi_state_supplement
         pna = p.personal_needs_allowance
-        federal_reduced = parameters(
-            period
-        ).gov.ssa.ssi.amount.institutional.individual
+        federal_reduced = parameters(period).gov.ssa.ssi.amount.institutional.individual
         return max_(pna - federal_reduced, 0) * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class tx_ssi_state_supplement_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Texas SSI State Supplement eligible"
+    definition_period = YEAR
+    defined_for = StateCode.TX
+    reference = (
+        "https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm",
+        "https://www.hhs.texas.gov/handbooks/medicaid-elderly-people-disabilities-handbook/h-6000-co-payment-ssi-cases",
+    )
+
+    def formula(person, period, parameters):
+        ssi_eligible = person("is_ssi_eligible_individual", period)
+        in_facility = person("is_in_medicaid_facility", period)
+        return ssi_eligible & in_facility

--- a/policyengine_us/variables/household/demographic/person/is_in_residential_care_facility.py
+++ b/policyengine_us/variables/household/demographic/person/is_in_residential_care_facility.py
@@ -1,0 +1,8 @@
+from policyengine_us.model_api import *
+
+
+class is_in_residential_care_facility(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether the person lives in a residential care facility"
+    definition_period = YEAR

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -24,6 +24,8 @@ class spm_unit_benefits(Variable):
             "co_ccap_subsidy",
             "co_state_supplement",
             "co_oap",
+            # South Carolina programs.
+            "sc_ssi_state_supplement",
             "snap",
             "wic",
             "free_school_meals",

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -24,8 +24,12 @@ class spm_unit_benefits(Variable):
             "co_ccap_subsidy",
             "co_state_supplement",
             "co_oap",
+            # New Mexico programs.
+            "nm_ssi_state_supplement",
             # South Carolina programs.
             "sc_ssi_state_supplement",
+            # Texas programs.
+            "tx_ssi_state_supplement",
             "snap",
             "wic",
             "free_school_meals",


### PR DESCRIPTION
## Summary

Revives three closed PRs implementing SSI state supplements for New Mexico, South Carolina, and Texas. All three were closed due to 2+ week stale conflicts.

Bundled together since they share integration surface (`spm_unit_benefits.py` and `household_state_benefits.yaml`) and each individual PR is small.

Supersedes:
- #7456 - New Mexico SSI state supplement
- #7455 - South Carolina SSI state supplement (OSS)
- #7341 - Texas SSI state supplement

Closes #7345, #7343, #7340.

## Changes

### New Mexico
Flat $100/month payment for SSI recipients aged 18+ in licensed Adult Residential Shelter Care Homes (ARSCH).

### South Carolina
Optional State Supplementation (OSS) program for residents of Community Residential Care Facilities (CRCF).

### Texas
Optional State Supplement (OSS) for SSI recipients in Medicaid-funded nursing facilities and ICF/IID facilities, with $75/month personal needs allowance and historical values back to 1999.

### Integration
- All three variables added to `spm_unit_benefits` and `household_state_benefits` (NM's original PR didn't modify these; added here for consistency).

## Test plan

- [x] NM SSI tests pass (18 tests)
- [x] SC SSI tests pass (31 tests)
- [x] TX SSI tests pass (15 tests)
- [ ] CI passes

Rebased on `upstream/main`. Cherry-picked original commits, resolved conflicts from `changelog_entry.yaml` → `changelog.d/` migration and overlapping edits to `household_state_benefits.yaml` / `spm_unit_benefits.py`.
