### PR TITLE
Gate aca_ptc on tax_unit_is_filer (closes #7748)

### DIFF
--- a/changelog.d/fix-aca-ptc-filer-gate.fixed.md
+++ b/changelog.d/fix-aca-ptc-filer-gate.fixed.md
@@ -1,0 +1,1 @@
+Gate aca_ptc on tax_unit_is_filer so non-filers receive zero per IRC 36B(a).

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
@@ -17,6 +17,7 @@
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
+    tax_unit_is_filer: true
   output:
     aca_ptc: 200  # 1200 - 0.04 * 25000 = 200
 
@@ -51,5 +52,30 @@
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
     takes_up_aca_if_eligible: false
+    tax_unit_is_filer: true
+  output:
+    aca_ptc: 200
+
+- name: ACA PTC is zero for non-filers (IRC 36B(a) requires filing Form 8962)
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    is_aca_ptc_eligible: true
+    slcsp: 1_200
+    aca_magi: 25_000
+    aca_required_contribution_percentage: 0.04
+    tax_unit_is_filer: false
+  output:
+    aca_ptc: 0
+
+- name: ACA PTC is paid to eligible filers (regression of filer gate)
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    is_aca_ptc_eligible: true
+    slcsp: 1_200
+    aca_magi: 25_000
+    aca_required_contribution_percentage: 0.04
+    tax_unit_is_filer: true
   output:
     aca_ptc: 200

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/selected_marketplace_plan_premium_proxy.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/selected_marketplace_plan_premium_proxy.yaml
@@ -6,6 +6,7 @@
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
+    tax_unit_is_filer: true
   output:
     selected_marketplace_plan_premium_proxy: 1_200
 
@@ -18,6 +19,7 @@
     aca_magi: 20_000
     aca_required_contribution_percentage: 0.04
     selected_marketplace_plan_benchmark_ratio: 0.8
+    tax_unit_is_filer: true
   output:
     selected_marketplace_plan_premium_proxy: 8_000
 

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/used_aca_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/used_aca_ptc.yaml
@@ -6,6 +6,7 @@
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
+    tax_unit_is_filer: true
   output:
     aca_ptc: 200
     used_aca_ptc: 200
@@ -20,6 +21,7 @@
     aca_magi: 20_000
     aca_required_contribution_percentage: 0.04
     selected_marketplace_plan_benchmark_ratio: 0.8
+    tax_unit_is_filer: true
   output:
     aca_ptc: 9_200
     selected_marketplace_plan_premium_proxy: 8_000

--- a/policyengine_us/variables/gov/aca/ptc/aca_ptc.py
+++ b/policyengine_us/variables/gov/aca/ptc/aca_ptc.py
@@ -17,4 +17,7 @@ class aca_ptc(Variable):
         plan_cost = tax_unit("slcsp", period)
         income = tax_unit("aca_magi", period)
         applicable_figure = tax_unit("aca_required_contribution_percentage", period)
-        return max_(0, plan_cost - income * applicable_figure)
+        # IRC § 36B(a) conditions the PTC on filing a return (Form 8962).
+        # Gate on tax_unit_is_filer so non-filers receive $0.
+        is_filer = tax_unit("tax_unit_is_filer", period)
+        return max_(0, plan_cost - income * applicable_figure) * is_filer


### PR DESCRIPTION
## Summary

`aca_ptc.formula_2024` returns non-zero values for tax units that are not filers, overestimating total ACA PTC in calibrated microsimulation datasets (~5x the IRS SOI target in one SC spot check — $578M modeled vs. $112M target).

IRC § 36B(a) only allows the Premium Tax Credit when Form 8962 is filed with a federal return. This PR gates `aca_ptc` on `tax_unit_is_filer` so non-filing tax units receive $0.

```python
# before
def formula_2024(tax_unit, period, parameters):
    plan_cost = tax_unit("slcsp", period)
    income = tax_unit("aca_magi", period)
    applicable_figure = tax_unit("aca_required_contribution_percentage", period)
    return max_(0, plan_cost - income * applicable_figure)

# after
def formula_2024(tax_unit, period, parameters):
    plan_cost = tax_unit("slcsp", period)
    income = tax_unit("aca_magi", period)
    applicable_figure = tax_unit("aca_required_contribution_percentage", period)
    # IRC § 36B(a) conditions the PTC on filing a return (Form 8962).
    # Gate on tax_unit_is_filer so non-filers receive $0.
    is_filer = tax_unit("tax_unit_is_filer", period)
    return max_(0, plan_cost - income * applicable_figure) * is_filer
```

## Why it matters

- `policyengine-us-data` calibration uses IRS SOI filer-only targets, so the calibration can't correct non-filer `aca_ptc` (~28% of tax units, disproportionately lower-income with higher PTC eligibility).
- With this gate, microsimulation totals line up with SOI targets on filer-only slices.

## Tests

Added two YAML regression cases to `aca_ptc.yaml`:
- `tax_unit_is_filer: false` -> `aca_ptc: 0` (was $200 without the fix)
- `tax_unit_is_filer: true` -> `aca_ptc: 200` (unchanged)

The non-filer test fails on `main` and passes with this change.

Four pre-existing scalar-input tests (aca_ptc, used_aca_ptc, selected_marketplace_plan_premium_proxy) were relying on the old non-gated behavior via implicit default filer status; they now explicitly pass `tax_unit_is_filer: true` to preserve their original intent. The full `gov/aca/` suite (166 tests) and `contrib/aca/` suite (38 tests) pass locally.

## Note on precedent

No other credit in policyengine-us gates on `tax_unit_is_filer` today. `aca_ptc` is the most acute case because of the inverse correlation between PTC eligibility and filing propensity. EITC / refundable CTC may warrant similar treatment in follow-up PRs.

Closes #7748
