### PR TITLE
Add federal AGI eligibility check to CalEITC

### DIFF
--- a/changelog.d/ca-eitc-federal-agi-check.fixed.md
+++ b/changelog.d/ca-eitc-federal-agi-check.fixed.md
@@ -1,0 +1,1 @@
+Add federal AGI upper-bound check to `ca_eitc_eligible` per FTB 3514 (Steps 7-8): CalEITC is denied when federal adjusted gross income exceeds the earned-income threshold (`gov.states.ca.tax.income.credits.earned_income.phase_out.final.end`).

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_eitc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_eitc_eligible.yaml
@@ -123,3 +123,41 @@
         state_code: CA
   output:
     ca_eitc_eligible: false
+
+- name: Ineligible for EITC because federal AGI exceeds CalEITC threshold (FTB 3514)
+  period: 2024
+  input:
+    people:
+      person_1:
+        age: 40
+        is_tax_unit_dependent: false
+    tax_units:
+      tax_unit:
+        members: [person_1]
+        eitc_relevant_investment_income: 0
+        adjusted_gross_income: 32_000
+    households:
+      household:
+        members: [person_1]
+        state_code: CA
+  output:
+    ca_eitc_eligible: false
+
+- name: Eligible for EITC when federal AGI is below CalEITC threshold
+  period: 2024
+  input:
+    people:
+      person_1:
+        age: 40
+        is_tax_unit_dependent: false
+    tax_units:
+      tax_unit:
+        members: [person_1]
+        eitc_relevant_investment_income: 0
+        adjusted_gross_income: 20_000
+    households:
+      household:
+        members: [person_1]
+        state_code: CA
+  output:
+    ca_eitc_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_eitc_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_eitc_integration.yaml
@@ -335,3 +335,33 @@
         state_code: CA
   output:
     ca_eitc: 39
+
+- name: taxsim_741_ca_single_2024_eitc_federal_agi_over_limit
+  # Per FTB 3514 (2024), single filer with 0 qualifying children is ineligible
+  # for CalEITC if federal AGI exceeds $31,950. Here federal AGI ~= $36,972.
+  absolute_error_margin: 1
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 68
+        employment_income: 11847.05
+        taxable_interest_income: 111.15
+        taxable_private_pension_income: 16756.77
+        social_security_retirement: 19409.18
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1]
+        state_fips: 6
+  output:
+    ca_eitc: 0

--- a/policyengine_us/variables/gov/states/ca/tax/income/credits/earned_income/ca_eitc_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/credits/earned_income/ca_eitc_eligible.py
@@ -28,4 +28,13 @@ class ca_eitc_eligible(Variable):
             eitc_investment_income <= p.eligibility.max_investment_income
         )
 
-        return meets_age_requirements & meets_investment_income_requirements
+        # FTB 3514 (Steps 7-8): federal AGI must also be below the CalEITC
+        # earnings threshold (p.phase_out.final.end).
+        federal_agi = tax_unit("adjusted_gross_income", period)
+        meets_agi_requirements = federal_agi < p.phase_out.final.end
+
+        return (
+            meets_age_requirements
+            & meets_investment_income_requirements
+            & meets_agi_requirements
+        )


### PR DESCRIPTION
## Summary

Adds the federal AGI upper-bound check to `ca_eitc_eligible` per FTB 3514 (Steps 7-8). CalEITC requires **both** earned income and federal AGI to be below the per-year threshold (`gov.states.ca.tax.income.credits.earned_income.phase_out.final.end` — e.g. $31,950 for 2024). Before this change, only earned income was checked (implicitly via the phase-out math in `ca_eitc.py`), so filers with earned income under the threshold but federal AGI above it were incorrectly granted CalEITC.

## Changes

- `policyengine_us/variables/gov/states/ca/tax/income/credits/earned_income/ca_eitc_eligible.py`: Add `meets_agi_requirements = federal_agi < p.phase_out.final.end` to the conjunction.
- `policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_eitc_eligible.yaml`: Add two cases (AGI above / below threshold).
- `policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_eitc_integration.yaml`: Add the taxsim 741 scenario (single filer, 2024, federal AGI ~= $36,972 > $31,950; expects `ca_eitc: 0`).
- `changelog.d/`: Add fixed-category fragment.

## Test plan

- [x] New eligibility and integration YAML tests
- [x] Full CA EITC suite passes (28/28)
- [x] Full CA state suite passes (526/526)
- [x] `ruff format --check` clean

## References

- FTB 3514 (2024) Booklet, Steps 7-8: https://www.ftb.ca.gov/forms/2024/2024-3514-booklet.html
- Originating TAXSIM issue: PolicyEngine/policyengine-taxsim#741

Closes #7871
