### PR TITLE
Fix 7 more breakdown range mismatches (2nd dimension)

### DIFF
--- a/changelog.d/fix-breakdown-mismatches-round-2.fixed.md
+++ b/changelog.d/fix-breakdown-mismatches-round-2.fixed.md
@@ -1,0 +1,1 @@
+Fix seven more parameter breakdown ranges (SNAP max allotment, SNAP utility deductions, ND TANF standard of need) where the second breakdown dimension excluded existing children. Surfaced by core 3.24.0's stricter validator.

--- a/policyengine_us/parameters/gov/states/nd/dhs/tanf/benefit/standard_of_need.yaml
+++ b/policyengine_us/parameters/gov/states/nd/dhs/tanf/benefit/standard_of_need.yaml
@@ -5,7 +5,7 @@ metadata:
   period: month
   breakdown:
     - range(0, 3)
-    - range(1, 11)
+    - range(0, 11)
   breakdown_label:
     - Number of caretakers
     - Number of children

--- a/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/limited/by_household_size/amount.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/limited/by_household_size/amount.yaml
@@ -259,7 +259,7 @@ metadata:
   label: SNAP LUAs by household size
   breakdown:
     - [AZ, NC, TN]
-    - range(1, 10)
+    - range(1, 11)
   breakdown_labels:
     - State
     - Household size

--- a/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/single/by_household_size/electricity.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/single/by_household_size/electricity.yaml
@@ -208,7 +208,7 @@ metadata:
   label: SNAP individual electricity utility allowance by household size
   breakdown:
     - [GU, HI]
-    - range(1, 10)
+    - range(1, 11)
   reference:
     - title: USDA SNAP utility allowances by state spreadsheet (FY2024)
       href: https://docs.google.com/spreadsheets/d/10otJJisAYUDyZ0d7XpZPn8rEql-rteVE/edit?gid=1837348310#gid=1837348310

--- a/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/single/by_household_size/gas_and_fuel.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/single/by_household_size/gas_and_fuel.yaml
@@ -198,7 +198,7 @@ metadata:
   label: SNAP individual gas and fuel utility allowance by household size
   breakdown:
     - [GU, HI]
-    - range(1, 10)
+    - range(1, 11)
   reference:
     - title: USDA SNAP utility allowances by state spreadsheet (FY2024)
       href: https://docs.google.com/spreadsheets/d/10otJJisAYUDyZ0d7XpZPn8rEql-rteVE/edit?gid=1837348310#gid=1837348310

--- a/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/single/by_household_size/water.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/single/by_household_size/water.yaml
@@ -188,7 +188,7 @@ metadata:
   label: SNAP individual water utility allowance by household size
   breakdown:
     - [GU, HI]
-    - range(1, 10)
+    - range(1, 11)
   reference:
     - title: USDA SNAP utility allowances by state spreadsheet (FY2024)
       href: https://docs.google.com/spreadsheets/d/10otJJisAYUDyZ0d7XpZPn8rEql-rteVE/edit?gid=1837348310#gid=1837348310

--- a/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/standard/by_household_size/amount.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/standard/by_household_size/amount.yaml
@@ -411,7 +411,7 @@ metadata:
   label: SNAP SUAs by household size
   breakdown:
     - [AZ, NC, TN, VA]
-    - range(1, 10)
+    - range(1, 11)
   breakdown_labels:
     - State
     - Household size

--- a/policyengine_us/parameters/gov/usda/snap/max_allotment.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/max_allotment.yaml
@@ -4,7 +4,7 @@ main:
   metadata:
     breakdown:
       - snap_region
-      - range(1, 9)
+      - range(0, 9)
     breakdown_labels:
       - SNAP region
       - Household size


### PR DESCRIPTION
## Summary

Follow-up to #8049. The initial audit only walked the FIRST breakdown dimension, so multi-dimensional breakdowns (e.g. `[snap_region, range(1, 9)]`) with a bad integer dimension went undetected. CI on #8035 caught one (`gov.usda.snap.max_allotment.main` has a `0` child but breakdown dim 1 is `range(1,9)`), so I widened the audit and found 7 total.

## Fixes

| Parameter | Dim | Old → New |
|---|---|---|
| `gov.states.nd.dhs.tanf.benefit.standard_of_need` | 2nd | `range(1,11)` → `range(0,11)` |
| `gov.usda.snap.max_allotment.main` | 2nd | `range(1,9)` → `range(0,9)` (has size-0 brackets) |
| `gov.usda.snap.income.deductions.utility.limited.by_household_size.amount` | 1st | `range(1,10)` → `range(1,11)` |
| `gov.usda.snap.income.deductions.utility.standard.by_household_size.amount` | 1st | `range(1,10)` → `range(1,11)` |
| `gov.usda.snap.income.deductions.utility.single.by_household_size.water` | 1st | `range(1,10)` → `range(1,11)` |
| `...electricity` | 1st | `range(1,10)` → `range(1,11)` |
| `...gas_and_fuel` | 1st | `range(1,10)` → `range(1,11)` |

## Test plan

- [x] Improved audit script confirms zero remaining breakdown mismatches
- [ ] CI: smoke-import + Full Suite should now pass under core ≥ 3.24.0
