### PR TITLE
Exempt US government bond interest from state income tax (IA, ID, IL, IN, KS, KY, LA, MA, MD, MI)

### DIFF
--- a/changelog.d/revive-state-bond-interest-exemption.added.md
+++ b/changelog.d/revive-state-bond-interest-exemption.added.md
@@ -1,0 +1,1 @@
+Add US government bond interest exemption for IA, ID, IL, IN, KS, KY, LA, MA, MD, MI.

--- a/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
@@ -1,6 +1,7 @@
 description: Illinois Base Income Subtraction Sources
 values:
   2021-01-01:
+    - us_govt_interest
     - taxable_social_security
     - taxable_pension_income
     - il_schedule_m_subtractions

--- a/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
@@ -1,11 +1,13 @@
 description: Maryland subtracts the following sources from federal adjusted gross income.
 values:
   2021-01-01:
+    - us_govt_interest
     - md_dependent_care_subtraction
     - md_pension_subtraction
     - md_socsec_subtraction
     - md_two_income_subtraction
   2022-01-01:
+    - us_govt_interest
     - md_dependent_care_subtraction
     - md_pension_subtraction
     - md_socsec_subtraction

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/consolidated/taxable_income/ia_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/consolidated/taxable_income/ia_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Iowa subtracts US government bond interest from taxable income
+  period: 2024
+  input:
+    us_govt_interest: 1_000
+    state_code: IA
+  output:
+    ia_subtractions_consolidated: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/id_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/subtractions/id_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Idaho subtracts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: ID
+  output:
+    id_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/income/il_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/income/il_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Illinois subtracts US government bond interest from base income
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: IL
+  output:
+    il_base_income_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_us_govt_interest_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_us_govt_interest_deduction.yaml
@@ -1,0 +1,7 @@
+- name: Indiana deducts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: IN
+  output:
+    in_deductions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_us_govt_interest_subtraction.yaml
@@ -1,0 +1,10 @@
+- name: Kansas subtracts US government bond interest from AGI
+  period: 2022
+  input:
+    adjusted_gross_income: 80_000
+    us_govt_interest: 1_000
+    state_code: KS
+  output:
+    # AGI exceeds OASDI limit so social security is not subtracted,
+    # but US government bond interest is still subtracted.
+    ks_agi_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/ky_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/tax/income/ky_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Kentucky subtracts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest_person: 1_000
+    state_code: KY
+  output:
+    ky_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/exempt_income/la_us_govt_interest_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/exempt_income/la_us_govt_interest_exemption.yaml
@@ -1,0 +1,7 @@
+- name: Louisiana exempts US government bond interest from AGI
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: LA
+  output:
+    la_agi_exempt_income: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_us_govt_interest_subtraction.yaml
@@ -1,0 +1,8 @@
+- name: Massachusetts subtracts US government bond interest from Part B AGI
+  period: 2022
+  input:
+    employment_income: 50_000
+    us_govt_interest: 1_000
+    state_code: MA
+  output:
+    ma_part_b_agi: 49_000

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/agi/md_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/agi/md_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Maryland subtracts US government bond interest from AGI
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: MD
+  output:
+    md_total_subtractions: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_us_govt_interest_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_us_govt_interest_subtraction.yaml
@@ -1,0 +1,7 @@
+- name: Michigan subtracts US government bond interest
+  period: 2022
+  input:
+    us_govt_interest: 1_000
+    state_code: MI
+  output:
+    mi_subtractions: 1_000

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_agi_subtractions.py
@@ -16,4 +16,6 @@ class ks_agi_subtractions(Variable):
         agi = tax_unit("adjusted_gross_income", period)
         taxable_oasdi = add(tax_unit, period, ["taxable_social_security"])
         p = parameters(period).gov.states.ks.tax.income.agi.subtractions
-        return where(agi <= p.oasdi.agi_limit, taxable_oasdi, 0)
+        oasdi_subtraction = where(agi <= p.oasdi.agi_limit, taxable_oasdi, 0)
+        us_govt_interest = add(tax_unit, period, ["us_govt_interest"])
+        return oasdi_subtraction + us_govt_interest

--- a/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/adjusted_gross_income/ma_part_b_agi.py
@@ -12,13 +12,18 @@ class ma_part_b_agi(Variable):
 
     def formula(tax_unit, period, parameters):
         part_b_gross_income = tax_unit("ma_part_b_gross_income", period)
-        parameters = parameters(period).gov
-        federal_deductions = parameters.irs.ald.deductions
-        disallowed_deductions = parameters.states.ma.tax.income.ald.disallowed
+        p = parameters(period).gov
+        federal_deductions = p.irs.ald.deductions
+        disallowed_deductions = p.states.ma.tax.income.ald.disallowed
         deductions = [
             deduction
             for deduction in federal_deductions
             if deduction not in disallowed_deductions
         ]
         deduction_value = add(tax_unit, period, deductions)
-        return max_(0, part_b_gross_income - deduction_value)
+        # U.S. government bond interest is exempt from MA tax.
+        us_govt_interest = add(tax_unit, period, ["us_govt_interest"])
+        return max_(
+            0,
+            part_b_gross_income - deduction_value - us_govt_interest,
+        )


### PR DESCRIPTION
## Summary

Revives #7673 (closed) as part of a series covering US government bond interest exemption across state income taxes. This PR completes coverage for 10 states: IA, ID, IL, IN, KS, KY, LA, MA, MD, MI.

- Adds `us_govt_interest` to subtraction/deduction parameter lists for **IL, KS, MA, MD** (code changes required)
- Adds YAML test cases for all 10 states, including **IA, ID, IN, KY, LA, MI** (which already had the exemption implemented upstream but lacked tests)
- Companion to merged PRs #7667 (AL, AR, CA, DC, DE), #7666 (MO, MS, NE, NJ, OH), and #7670 (OR, PA, UT, WI)

Federal law (31 U.S.C. 3124) prohibits states from taxing interest on US government obligations.

## Test plan

- [x] `policyengine-core test` passes for all 10 state YAML test files
- [x] `ruff format` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
