### PR TITLE
Implement IRC § 461(l) excess business loss limitation

### DIFF
--- a/changelog.d/revive-section-461l-ebl.added.md
+++ b/changelog.d/revive-section-461l-ebl.added.md
@@ -1,0 +1,1 @@
+Implement the IRC § 461(l) excess business loss limitation, applying it to self-employment, farm, rental, estate/trust, partnership/S-corp, and Form 4797 other net gain losses. Treat capital losses separately under the Section 1211 limit. Extend the limitation permanently for 2027 onwards per OBBBA § 70601.

--- a/policyengine_us/parameters/gov/irs/ald/loss/max.yaml
+++ b/policyengine_us/parameters/gov/irs/ald/loss/max.yaml
@@ -8,6 +8,8 @@ metadata:
   reference:
     - title: 26 U.S. Code § 461 - General rule for taxable year of deduction (l)(3)(A)(ii)(II)
       href: https://www.law.cornell.edu/uscode/text/26/461#l_3_A_ii_II
+    - title: OBBBA § 70601 - Permanent extension of limitation on excess business losses of noncorporate taxpayers
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1/text
     - title: 2024 IRS data release
       href: https://www.irs.gov/pub/irs-drop/rp-23-34.pdf#page=20
     - title: 2023 IRS data release
@@ -29,7 +31,6 @@ HEAD_OF_HOUSEHOLD:
     2022-01-01: 270_000
     2023-01-01: 289_000
     2024-01-01: 305_000
-    2027-01-01: .inf
 JOINT:
   values:
     2013-01-01: .inf
@@ -40,7 +41,6 @@ JOINT:
     2022-01-01: 540_000
     2023-01-01: 578_000
     2024-01-01: 610_000
-    2027-01-01: .inf
 SEPARATE:
   values:
     2013-01-01: .inf
@@ -51,7 +51,6 @@ SEPARATE:
     2022-01-01: 270_000
     2023-01-01: 289_000
     2024-01-01: 305_000
-    2027-01-01: .inf
 SINGLE:
   values:
     2013-01-01: .inf
@@ -62,7 +61,6 @@ SINGLE:
     2022-01-01: 270_000
     2023-01-01: 289_000
     2024-01-01: 305_000
-    2027-01-01: .inf
 SURVIVING_SPOUSE:
   values:
     2013-01-01: .inf
@@ -73,4 +71,3 @@ SURVIVING_SPOUSE:
     2022-01-01: 540_000
     2023-01-01: 578_000
     2024-01-01: 610_000
-    2027-01-01: .inf

--- a/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
+++ b/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
@@ -5,8 +5,9 @@ values:
     - self_employment_income
     - sstb_self_employment_income
     - partnership_s_corp_income
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
+    - other_net_gain_gross_income
     - capital_gains
     - taxable_interest_income
     - rental_income

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.yaml
@@ -1,0 +1,314 @@
+# Tests for Section 461(l) excess business loss limitation
+# Reference: https://www.law.cornell.edu/uscode/text/26/461#l
+
+- name: S-corp loss with Section 461(l) limitation (from issue #7015)
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 26
+        partnership_s_corp_income: -419_487
+        short_term_capital_gains: -111_233
+        long_term_capital_gains: -1_187
+        taxable_interest_income: 10
+        is_tax_unit_head: true
+      person2:
+        age: 27
+        employment_income: 82_813
+        partnership_s_corp_income: -419_487
+        short_term_capital_gains: -111_233
+        long_term_capital_gains: -1_187
+        taxable_interest_income: 10
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: RI
+  output:
+    # Total S-corp loss: -838,974
+    # Section 461(l) threshold for MFJ 2024: $610,000
+    # Limited business loss: $610,000
+    # Capital losses: 224,840 (111,233 + 1,187) * 2 = 224,840
+    # Limited capital loss: $3,000 (Section 1211 limit)
+    # Total loss_ald: 610,000 + 3,000 = 613,000
+    # Gross income: 82,813 + 20 (interest) = 82,833
+    # AGI: 82,833 - 613,000 = -530,167
+    loss_ald: 613_000
+    adjusted_gross_income: -530_167
+
+- name: Self-employment loss under Section 461(l) threshold - single filer
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        self_employment_income: -100_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Business loss: $100,000
+    # 461(l) threshold for single 2024: $305,000
+    # Loss is under threshold, so full deduction
+    loss_ald: 100_000
+
+- name: Combined SE and S-corp loss exceeding Section 461(l) threshold
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        self_employment_income: -200_000
+        partnership_s_corp_income: -200_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Total business loss: $400,000
+    # 461(l) threshold for single 2024: $305,000
+    # Limited to threshold
+    loss_ald: 305_000
+
+- name: Business income offsets business losses before Section 461(l) cap
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        self_employment_income: -500_000
+        partnership_s_corp_income: 300_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Business income: $300,000
+    # Business loss: $500,000
+    # 461(l) threshold for single 2024: $305,000
+    # Max deductible business loss: 300,000 + 305,000 = 605,000
+    # Full $500,000 loss is deductible
+    loss_ald: 500_000
+    adjusted_gross_income: -200_000
+
+- name: Business losses plus capital losses - limits apply separately
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        self_employment_income: -400_000
+        short_term_capital_gains: -50_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Business loss: $400,000
+    # 461(l) threshold for single 2024: $305,000
+    # Limited business loss: $305,000
+    # Capital loss: $50,000
+    # Limited capital loss: $3,000 (Section 1211)
+    # Total: $305,000 + $3,000 = $308,000
+    loss_ald: 308_000
+    limited_capital_loss: 3_000
+
+- name: Farm loss is subject to Section 461(l) limitation
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        farm_operations_income: -500_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Farm loss: $500,000
+    # 461(l) threshold for single 2024: $305,000
+    # Limited to threshold
+    loss_ald: 305_000
+    adjusted_gross_income: -305_000
+
+- name: Qualified rental loss is subject to Section 461(l) limitation
+  # Schedule E rental losses are included in the Section 461(l) bucket.
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        rental_income: -500_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Qualified rental loss: $500,000
+    # 461(l) threshold for single 2024: $305,000
+    # Limited to threshold
+    loss_ald: 305_000
+    adjusted_gross_income: -305_000
+
+- name: Estate loss is subject to Section 461(l) limitation
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        estate_income: -500_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Estate/trust loss: $500,000
+    # 461(l) threshold for single 2024: $305,000
+    # Limited to threshold
+    loss_ald: 305_000
+    adjusted_gross_income: -305_000
+
+- name: Other net gain offsets business losses before Section 461(l) cap
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        self_employment_income: -500_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        other_net_gain: 300_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # Business loss: $500,000
+    # Other net gain: $300,000
+    # 461(l) threshold for single 2024: $305,000
+    # Max deductible business loss: 300,000 + 305,000 = 605,000
+    # Full loss is deductible, and the gain is included in gross income.
+    loss_ald: 500_000
+    adjusted_gross_income: -200_000
+
+- name: MFJ gets higher Section 461(l) threshold
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        partnership_s_corp_income: -500_000
+        is_tax_unit_head: true
+      person2:
+        age: 38
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    # Business loss: $500,000
+    # 461(l) threshold for MFJ 2024: $610,000
+    # Under threshold, so full deduction
+    loss_ald: 500_000
+
+- name: Section 461(l) remains in effect in 2027 under OBBBA (permanent)
+  # OBBBA § 70601 made the excess business loss limitation permanent.
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    people:
+      person1:
+        age: 40
+        partnership_s_corp_income: -1_000_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # 461(l) threshold carries forward from 2024 ($305,000 single) under OBBBA.
+    loss_ald: 305_000

--- a/policyengine_us/tests/policy/baseline/gov/irs/irs_gross_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/irs_gross_income.yaml
@@ -8,6 +8,26 @@
   output:
     irs_gross_income: 1 + 2 + 3 + 4
 
+- name: IRS gross income includes farm operations income.
+  period: 2022
+  input:
+    farm_operations_income: 100
+  output:
+    irs_gross_income: 100
+
+- name: IRS gross income includes positive other net gain.
+  period: 2022
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        other_net_gain: 100
+  output:
+    irs_gross_income: 100
+
 - name: Tax unit with tax-exempt pension income as sole income source.
   absolute_error_margin: 0.01
   period: 2021

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_self_employment_loss_addition.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_self_employment_loss_addition.yaml
@@ -53,10 +53,12 @@
     state_code: DC
   output:
     # limited_capital_loss = min(3_000, 5_000) = 3_000
-    # loss_ald = min(305_000, 25_000_000 + 3_000) = 305_000
-    # SE portion of loss_ald: 305_000 - 3_000 = 302_000
-    # DC addition: max(0, 302_000 - 12_000) = 290_000
-    dc_self_employment_loss_addition: 290_000
+    # Section 461(l) caps the business-loss portion at 305,000.
+    # Capital losses are capped separately under Section 1211 and added on top.
+    # loss_ald = 305_000 + 3_000 = 308_000
+    # SE portion of loss_ald: 308_000 - 3_000 = 305_000
+    # DC addition: max(0, 305_000 - 12_000) = 293_000
+    dc_self_employment_loss_addition: 293_000
 
 - name: Case 7, SE loss exactly at DC threshold.
   absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_household_resources.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_household_resources.yaml
@@ -62,8 +62,10 @@
     state_code: MI
   output:
     # Per MI-1040CR-7 Line 22: "If negative, enter 0"
-    # Rental income floored at 0, so only employment income counts
-    mi_household_resources: 50_000
+    # Rental income floored at 0 for the MI source line,
+    # but federal above_the_line_deductions includes loss_ald of 30,000.
+    # Total: 50,000 - 30,000 = 20,000
+    mi_household_resources: 20_000
 
 - name: Large capital gains loss limited to 3000
   period: 2024

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/heptc/wv_homestead_excess_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/heptc/wv_homestead_excess_property_tax_credit.yaml
@@ -70,5 +70,13 @@
         members: [person1, person2]
         state_fips: 54
   output:
-    adjusted_gross_income: -3_000
+    # AGI calculation with Section 461(l):
+    # - Partnership/S-corp loss: 2 * 727,887.75 = 1,455,775.50
+    # - Limited by Section 461(l) for MFJ: $610,000
+    # - Capital loss: 2 * 896,056.95 = 1,792,113.90
+    # - Limited by Section 1211: $3,000
+    # - Gross income: ~$0.02 (interest only)
+    # - loss_ald = 610,000 + 3,000 = 613,000
+    # - AGI = 0 - 613,000 = -613,000
+    adjusted_gross_income: -613_000
     wv_homestead_excess_property_tax_credit: 0

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.py
@@ -6,15 +6,86 @@ class loss_ald(Variable):
     entity = TaxUnit
     label = "Business loss ALD"
     unit = USD
-    documentation = "Above-the-line deduction from gross income for business losses."
+    documentation = (
+        "Above-the-line deduction from gross income for business and capital losses."
+    )
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/26/165"
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/26/165",
+        "https://www.law.cornell.edu/uscode/text/26/461#l",
+    )
 
     def formula(tax_unit, period, parameters):
         filing_status = tax_unit("filing_status", period)
-        max_loss = parameters(period).gov.irs.ald.loss.max[filing_status]
+        # Section 461(l) excess business loss limitation
+        threshold_amount = parameters(period).gov.irs.ald.loss.max[filing_status]
         person = tax_unit.members
+
+        # Section 461(l) compares business deductions to business gross
+        # income/gains plus the threshold amount. In this model, positive
+        # business amounts flow into gross income and losses are deducted here,
+        # so allowable business losses are capped at business income plus
+        # the threshold.
+        indiv_se_income = max_(0, person("total_self_employment_income", period))
         indiv_se_loss = max_(0, -person("total_self_employment_income", period))
+        self_employment_income = tax_unit.sum(indiv_se_income)
         self_employment_loss = tax_unit.sum(indiv_se_loss)
+
+        # Schedule F farm business income/losses.
+        indiv_farm_income = max_(0, person("farm_operations_income", period))
+        indiv_farm_loss = max_(0, -person("farm_operations_income", period))
+        farm_income = tax_unit.sum(indiv_farm_income)
+        farm_loss = tax_unit.sum(indiv_farm_loss)
+
+        # Schedule E rental, farm-rent, and estate/trust items.
+        indiv_rental_income = max_(0, person("rental_income", period))
+        indiv_rental_loss = max_(0, -person("rental_income", period))
+        rental_income = tax_unit.sum(indiv_rental_income)
+        rental_loss = tax_unit.sum(indiv_rental_loss)
+
+        indiv_farm_rent_income = max_(0, person("farm_rent_income", period))
+        indiv_farm_rent_loss = max_(0, -person("farm_rent_income", period))
+        farm_rent_income = tax_unit.sum(indiv_farm_rent_income)
+        farm_rent_loss = tax_unit.sum(indiv_farm_rent_loss)
+
+        indiv_estate_income = max_(0, person("estate_income", period))
+        indiv_estate_loss = max_(0, -person("estate_income", period))
+        estate_income = tax_unit.sum(indiv_estate_income)
+        estate_loss = tax_unit.sum(indiv_estate_loss)
+
+        # Partnership/S-corp losses (Schedule E)
+        indiv_scorp_income = max_(0, person("partnership_s_corp_income", period))
+        indiv_scorp_loss = max_(0, -person("partnership_s_corp_income", period))
+        partnership_s_corp_income = tax_unit.sum(indiv_scorp_income)
+        partnership_s_corp_loss = tax_unit.sum(indiv_scorp_loss)
+
+        other_net_gain = tax_unit("other_net_gain", period)
+        other_business_gain = max_(0, other_net_gain)
+        other_business_loss = max_(0, -other_net_gain)
+
+        # Total business losses subject to Section 461(l) limitation
+        total_business_income = (
+            self_employment_income
+            + farm_income
+            + rental_income
+            + farm_rent_income
+            + estate_income
+            + partnership_s_corp_income
+            + other_business_gain
+        )
+        total_business_loss = (
+            self_employment_loss
+            + farm_loss
+            + rental_loss
+            + farm_rent_loss
+            + estate_loss
+            + partnership_s_corp_loss
+            + other_business_loss
+        )
+        max_deductible_business_loss = total_business_income + threshold_amount
+        limited_business_loss = min_(total_business_loss, max_deductible_business_loss)
+
+        # Capital losses have separate limit under Section 1211 ($3,000)
         limited_capital_loss = tax_unit("limited_capital_loss", period)
-        return min_(max_loss, self_employment_loss + limited_capital_loss)
+
+        return limited_business_loss + limited_capital_loss

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/other_net_gain_gross_income.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/other_net_gain_gross_income.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class other_net_gain_gross_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Allocated other net gain included in gross income"
+    unit = USD
+    documentation = "Positive Form 4797 other net gain allocated across primary tax-unit filers for gross-income calculations."
+    definition_period = YEAR
+    reference = "https://www.irs.gov/instructions/i461"
+
+    def formula(person, period, parameters):
+        tax_unit = person.tax_unit
+        # Avoid filing_status dependence (dependent_gross_income iterates over
+        # gross-income sources and filing_status ultimately depends on
+        # dependent_gross_income via head_of_household_eligible). Allocate the
+        # tax-unit-level other_net_gain across head + spouse equally.
+        is_head = person("is_tax_unit_head", period)
+        is_spouse = person("is_tax_unit_spouse", period)
+        is_head_or_spouse = is_head | is_spouse
+        num_head_or_spouse = tax_unit.sum(is_head_or_spouse)
+        share = where(num_head_or_spouse > 0, 1 / num_head_or_spouse, 0)
+        positive_other_net_gain = max_(0, tax_unit("other_net_gain", period))
+        return is_head_or_spouse * positive_other_net_gain * share


### PR DESCRIPTION
## Summary
- Revives #7298 to implement the IRC § 461(l) excess business loss limitation.
- Applies the threshold to self-employment, farm, rental, estate/trust, partnership/S-corp, and Form 4797 other-net-gain losses, netting them against business income before comparing to the threshold.
- Keeps the Section 1211 $3,000 capital-loss limit separate from the § 461(l) bucket.
- Extends the § 461(l) threshold permanently for 2027+ under OBBBA § 70601 (removes the TCJA sunset).

## Changes
- `policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.py`: Apply § 461(l) to the business-loss bucket, net business income and losses, and add capital losses separately via `limited_capital_loss`.
- `policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/other_net_gain_gross_income.py` (new): Allocate the tax-unit Form 4797 other net gain across head/spouse. Avoids filing_status so `dependent_gross_income` does not trigger a circular dependency through `head_of_household_eligible`.
- `policyengine_us/parameters/gov/irs/gross_income/sources.yaml`: Use `farm_operations_income` (Schedule F active farming) and include `other_net_gain_gross_income` in the gross-income sources.
- `policyengine_us/parameters/gov/irs/ald/loss/max.yaml`: Drop the 2027 revert to `.inf` per OBBBA § 70601 so the § 461(l) threshold carries forward.
- `changelog.d/revive-section-461l-ebl.added.md`: Changelog entry.
- Fixture updates:
  - `policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.yaml` (new): issue-#7015 scenario plus SE, farm, rental, estate, Form 4797, combined, MFJ, and OBBBA-permanence cases.
  - `policyengine_us/tests/policy/baseline/gov/irs/irs_gross_income.yaml`: Added coverage for `farm_operations_income` and positive `other_net_gain`.
  - `policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_self_employment_loss_addition.yaml`, `.../mi/tax/income/mi_household_resources.yaml`, `.../wv/tax/income/credits/heptc/wv_homestead_excess_property_tax_credit.yaml`: Updated expected values to reflect the revised `loss_ald` (business bucket capped at the § 461(l) threshold, capital losses separate).

## Attribution
This PR revives the eleven commits from PR #7298 (authored by @MaxGhenis and @PavelMakarchuk). They are squashed into a single commit to simplify the history. The original branch is preserved under the `section-461l` name on this fork.

## Test plan
- [x] `loss_ald` integration fixture (11 cases) passes.
- [x] All 769 `gov/irs` baseline tests pass locally.
- [x] DC / MI / WV state fixtures touched by the revised `loss_ald` pass.
- [ ] `gov/states` baseline suite (running at PR-open time); CI will finalize.

Closes #7015
