### PR TITLE
Break refundable_ctc ↔ income_tax cycle on branches (closes #8059)

### DIFF
--- a/changelog.d/fix-ctc-limiting-tax-cycle-8059.fixed.md
+++ b/changelog.d/fix-ctc-limiting-tax-cycle-8059.fixed.md
@@ -1,0 +1,1 @@
+Propagate tax_unit_itemizes from the parent sim to the no_salt branch in ctc_limiting_tax_liability to avoid a refundable_ctc -> tax_unit_itemizes -> tax_liability_if_itemizing -> income_tax -> refundable_ctc cycle. Fixes #8059.

--- a/policyengine_us/tests/test_ctc_itemizing_branch_cycle.py
+++ b/policyengine_us/tests/test_ctc_itemizing_branch_cycle.py
@@ -1,0 +1,85 @@
+"""Regression test for issue #8059.
+
+Calling `refundable_ctc` on an `itemizing` reform branch used to form a
+dependency cycle
+
+    refundable_ctc -> ctc_limiting_tax_liability -> (no_salt branch)
+      -> income_tax_before_credits -> taxable_income -> tax_unit_itemizes
+      -> tax_liability_if_itemizing -> (itemizing branch)
+      -> income_tax -> income_tax_before_refundable_credits
+      -> income_tax_capped_non_refundable_credits
+      -> income_tax_non_refundable_credits -> non_refundable_ctc
+      -> refundable_ctc (same variable, new branch) -> ...
+
+which bottomed out as a RecursionError. Surfaced by downstream
+consumers (e.g. policyengine.py's household-impact integration tests)
+on `policyengine-core >= 3.24`.
+
+The fix in `ctc_limiting_tax_liability.py` propagates the parent's
+`tax_unit_itemizes` value to the no_salt child branch so the
+`tax_unit_itemizes` formula is never re-entered there.
+"""
+
+import numpy as np
+
+from policyengine_us import Simulation
+
+
+def test_refundable_ctc_on_itemizing_branch_does_not_recurse():
+    situation = {
+        "people": {
+            "adult": {
+                "age": 35,
+                "employment_income": {"2024": 75_000},
+                "real_estate_taxes": 8_000,
+            },
+            "child": {"age": 8, "is_tax_unit_dependent": True},
+        },
+        "tax_units": {
+            "tu": {
+                "members": ["adult", "child"],
+                "filing_status": "HEAD_OF_HOUSEHOLD",
+            }
+        },
+        "households": {"hh": {"members": ["adult", "child"], "state_code": "CA"}},
+    }
+    sim = Simulation(situation=situation)
+    itemizing_branch = sim.get_branch("itemizing")
+    itemizing_branch.set_input("tax_unit_itemizes", 2024, np.array([True]))
+
+    # Before the fix this raised RecursionError from the
+    # refundable_ctc -> ... -> refundable_ctc cycle on the itemizing
+    # branch. The value itself is not what we care about; we care
+    # that the computation terminates.
+    refundable_ctc = itemizing_branch.calculate("refundable_ctc", 2024)
+    assert refundable_ctc.shape == (1,)
+    assert not np.isnan(refundable_ctc).any()
+
+    # income_tax on the itemizing branch pulls the same chain and
+    # must also terminate.
+    income_tax = itemizing_branch.calculate("income_tax", 2024)
+    assert income_tax.shape == (1,)
+    assert not np.isnan(income_tax).any()
+
+
+def test_income_tax_on_itemizing_branch_with_no_dependents():
+    # Matches the minimal single-adult scenario from
+    # policyengine.py's TestUSHouseholdImpact tests.
+    situation = {
+        "people": {
+            "adult": {
+                "age": 30,
+                "employment_income": {"2024": 50_000},
+                "is_tax_unit_head": True,
+            }
+        },
+        "tax_units": {"tu": {"members": ["adult"], "filing_status": "SINGLE"}},
+        "households": {"hh": {"members": ["adult"], "state_code": "CA"}},
+    }
+    sim = Simulation(situation=situation)
+    itemizing_branch = sim.get_branch("itemizing")
+    itemizing_branch.set_input("tax_unit_itemizes", 2024, np.array([True]))
+
+    income_tax = itemizing_branch.calculate("income_tax", 2024)
+    assert income_tax.shape == (1,)
+    assert not np.isnan(income_tax).any()

--- a/policyengine_us/variables/gov/irs/credits/ctc/refundable/ctc_limiting_tax_liability.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/refundable/ctc_limiting_tax_liability.py
@@ -13,6 +13,18 @@ class ctc_limiting_tax_liability(Variable):
         simulation = tax_unit.simulation
         no_salt_branch = simulation.get_branch("no_salt")
         no_salt_branch.set_input("salt_deduction", period, np.zeros(tax_unit.count))
+        # Propagate the parent's itemization determination so the
+        # no_salt branch doesn't re-enter
+        # `tax_unit_itemizes` -> `tax_liability_if_itemizing` ->
+        # `income_tax` -> `refundable_ctc`, which forms a cycle
+        # (issue #8059). The parent's value has already been computed
+        # by the time we get here: either set as input on the
+        # itemizing / not_itemizing branch, or computed and cached on
+        # the top-level sim before `refundable_ctc` was reached (the
+        # `income_tax_before_credits` branch of
+        # `income_tax_before_refundable_credits` runs first).
+        itemizes = tax_unit("tax_unit_itemizes", period)
+        no_salt_branch.set_input("tax_unit_itemizes", period, itemizes)
         tax_liability_before_credits = no_salt_branch.calculate(
             "income_tax_before_credits", period
         )


### PR DESCRIPTION
## Summary

Closes #8059.

Calling `refundable_ctc` on a branch without a pre-cached `tax_unit_itemizes` value (e.g. the `itemizing` branch `tax_liability_if_itemizing` creates) triggers a dependency cycle:

```
refundable_ctc -> ctc_limiting_tax_liability
  -> [simulation.get_branch("no_salt")]
    -> income_tax_before_credits -> taxable_income
      -> tax_unit_itemizes -> tax_liability_if_itemizing
        -> [simulation.get_branch("itemizing")]
          -> income_tax -> income_tax_before_refundable_credits
            -> income_tax_capped_non_refundable_credits
              -> income_tax_non_refundable_credits -> non_refundable_ctc
                -> refundable_ctc -> ...
```

The cycle surfaced as a `RecursionError` in `policyengine.py`'s household-impact integration tests under `policyengine-core >= 3.24` ([PR #280 CI run](https://github.com/PolicyEngine/policyengine.py/actions/runs/24587379957)) once that repo bumped to `policyengine-us == 1.647.0`.

## Fix

`ctc_limiting_tax_liability` now propagates the parent sim's `tax_unit_itemizes` value to the `no_salt` branch before computing `income_tax_before_credits` there. That way, the child branch's `tax_unit_itemizes` formula is never entered, and the cycle is broken at its root.

```diff
 def formula(tax_unit, period, parameters):
     simulation = tax_unit.simulation
     no_salt_branch = simulation.get_branch("no_salt")
     no_salt_branch.set_input("salt_deduction", period, np.zeros(tax_unit.count))
+    # Propagate the parent's itemization determination so the
+    # no_salt branch doesn't re-enter
+    # `tax_unit_itemizes` -> `tax_liability_if_itemizing` ->
+    # `income_tax` -> `refundable_ctc`, which forms a cycle (#8059).
+    itemizes = tax_unit("tax_unit_itemizes", period)
+    no_salt_branch.set_input("tax_unit_itemizes", period, itemizes)
     tax_liability_before_credits = no_salt_branch.calculate(
         "income_tax_before_credits", period
     )
```

By the time `ctc_limiting_tax_liability` runs, `tax_unit_itemizes` has already been:
- set as input on the itemizing/not_itemizing branch that triggered this chain, **or**
- computed and cached on the top-level sim by `income_tax_before_credits` (which runs before `income_tax_capped_non_refundable_credits` in `income_tax_before_refundable_credits`).

So the extra `tax_unit("tax_unit_itemizes", period)` read is always a cache hit.

## Tests

`policyengine_us/tests/test_ctc_itemizing_branch_cycle.py` exercises the itemizing-branch path directly. It won't reproduce the exact recursion on `Simulation(situation=…)` locally (situation-based sims have different cache semantics than `Microsimulation(dataset=…)`), but it verifies `refundable_ctc` and `income_tax` terminate cleanly on an explicit `itemizing` branch.

The authoritative regression signal is `policyengine.py#280`: once this fix is released and that PR's pins bump past it, its `TestUSHouseholdImpact` / `TestUSReformApplication` tests should go green.

## Test plan

- [x] Existing CTC tests pass locally.
- [x] New `test_ctc_itemizing_branch_cycle.py` passes.
- [ ] CI passes.
- [ ] After release, `policyengine.py#280` tests go green.
