### PR TITLE
Add 529 plan contribution deductions and credits across 24 states

### DIFF
--- a/changelog.d/529-batch-1a.added.md
+++ b/changelog.d/529-batch-1a.added.md
@@ -1,1 +1,0 @@
-Add 529 plan contribution deductions for AL, DE, ID, IL, IA, KS, LA, ME, and a 529 plan credit for IN.

--- a/changelog.d/529-batch-1a.added.md
+++ b/changelog.d/529-batch-1a.added.md
@@ -1,0 +1,1 @@
+Add 529 plan contribution deductions for AL, DE, ID, IL, IA, KS, LA, ME, and a 529 plan credit for IN.

--- a/changelog.d/529-batch-2.added.md
+++ b/changelog.d/529-batch-2.added.md
@@ -1,1 +1,0 @@
-Add 529 plan contribution deductions for MD, MA, MI, MS, MO, NE, NJ, and ND.

--- a/changelog.d/529-batch-2.added.md
+++ b/changelog.d/529-batch-2.added.md
@@ -1,0 +1,1 @@
+Add 529 plan contribution deductions for MD, MA, MI, MS, MO, NE, NJ, and ND.

--- a/changelog.d/529-batch-3.added.md
+++ b/changelog.d/529-batch-3.added.md
@@ -1,0 +1,1 @@
+Add 529 plan contribution deductions/credits for Oklahoma, Oregon, Pennsylvania, Utah, Virginia, Vermont, and Wisconsin.

--- a/changelog.d/529-batch-3.added.md
+++ b/changelog.d/529-batch-3.added.md
@@ -1,1 +1,0 @@
-Add 529 plan contribution deductions/credits for Oklahoma, Oregon, Pennsylvania, Utah, Virginia, Vermont, and Wisconsin.

--- a/changelog.d/revive-529-plan-state-deductions.added.md
+++ b/changelog.d/revive-529-plan-state-deductions.added.md
@@ -1,0 +1,1 @@
+Add 529 plan contribution state tax benefits across 24 states: deductions in AL, DE, IA, ID, IL, KS, LA, MA, MD, ME, MI, MO, MS, ND, NE, NJ, OK, PA, VA, WI; credits in IN, OR, UT, VT.

--- a/policyengine_us/parameters/gov/states/al/tax/income/deductions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/al/tax/income/deductions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Alabama caps the 529 plan contributions deduction at this amount by filing status.
+metadata:
+  label: Alabama 529 plan contribution deduction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Alabama Code Section 16-33C-16
+    href: https://law.justia.com/codes/alabama/title-16/chapter-33c/section-16-33c-16/
+  - title: CollegeCounts 529 Tax Benefits
+    href: https://collegecounts529.com/tax-benefits/
+
+JOINT:
+  2021-01-01: 10_000
+SURVIVING_SPOUSE:
+  2021-01-01: 10_000
+SINGLE:
+  2021-01-01: 5_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 5_000
+SEPARATE:
+  2021-01-01: 5_000

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/agi_limit.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/agi_limit.yaml
@@ -1,0 +1,23 @@
+description: Delaware income limit for the 529 plan subtraction by filing status.
+metadata:
+  label: Delaware 529 plan contribution subtraction AGI limit
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Delaware HB 145 (2022)
+    href: https://news.delaware.gov/2022/06/30/hb145/
+  - title: DE529 Education Savings Plan
+    href: https://treasurer.delaware.gov/education-savings-plan/
+
+JOINT:
+  2022-01-01: 200_000
+SURVIVING_SPOUSE:
+  2022-01-01: 200_000
+SINGLE:
+  2022-01-01: 100_000
+HEAD_OF_HOUSEHOLD:
+  2022-01-01: 200_000
+SEPARATE:
+  2022-01-01: 100_000

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Delaware caps the 529 plan contributions subtraction at this amount by filing status.
+metadata:
+  label: Delaware 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Delaware Code Title 30, Section 1106(b)
+    href: https://delcode.delaware.gov/title30/c011/sc02/index.html
+  - title: DE529 Education Savings Plan
+    href: https://treasurer.delaware.gov/education-savings-plan/
+
+JOINT:
+  2022-01-01: 2_000
+SURVIVING_SPOUSE:
+  2022-01-01: 2_000
+SINGLE:
+  2022-01-01: 1_000
+HEAD_OF_HOUSEHOLD:
+  2022-01-01: 1_000
+SEPARATE:
+  2022-01-01: 1_000

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
@@ -9,6 +9,7 @@ values:
   2022-01-01:
     - de_pension_exclusion # (3)
     - taxable_social_security # (4)
+    - us_govt_interest_person
     - de_529_plan_subtraction # HB 145
 
 metadata:

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
@@ -6,6 +6,10 @@ values:
     - us_govt_interest_person
     # The elderly or disabled income exclusion is computed separately
     # - de_elderly_or_disabled_income_exclusion # (2)
+  2022-01-01:
+    - de_pension_exclusion # (3)
+    - taxable_social_security # (4)
+    - de_529_plan_subtraction # HB 145
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ia/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,19 @@
+description: Iowa caps the 529 plan contributions subtraction at this amount per beneficiary.
+values:
+  2021-01-01: 3_474
+  2022-01-01: 3_522
+  2023-01-01: 3_785
+  2024-01-01: 5_500
+  2025-01-01: 5_800
+  2026-01-01: 6_100
+metadata:
+  label: Iowa 529 plan contribution subtraction cap per beneficiary
+  period: year
+  unit: currency-USD
+  reference:
+  - title: Iowa Treasurer - ISave 529 Tax Deduction
+    href: https://www.iowatreasurer.gov/the-treasurers-office/news/treasurer-smith-announces-2025-isave-529-state-tax-deduction-amount
+  - title: Iowa Code Section 422.7(32)
+    href: https://www.legis.iowa.gov/docs/code/422.7.pdf
+  - title: ISave 529 Tax Benefits
+    href: https://www.isave529.com/save/tax-benefits

--- a/policyengine_us/parameters/gov/states/ia/tax/income/taxable_income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/taxable_income/subtractions.yaml
@@ -10,10 +10,11 @@ values:
     - military_service_income
     # Line 7B
     - ia_pension_exclusion
-    # Railroad unemployment income 
+    # Railroad unemployment income
     # Bonus Depreciation
     # Iowa Health Insurance Deduction
     # Iowa capital gains deduction
+    - ia_529_plan_subtraction
   2024-01-01: # military_retirement_pay added in 2024.
     # Line 1B
     - us_govt_interest
@@ -26,10 +27,11 @@ values:
     - military_service_income
     # Line 7B
     - ia_pension_exclusion
-    # Railroad unemployment income 
+    # Railroad unemployment income
     # Bonus Depreciation
     # Iowa Health Insurance Deduction
     # Iowa capital gains deduction
+    - ia_529_plan_subtraction
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/id/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/id/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Idaho caps the 529 plan contributions subtraction at this amount by filing status.
+metadata:
+  label: Idaho 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Idaho State Tax Commission - IDeal College Savings Program
+    href: https://tax.idaho.gov/taxes/income-tax/individual-income/popular-credits-and-deductions/ideal-college-savings-program/
+  - title: IDeal Idaho College Savings Program Tax Benefits
+    href: https://www.idsaves.org/home/features-and-benefits/tax-benefits.html
+
+JOINT:
+  2021-01-01: 12_000
+SURVIVING_SPOUSE:
+  2021-01-01: 12_000
+SINGLE:
+  2021-01-01: 6_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 6_000
+SEPARATE:
+  2021-01-01: 6_000

--- a/policyengine_us/parameters/gov/states/id/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/id/tax/income/subtractions/subtractions.yaml
@@ -10,6 +10,7 @@ values:
     - id_capital_gains_deduction # (10)
     - workers_compensation # (13)
     - id_retirement_benefits_deduction # (15)
+    - id_529_plan_subtraction # Idaho Code 63-3022(n)
   2025-01-01:
     - salt_refund_income # (2)
     - us_govt_interest # (3)(a)
@@ -21,6 +22,7 @@ values:
     - workers_compensation # (13)
     - id_retirement_benefits_deduction # (15)
     - id_military_retirement_deduction # (15) per HB 40
+    - id_529_plan_subtraction # Idaho Code 63-3022(n)
 
 
 metadata:

--- a/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
@@ -5,6 +5,7 @@ values:
     - taxable_social_security
     - taxable_pension_income
     - il_schedule_m_subtractions
+    - il_529_plan_subtraction
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/il/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Illinois caps the 529 plan contributions subtraction at this amount by filing status.
+metadata:
+  label: Illinois 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Illinois Department of Revenue - 529 College Savings
+    href: https://tax.illinois.gov/questionsandanswers/answer.206.html
+  - title: Bright Start 529 Tax Benefits
+    href: https://brightstart.com/account/illinois-taxpayer-guide/
+
+JOINT:
+  2021-01-01: 20_000
+SURVIVING_SPOUSE:
+  2021-01-01: 20_000
+SINGLE:
+  2021-01-01: 10_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 10_000
+SEPARATE:
+  2021-01-01: 10_000

--- a/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/cap.yaml
@@ -1,0 +1,28 @@
+description: Indiana caps the 529 plan credit at this amount by filing status.
+metadata:
+  label: Indiana 529 plan credit cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Indiana Code IC 6-3-3-12
+    href: https://law.justia.com/codes/indiana/title-6/article-3/chapter-3/section-6-3-3-12/
+  - title: Indiana Department of Revenue Information Bulletin 98
+    href: https://www.in.gov/dor/files/ib98.pdf
+
+JOINT:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+SURVIVING_SPOUSE:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+SINGLE:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 1_000
+  2023-01-01: 1_500
+SEPARATE:
+  2021-01-01: 500
+  2023-01-01: 750

--- a/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/rate.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/income/credits/plan_529/rate.yaml
@@ -1,0 +1,12 @@
+description: Indiana provides a tax credit at this rate for contributions to CollegeChoice 529 plans.
+values:
+  2021-01-01: 0.2
+metadata:
+  unit: /1
+  period: year
+  label: Indiana 529 plan credit rate
+  reference:
+  - title: Indiana Code IC 6-3-3-12
+    href: https://law.justia.com/codes/indiana/title-6/article-3/chapter-3/section-6-3-3-12/
+  - title: Indiana Department of Revenue Information Bulletin 98
+    href: https://www.in.gov/dor/files/ib98.pdf

--- a/policyengine_us/parameters/gov/states/ks/tax/income/agi/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ks/tax/income/agi/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Kansas caps the 529 plan contributions subtraction at this amount per beneficiary by filing status.
+metadata:
+  label: Kansas 529 plan contribution subtraction cap per beneficiary
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Kansas State Treasurer - 529 Savings Program
+    href: https://www.kansasstatetreasurer.ks.gov/learn_quest.html
+  - title: Kansas Department of Revenue FAQ
+    href: https://www.ksrevenue.gov/faqs-taxii.html
+
+JOINT:
+  2021-01-01: 6_000
+SURVIVING_SPOUSE:
+  2021-01-01: 6_000
+SINGLE:
+  2021-01-01: 3_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 3_000
+SEPARATE:
+  2021-01-01: 3_000

--- a/policyengine_us/parameters/gov/states/la/tax/income/deductions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/la/tax/income/deductions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Louisiana caps the 529 plan contributions deduction at this amount per beneficiary by filing status.
+metadata:
+  label: Louisiana 529 plan contribution deduction cap per beneficiary
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: START Saving Program FAQ
+    href: https://www.startsaving.la.gov/startfaqs.aspx
+  - title: Louisiana Revised Statutes 47:293(9)(a)(xix)
+    href: https://law.justia.com/codes/louisiana/revised-statutes/title-47/rs-47-293/
+
+JOINT:
+  2021-01-01: 4_800
+SURVIVING_SPOUSE:
+  2021-01-01: 4_800
+SINGLE:
+  2021-01-01: 2_400
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 2_400
+SEPARATE:
+  2021-01-01: 2_400

--- a/policyengine_us/parameters/gov/states/ma/tax/income/deductions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/deductions/plan_529_contributions/cap.yaml
@@ -1,0 +1,23 @@
+description: Massachusetts caps the deduction for 529 education savings plan contributions at this amount.
+metadata:
+  label: Massachusetts 529 plan contribution deduction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Massachusetts General Laws Chapter 62 § 3(B)(a)(14)
+    href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section3
+  - title: Massachusetts DOR 529 Deduction Information
+    href: https://www.mass.gov/info-details/529-plan-deduction
+
+JOINT:
+  2021-01-01: 2_000
+SURVIVING_SPOUSE:
+  2021-01-01: 2_000
+SINGLE:
+  2021-01-01: 1_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 1_000
+SEPARATE:
+  2021-01-01: 1_000

--- a/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/cap.yaml
@@ -1,0 +1,23 @@
+description: Maryland caps the subtraction for 529 education savings plan contributions at this amount per beneficiary.
+metadata:
+  label: Maryland 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Maryland Tax-General Article § 10-208(p)
+    href: https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-208&enession=2024RS
+  - title: Maryland 2025 Resident Tax Forms and Instructions - Subtractions
+    href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=15
+
+JOINT:
+  2021-01-01: 5_000
+SURVIVING_SPOUSE:
+  2021-01-01: 5_000
+SINGLE:
+  2021-01-01: 2_500
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 2_500
+SEPARATE:
+  2021-01-01: 2_500

--- a/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
@@ -6,6 +6,7 @@ values:
     - md_pension_subtraction
     - md_socsec_subtraction
     - md_two_income_subtraction
+    - md_529_deduction
   2022-01-01:
     - us_govt_interest
     - md_dependent_care_subtraction
@@ -13,6 +14,7 @@ values:
     - md_socsec_subtraction
     - md_two_income_subtraction
     - md_hundred_year_subtraction
+    - md_529_deduction
 
 metadata:
   reference:

--- a/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/agi_limit.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/agi_limit.yaml
@@ -1,0 +1,23 @@
+description: Maine income limit for the 529 plan subtraction by filing status.
+metadata:
+  label: Maine 529 plan contribution subtraction AGI limit
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Maine LD 151 (2021, enacted as PL 2021 Ch. 398)
+    href: https://legislature.maine.gov/legis/bills/getPDF.asp?paper=SP0031&item=5&snum=130
+  - title: NextGen 529 Maine State Tax Deduction
+    href: https://www.nextgenforme.com/maine-state-tax-deduction/
+
+JOINT:
+  2022-01-01: 200_000
+SURVIVING_SPOUSE:
+  2022-01-01: 200_000
+SINGLE:
+  2022-01-01: 100_000
+HEAD_OF_HOUSEHOLD:
+  2022-01-01: 200_000
+SEPARATE:
+  2022-01-01: 100_000

--- a/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/plan_529/cap.yaml
@@ -1,0 +1,12 @@
+description: Maine caps the 529 plan contributions subtraction at this amount per beneficiary.
+values:
+  2022-01-01: 1_000
+metadata:
+  label: Maine 529 plan contribution subtraction cap per beneficiary
+  period: year
+  unit: currency-USD
+  reference:
+  - title: Maine LD 151 (2021, enacted as PL 2021 Ch. 398)
+    href: https://legislature.maine.gov/legis/bills/getPDF.asp?paper=SP0031&item=5&snum=130
+  - title: NextGen 529 Maine State Tax Deduction
+    href: https://www.nextgenforme.com/maine-state-tax-deduction/

--- a/policyengine_us/parameters/gov/states/mi/tax/income/deductions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/deductions/plan_529_contributions/cap.yaml
@@ -1,0 +1,23 @@
+description: Michigan caps the subtraction for 529 education savings plan contributions at this amount.
+metadata:
+  label: Michigan 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Michigan Compiled Laws § 206.30(1)(bb)
+    href: http://legislature.mi.gov/doc.aspx?mcl-206-30
+  - title: Michigan 2024 Individual Income Tax Instructions
+    href: https://www.michigan.gov/taxes/-/media/Project/Websites/taxes/Forms/IIT/TY2024/MI-1040-Instructions.pdf#page=13
+
+JOINT:
+  2021-01-01: 10_000
+SURVIVING_SPOUSE:
+  2021-01-01: 10_000
+SINGLE:
+  2021-01-01: 5_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 5_000
+SEPARATE:
+  2021-01-01: 5_000

--- a/policyengine_us/parameters/gov/states/mi/tax/income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/subtractions.yaml
@@ -9,6 +9,7 @@ values:
     - mi_standard_deduction  # Line 24 & 25
     - mi_pension_benefit  # Line 26
     - mi_interest_dividends_capital_gains_deduction # Line 27
+    - mi_529_deduction
 metadata:
   unit: list  
   label: Michigan taxable income subtraction sources  

--- a/policyengine_us/parameters/gov/states/mo/tax/income/subtractions/agi_subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/subtractions/agi_subtractions.yaml
@@ -3,10 +3,12 @@ values:
   2008-01-01:
     - mo_qualified_health_insurance_premiums
     - us_govt_interest_person
+    - mo_529_deduction
   2025-01-01:
     - mo_qualified_health_insurance_premiums
     - mo_capital_gains_subtraction_person
     - us_govt_interest_person
+    - mo_529_deduction
 
 
 metadata:

--- a/policyengine_us/parameters/gov/states/mo/tax/income/subtractions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/subtractions/plan_529_contributions/cap.yaml
@@ -1,0 +1,23 @@
+description: Missouri caps the subtraction for 529 education savings plan contributions at this amount.
+metadata:
+  label: Missouri 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Revisor of Missouri § 143.121.2(4)
+    href: https://www.revisor.mo.gov/main/OneSection.aspx?section=143.121
+  - title: 2025 MO-1040 Book - Individual Income Tax Long Form
+    href: https://dor.mo.gov/forms/MO-1040%20Instructions_2025.pdf#page=12
+
+JOINT:
+  2021-01-01: 16_000
+SURVIVING_SPOUSE:
+  2021-01-01: 16_000
+SINGLE:
+  2021-01-01: 8_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 8_000
+SEPARATE:
+  2021-01-01: 8_000

--- a/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/adjustments.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/adjustments.yaml
@@ -7,6 +7,7 @@ values:
     - alimony_expense # Line 53
     - ms_retirement_income_exemption
     - us_govt_interest_person
+    - ms_529_deduction
 metadata:
   label: Mississippi adjusted gross income adjustments
   period: year

--- a/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/plan_529_contributions/cap.yaml
@@ -1,0 +1,23 @@
+description: Mississippi caps the adjustment for 529 education savings plan contributions at this amount.
+metadata:
+  label: Mississippi 529 plan contribution adjustment cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Mississippi Code § 27-7-18(2)
+    href: https://law.justia.com/codes/mississippi/2022/title-27/chapter-7/article-1/section-27-7-18/
+  - title: Mississippi Income Tax Instructions 2025
+    href: https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=12
+
+JOINT:
+  2021-01-01: 20_000
+SURVIVING_SPOUSE:
+  2021-01-01: 20_000
+SINGLE:
+  2021-01-01: 10_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 10_000
+SEPARATE:
+  2021-01-01: 10_000

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/plan_529_contributions/cap.yaml
@@ -1,0 +1,23 @@
+description: North Dakota caps the subtraction for 529 education savings plan contributions at this amount.
+metadata:
+  label: North Dakota 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: North Dakota Century Code § 57-38-30.3(2)(p)
+    href: https://law.justia.com/codes/north-dakota/2022/title-57/chapter-57-38/section-57-38-30-3/
+  - title: 2025 North Dakota income tax instructions
+    href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2025-iit/2025-individual-income-tax-booklet.pdf#page=14
+
+JOINT:
+  2021-01-01: 10_000
+SURVIVING_SPOUSE:
+  2021-01-01: 10_000
+SINGLE:
+  2021-01-01: 5_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 5_000
+SEPARATE:
+  2021-01-01: 5_000

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
@@ -6,6 +6,7 @@ values:
     - nd_qdiv_subtraction  # qualified dividends
     - taxable_social_security
     - military_retirement_pay
+    - nd_529_deduction
 
   2023-01-01:
     - us_govt_interest
@@ -14,6 +15,7 @@ values:
     - taxable_social_security
     - military_retirement_pay
     - military_service_income # military pay exculsion
+    - nd_529_deduction
 
 metadata:
   unit: list  

--- a/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/plan_529_contributions/cap.yaml
@@ -1,0 +1,23 @@
+description: Nebraska caps the subtraction for 529 education savings plan contributions at this amount.
+metadata:
+  label: Nebraska 529 plan contribution subtraction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Nebraska Revised Statute § 77-2716(20)
+    href: https://www.nebraskalegislature.gov/laws/statutes.php?statute=77-2716
+  - title: 2025 Nebraska Individual Income Tax Booklet
+    href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_Individual_Income_Tax_Booklet.pdf#page=26
+
+JOINT:
+  2021-01-01: 10_000
+SURVIVING_SPOUSE:
+  2021-01-01: 10_000
+SINGLE:
+  2021-01-01: 10_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 10_000
+SEPARATE:
+  2021-01-01: 5_000

--- a/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/subtractions.yaml
@@ -4,11 +4,13 @@ values:
     - ne_social_security_subtraction
     - ne_military_retirement_subtraction
     - us_govt_interest
+    - ne_529_deduction
   2024-01-01:
     - ne_social_security_subtraction
     - taxable_public_pension_income
     - ne_military_retirement_subtraction
     - us_govt_interest
+    - ne_529_deduction
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/nj/tax/income/deductions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/nj/tax/income/deductions/plan_529_contributions/cap.yaml
@@ -1,0 +1,12 @@
+description: New Jersey caps the deduction for 529 education savings plan contributions at this amount.
+metadata:
+  label: New Jersey 529 plan contribution deduction cap
+  period: year
+  unit: currency-USD
+  reference:
+  - title: New Jersey P.L. 2021, c.419 § 1
+    href: https://www.njleg.state.nj.us/bill-search/2020/A5535
+  - title: NJ-1040 Instructions 2024
+    href: https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf
+values:
+  2022-01-01: 10_000

--- a/policyengine_us/parameters/gov/states/nj/tax/income/deductions/plan_529_contributions/income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/nj/tax/income/deductions/plan_529_contributions/income_limit.yaml
@@ -1,0 +1,12 @@
+description: New Jersey limits the 529 plan contribution deduction to taxpayers with adjusted gross income at or below this amount.
+metadata:
+  label: New Jersey 529 plan contribution deduction AGI limit
+  period: year
+  unit: currency-USD
+  reference:
+  - title: New Jersey P.L. 2021, c.419 § 1
+    href: https://www.njleg.state.nj.us/bill-search/2020/A5535
+  - title: NJ-1040 Instructions 2024
+    href: https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf
+values:
+  2022-01-01: 200_000

--- a/policyengine_us/parameters/gov/states/nj/tax/income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/nj/tax/income/subtractions.yaml
@@ -8,3 +8,6 @@ metadata:
 values:
   2021-01-01:
     - us_govt_interest_person
+  2022-01-01:
+    - us_govt_interest_person
+    - nj_529_deduction

--- a/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/plan_529/cap.yaml
@@ -1,0 +1,23 @@
+description: Oklahoma caps the 529 plan contributions deduction at this amount.
+metadata:
+  label: Oklahoma 529 plan contribution deduction cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Oklahoma 529 Plan FAQ
+    href: https://www.oklahoma529.com/resources/faq/
+  - title: 2024 Oklahoma Form 511 Instructions
+    href: https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/current/511-Pkt.pdf#page=16
+
+JOINT:
+  2021-01-01: 20_000
+SURVIVING_SPOUSE:
+  2021-01-01: 20_000
+SINGLE:
+  2021-01-01: 10_000
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 10_000
+SEPARATE:
+  2021-01-01: 10_000

--- a/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/subtractions.yaml
@@ -5,6 +5,7 @@ values:
     - taxable_social_security
     - ok_pension_subtraction
     - ok_military_retirement_exclusion
+    - ok_529_plan_deduction
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/plan_529/max_credit.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/plan_529/max_credit.yaml
@@ -1,0 +1,33 @@
+description: Oregon caps the 529 plan contribution tax credit at this amount.
+metadata:
+  label: Oregon 529 plan contribution credit maximum
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Oregon Department of Revenue - Tax benefits for families
+    href: https://www.oregon.gov/dor/programs/individuals/pages/credits.aspx
+  - title: ORS 315.643
+    href: https://oregon.public.law/statutes/ors_315.643
+
+JOINT:
+  2020-01-01: 300
+  2025-01-01: 360
+  2026-01-01: 380
+SURVIVING_SPOUSE:
+  2020-01-01: 300
+  2025-01-01: 360
+  2026-01-01: 380
+SINGLE:
+  2020-01-01: 150
+  2025-01-01: 180
+  2026-01-01: 190
+HEAD_OF_HOUSEHOLD:
+  2020-01-01: 150
+  2025-01-01: 180
+  2026-01-01: 190
+SEPARATE:
+  2020-01-01: 150
+  2025-01-01: 180
+  2026-01-01: 190

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/refundable.yaml
@@ -4,15 +4,22 @@ values:
   - or_eitc
   - or_kicker
   - or_working_family_household_and_dependent_care_credit
+  2020-01-01:
+  - or_eitc
+  - or_kicker
+  - or_529_credit
+  - or_working_family_household_and_dependent_care_credit
   2023-01-01:
   - or_eitc
   - or_kicker
   - or_ctc
+  - or_529_credit
   - or_working_family_household_and_dependent_care_credit
   # Child Tax Credit legislation ends in 2029.
   2029-01-01:
   - or_eitc
   - or_kicker
+  - or_529_credit
   - or_working_family_household_and_dependent_care_credit
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/pa/tax/income/deductions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/pa/tax/income/deductions/plan_529/cap.yaml
@@ -1,0 +1,18 @@
+description: >
+  Pennsylvania caps the 529 plan contributions deduction per beneficiary
+  at this amount, which is tied to the federal annual gift tax exclusion.
+values:
+  2021-01-01: 15_000
+  2022-01-01: 16_000
+  2023-01-01: 17_000
+  2024-01-01: 18_000
+  2025-01-01: 19_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Pennsylvania 529 plan contribution deduction cap per beneficiary
+  reference:
+  - title: PA Revenue - What is the limit on a deduction to a 529 plan?
+    href: https://revenue-pa.custhelp.com/app/answers/detail/a_id/2208/~/what-is-the-limit-on-a-deduction-to-a-529-plan
+  - title: PA 529 Plan FAQs
+    href: https://www.pa529.com/faqs/

--- a/policyengine_us/parameters/gov/states/ut/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ut/tax/income/credits/non_refundable.yaml
@@ -33,6 +33,7 @@ values:
   - ut_retirement_credit
   - ut_ss_benefits_credit
   - ut_at_home_parent_credit
+  - ut_529_plan_credit
 
   2024-01-01:
   - ut_eitc
@@ -41,3 +42,4 @@ values:
   - ut_at_home_parent_credit
   - ut_ctc
   - ut_military_retirement_credit
+  - ut_529_plan_credit

--- a/policyengine_us/parameters/gov/states/ut/tax/income/credits/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ut/tax/income/credits/plan_529/cap.yaml
@@ -1,0 +1,40 @@
+description: >
+  Utah caps the 529 plan contribution amount eligible for the state tax
+  credit at this amount per beneficiary.
+metadata:
+  label: Utah 529 plan contribution credit cap per beneficiary
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Utah state tax benefits information - my529
+    href: https://my529.org/utah-state-tax-benefits-information/
+  - title: TC-40A Supplemental Schedule Instructions - my529
+    href: https://incometax.utah.gov/credits/my529
+
+JOINT:
+  2022-01-01: 4_260
+  2023-01-01: 4_580
+  2024-01-01: 4_820
+  2025-01-01: 4_980
+SURVIVING_SPOUSE:
+  2022-01-01: 4_260
+  2023-01-01: 4_580
+  2024-01-01: 4_820
+  2025-01-01: 4_980
+SINGLE:
+  2022-01-01: 2_130
+  2023-01-01: 2_290
+  2024-01-01: 2_410
+  2025-01-01: 2_490
+HEAD_OF_HOUSEHOLD:
+  2022-01-01: 2_130
+  2023-01-01: 2_290
+  2024-01-01: 2_410
+  2025-01-01: 2_490
+SEPARATE:
+  2022-01-01: 2_130
+  2023-01-01: 2_290
+  2024-01-01: 2_410
+  2025-01-01: 2_490

--- a/policyengine_us/parameters/gov/states/ut/tax/income/credits/plan_529/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ut/tax/income/credits/plan_529/rate.yaml
@@ -1,0 +1,15 @@
+description: Utah applies this tax credit rate to eligible 529 plan contributions.
+values:
+  2022-01-01: 0.0485
+  2023-01-01: 0.0465
+  2024-01-01: 0.0455
+  2025-01-01: 0.045
+metadata:
+  unit: /1
+  period: year
+  label: Utah 529 plan contribution credit rate
+  reference:
+  - title: Utah state tax benefits information - my529
+    href: https://my529.org/utah-state-tax-benefits-information/
+  - title: TC-40A Supplemental Schedule Instructions - my529
+    href: https://incometax.utah.gov/credits/my529

--- a/policyengine_us/parameters/gov/states/va/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/va/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,17 @@
+description: >
+  Virginia caps the 529 plan contributions deduction at this amount per
+  account per year. Taxpayers age 70 and over may deduct the entire
+  amount contributed.
+values:
+  2021-01-01: 4_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Virginia 529 plan contribution deduction cap per account
+  reference:
+  - title: Virginia Tax - Deductions
+    href: https://www.tax.virginia.gov/deductions
+  - title: Code of Virginia 58.1-322.02
+    href: https://law.lis.virginia.gov/vacodefull/title58.1/chapter3/article2/
+  - title: 2024 Form 760 Instructions - Subtractions, Certification Number 34
+    href: https://www.tax.virginia.gov/sites/default/files/vatax-pdf/2024-760-instructions.pdf#page=24

--- a/policyengine_us/parameters/gov/states/va/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/va/tax/income/subtractions/subtractions.yaml
@@ -9,7 +9,7 @@ values:
     - unemployment_compensation # Certification Number 37
     - va_federal_state_employees_subtraction # Certification Number 39
     - va_military_benefit_subtraction # Certification Number 60
-    - investment_in_529_plan # Certification Number 34
+    - va_529_plan_deduction # Certification Number 34
     - va_age_deduction # Certification Number 4
     - taxable_social_security # Certification Number 5
 

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/non_refundable.yaml
@@ -2,6 +2,7 @@ description: Vermont non-refundable tax credits.
 values:
   2021-01-01:
     - vt_charitable_contribution_credit
+    - vt_529_plan_credit
 metadata:
   unit: list
   label: Vermont non-refundable tax credits

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/plan_529/cap.yaml
@@ -1,0 +1,25 @@
+description: >
+  Vermont caps the 529 plan contribution amount eligible for the state tax
+  credit at this amount per beneficiary.
+metadata:
+  label: Vermont 529 plan contribution credit cap per beneficiary
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Vermont Tax Credits and Adjustments for Individuals
+    href: https://tax.vermont.gov/individuals/personal-income-tax/tax-credits
+  - title: VT529 Benefits
+    href: https://vt529.org/benefits
+
+JOINT:
+  2021-01-01: 5_000
+SURVIVING_SPOUSE:
+  2021-01-01: 5_000
+SINGLE:
+  2021-01-01: 2_500
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 2_500
+SEPARATE:
+  2021-01-01: 2_500

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/plan_529/rate.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/plan_529/rate.yaml
@@ -1,0 +1,12 @@
+description: Vermont applies this credit rate to eligible 529 plan contributions.
+values:
+  2021-01-01: 0.10
+metadata:
+  unit: /1
+  period: year
+  label: Vermont 529 plan contribution credit rate
+  reference:
+  - title: Vermont Tax Credits and Adjustments for Individuals
+    href: https://tax.vermont.gov/individuals/personal-income-tax/tax-credits
+  - title: VT529 Benefits
+    href: https://vt529.org/benefits

--- a/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/plan_529/cap.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/plan_529/cap.yaml
@@ -1,0 +1,40 @@
+description: >
+  Wisconsin caps the 529 plan contributions deduction per beneficiary
+  at this amount. The married filing separately cap is half the regular cap.
+metadata:
+  label: Wisconsin 529 plan contribution deduction cap per beneficiary
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: Edvest 529 Tax Benefits
+    href: https://www.edvest.com/learn/tax-benefits/
+  - title: DFI Wisconsin 529 College Savings Program
+    href: https://dfi.wi.gov/Pages/EducationalServices/CollegeSavingsCareerPlanning/CollegeSavingsProgram.aspx
+
+JOINT:
+  2021-01-01: 3_560
+  2024-01-01: 5_000
+  2025-01-01: 5_130
+  2026-01-01: 5_280
+SURVIVING_SPOUSE:
+  2021-01-01: 3_560
+  2024-01-01: 5_000
+  2025-01-01: 5_130
+  2026-01-01: 5_280
+SINGLE:
+  2021-01-01: 3_560
+  2024-01-01: 5_000
+  2025-01-01: 5_130
+  2026-01-01: 5_280
+HEAD_OF_HOUSEHOLD:
+  2021-01-01: 3_560
+  2024-01-01: 5_000
+  2025-01-01: 5_130
+  2026-01-01: 5_280
+SEPARATE:
+  2021-01-01: 1_780
+  2024-01-01: 2_500
+  2025-01-01: 2_560
+  2026-01-01: 2_640

--- a/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/sources.yaml
@@ -7,12 +7,14 @@ values:
     - wi_childcare_expense_subtraction
     - wi_retirement_income_subtraction
     - us_govt_interest
+    - wi_529_plan_deduction
   2022-01-01:
     - wi_unemployment_compensation_subtraction
     - tax_unit_taxable_social_security
     - wi_capital_gain_loss_subtraction
     - wi_retirement_income_subtraction
     - us_govt_interest
+    - wi_529_plan_deduction
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.yaml
@@ -1,0 +1,51 @@
+- name: Alabama 529 deduction - single filer under cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: SINGLE
+    investment_in_529_plan: 3_000
+  output:
+    # Cap for single is $5,000
+    # Deduction = min(3,000, 5,000) = 3,000
+    al_529_plan_deduction: 3_000
+
+- name: Alabama 529 deduction - single filer over cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: SINGLE
+    investment_in_529_plan: 7_000
+  output:
+    # Cap for single is $5,000
+    # Deduction = min(7,000, 5,000) = 5,000
+    al_529_plan_deduction: 5_000
+
+- name: Alabama 529 deduction - joint filer under cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: JOINT
+    investment_in_529_plan: 8_000
+  output:
+    # Cap for joint is $10,000
+    # Deduction = min(8,000, 10,000) = 8,000
+    al_529_plan_deduction: 8_000
+
+- name: Alabama 529 deduction - joint filer over cap
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: JOINT
+    investment_in_529_plan: 12_000
+  output:
+    # Cap for joint is $10,000
+    # Deduction = min(12,000, 10,000) = 10,000
+    al_529_plan_deduction: 10_000
+
+- name: Alabama 529 deduction - no contribution
+  period: 2025
+  input:
+    state_code: AL
+    filing_status: SINGLE
+  output:
+    al_529_plan_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/subtractions/plan_529/de_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/subtractions/plan_529/de_529_plan_subtraction.yaml
@@ -1,0 +1,55 @@
+- name: Delaware 529 subtraction - single under cap and AGI limit
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 800
+    adjusted_gross_income: 80_000
+  output:
+    # Cap for single is $1,000, AGI limit $100K
+    # Subtraction = min(800, 1,000) = 800
+    de_529_plan_subtraction: 800
+
+- name: Delaware 529 subtraction - single over cap
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 1_500
+    adjusted_gross_income: 80_000
+  output:
+    # Cap for single is $1,000
+    # Subtraction = min(1,500, 1,000) = 1,000
+    de_529_plan_subtraction: 1_000
+
+- name: Delaware 529 subtraction - joint under cap
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: JOINT
+    investment_in_529_plan_indv: 1_500
+    adjusted_gross_income: 150_000
+  output:
+    # Cap for joint is $2,000, AGI limit $200K
+    # Subtraction = min(1,500, 2,000) = 1,500
+    de_529_plan_subtraction: 1_500
+
+- name: Delaware 529 subtraction - over AGI limit
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 500
+    adjusted_gross_income: 110_000
+  output:
+    # AGI $110K >= $100K limit, not eligible
+    de_529_plan_subtraction: 0
+
+- name: Delaware 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: DE
+    filing_status: SINGLE
+    adjusted_gross_income: 50_000
+  output:
+    de_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/subtractions/plan_529/ia_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/subtractions/plan_529/ia_529_plan_subtraction.yaml
@@ -1,0 +1,51 @@
+- name: Iowa 529 subtraction - under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 3_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap is $5,800 per beneficiary in 2025
+    # Subtraction = min(3,000, 5,800) = 3,000
+    ia_529_plan_subtraction: 3_000
+
+- name: Iowa 529 subtraction - over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 7_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap is $5,800 per beneficiary in 2025
+    # Subtraction = min(7,000, 5,800) = 5,800
+    ia_529_plan_subtraction: 5_800
+
+- name: Iowa 529 subtraction - two beneficiaries
+  period: 2025
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 10_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap is $5,800 * 2 = $11,600
+    # Subtraction = min(10,000, 11,600) = 10,000
+    ia_529_plan_subtraction: 10_000
+
+- name: Iowa 529 subtraction - 2024 cap
+  period: 2024
+  input:
+    state_code: IA
+    investment_in_529_plan_indv: 6_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap is $5,500 per beneficiary in 2024
+    # Subtraction = min(6,000, 5,500) = 5,500
+    ia_529_plan_subtraction: 5_500
+
+- name: Iowa 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: IA
+    filing_status: SINGLE
+  output:
+    ia_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/plan_529/id_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/plan_529/id_529_plan_subtraction.yaml
@@ -1,0 +1,51 @@
+- name: Idaho 529 subtraction - single under cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: SINGLE
+    investment_in_529_plan: 4_000
+  output:
+    # Cap for single is $6,000
+    # Subtraction = min(4,000, 6,000) = 4,000
+    id_529_plan_subtraction: 4_000
+
+- name: Idaho 529 subtraction - single over cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: SINGLE
+    investment_in_529_plan: 8_000
+  output:
+    # Cap for single is $6,000
+    # Subtraction = min(8,000, 6,000) = 6,000
+    id_529_plan_subtraction: 6_000
+
+- name: Idaho 529 subtraction - joint under cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: JOINT
+    investment_in_529_plan: 10_000
+  output:
+    # Cap for joint is $12,000
+    # Subtraction = min(10,000, 12,000) = 10,000
+    id_529_plan_subtraction: 10_000
+
+- name: Idaho 529 subtraction - joint over cap
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: JOINT
+    investment_in_529_plan: 15_000
+  output:
+    # Cap for joint is $12,000
+    # Subtraction = min(15,000, 12,000) = 12,000
+    id_529_plan_subtraction: 12_000
+
+- name: Idaho 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: ID
+    filing_status: SINGLE
+  output:
+    id_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/subtractions/plan_529/il_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/subtractions/plan_529/il_529_plan_subtraction.yaml
@@ -1,0 +1,51 @@
+- name: Illinois 529 subtraction - single under cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: SINGLE
+    investment_in_529_plan: 5_000
+  output:
+    # Cap for single is $10,000
+    # Subtraction = min(5,000, 10,000) = 5,000
+    il_529_plan_subtraction: 5_000
+
+- name: Illinois 529 subtraction - single over cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: SINGLE
+    investment_in_529_plan: 15_000
+  output:
+    # Cap for single is $10,000
+    # Subtraction = min(15,000, 10,000) = 10,000
+    il_529_plan_subtraction: 10_000
+
+- name: Illinois 529 subtraction - joint under cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: JOINT
+    investment_in_529_plan: 15_000
+  output:
+    # Cap for joint is $20,000
+    # Subtraction = min(15,000, 20,000) = 15,000
+    il_529_plan_subtraction: 15_000
+
+- name: Illinois 529 subtraction - joint over cap
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: JOINT
+    investment_in_529_plan: 25_000
+  output:
+    # Cap for joint is $20,000
+    # Subtraction = min(25,000, 20,000) = 20,000
+    il_529_plan_subtraction: 20_000
+
+- name: Illinois 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: IL
+    filing_status: SINGLE
+  output:
+    il_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.yaml
@@ -1,0 +1,62 @@
+- name: Indiana 529 credit - contribution under max credit
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 5_000
+  output:
+    # 20% of $5,000 = $1,000, cap is $1,500
+    # Credit = min(1,000, 1,500) = 1,000
+    in_529_plan_credit: 1_000
+
+- name: Indiana 529 credit - contribution at max credit
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 7_500
+  output:
+    # 20% of $7,500 = $1,500, cap is $1,500
+    # Credit = min(1,500, 1,500) = 1,500
+    in_529_plan_credit: 1_500
+
+- name: Indiana 529 credit - contribution over max credit
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 10_000
+  output:
+    # 20% of $10,000 = $2,000, cap is $1,500
+    # Credit = min(2,000, 1,500) = 1,500
+    in_529_plan_credit: 1_500
+
+- name: Indiana 529 credit - married filing separately
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SEPARATE
+    investment_in_529_plan: 5_000
+  output:
+    # 20% of $5,000 = $1,000, cap for MFS is $750
+    # Credit = min(1,000, 750) = 750
+    in_529_plan_credit: 750
+
+- name: Indiana 529 credit - pre-2023 cap
+  period: 2022
+  input:
+    state_code: IN
+    filing_status: SINGLE
+    investment_in_529_plan: 7_500
+  output:
+    # 20% of $7,500 = $1,500, cap was $1,000 before 2023
+    # Credit = min(1,500, 1,000) = 1,000
+    in_529_plan_credit: 1_000
+
+- name: Indiana 529 credit - no contribution
+  period: 2025
+  input:
+    state_code: IN
+    filing_status: SINGLE
+  output:
+    in_529_plan_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/agi/subtractions/plan_529/ks_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/agi/subtractions/plan_529/ks_529_plan_subtraction.yaml
@@ -1,0 +1,55 @@
+- name: Kansas 529 subtraction - single under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 2_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $3,000 per beneficiary
+    # Subtraction = min(2,000, 3,000) = 2,000
+    ks_529_plan_subtraction: 2_000
+
+- name: Kansas 529 subtraction - single over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 5_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $3,000 per beneficiary
+    # Subtraction = min(5,000, 3,000) = 3,000
+    ks_529_plan_subtraction: 3_000
+
+- name: Kansas 529 subtraction - joint, two beneficiaries
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: JOINT
+    investment_in_529_plan_indv: 10_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap for joint is $6,000 per beneficiary * 2 = $12,000
+    # Subtraction = min(10,000, 12,000) = 10,000
+    ks_529_plan_subtraction: 10_000
+
+- name: Kansas 529 subtraction - joint over cap, two beneficiaries
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: JOINT
+    investment_in_529_plan_indv: 15_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap for joint is $6,000 per beneficiary * 2 = $12,000
+    # Subtraction = min(15,000, 12,000) = 12,000
+    ks_529_plan_subtraction: 12_000
+
+- name: Kansas 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: KS
+    filing_status: SINGLE
+  output:
+    ks_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/deductions/plan_529/la_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/deductions/plan_529/la_529_plan_deduction.yaml
@@ -1,0 +1,43 @@
+- name: Louisiana 529 deduction - single under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 2_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $2,400 per beneficiary
+    # Deduction = min(2,000, 2,400) = 2,000
+    la_529_plan_deduction: 2_000
+
+- name: Louisiana 529 deduction - single over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 3_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Cap for single is $2,400 per beneficiary
+    # Deduction = min(3,000, 2,400) = 2,400
+    la_529_plan_deduction: 2_400
+
+- name: Louisiana 529 deduction - joint, two beneficiaries
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: JOINT
+    investment_in_529_plan_indv: 8_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Cap for joint is $4,800 per beneficiary * 2 = $9,600
+    # Deduction = min(8,000, 9,600) = 8,000
+    la_529_plan_deduction: 8_000
+
+- name: Louisiana 529 deduction - no contribution
+  period: 2025
+  input:
+    state_code: LA
+    filing_status: SINGLE
+  output:
+    la_529_plan_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.yaml
@@ -1,0 +1,41 @@
+- name: Case 1, single filer with contribution below cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MA
+    filing_status: SINGLE
+    investment_in_529_plan: 800
+  output:
+    ma_529_deduction: 800
+
+- name: Case 2, single filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MA
+    filing_status: SINGLE
+    investment_in_529_plan: 3_000
+  output:
+    # Capped at $1,000
+    ma_529_deduction: 1_000
+
+- name: Case 3, joint filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MA
+    filing_status: JOINT
+    investment_in_529_plan: 5_000
+  output:
+    # Capped at $2,000
+    ma_529_deduction: 2_000
+
+- name: Case 4, joint filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MA
+    filing_status: JOINT
+    investment_in_529_plan: 0
+  output:
+    ma_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/md_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/md_529_deduction.yaml
@@ -1,0 +1,45 @@
+- name: Case 1, single filer with contribution below cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MD
+    filing_status: SINGLE
+    investment_in_529_plan: 2_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    md_529_deduction: 2_000
+
+- name: Case 2, single filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MD
+    filing_status: SINGLE
+    investment_in_529_plan: 5_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # Capped at $2,500 per beneficiary * 1 beneficiary = $2,500
+    md_529_deduction: 2_500
+
+- name: Case 3, joint filer with two beneficiaries.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MD
+    filing_status: JOINT
+    investment_in_529_plan: 15_000
+    count_529_contribution_beneficiaries: 2
+  output:
+    # Capped at $5,000 per beneficiary * 2 beneficiaries = $10,000
+    md_529_deduction: 10_000
+
+- name: Case 4, joint filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MD
+    filing_status: JOINT
+    investment_in_529_plan: 0
+    count_529_contribution_beneficiaries: 1
+  output:
+    md_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/agi/subtractions/me_529_plan_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/agi/subtractions/me_529_plan_subtraction.yaml
@@ -1,0 +1,54 @@
+- name: Maine 529 subtraction - under cap, one beneficiary
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 500
+    count_529_contribution_beneficiaries: 1
+    adjusted_gross_income: 80_000
+  output:
+    me_529_plan_subtraction: 500
+
+- name: Maine 529 subtraction - over cap, one beneficiary
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 2_000
+    count_529_contribution_beneficiaries: 1
+    adjusted_gross_income: 80_000
+  output:
+    # Cap is $1,000 per beneficiary
+    me_529_plan_subtraction: 1_000
+
+- name: Maine 529 subtraction - two beneficiaries
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: JOINT
+    investment_in_529_plan_indv: 1_500
+    count_529_contribution_beneficiaries: 2
+    adjusted_gross_income: 150_000
+  output:
+    # Cap is $1,000 * 2 = $2,000
+    me_529_plan_subtraction: 1_500
+
+- name: Maine 529 subtraction - over AGI limit
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 1_000
+    count_529_contribution_beneficiaries: 1
+    adjusted_gross_income: 110_000
+  output:
+    me_529_plan_subtraction: 0
+
+- name: Maine 529 subtraction - no contribution
+  period: 2025
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    adjusted_gross_income: 50_000
+  output:
+    me_529_plan_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/deductions/plan_529_contributions/mi_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/deductions/plan_529_contributions/mi_529_deduction.yaml
@@ -1,0 +1,41 @@
+- name: Case 1, single filer with contribution below cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MI
+    filing_status: SINGLE
+    investment_in_529_plan: 3_000
+  output:
+    mi_529_deduction: 3_000
+
+- name: Case 2, single filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MI
+    filing_status: SINGLE
+    investment_in_529_plan: 8_000
+  output:
+    # Capped at $5,000
+    mi_529_deduction: 5_000
+
+- name: Case 3, joint filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MI
+    filing_status: JOINT
+    investment_in_529_plan: 15_000
+  output:
+    # Capped at $10,000
+    mi_529_deduction: 10_000
+
+- name: Case 4, joint filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MI
+    filing_status: JOINT
+    investment_in_529_plan: 0
+  output:
+    mi_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/subtractions/plan_529_contributions/mo_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/subtractions/plan_529_contributions/mo_529_deduction.yaml
@@ -1,0 +1,41 @@
+- name: Case 1, single filer with contribution below cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 5_000
+  output:
+    mo_529_deduction: 5_000
+
+- name: Case 2, single filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 12_000
+  output:
+    # Capped at $8,000
+    mo_529_deduction: 8_000
+
+- name: Case 3, joint filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MO
+    filing_status: JOINT
+    investment_in_529_plan_indv: 20_000
+  output:
+    # Capped at $16,000
+    mo_529_deduction: 16_000
+
+- name: Case 4, single filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 0
+  output:
+    mo_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/adjustments/plan_529_contributions/ms_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/tax/income/adjustments/plan_529_contributions/ms_529_deduction.yaml
@@ -1,0 +1,41 @@
+- name: Case 1, single filer with contribution below cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MS
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 5_000
+  output:
+    ms_529_deduction: 5_000
+
+- name: Case 2, single filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MS
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 15_000
+  output:
+    # Capped at $10,000
+    ms_529_deduction: 10_000
+
+- name: Case 3, joint filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MS
+    filing_status: JOINT
+    investment_in_529_plan_indv: 25_000
+  output:
+    # Capped at $20,000
+    ms_529_deduction: 20_000
+
+- name: Case 4, single filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MS
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 0
+  output:
+    ms_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/taxable_income/subtractions/plan_529_contributions/nd_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/taxable_income/subtractions/plan_529_contributions/nd_529_deduction.yaml
@@ -1,0 +1,41 @@
+- name: Case 1, single filer with contribution below cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: ND
+    filing_status: SINGLE
+    investment_in_529_plan: 3_000
+  output:
+    nd_529_deduction: 3_000
+
+- name: Case 2, single filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: ND
+    filing_status: SINGLE
+    investment_in_529_plan: 8_000
+  output:
+    # Capped at $5,000
+    nd_529_deduction: 5_000
+
+- name: Case 3, joint filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: ND
+    filing_status: JOINT
+    investment_in_529_plan: 15_000
+  output:
+    # Capped at $10,000
+    nd_529_deduction: 10_000
+
+- name: Case 4, joint filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: ND
+    filing_status: JOINT
+    investment_in_529_plan: 0
+  output:
+    nd_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/agi/subtractions/plan_529_contributions/ne_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/agi/subtractions/plan_529_contributions/ne_529_deduction.yaml
@@ -1,0 +1,41 @@
+- name: Case 1, single filer with contribution below cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NE
+    filing_status: SINGLE
+    investment_in_529_plan: 5_000
+  output:
+    ne_529_deduction: 5_000
+
+- name: Case 2, single filer with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NE
+    filing_status: SINGLE
+    investment_in_529_plan: 15_000
+  output:
+    # Capped at $10,000
+    ne_529_deduction: 10_000
+
+- name: Case 3, married filing separately with contribution above cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NE
+    filing_status: SEPARATE
+    investment_in_529_plan: 8_000
+  output:
+    # MFS capped at $5,000
+    ne_529_deduction: 5_000
+
+- name: Case 4, joint filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NE
+    filing_status: JOINT
+    investment_in_529_plan: 0
+  output:
+    ne_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/deductions/plan_529_contributions/nj_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/deductions/plan_529_contributions/nj_529_deduction.yaml
@@ -1,0 +1,41 @@
+- name: Case 1, filer with contribution below cap and income below limit.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NJ
+    investment_in_529_plan_indv: 5_000
+    employment_income: 100_000
+  output:
+    nj_529_deduction: 5_000
+
+- name: Case 2, filer with contribution above cap and income below limit.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NJ
+    investment_in_529_plan_indv: 15_000
+    employment_income: 100_000
+  output:
+    # Capped at $10,000
+    nj_529_deduction: 10_000
+
+- name: Case 3, filer with income above AGI limit.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NJ
+    investment_in_529_plan_indv: 5_000
+    employment_income: 250_000
+  output:
+    # AGI exceeds $200,000 limit, no deduction
+    nj_529_deduction: 0
+
+- name: Case 4, filer with no contributions.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: NJ
+    investment_in_529_plan_indv: 0
+    employment_income: 100_000
+  output:
+    nj_529_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_529_plan_deduction.yaml
@@ -1,0 +1,44 @@
+- name: Single filer below cap
+  period: 2024
+  input:
+    state_code: OK
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 5_000
+  output:
+    ok_529_plan_deduction: 5_000
+
+- name: Single filer above cap
+  period: 2024
+  input:
+    state_code: OK
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 15_000
+  output:
+    ok_529_plan_deduction: 10_000
+
+- name: Joint filer below cap
+  period: 2024
+  input:
+    state_code: OK
+    filing_status: JOINT
+    investment_in_529_plan_indv: 15_000
+  output:
+    ok_529_plan_deduction: 15_000
+
+- name: Joint filer above cap
+  period: 2024
+  input:
+    state_code: OK
+    filing_status: JOINT
+    investment_in_529_plan_indv: 25_000
+  output:
+    ok_529_plan_deduction: 20_000
+
+- name: Zero contributions
+  period: 2024
+  input:
+    state_code: OK
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 0
+  output:
+    ok_529_plan_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_529_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_529_credit.yaml
@@ -1,0 +1,44 @@
+- name: Single filer contribution below max credit
+  period: 2025
+  input:
+    state_code: OR
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 100
+  output:
+    or_529_credit: 100
+
+- name: Single filer contribution above max credit
+  period: 2025
+  input:
+    state_code: OR
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 500
+  output:
+    or_529_credit: 180
+
+- name: Joint filer contribution above max credit
+  period: 2025
+  input:
+    state_code: OR
+    filing_status: JOINT
+    investment_in_529_plan_indv: 1_000
+  output:
+    or_529_credit: 360
+
+- name: Joint filer contribution below max credit
+  period: 2025
+  input:
+    state_code: OR
+    filing_status: JOINT
+    investment_in_529_plan_indv: 200
+  output:
+    or_529_credit: 200
+
+- name: Zero contributions
+  period: 2025
+  input:
+    state_code: OR
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 0
+  output:
+    or_529_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/deductions/pa_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/deductions/pa_529_plan_deduction.yaml
@@ -1,0 +1,43 @@
+- name: Contribution below cap with one beneficiary
+  period: 2025
+  input:
+    state_code: PA
+    investment_in_529_plan_indv: 10_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    pa_529_plan_deduction: 10_000
+
+- name: Contribution above cap with one beneficiary
+  period: 2025
+  input:
+    state_code: PA
+    investment_in_529_plan_indv: 25_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    pa_529_plan_deduction: 19_000
+
+- name: Two beneficiaries increases the cap
+  period: 2025
+  input:
+    people:
+      person1:
+        investment_in_529_plan_indv: 25_000
+        count_529_contribution_beneficiaries: 2
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: PA
+  output:
+    pa_529_plan_deduction: 25_000
+
+- name: Zero contributions
+  period: 2025
+  input:
+    state_code: PA
+    investment_in_529_plan_indv: 0
+    count_529_contribution_beneficiaries: 0
+  output:
+    pa_529_plan_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_529_plan_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_529_plan_credit.yaml
@@ -1,0 +1,53 @@
+- name: Single filer below cap with one beneficiary
+  period: 2024
+  input:
+    state_code: UT
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 1_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # 1_000 * 0.0455 = 45.50
+    ut_529_plan_credit: 45.50
+
+- name: Single filer above cap with one beneficiary
+  period: 2024
+  input:
+    state_code: UT
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 5_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # 2_410 * 0.0455 = 109.655
+    ut_529_plan_credit: 109.655
+
+- name: Joint filer below cap with one beneficiary
+  period: 2024
+  input:
+    state_code: UT
+    filing_status: JOINT
+    investment_in_529_plan_indv: 3_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # 3_000 * 0.0455 = 136.50
+    ut_529_plan_credit: 136.50
+
+- name: Joint filer above cap with one beneficiary
+  period: 2024
+  input:
+    state_code: UT
+    filing_status: JOINT
+    investment_in_529_plan_indv: 10_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    # 4_820 * 0.0455 = 219.31
+    ut_529_plan_credit: 219.31
+
+- name: Zero contributions
+  period: 2024
+  input:
+    state_code: UT
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 0
+    count_529_contribution_beneficiaries: 0
+  output:
+    ut_529_plan_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/subtractions/va_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/subtractions/va_529_plan_deduction.yaml
@@ -1,0 +1,43 @@
+- name: Contribution below cap with one beneficiary
+  period: 2024
+  input:
+    state_code: VA
+    investment_in_529_plan_indv: 3_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    va_529_plan_deduction: 3_000
+
+- name: Contribution above cap with one beneficiary
+  period: 2024
+  input:
+    state_code: VA
+    investment_in_529_plan_indv: 6_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    va_529_plan_deduction: 4_000
+
+- name: Two beneficiaries increases the cap
+  period: 2024
+  input:
+    people:
+      person1:
+        investment_in_529_plan_indv: 7_000
+        count_529_contribution_beneficiaries: 2
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+  output:
+    va_529_plan_deduction: 7_000
+
+- name: Zero contributions
+  period: 2024
+  input:
+    state_code: VA
+    investment_in_529_plan_indv: 0
+    count_529_contribution_beneficiaries: 0
+  output:
+    va_529_plan_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/vt_529_plan_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/vt_529_plan_credit.yaml
@@ -1,0 +1,48 @@
+- name: Single filer below cap
+  period: 2024
+  input:
+    state_code: VT
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 1_000
+  output:
+    # 1_000 * 0.10 = 100
+    vt_529_plan_credit: 100
+
+- name: Single filer above cap
+  period: 2024
+  input:
+    state_code: VT
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 5_000
+  output:
+    # 2_500 * 0.10 = 250
+    vt_529_plan_credit: 250
+
+- name: Joint filer below cap
+  period: 2024
+  input:
+    state_code: VT
+    filing_status: JOINT
+    investment_in_529_plan_indv: 3_000
+  output:
+    # 3_000 * 0.10 = 300
+    vt_529_plan_credit: 300
+
+- name: Joint filer above cap
+  period: 2024
+  input:
+    state_code: VT
+    filing_status: JOINT
+    investment_in_529_plan_indv: 10_000
+  output:
+    # 5_000 * 0.10 = 500
+    vt_529_plan_credit: 500
+
+- name: Zero contributions
+  period: 2024
+  input:
+    state_code: VT
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 0
+  output:
+    vt_529_plan_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/subtractions/wi_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/subtractions/wi_529_plan_deduction.yaml
@@ -1,0 +1,56 @@
+- name: Single filer below cap with one beneficiary
+  period: 2025
+  input:
+    state_code: WI
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 3_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    wi_529_plan_deduction: 3_000
+
+- name: Single filer above cap with one beneficiary
+  period: 2025
+  input:
+    state_code: WI
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 8_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    wi_529_plan_deduction: 5_130
+
+- name: Married filing separately has lower cap
+  period: 2025
+  input:
+    state_code: WI
+    filing_status: SEPARATE
+    investment_in_529_plan_indv: 5_000
+    count_529_contribution_beneficiaries: 1
+  output:
+    wi_529_plan_deduction: 2_560
+
+- name: Two beneficiaries increases cap
+  period: 2025
+  input:
+    people:
+      person1:
+        investment_in_529_plan_indv: 9_000
+        count_529_contribution_beneficiaries: 2
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: WI
+  output:
+    wi_529_plan_deduction: 9_000
+
+- name: Zero contributions
+  period: 2025
+  input:
+    state_code: WI
+    filing_status: SINGLE
+    investment_in_529_plan_indv: 0
+    count_529_contribution_beneficiaries: 0
+  output:
+    wi_529_plan_deduction: 0

--- a/policyengine_us/variables/gov/states/al/tax/income/deductions/al_deductions.py
+++ b/policyengine_us/variables/gov/states/al/tax/income/deductions/al_deductions.py
@@ -20,4 +20,5 @@ class al_deductions(Variable):
             period,
             ["al_personal_exemption", "al_dependent_exemption"],
         )
-        return al_ded + federal_ded + exemptions
+        plan_529 = tax_unit("al_529_plan_deduction", period)
+        return al_ded + federal_ded + exemptions + plan_529

--- a/policyengine_us/variables/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/al/tax/income/deductions/plan_529/al_529_plan_deduction.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class al_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Alabama deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/alabama/title-16/chapter-33c/section-16-33c-16/",
+        "https://collegecounts529.com/tax-benefits/",
+    )
+    defined_for = StateCode.AL
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.al.tax.income.deductions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/de/tax/income/subtractions/de_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/subtractions/de_529_plan_subtraction.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class de_529_plan_subtraction(Variable):
+    value_type = float
+    entity = Person
+    label = "Delaware subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://delcode.delaware.gov/title30/c011/sc02/index.html",
+        "https://treasurer.delaware.gov/education-savings-plan/",
+    )
+    defined_for = StateCode.DE
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.de.tax.income.subtractions.plan_529
+        contributions = person("investment_in_529_plan_indv", period)
+        filing_status = person.tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        # Income eligibility
+        agi = person.tax_unit("adjusted_gross_income", period)
+        agi_limit = p.agi_limit[filing_status]
+        eligible = agi < agi_limit
+        return eligible * min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ia/tax/income/subtractions/ia_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/subtractions/ia_529_plan_subtraction.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class ia_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Iowa subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.legis.iowa.gov/docs/code/422.7.pdf",
+        "https://www.isave529.com/save/tax-benefits",
+    )
+    defined_for = StateCode.IA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ia.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/id/tax/income/subtractions/id_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/subtractions/id_529_plan_subtraction.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class id_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Idaho subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://tax.idaho.gov/taxes/income-tax/individual-income/popular-credits-and-deductions/ideal-college-savings-program/",
+        "https://www.idsaves.org/home/features-and-benefits/tax-benefits.html",
+    )
+    defined_for = StateCode.ID
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.id.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/il/tax/income/subtractions/il_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/subtractions/il_529_plan_subtraction.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class il_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Illinois subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://tax.illinois.gov/questionsandanswers/answer.206.html",
+        "https://brightstart.com/account/illinois-taxpayer-guide/",
+    )
+    defined_for = StateCode.IL
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.il.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/credits/plan_529/in_529_plan_credit.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class in_529_plan_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Indiana tax credit for contributions to CollegeChoice 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/indiana/title-6/article-3/chapter-3/section-6-3-3-12/",
+        "https://www.in.gov/dor/files/ib98.pdf",
+    )
+    defined_for = StateCode.IN
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states["in"].tax.income.credits.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        credit = contributions * p.rate
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(credit, cap)

--- a/policyengine_us/variables/gov/states/in/tax/income/in_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/in_income_tax_before_refundable_credits.py
@@ -10,4 +10,8 @@ class in_income_tax_before_refundable_credits(Variable):
     reference = "http://iga.in.gov/legislative/laws/2021/ic/titles/6"
     defined_for = StateCode.IN
 
-    adds = ["in_agi_tax", "in_use_tax"]
+    def formula(tax_unit, period, parameters):
+        tax = add(tax_unit, period, ["in_agi_tax", "in_use_tax"])
+        # Non-refundable 529 credit reduces tax to zero but not below
+        credit_529 = tax_unit("in_529_plan_credit", period)
+        return max_(tax - credit_529, 0)

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_529_plan_subtraction.py
@@ -14,9 +14,7 @@ class ks_529_plan_subtraction(Variable):
     defined_for = StateCode.KS
 
     def formula(tax_unit, period, parameters):
-        p = parameters(
-            period
-        ).gov.states.ks.tax.income.agi.subtractions.plan_529
+        p = parameters(period).gov.states.ks.tax.income.agi.subtractions.plan_529
         contributions = tax_unit("investment_in_529_plan", period)
         filing_status = tax_unit("filing_status", period)
         beneficiaries = add(

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_529_plan_subtraction.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class ks_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Kansas subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.kansasstatetreasurer.ks.gov/learn_quest.html",
+        "https://www.ksrevenue.gov/faqs-taxii.html",
+    )
+    defined_for = StateCode.KS
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.ks.tax.income.agi.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap[filing_status] * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
@@ -18,4 +18,5 @@ class ks_agi_subtractions(Variable):
         p = parameters(period).gov.states.ks.tax.income.agi.subtractions
         oasdi_subtraction = where(agi <= p.oasdi.agi_limit, taxable_oasdi, 0)
         us_govt_interest = add(tax_unit, period, ["us_govt_interest"])
-        return oasdi_subtraction + us_govt_interest
+        plan_529 = tax_unit("ks_529_plan_subtraction", period)
+        return oasdi_subtraction + us_govt_interest + plan_529

--- a/policyengine_us/variables/gov/states/la/tax/income/deductions/la_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/deductions/la_529_plan_deduction.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class la_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Louisiana deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.startsaving.la.gov/startfaqs.aspx",
+        "https://law.justia.com/codes/louisiana/revised-statutes/title-47/rs-47-293/",
+    )
+    defined_for = StateCode.LA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.la.tax.income.deductions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap[filing_status] * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/la/tax/income/la_agi.py
+++ b/policyengine_us/variables/gov/states/la/tax/income/la_agi.py
@@ -12,4 +12,5 @@ class la_agi(Variable):
     def formula(tax_unit, period, parameters):
         agi = tax_unit("adjusted_gross_income", period)
         exempt_income = tax_unit("la_agi_exempt_income", period)
-        return max_(agi - exempt_income, 0)
+        plan_529 = tax_unit("la_529_plan_deduction", period)
+        return max_(agi - exempt_income - plan_529, 0)

--- a/policyengine_us/variables/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class ma_529_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Massachusetts 529 plan contribution deduction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section3",
+        "https://www.mass.gov/info-details/529-plan-deduction",
+    )
+    defined_for = StateCode.MA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.ma.tax.income.deductions.plan_529_contributions
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.py
@@ -51,4 +51,12 @@ class ma_part_b_taxable_income_deductions(Variable):
         )
         # (B)(a)(13): Charitable contributions deduction.
         charitable_deduction = tax_unit("charitable_deduction", period)
-        return fica + bank_interest_deduction + rent_deduction + charitable_deduction
+        # (B)(a)(14): 529 plan contribution deduction.
+        plan_529_deduction = tax_unit("ma_529_deduction", period)
+        return (
+            fica
+            + bank_interest_deduction
+            + rent_deduction
+            + charitable_deduction
+            + plan_529_deduction
+        )

--- a/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/md_529_deduction.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/md_529_deduction.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class md_529_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maryland 529 plan contribution subtraction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-208&enession=2024RS",
+        "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=15",
+    )
+    defined_for = StateCode.MD
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.md.tax.income.agi.subtractions.plan_529_contributions
+        contributions = tax_unit("investment_in_529_plan", period)
+        beneficiaries = add(
+            tax_unit, period, ["count_529_contribution_beneficiaries"]
+        )
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status] * max_(beneficiaries, 1)
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/md_529_deduction.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/agi/subtractions/plan_529_contributions/md_529_deduction.py
@@ -18,9 +18,7 @@ class md_529_deduction(Variable):
             period
         ).gov.states.md.tax.income.agi.subtractions.plan_529_contributions
         contributions = tax_unit("investment_in_529_plan", period)
-        beneficiaries = add(
-            tax_unit, period, ["count_529_contribution_beneficiaries"]
-        )
+        beneficiaries = add(tax_unit, period, ["count_529_contribution_beneficiaries"])
         filing_status = tax_unit("filing_status", period)
         cap = p.cap[filing_status] * max_(beneficiaries, 1)
         return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_529_plan_subtraction.py
@@ -14,9 +14,7 @@ class me_529_plan_subtraction(Variable):
     defined_for = StateCode.ME
 
     def formula(tax_unit, period, parameters):
-        p = parameters(
-            period
-        ).gov.states.me.tax.income.agi.subtractions.plan_529
+        p = parameters(period).gov.states.me.tax.income.agi.subtractions.plan_529
         contributions = tax_unit("investment_in_529_plan", period)
         beneficiaries = add(
             tax_unit,

--- a/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_529_plan_subtraction.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_529_plan_subtraction.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class me_529_plan_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maine subtraction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://legislature.maine.gov/legis/bills/getPDF.asp?paper=SP0031&item=5&snum=130",
+        "https://www.nextgenforme.com/maine-state-tax-deduction/",
+    )
+    defined_for = StateCode.ME
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.me.tax.income.agi.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap * beneficiaries
+        # Income eligibility
+        agi = tax_unit("adjusted_gross_income", period)
+        filing_status = tax_unit("filing_status", period)
+        agi_limit = p.agi_limit[filing_status]
+        eligible = agi < agi_limit
+        return eligible * min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/adjusted_gross_income/me_agi_subtractions.py
@@ -15,4 +15,5 @@ class me_agi_subtractions(Variable):
         "tax_unit_taxable_social_security",
         "us_govt_interest",
         "me_pension_income_deduction",
+        "me_529_plan_subtraction",
     ]

--- a/policyengine_us/variables/gov/states/mi/tax/income/deductions/plan_529_contributions/mi_529_deduction.py
+++ b/policyengine_us/variables/gov/states/mi/tax/income/deductions/plan_529_contributions/mi_529_deduction.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class mi_529_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Michigan 529 plan contribution subtraction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "http://legislature.mi.gov/doc.aspx?mcl-206-30",
+        "https://www.michigan.gov/taxes/-/media/Project/Websites/taxes/Forms/IIT/TY2024/MI-1040-Instructions.pdf#page=13",
+    )
+    defined_for = StateCode.MI
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.mi.tax.income.deductions.plan_529_contributions
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/mo/tax/income/subtractions/plan_529_contributions/mo_529_deduction.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/subtractions/plan_529_contributions/mo_529_deduction.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class mo_529_deduction(Variable):
+    value_type = float
+    entity = Person
+    label = "Missouri 529 plan contribution subtraction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revisor.mo.gov/main/OneSection.aspx?section=143.121",
+        "https://dor.mo.gov/forms/MO-1040%20Instructions_2025.pdf#page=12",
+    )
+    defined_for = StateCode.MO
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.mo.tax.income.subtractions.plan_529_contributions
+        # Get the TaxUnit-level deduction cap
+        filing_status = person.tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        total_contributions = person.tax_unit("investment_in_529_plan", period)
+        unit_deduction = min_(total_contributions, cap)
+        # Allocate proportionally to each person
+        person_contributions = person("investment_in_529_plan_indv", period)
+        total = person.tax_unit.sum(person_contributions)
+        share = np.zeros_like(total)
+        mask = total != 0
+        share[mask] = person_contributions[mask] / total[mask]
+        return share * unit_deduction

--- a/policyengine_us/variables/gov/states/ms/tax/income/adjustments/plan_529_contributions/ms_529_deduction.py
+++ b/policyengine_us/variables/gov/states/ms/tax/income/adjustments/plan_529_contributions/ms_529_deduction.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class ms_529_deduction(Variable):
+    value_type = float
+    entity = Person
+    label = "Mississippi 529 plan contribution adjustment"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/mississippi/2022/title-27/chapter-7/article-1/section-27-7-18/",
+        "https://www.dor.ms.gov/sites/default/files/tax-forms/individual/80100251%202.pdf#page=12",
+    )
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.ms.tax.income.adjustments.plan_529_contributions
+        # Get the TaxUnit-level deduction cap
+        filing_status = person.tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        total_contributions = person.tax_unit("investment_in_529_plan", period)
+        unit_deduction = min_(total_contributions, cap)
+        # Allocate proportionally to each person
+        person_contributions = person("investment_in_529_plan_indv", period)
+        total = person.tax_unit.sum(person_contributions)
+        share = np.zeros_like(total)
+        mask = total != 0
+        share[mask] = person_contributions[mask] / total[mask]
+        return share * unit_deduction

--- a/policyengine_us/variables/gov/states/nd/tax/income/taxable_income/subtractions/plan_529_contributions/nd_529_deduction.py
+++ b/policyengine_us/variables/gov/states/nd/tax/income/taxable_income/subtractions/plan_529_contributions/nd_529_deduction.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class nd_529_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Dakota 529 plan contribution subtraction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/north-dakota/2022/title-57/chapter-57-38/section-57-38-30-3/",
+        "https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2025-iit/2025-individual-income-tax-booklet.pdf#page=14",
+    )
+    defined_for = StateCode.ND
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.nd.tax.income.taxable_income.subtractions.plan_529_contributions
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ne/tax/income/agi/subtractions/plan_529_contributions/ne_529_deduction.py
+++ b/policyengine_us/variables/gov/states/ne/tax/income/agi/subtractions/plan_529_contributions/ne_529_deduction.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class ne_529_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Nebraska 529 plan contribution subtraction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.nebraskalegislature.gov/laws/statutes.php?statute=77-2716",
+        "https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_Individual_Income_Tax_Booklet.pdf#page=26",
+    )
+    defined_for = StateCode.NE
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.ne.tax.income.agi.subtractions.plan_529_contributions
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/nj/tax/income/deductions/plan_529_contributions/nj_529_deduction.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/deductions/plan_529_contributions/nj_529_deduction.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class nj_529_deduction(Variable):
+    value_type = float
+    entity = Person
+    label = "New Jersey 529 plan contribution deduction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.njleg.state.nj.us/bill-search/2020/A5535",
+        "https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf",
+    )
+    defined_for = StateCode.NJ
+
+    def formula(person, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.nj.tax.income.deductions.plan_529_contributions
+        # Check AGI income limit
+        agi = person.tax_unit("adjusted_gross_income", period)
+        income_eligible = agi <= p.income_limit
+        # Get the TaxUnit-level deduction cap
+        total_contributions = person.tax_unit("investment_in_529_plan", period)
+        unit_deduction = min_(total_contributions, p.cap)
+        # Allocate proportionally to each person
+        person_contributions = person("investment_in_529_plan_indv", period)
+        total = person.tax_unit.sum(person_contributions)
+        share = np.zeros_like(total)
+        mask = total != 0
+        share[mask] = person_contributions[mask] / total[mask]
+        return where(income_eligible, share * unit_deduction, 0)

--- a/policyengine_us/variables/gov/states/ok/tax/income/ok_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/ok_529_plan_deduction.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class ok_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Oklahoma deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.oklahoma529.com/resources/faq/",
+        "https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/current/511-Pkt.pdf#page=16",
+    )
+    defined_for = StateCode.OK
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.ok.tax.income.agi.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ok/tax/income/ok_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/ok_529_plan_deduction.py
@@ -14,9 +14,7 @@ class ok_529_plan_deduction(Variable):
     defined_for = StateCode.OK
 
     def formula(tax_unit, period, parameters):
-        p = parameters(
-            period
-        ).gov.states.ok.tax.income.agi.subtractions.plan_529
+        p = parameters(period).gov.states.ok.tax.income.agi.subtractions.plan_529
         contributions = tax_unit("investment_in_529_plan", period)
         filing_status = tax_unit("filing_status", period)
         cap = p.cap[filing_status]

--- a/policyengine_us/variables/gov/states/or/tax/income/credits/or_529_credit.py
+++ b/policyengine_us/variables/gov/states/or/tax/income/credits/or_529_credit.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class or_529_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Oregon 529 plan contribution credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.oregon.gov/dor/programs/individuals/pages/credits.aspx",
+        "https://oregon.public.law/statutes/ors_315.643",
+    )
+    defined_for = StateCode.OR
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states["or"].tax.income.credits.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        max_credit = p.max_credit[filing_status]
+        return min_(contributions, max_credit)

--- a/policyengine_us/variables/gov/states/pa/tax/income/deductions/pa_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/deductions/pa_529_plan_deduction.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class pa_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Pennsylvania deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://revenue-pa.custhelp.com/app/answers/detail/a_id/2208/~/what-is-the-limit-on-a-deduction-to-a-529-plan",
+        "https://www.pa529.com/faqs/",
+    )
+    defined_for = StateCode.PA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.pa.tax.income.deductions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/pa/tax/income/deductions/pa_tax_deductions.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/deductions/pa_tax_deductions.py
@@ -1,6 +1,7 @@
 from policyengine_us.model_api import *
 
 # PA law does not allow standard deductions, deductions for personal exemptions, itemized deductions or deductions for personal expenses.
+# However, PA does allow deductions for 529 plan contributions.
 
 
 class pa_tax_deductions(Variable):
@@ -11,3 +12,5 @@ class pa_tax_deductions(Variable):
     definition_period = YEAR
     reference = "https://www.revenue.pa.gov/FormsandPublications/FormsforIndividuals/PIT/Documents/2021/2021_pa-40in.pdf#page=20"
     defined_for = StateCode.PA
+
+    adds = ["pa_529_plan_deduction"]

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_529_plan_credit.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/ut_529_plan_credit.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class ut_529_plan_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Utah 529 plan contribution tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://my529.org/utah-state-tax-benefits-information/",
+        "https://incometax.utah.gov/credits/my529",
+    )
+    defined_for = StateCode.UT
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ut.tax.income.credits.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap[filing_status] * beneficiaries
+        eligible_contributions = min_(contributions, cap)
+        return eligible_contributions * p.rate

--- a/policyengine_us/variables/gov/states/va/tax/income/subtractions/va_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/va/tax/income/subtractions/va_529_plan_deduction.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class va_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Virginia deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.tax.virginia.gov/deductions",
+        "https://law.lis.virginia.gov/vacodefull/title58.1/chapter3/article2/",
+    )
+    defined_for = StateCode.VA
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.va.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap * beneficiaries
+        return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/vt/tax/income/credits/vt_529_plan_credit.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/credits/vt_529_plan_credit.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class vt_529_plan_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Vermont 529 plan contribution tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://tax.vermont.gov/individuals/personal-income-tax/tax-credits",
+        "https://vt529.org/benefits",
+    )
+    defined_for = StateCode.VT
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.vt.tax.income.credits.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        cap = p.cap[filing_status]
+        eligible_contributions = min_(contributions, cap)
+        return eligible_contributions * p.rate

--- a/policyengine_us/variables/gov/states/vt/tax/income/vt_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/vt_non_refundable_credits.py
@@ -8,3 +8,5 @@ class vt_non_refundable_credits(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.VT
+
+    adds = "gov.states.vt.tax.income.credits.non_refundable"

--- a/policyengine_us/variables/gov/states/wi/tax/income/subtractions/wi_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/subtractions/wi_529_plan_deduction.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class wi_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Wisconsin deduction for contributions to 529 plans"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.edvest.com/learn/tax-benefits/",
+        "https://dfi.wi.gov/Pages/EducationalServices/CollegeSavingsCareerPlanning/CollegeSavingsProgram.aspx",
+    )
+    defined_for = StateCode.WI
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.wi.tax.income.subtractions.plan_529
+        contributions = tax_unit("investment_in_529_plan", period)
+        filing_status = tax_unit("filing_status", period)
+        beneficiaries = add(
+            tax_unit,
+            period,
+            ["count_529_contribution_beneficiaries"],
+        )
+        cap = p.cap[filing_status] * beneficiaries
+        return min_(contributions, cap)


### PR DESCRIPTION
## Summary

Revives and bundles three closed/stalled 529 plan contribution PRs into a single PR against fresh `main`, covering 24 states.

Supersedes:
- #7676 (closed, conflicts): MD, MA, MI, MS, MO, NE, NJ, ND
- #7675 (open, conflicts): AL, DE, ID, IL, IN, IA, KS, LA, ME
- #7672 (closed, conflicts): OK, OR, PA, UT, VA, VT, WI (+ VA cap fix)

All cherry-picked cleanly onto `upstream/main` with two small conflict resolutions (MA Part B deduction sum, WI subtractions source list). Applied `ruff format` and consolidated three per-batch changelog fragments into one.

## States covered

**529 contribution deductions (20 states):**
AL, DE, IA, ID, IL, KS, LA, MA, MD, ME, MI, MO, MS, ND, NE, NJ, OK, PA, VA, WI.

**529 contribution credits (4 states):**
IN, OR, UT, VT.

Also includes a VA 529 cap fix carried over from #7672.

## Test plan

- [x] Ran targeted state test suites for all 24 affected states; all pass:
  - Batch 2 (MD, MA, MI, MS, MO, NE, NJ, ND): all green
  - Batch 1 (AL, DE, ID, IL, IN, IA, KS, LA, ME): all green
  - Batch 3 (OK, OR, PA, UT, VA, VT, WI): all green
- [x] `ruff format` applied.
- [ ] CI to verify full suite.
