### PR TITLE
Freeze Maine standard deduction at pre-OBBBA amounts

### DIFF
--- a/changelog.d/fix-7900-me-std-deduction-no-obbb.fixed.md
+++ b/changelog.d/fix-7900-me-std-deduction-no-obbb.fixed.md
@@ -1,0 +1,1 @@
+Freeze Maine standard deduction at pre-OBBBA amounts because Maine conforms to the Internal Revenue Code as of December 31, 2024 (36 MRSA Sec. 111) and did not adopt the One Big Beautiful Bill Act increase.

--- a/policyengine_us/parameters/gov/states/household/state_standard_deductions.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_standard_deductions.yaml
@@ -19,7 +19,7 @@ values:
     - la_standard_deduction  # Louisiana
     # Massachusetts doesn't have deductions in a standard form.
     - md_standard_deduction  # Maryland
-    # Maine adopts federal standard deduction.
+    - me_standard_deduction  # Maine
     - mi_standard_deduction  # Michigan
     - mn_standard_deduction  # Minnesota
     # Missouri adopts federal standard deduction

--- a/policyengine_us/parameters/gov/states/me/tax/income/deductions/standard/aged_or_blind.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/deductions/standard/aged_or_blind.yaml
@@ -1,0 +1,54 @@
+description: Maine additional standard deduction per aged or blind box checked, by filing status. Because Maine conforms to the IRC as of December 31, 2024 (36 MRSA § 111) and did not adopt the One Big Beautiful Bill Act (OBBBA), the additional amount for 2025 remains at the pre-OBBBA federal projection rather than the OBBBA level.
+metadata:
+  label: Maine additional standard deduction for aged or blind
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: 36 MRSA § 111 (Maine IRC conformity as of December 31, 2024)
+    href: https://www.mainelegislature.org/legis/statutes/36/title36sec111.html
+  - title: 36 MRSA § 5124-C (Maine standard deduction)
+    href: https://www.mainelegislature.org/legis/statutes/36/title36sec5124-C.html
+  - title: Maine 2025 Form 1040ME Individual Income Tax Booklet, Standard Deduction Chart for line 17 (page 4)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf
+SINGLE:
+  2018-01-01: 1_600
+  2019-01-01: 1_650
+  2021-01-01: 1_700
+  2022-01-01: 1_750
+  2023-01-01: 1_850
+  2024-01-01: 1_950
+  2025-01-01: 2_000
+JOINT:
+  2018-01-01: 1_300
+  2019-01-01: 1_300
+  2021-01-01: 1_350
+  2022-01-01: 1_400
+  2023-01-01: 1_500
+  2024-01-01: 1_550
+  2025-01-01: 1_600
+SEPARATE:
+  2018-01-01: 1_300
+  2019-01-01: 1_300
+  2021-01-01: 1_350
+  2022-01-01: 1_400
+  2023-01-01: 1_500
+  2024-01-01: 1_550
+  2025-01-01: 1_600
+HEAD_OF_HOUSEHOLD:
+  2018-01-01: 1_600
+  2019-01-01: 1_650
+  2021-01-01: 1_700
+  2022-01-01: 1_750
+  2023-01-01: 1_850
+  2024-01-01: 1_950
+  2025-01-01: 2_000
+SURVIVING_SPOUSE:
+  2018-01-01: 1_300
+  2019-01-01: 1_300
+  2021-01-01: 1_350
+  2022-01-01: 1_400
+  2023-01-01: 1_500
+  2024-01-01: 1_550
+  2025-01-01: 1_600

--- a/policyengine_us/parameters/gov/states/me/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/deductions/standard/amount.yaml
@@ -1,0 +1,63 @@
+description: Maine basic standard deduction amount by filing status. Maine uses fixed-date IRC conformity (as of December 31, 2024) per 36 MRSA § 111, so it did not adopt the One Big Beautiful Bill Act (OBBBA) increase to the federal standard deduction that took effect in 2025.
+metadata:
+  label: Maine basic standard deduction
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  - title: 36 MRSA § 111 (Maine IRC conformity as of December 31, 2024)
+    href: https://www.mainelegislature.org/legis/statutes/36/title36sec111.html
+  - title: 36 MRSA § 5124-C (Maine standard deduction)
+    href: https://www.mainelegislature.org/legis/statutes/36/title36sec5124-C.html
+  - title: Maine 2025 Form 1040ME Individual Income Tax Booklet, Standard Deduction Chart for line 17 (page 4)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf
+  - title: Maine 2024 Form 1040ME Individual Income Tax Booklet
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_1040me_book_gen_instr.pdf
+  - title: Maine Revenue Services 2025 Income Tax Important Update (OBBBA non-conformity)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf
+SINGLE:
+  2018-01-01: 12_000
+  2019-01-01: 12_200
+  2020-01-01: 12_400
+  2021-01-01: 12_550
+  2022-01-01: 12_950
+  2023-01-01: 13_850
+  2024-01-01: 14_600
+  2025-01-01: 15_000
+JOINT:
+  2018-01-01: 24_000
+  2019-01-01: 24_400
+  2020-01-01: 24_800
+  2021-01-01: 25_100
+  2022-01-01: 25_900
+  2023-01-01: 27_700
+  2024-01-01: 29_200
+  2025-01-01: 30_000
+SEPARATE:
+  2018-01-01: 12_000
+  2019-01-01: 12_200
+  2020-01-01: 12_400
+  2021-01-01: 12_550
+  2022-01-01: 12_950
+  2023-01-01: 13_850
+  2024-01-01: 14_600
+  2025-01-01: 15_000
+HEAD_OF_HOUSEHOLD:
+  2018-01-01: 18_000
+  2019-01-01: 18_350
+  2020-01-01: 18_650
+  2021-01-01: 18_800
+  2022-01-01: 19_400
+  2023-01-01: 20_800
+  2024-01-01: 21_900
+  2025-01-01: 22_500
+SURVIVING_SPOUSE:
+  2018-01-01: 24_000
+  2019-01-01: 24_400
+  2020-01-01: 24_800
+  2021-01-01: 25_100
+  2022-01-01: 25_900
+  2023-01-01: 27_700
+  2024-01-01: 29_200
+  2025-01-01: 30_000

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/taxable_income/deductions/me_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/taxable_income/deductions/me_deductions.yaml
@@ -4,7 +4,7 @@
   input:
     state_code: NY
     me_deduction_phaseout_percentage: 0.40
-    standard_deduction: 20_000
+    me_standard_deduction: 20_000
     me_itemized_deductions_pre_phaseout: 25_000
   output:
     me_deductions: 0
@@ -15,7 +15,7 @@
   input:
     state_code: ME
     me_deduction_phaseout_percentage: 0.90
-    standard_deduction: 25_000
+    me_standard_deduction: 25_000
     me_itemized_deductions_pre_phaseout: 20_000
   output:
     me_deductions: 2_500
@@ -27,7 +27,7 @@
     gov.simulation.branch_to_determine_itemization: true
     state_code: ME
     me_deduction_phaseout_percentage: 0.40
-    standard_deduction: 10_000
+    me_standard_deduction: 10_000
     me_itemized_deductions_pre_phaseout: 15_000
   output:
     tax_liability_if_itemizing: 0
@@ -35,3 +35,32 @@
     state_standard_deduction: 10_000
     state_itemized_deductions: 15_000
     me_deductions: 9_000
+
+- name: ME single 2025 100K self-employment (TaxAct verified, taxsim issue 790)
+  absolute_error_margin: 1
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 54
+        self_employment_income: 100_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0
+        local_income_tax: 0
+        state_sales_tax: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1]
+        state_fips: 23
+  output:
+    me_deductions: 15_000
+    me_taxable_income: 72_785
+    me_income_tax: 4_695

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/taxable_income/deductions/me_itemized_deductions_pre_phaseout.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/taxable_income/deductions/me_itemized_deductions_pre_phaseout.yaml
@@ -53,7 +53,7 @@
         tax_unit_itemizes: false
         medical_expense_deduction: 500
         charitable_deduction: 10_000
-        standard_deduction: 5_000
+        me_standard_deduction: 5_000
     households:
       household:
         members: [person1]

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/taxable_income/deductions/me_standard_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/taxable_income/deductions/me_standard_deduction.yaml
@@ -1,0 +1,135 @@
+- name: 2024 Maine single standard deduction matches federal (pre-OBBBA)
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_fips: 23
+  output:
+    me_standard_deduction: 14_600
+
+- name: 2025 Maine single standard deduction is $15,000 (not the OBBBA $15,750)
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 54
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_fips: 23
+  output:
+    me_standard_deduction: 15_000
+
+- name: 2025 Maine MFJ standard deduction is $30,000 (not the OBBBA $31,500)
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+      person2:
+        age: 40
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 23
+  output:
+    me_standard_deduction: 30_000
+
+- name: 2025 Maine HOH standard deduction is $22,500 (not the OBBBA $23,625)
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+      person2:
+        age: 10
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 23
+  output:
+    me_standard_deduction: 22_500
+
+- name: 2025 Maine single age 65+ gets $15,000 base plus $2,000 additional
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 67
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_fips: 23
+  output:
+    me_standard_deduction: 17_000
+
+- name: 2025 Maine MFJ with both aged gets $30,000 plus 2 x $1,600
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 67
+        is_tax_unit_head: true
+      person2:
+        age: 67
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 23
+  output:
+    me_standard_deduction: 33_200
+
+- name: Maine standard deduction is $0 outside of Maine
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_fips: 36
+  output:
+    me_standard_deduction: 0

--- a/policyengine_us/variables/gov/states/me/tax/income/taxable_income/deductions/me_standard_deduction.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/taxable_income/deductions/me_standard_deduction.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class me_standard_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maine standard deduction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.mainelegislature.org/legis/statutes/36/title36sec111.html",
+        "https://www.mainelegislature.org/legis/statutes/36/title36sec5124-C.html",
+        "https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf",
+    )
+    defined_for = StateCode.ME
+
+    def formula(tax_unit, period, parameters):
+        # Maine conforms to the Internal Revenue Code as of December 31, 2024
+        # (36 MRSA Sec. 111), so it did not adopt the One Big Beautiful Bill
+        # Act (OBBBA) increase to the federal standard deduction starting in
+        # 2025. Maine publishes its own Standard Deduction Chart in the Form
+        # 1040ME instructions.
+        p = parameters(period).gov.states.me.tax.income.deductions.standard
+        filing_status = tax_unit("filing_status", period)
+        basic = p.amount[filing_status]
+        additional = p.aged_or_blind[filing_status] * tax_unit(
+            "aged_blind_count", period
+        )
+        return basic + additional

--- a/policyengine_us/variables/gov/states/me/tax/income/taxable_income/me_deductions.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/taxable_income/me_deductions.py
@@ -8,6 +8,7 @@ class me_deductions(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
+        "https://www.mainelegislature.org/legis/statutes/36/title36sec111.html",
         "https://www.mainelegislature.org/legis/statutes/36/title36sec5124-C.html",
         "https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_item_stand_%20ded_phaseout_wksht.pdf",
     )
@@ -18,9 +19,13 @@ class me_deductions(Variable):
         phaseout_percent = tax_unit("me_deduction_phaseout_percentage", period)
 
         # Get the relevant deduction amount (Line 6).
-        # Either itemized deduction or federal standard deduction.
+        # Either itemized deduction or Maine's standard deduction.
+        # Maine publishes its own standard deduction because it uses fixed-date
+        # IRC conformity (as of December 31, 2024) per 36 MRSA Sec. 111 and did
+        # not adopt the OBBBA federal standard deduction increase starting in
+        # 2025.
         itemizes = tax_unit("tax_unit_itemizes", period)
-        standard_deduction = tax_unit("standard_deduction", period)
+        standard_deduction = tax_unit("me_standard_deduction", period)
         larger_deduction = max_(
             tax_unit("me_itemized_deductions_pre_phaseout", period),
             standard_deduction,

--- a/policyengine_us/variables/gov/states/tax/income/state_standard_deduction.py
+++ b/policyengine_us/variables/gov/states/tax/income/state_standard_deduction.py
@@ -14,7 +14,6 @@ class state_standard_deduction(Variable):
         FEDERAL_STANDARD_DEDUCTION_STATES = [
             "CT",  # Connecticut
             "ID",  # Idaho
-            "ME",  # Maine
             "MO",  # Missouri
             "ND",  # North Dakota
             "NM",  # New Mexico


### PR DESCRIPTION
## Summary

- Fix #7900: freeze Maine's standard deduction at pre-OBBBA amounts because Maine conforms to the IRC as of December 31, 2024 (36 MRSA Sec. 111) and did not adopt OBBBA
- Introduce Maine-specific basic and aged-or-blind standard-deduction parameters that match the 2025 Form 1040ME Standard Deduction Chart (single $15,000 / MFJ $30,000 / HOH $22,500 / MFS $15,000, plus $1,600 or $2,000 per aged-or-blind box depending on filing status)
- Add `me_standard_deduction` variable and switch `me_deductions` to use it instead of the federal `standard_deduction`; remove Maine from the federal-adoption list in `state_standard_deduction`

## Before / after (single, age 54, ME, $100K self-employment, 2025, taxsim #790)

| Variable | Before | After | TaxAct (authoritative) |
|---|---|---|---|
| `me_deductions` | 15,750 | **15,000** | 15,000 |
| `me_taxable_income` | 72,035 | **72,785** | 72,785 |
| `me_income_tax` | 4,642 | **4,695** | 4,695 |

## Test plan

- [x] Added `me_standard_deduction.yaml` covering 2024 baseline, 2025 amounts by filing status, aged additions, and non-ME zeroing
- [x] Added the integration test from the issue (ME single 2025 $100K self-employment) to `me_deductions.yaml`
- [x] Updated `me_itemized_deductions_pre_phaseout.yaml` case that previously injected the federal `standard_deduction` to use `me_standard_deduction`
- [x] `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/me -c policyengine_us` -> 393 passed
- [x] `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/tax -c policyengine_us` -> 47 passed
- [x] `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions -c policyengine_us` -> 174 passed

## Sources

- 36 MRSA Sec. 111 (Maine IRC conformity): https://www.mainelegislature.org/legis/statutes/36/title36sec111.html
- 36 MRSA Sec. 5124-C (Maine standard deduction): https://www.mainelegislature.org/legis/statutes/36/title36sec5124-C.html
- 2025 Form 1040ME Individual Income Tax Booklet, Standard Deduction Chart for line 17 (page 4): https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf
- 2025 Maine Income Tax Important Update (OBBBA non-conformity, page 1): https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf
- policyengine-taxsim #790 (reproducer)

Closes #7900
