### PR TITLE
Fix Lifetime Learning Credit phase-out thresholds before 2021

### DIFF
--- a/changelog.d/fix-issue-1324.fixed.md
+++ b/changelog.d/fix-issue-1324.fixed.md
@@ -1,0 +1,1 @@
+Corrected the Lifetime Learning Credit phase-out thresholds to use pre-2021 IRS Form 8863 values, which differed from the American Opportunity Credit before the Consolidated Appropriations Act, 2021 harmonized them.

--- a/policyengine_us/parameters/gov/irs/credits/education/lifetime_learning_credit/phase_out.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/lifetime_learning_credit/phase_out.yaml
@@ -1,0 +1,67 @@
+start:
+  description: Phase-out start for the Lifetime Learning Credit on AGI. Before 2021, the LLC used lower thresholds than the American Opportunity Credit; the Consolidated Appropriations Act, 2021 harmonized them (IRC 25A(i)).
+  single:
+    description: Phase-out start for the Lifetime Learning Credit on AGI (single filers).
+    values:
+      2010-01-01: 50_000
+      2011-01-01: 51_000
+      2012-01-01: 52_000
+      2013-01-01: 53_000
+      2014-01-01: 54_000
+      2015-01-01: 55_000
+      2017-01-01: 56_000
+      2018-01-01: 57_000
+      2019-01-01: 58_000
+      2020-01-01: 59_000
+      2021-01-01: 80_000
+    metadata:
+      unit: currency-USD
+      period: year
+      label: Lifetime Learning Credit phase-out start (single filers)
+  joint:
+    description: Phase-out start for the Lifetime Learning Credit on AGI (joint filers).
+    values:
+      2010-01-01: 100_000
+      2011-01-01: 102_000
+      2012-01-01: 104_000
+      2013-01-01: 107_000
+      2014-01-01: 108_000
+      2015-01-01: 110_000
+      2016-01-01: 111_000
+      2017-01-01: 112_000
+      2018-01-01: 114_000
+      2019-01-01: 116_000
+      2020-01-01: 118_000
+      2021-01-01: 160_000
+    metadata:
+      unit: currency-USD
+      period: year
+      label: Lifetime Learning Credit phase-out start (joint filers)
+length:
+  description: Length of the phase-out range for the Lifetime Learning Credit on AGI (excess income at which the credit is reduced to zero).
+  single:
+    description: Length of the phase-out range for the Lifetime Learning Credit on AGI (single filers).
+    values:
+      2010-01-01: 10_000
+    metadata:
+      unit: currency-USD
+      period: year
+      label: Lifetime Learning Credit phase-out length (single filers)
+  joint:
+    description: Length of the phase-out range for the Lifetime Learning Credit on AGI (joint filers).
+    values:
+      2010-01-01: 20_000
+    metadata:
+      unit: currency-USD
+      period: year
+      label: Lifetime Learning Credit phase-out length (joint filers)
+metadata:
+  reference:
+    - title: 26 U.S. Code § 25A(d)(1)
+      href: https://www.law.cornell.edu/uscode/text/26/25A#d_1
+    - title: 2020 IRS Form 8863 (Part II lines 13, 16)
+      href: https://www.irs.gov/pub/irs-prior/f8863--2020.pdf
+    - title: 2015 IRS Form 8863 (Part II lines 13, 16)
+      href: https://www.irs.gov/pub/irs-prior/f8863--2015.pdf
+    - title: IRC 25A(i) (harmonized phase-out from 2021)
+      href: https://www.law.cornell.edu/uscode/text/26/25A#i

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit_pre_2021_phase_out.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit_pre_2021_phase_out.yaml
@@ -1,0 +1,54 @@
+# Regression tests for issue #1324.
+# Before 2021, the Lifetime Learning Credit used separate AGI phase-out
+# parameters from the American Opportunity Credit (see IRS Form 8863 Part II
+# lines 13/16). The LLC phase-out began at lower AGI than the AOC until the
+# Consolidated Appropriations Act, 2021 harmonized them at $80k single /
+# $160k joint (IRC 25A(i)).
+#
+# Prior to the fix, both credits shared the AOC phase-out, so LLC was
+# computed as nonzero for filers who in fact had AGI above the LLC phase-out.
+
+- name: 2020 joint filer with AGI $146k is above the $138k LLC phase-out end (issue #1324)
+  period: 2020
+  input:
+    adjusted_gross_income: 146_000
+    qualified_tuition_expenses: 4_000
+    filing_status: JOINT
+    tax_unit_is_joint: true
+    is_eligible_for_american_opportunity_credit: false
+  output:
+    # Joint LLC phase-out in 2020: starts $118k, ends $138k.
+    # AGI $146k is above phase-out end, so LLC potential is $0.
+    # Before the fix, code used AOC joint params ($160k/$180k), so LLC
+    # potential was computed as $800 - 800 * (146000 - 160000)/20000 clamped
+    # = $800 (since AGI was below the AOC phase-out start).
+    lifetime_learning_credit_potential: 0
+
+- name: 2020 single filer with AGI $65k is partly phased out for the LLC (issue #1324)
+  period: 2020
+  input:
+    adjusted_gross_income: 65_000
+    qualified_tuition_expenses: 5_000
+    filing_status: SINGLE
+    tax_unit_is_joint: false
+    is_eligible_for_american_opportunity_credit: false
+  output:
+    # Single LLC phase-out in 2020: starts $59k, ends $69k.
+    # Potential (pre-phase-out) = 0.2 * min(5000, 10000) = $1,000.
+    # Phase-out fraction = (65000 - 59000) / 10000 = 0.6.
+    # Potential = 1000 * (1 - 0.6) = $400.
+    lifetime_learning_credit_potential: 400
+
+- name: 2021 joint filer uses harmonized $160k/$180k phase-out
+  period: 2021
+  input:
+    adjusted_gross_income: 146_000
+    qualified_tuition_expenses: 4_000
+    filing_status: JOINT
+    tax_unit_is_joint: true
+    is_eligible_for_american_opportunity_credit: false
+  output:
+    # Starting 2021, LLC and AOC share phase-out ($160k/$180k joint).
+    # AGI $146k is below the $160k start: no phase-out applied.
+    # Potential = 0.2 * min(4000, 10000) = $800.
+    lifetime_learning_credit_potential: 800

--- a/policyengine_us/variables/gov/irs/credits/education/lifetime_learning_credit_phase_out.py
+++ b/policyengine_us/variables/gov/irs/credits/education/lifetime_learning_credit_phase_out.py
@@ -1,0 +1,34 @@
+from policyengine_us.model_api import *
+
+
+class lifetime_learning_credit_phase_out(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Lifetime Learning Credit phase-out"
+    unit = "/1"
+    documentation = (
+        "Fraction of the Lifetime Learning Credit that is phased out "
+        "based on AGI. Before 2021 the LLC had lower phase-out thresholds "
+        "than the American Opportunity Credit (IRS Form 8863, Part II); "
+        "the Consolidated Appropriations Act, 2021 harmonized them "
+        "(IRC 25A(i))."
+    )
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#d_1"
+
+    def formula(tax_unit, period, parameters):
+        llc = parameters(period).gov.irs.credits.education.lifetime_learning_credit
+        agi = tax_unit("adjusted_gross_income", period)
+        is_joint = tax_unit("tax_unit_is_joint", period)
+        phase_out_start = where(
+            is_joint,
+            llc.phase_out.start.joint,
+            llc.phase_out.start.single,
+        )
+        phase_out_length = where(
+            is_joint,
+            llc.phase_out.length.joint,
+            llc.phase_out.length.single,
+        )
+        excess_agi = max_(0, agi - phase_out_start)
+        return min_(1, excess_agi / phase_out_length)

--- a/policyengine_us/variables/gov/irs/credits/education/lifetime_learning_credit_potential.py
+++ b/policyengine_us/variables/gov/irs/credits/education/lifetime_learning_credit_potential.py
@@ -20,7 +20,7 @@ class lifetime_learning_credit_potential(Variable):
         )
         capped_expenses = min_(llc.expense_limit, eligible_expenses)
         maximum_amount = llc.rate * capped_expenses
-        phase_out = tax_unit("education_credit_phase_out", period)
+        phase_out = tax_unit("lifetime_learning_credit_phase_out", period)
         if llc.abolition:
             return 0
         return max_(0, maximum_amount * (1 - phase_out))


### PR DESCRIPTION
## Summary

- Split the Lifetime Learning Credit phase-out from the American Opportunity Credit phase-out for tax years before 2021
- Pre-2021, the LLC phased out at substantially lower AGI than the AOC (see IRS Form 8863, Part II lines 13 and 16); the Consolidated Appropriations Act, 2021 harmonized them at $80k/$160k (IRC 25A(i))
- Before this change, both credits shared `education.phase_out`, so pre-2021 LLC was computed as non-zero for filers whose AGI actually exceeded the LLC phase-out

## Changes

- New parameter file `parameters/gov/irs/credits/education/lifetime_learning_credit/phase_out.yaml` with pre-2021 LLC thresholds sourced from IRS Form 8863 (2010-2020) and harmonized AOC values from 2021 onward
- New variable `lifetime_learning_credit_phase_out` that reads the dedicated LLC parameters
- `lifetime_learning_credit_potential` now uses the new phase-out variable; the legacy `education_credit_phase_out` continues to serve the AOC

## Test plan

- [x] New YAML regression tests in `tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit_pre_2021_phase_out.yaml` cover the 2020 joint-filer case from issue #1324, a 2020 single-filer partial phase-out, and the 2021 harmonized phase-out
- [x] Tests failed on upstream/main baseline (confirmed TDD) and pass with the fix
- [x] All other LLC and AOC tests continue to pass locally
- [ ] Full CI on PolicyEngine CI runners

Closes #1324

---

Generated with [Claude Code](https://claude.com/claude-code)
