### PR TITLE
Gate tip deduction on both legacy and split SSTB inputs

### DIFF
--- a/changelog.d/fix-tip-deduction-sstb-mixed.fixed.md
+++ b/changelog.d/fix-tip-deduction-sstb-mixed.fixed.md
@@ -1,0 +1,5 @@
+Extend `tip_income_deduction_occupation_requirement_met` to recognize
+SSTB status from the per-category `sstb_self_employment_income` input,
+not only the legacy all-or-nothing `business_is_sstb` flag. This keeps
+the §224 SSTB exclusion in force for self-employed tipped workers who
+populate the new SSTB inputs added in #7944.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/tip_income/tip_income_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/tip_income/tip_income_deduction.yaml
@@ -139,3 +139,24 @@
   output:
     tip_income_deduction_occupation_requirement_met: false
     tip_income_deduction: 0
+
+- name: SSTB self-employment income blocks tip deduction even without legacy flag
+  period: 2025
+  input:
+    people:
+      worker:
+        ssn_card_type: CITIZEN
+        is_tax_unit_head: true
+        is_tax_unit_spouse: false
+        tip_income: 5_000
+        treasury_tipped_occupation_code: 102
+        business_is_sstb: false
+        sstb_self_employment_income: 50_000
+    tax_units:
+      tax_unit:
+        adjusted_gross_income: 100_000
+        filing_status: SINGLE
+        members: [worker]
+  output:
+    tip_income_deduction_occupation_requirement_met: false
+    tip_income_deduction: 0

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tip_income/tip_income_deduction_occupation_requirement_met.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/tip_income/tip_income_deduction_occupation_requirement_met.py
@@ -20,5 +20,9 @@ class tip_income_deduction_occupation_requirement_met(Variable):
         treasury_tipped_occupation_code = person(
             "treasury_tipped_occupation_code", period
         )
-        is_sstb = person("business_is_sstb", period)
+        is_sstb_legacy = person("business_is_sstb", period)
+        has_sstb_self_employment_income = (
+            person("sstb_self_employment_income", period) > 0
+        )
+        is_sstb = is_sstb_legacy | has_sstb_self_employment_income
         return (treasury_tipped_occupation_code > 0) & ~is_sstb


### PR DESCRIPTION
## Summary

`tip_income_deduction_occupation_requirement_met` currently checks only the legacy per-person `business_is_sstb` flag to apply OBBBA §224's SSTB exclusion:

```python
is_sstb = person("business_is_sstb", period)
return (treasury_tipped_occupation_code > 0) & ~is_sstb
```

After #7944 split QBI into SSTB and non-SSTB components, a self-employed tipped worker can route their activity through `sstb_self_employment_income` and leave the legacy flag unset. That path silently bypasses the §224 SSTB exclusion and grants the deduction.

## Fix

Treat a person as "in the course of" an SSTB if *either* the legacy flag is set or `sstb_self_employment_income > 0`. Behavior for anyone using only the legacy flag is unchanged; anyone using only the new split inputs is now correctly excluded.

## TDD

Failing test added first:

```yaml
- name: SSTB self-employment income blocks tip deduction even without legacy flag
  input:
    sstb_self_employment_income: 50_000
    business_is_sstb: false
    treasury_tipped_occupation_code: 102
    tip_income: 5_000
  output:
    tip_income_deduction_occupation_requirement_met: false
    tip_income_deduction: 0
```

Reproduced the regression (`met = True` instead of `False`), then applied the fix.

## Test plan

- [x] New YAML case fails on unmodified main, passes after fix.
- [x] All 13 existing tip-deduction YAML cases still pass.
- [x] `make format` clean.
- [ ] PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
