### PR TITLE
Fall back to default ACA rating area when LA zip lookup returns 0 (closes #7740)

### DIFF
--- a/changelog.d/fix-la-aca-rating-area-fallback.fixed.md
+++ b/changelog.d/fix-la-aca-rating-area-fallback.fixed.md
@@ -1,0 +1,1 @@
+Fall back to the county-level slcsp_rating_area_default when the LA County zip-code lookup returns 0, so LA households without a three_digit_zip_code still receive a valid ACA PTC.

--- a/policyengine_us/tests/policy/baseline/gov/aca/slcsp/slcsp_rating_area.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/slcsp/slcsp_rating_area.yaml
@@ -40,4 +40,22 @@
     county_str: LOS_ANGELES_COUNTY_CA
   output:
     slcsp_rating_area: 15
-  
+
+- name: LA county falls back to county-level rating area when zip code is missing
+  period: 2024
+  input:
+    county_str: LOS_ANGELES_COUNTY_CA
+    three_digit_zip_code: ""
+  output:
+    # The zip-based LA lookup returns 0 without a zip, so the formula must
+    # fall back to slcsp_rating_area_default, which maps LA County to 16.
+    slcsp_rating_area: 16
+
+- name: LA county with unmapped zip prefix falls back to county default
+  period: 2024
+  input:
+    county_str: LOS_ANGELES_COUNTY_CA
+    three_digit_zip_code: "999"
+  output:
+    slcsp_rating_area: 16
+

--- a/policyengine_us/variables/gov/aca/slspc/slcsp_rating_area.py
+++ b/policyengine_us/variables/gov/aca/slspc/slcsp_rating_area.py
@@ -8,8 +8,15 @@ class slcsp_rating_area(Variable):
     definition_period = YEAR
 
     def formula(household, period, parameters):
+        # For LA County households, try the zip-code-specific lookup first.
+        # That lookup returns 0 when the three_digit_zip_code is missing
+        # (e.g., CPS records) or unmapped, in which case we fall back to the
+        # county-level aca_rating_areas.csv mapping so LA still gets a valid
+        # rating area (16) rather than an unknown (0) that zeros out slcsp.
+        default_rating_area = household("slcsp_rating_area_default", period)
+        la_rating_area = household("slcsp_rating_area_la_county", period)
         return where(
             household("in_la", period),
-            household("slcsp_rating_area_la_county", period),
-            household("slcsp_rating_area_default", period),
+            where(la_rating_area == 0, default_rating_area, la_rating_area),
+            default_rating_area,
         )


### PR DESCRIPTION
## Summary

`slcsp_rating_area` routes Los Angeles County households to `slcsp_rating_area_la_county`, which requires `three_digit_zip_code` to pick rating area 15 or 16. CPS records have no zip code, so the lookup returns `0`, which `slcsp_age_0` treats as "unknown" — zeroing out `slcsp` and `aca_ptc` for every LA household.

This PR falls back to the county-level mapping (`slcsp_rating_area_default`) whenever the zip-based LA lookup returns 0. LA records with a known zip still get the fine-grained 15 vs. 16 split.

```python
# before
return where(
    household("in_la", period),
    household("slcsp_rating_area_la_county", period),
    household("slcsp_rating_area_default", period),
)

# after
default_rating_area = household("slcsp_rating_area_default", period)
la_rating_area = household("slcsp_rating_area_la_county", period)
return where(
    household("in_la", period),
    where(la_rating_area == 0, default_rating_area, la_rating_area),
    default_rating_area,
)
```

## Impact

~$453M in ACA PTC across 10 LA Congressional Districts (CA-27, 28, 29, 30, 31, 32, 34, 36, 37, 42, 43, 44) — previously zeroed out in CPS-based microsimulation.

Discovered via PolicyEngine/policyengine-us-data#538.

## Tests

Added two YAML regression cases to `slcsp_rating_area.yaml`:
- LA County + missing zip -> rating area 16 (was 0 without the fix)
- LA County + unmapped zip prefix -> rating area 16 (was 0 without the fix)

Both tests fail on `main` and pass with this change. The full `gov/aca/` test suite (166 tests) passes locally.

Closes #7740
