### PR TITLE
Fix 8 parameter breakdown range mismatches

### DIFF
--- a/changelog.d/fix-breakdown-mismatches.fixed.md
+++ b/changelog.d/fix-breakdown-mismatches.fixed.md
@@ -1,0 +1,1 @@
+Fix eight parameter breakdown ranges that declared fewer (or different) children than the parameter actually had. These were silently mismatched until core 3.24.0 upgraded the mismatch from a warning to an error.

--- a/policyengine_us/parameters/gov/irs/income/bracket.yaml
+++ b/policyengine_us/parameters/gov/irs/income/bracket.yaml
@@ -34,7 +34,7 @@ thresholds:
     unit: currency-USD
     label: Individual income tax rate thresholds
     breakdown:
-      - range(1, 7)
+      - range(1, 8)
       - filing_status
     breakdown_labels:
       - Bracket

--- a/policyengine_us/parameters/gov/states/ma/eec/ccfa/copay/fee_level/fee_percentages.yaml
+++ b/policyengine_us/parameters/gov/states/ma/eec/ccfa/copay/fee_level/fee_percentages.yaml
@@ -4,7 +4,7 @@ metadata:
   unit: /1
   label: Massachusetts CCFA fee percentage by fee level
   breakdown:
-    - range(1,29)
+    - range(0,29)
   breakdown_labels:
     - Fee level
   reference:

--- a/policyengine_us/parameters/gov/states/ma/eec/ccfa/copay/fee_level/income_ratio_increments.yaml
+++ b/policyengine_us/parameters/gov/states/ma/eec/ccfa/copay/fee_level/income_ratio_increments.yaml
@@ -4,7 +4,7 @@ metadata:
   unit: /1
   label: Massachusetts CCFA income ratio increments by household size
   breakdown:
-    - range(1,13)
+    - range(0,13)
   breakdown_labels:
     - Household size
   reference:

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/senior_tax/amount/joint.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/senior_tax/amount/joint.yaml
@@ -15,7 +15,7 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-    - range(0,2)
+    - range(0,3)
   breakdown_labels:
     - Number of aged people
 1:

--- a/policyengine_us/parameters/gov/states/nd/dhs/tanf/benefit/standard_of_need.yaml
+++ b/policyengine_us/parameters/gov/states/nd/dhs/tanf/benefit/standard_of_need.yaml
@@ -4,7 +4,7 @@ metadata:
   unit: currency-USD
   period: month
   breakdown:
-    - range(1, 3)
+    - range(0, 3)
     - range(1, 11)
   breakdown_label:
     - Number of caretakers

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/wfhdc/match.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/wfhdc/match.yaml
@@ -3,7 +3,7 @@ metadata:
   unit: /1
   period: year
   breakdown:
-  - list(range(0,30))
+  - list(range(0,31))
   - or_wfhdc_eligibility_category
   breakdown_labels:
   - FPL bracket

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/fifty_percent.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/fifty_percent.yaml
@@ -3,7 +3,7 @@ metadata:
   unit: /1
   period: year
   breakdown:
-  - list(range(1,8))
+  - list(range(1,9))
   breakdown_labels:
   - Household size
   label: Vermont partial renter credit income limit

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/thirty_percent.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/renter/income_limit_ami/thirty_percent.yaml
@@ -3,7 +3,7 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-  - list(range(1,8))
+  - list(range(1,9))
   breakdown_labels:
   - Household size
   label: Vermont full renter credit income limit


### PR DESCRIPTION
## Summary

Eight parameter breakdown ranges declared fewer (or offset) children than the parameter actually had. These were silent warnings under `policyengine-core <= 3.23.6`; core 3.24.0 (PolicyEngine/policyengine-core#449) upgraded the mismatch to a hard error, so installing `policyengine-us` with the newer core now breaks `CountryTaxBenefitSystem()` at import time.

## Fixes

All 8 are one-line YAML changes extending the range to include all existing children — no data change, just making the breakdown declaration match reality:

| File | Old → New |
|---|---|
| `gov/irs/income/bracket.yaml` (thresholds) | `range(1,7)` → `range(1,8)` |
| `gov/states/or/tax/income/credits/wfhdc/match.yaml` | `list(range(0,30))` → `list(range(0,31))` |
| `gov/states/md/tax/income/credits/senior_tax/amount/joint.yaml` | `range(0,2)` → `range(0,3)` |
| `gov/states/nd/dhs/tanf/benefit/standard_of_need.yaml` | `range(1,3)` → `range(0,3)` |
| `gov/states/ma/eec/ccfa/copay/fee_level/fee_percentages.yaml` | `range(1,29)` → `range(0,29)` |
| `gov/states/ma/eec/ccfa/copay/fee_level/income_ratio_increments.yaml` | `range(1,13)` → `range(0,13)` |
| `gov/states/vt/.../renter/income_limit_ami/fifty_percent.yaml` | `list(range(1,8))` → `list(range(1,9))` |
| `gov/states/vt/.../renter/income_limit_ami/thirty_percent.yaml` | `list(range(1,8))` → `list(range(1,9))` |

## Test plan

- [x] Audit script confirms zero remaining breakdown/child mismatches across `policyengine_us/parameters/**.yaml`
- [ ] CI: Full Suite should be green (the test suite was already exercising these parameters; this just stops the strict validator from aborting init)
