### PR TITLE
Add regression test for parameter breakdown mismatch (closes #8055)

### DIFF
--- a/changelog.d/test-system-import-tdd-8055.fixed.md
+++ b/changelog.d/test-system-import-tdd-8055.fixed.md
@@ -1,0 +1,1 @@
+Add regression test that constructs the tax-benefit system and bump policyengine-core floor to 3.24.0 so parameter breakdown/children mismatches fail CI rather than at user import time (issue #8055).

--- a/policyengine_us/tests/test_system_import.py
+++ b/policyengine_us/tests/test_system_import.py
@@ -1,0 +1,38 @@
+"""Regression tests for the top-level package import.
+
+These tests catch parameter-tree mismatches that block construction of
+`CountryTaxBenefitSystem` at import time — including the
+`breakdown` vs. parameter-children kind of mismatch that
+`policyengine-core >= 3.24.0` raises as a hard error.
+
+History: three separate PRs (#8045, #8049, #8051) each fixed a subset
+of `range(a, b)` breakdown dimensions that declared fewer children than
+the underlying parameter keys. Each partial fix still left other files
+broken, so end users on intermediate releases (e.g. 1.645.0) continued
+to hit `ValueError` at import time (issue #8055). This test loads the
+whole system once, which will fail loudly on any future mismatch.
+"""
+
+
+def test_country_tax_benefit_system_constructs_cleanly():
+    """Constructing the tax-benefit system runs parameter homogenization,
+    which validates every `breakdown` declaration against its children.
+    Any mismatch raises `ValueError` from
+    `policyengine_core.parameters.operations.homogenize_parameters`.
+    """
+    from policyengine_us.system import CountryTaxBenefitSystem
+
+    CountryTaxBenefitSystem()
+
+
+def test_package_import_does_not_raise():
+    """Smoke test: the top-level `policyengine_us` import triggers
+    `system.py` module-load which in turn instantiates the tax-benefit
+    system. A partial parameter-tree regression surfaces here before
+    any simulation code runs (mirrors the failure Martin Holmer hit in
+    issue #8055 under policyengine-us 1.644.0 / 1.645.0).
+    """
+    import importlib
+    import policyengine_us
+
+    importlib.reload(policyengine_us)


### PR DESCRIPTION
## Summary

Closes #8055.

Martin Holmer reported that `policyengine-us 1.644.0` (and then 1.645.0) failed at import time with:

```
ValueError: Parameter gov.usda.snap.income.deductions.utility.single.by_household_size.water.GU
has children ['10'] that are not in the possible values of the breakdown variable 'range(1, 10)'.
```

Three separate PRs today each fixed *subsets* of this class of bug (#8045, #8049, #8051), each incomplete, so users on intermediate releases continued to crash. The full SNAP utility fix landed in **1.646.1**; I've already commented on the issue confirming that.

## Why CI didn't catch the class of bug earlier

- `uv.lock` pinned `policyengine-core == 3.23.6`, where breakdown/children mismatches were only a **warning**.
- PyPI users install the latest `policyengine-core >= 3.24.0`, which promotes the mismatch to a **hard `ValueError`** at `CountryTaxBenefitSystem()` construction — exactly the failure Martin hit.

## Fix (TDD)

1. **Add `policyengine_us/tests/test_system_import.py`** with two regression tests that instantiate the tax-benefit system end-to-end. Any future parameter breakdown/children mismatch now fails CI directly, before release:

   ```python
   def test_country_tax_benefit_system_constructs_cleanly():
       from policyengine_us.system import CountryTaxBenefitSystem
       CountryTaxBenefitSystem()
   ```

2. **Bump `policyengine-core` floor** from `>=3.23.5` to `>=3.24.0` so the strict validator runs in CI and against fresh installs.

## Verified

- On clean `upstream/main` with core 3.24.1: both tests pass.
- After reverting `single/by_household_size/water.yaml` to the buggy `range(1, 10)`: test fails with Martin's exact error message.
- Running the existing `test_parameter_files.py` (YAML syntax) still passes — that test was orthogonal and wouldn't have caught this.

## Martin's coverage comment

Re his 100%-coverage question: the reported coverage is line coverage of formula code, not structural validation of the parameter tree. These tests fix the gap by asserting the tree loads at all.

## Test plan

- [x] `test_system_import.py` passes on clean tree with core 3.24.1.
- [x] Reproduces issue #8055 error on reverted tree.
- [ ] CI passes.
