### PR TITLE
Fix additional_tax_bracket breakdown range

### DIFF
--- a/changelog.d/fix-additional-bracket-breakdown.fixed.md
+++ b/changelog.d/fix-additional-bracket-breakdown.fixed.md
@@ -1,0 +1,1 @@
+Fix breakdown range in `gov.contrib.additional_tax_bracket.bracket` — parameter has children `1-8` (the contrib adds an 8th bracket) but breakdown was `range(1, 8)` = `[1..7]`, omitting the 8th child. Update to `range(1, 9)`. This was previously a warning in policyengine-core but became an error in core 3.24.0, breaking parameter load at import time.

--- a/policyengine_us/parameters/gov/contrib/additional_tax_bracket/bracket.yaml
+++ b/policyengine_us/parameters/gov/contrib/additional_tax_bracket/bracket.yaml
@@ -5,7 +5,7 @@ rates:
     unit: /1
     propagate_metadata_to_children: true
     breakdown:
-      - range(1, 8)
+      - range(1, 9)
     breakdown_labels:
       - Bracket
     label: Individual income tax rates
@@ -42,7 +42,7 @@ thresholds:
     unit: currency-USD
     label: Individual income tax rate thresholds
     breakdown:
-      - range(1, 8)
+      - range(1, 9)
       - filing_status
     breakdown_labels:
       - Bracket


### PR DESCRIPTION
## Summary

`gov.contrib.additional_tax_bracket.bracket.rates` and `.thresholds` have children `1` through `8` (the contrib adds an 8th bracket above the federal 7), but the breakdown metadata was `range(1, 8)` which is `[1..7]` — missing the 8th child.

In `policyengine-core <= 3.23.6` this emitted a warning and init proceeded. `policyengine-core 3.24.0` (PR PolicyEngine/policyengine-core#449, just published) upgraded the mismatch to an error, so any install resolving to the new core fails at `CountryTaxBenefitSystem()` with:

```
ValueError: Parameter gov.contrib.additional_tax_bracket.bracket.rates has children ['8'] that are not in the possible values of the breakdown variable 'range(1, 8)'
```

Fix: bump the breakdown to `range(1, 9)` so the range actually includes bracket 8.

## Test plan

- [x] `range(1, 9)` = `[1,2,3,4,5,6,7,8]` matches the children present
- [ ] CI passes (the `Install + smoke-import` job on py3.11+ will now resolve to core 3.24.0 and exercise the strict validator; this fix is what makes that green)
