### PR TITLE
Apply IRS Form 8917 cap to pre-2021 tuition ALD

### DIFF
--- a/changelog.d/fix-issue-1318.fixed.md
+++ b/changelog.d/fix-issue-1318.fixed.md
@@ -1,0 +1,1 @@
+Applied the IRS Form 8917 cap to the pre-2021 tuition above-the-line deduction, which previously flowed into AGI uncapped.

--- a/policyengine_us/parameters/gov/irs/ald/deductions.yaml
+++ b/policyengine_us/parameters/gov/irs/ald/deductions.yaml
@@ -7,7 +7,7 @@ values:
     - early_withdrawal_penalty
     - alimony_expense
     - educator_expense
-    - qualified_tuition_expenses
+    - capped_qualified_tuition_expenses_ald
     - domestic_production_ald
     - health_savings_account_ald
     - self_employed_health_insurance_ald
@@ -24,7 +24,7 @@ values:
     - early_withdrawal_penalty
     - alimony_expense
     - educator_expense
-    - qualified_tuition_expenses
+    - capped_qualified_tuition_expenses_ald
     - health_savings_account_ald
     - self_employed_health_insurance_ald
     - self_employed_pension_contribution_ald

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/capped_qualified_tuition_expenses_ald.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/capped_qualified_tuition_expenses_ald.yaml
@@ -1,0 +1,99 @@
+# Regression tests for issue #1318.
+# Before 2021, the above-the-line deduction for qualified tuition expenses
+# (IRS Form 8917) was capped at $4,000 (or $2,000 for higher-MAGI filers).
+# The raw `qualified_tuition_expenses` variable previously flowed straight
+# into `above_the_line_deductions`, bypassing the cap. After the fix, the
+# contribution goes through `capped_qualified_tuition_expenses_ald`, which
+# applies the Form 8917 cap using a locally computed MAGI.
+
+- name: Capped tuition ALD at low income hits the $4,000 Form 8917 cap (issue #1318)
+  period: 2020
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 25
+        employment_income: 44_000
+        qualified_tuition_expenses: 14_000
+        is_eligible_for_american_opportunity_credit: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # MAGI for Form 8917 is $44,000 (gross income with no other ALDs);
+    # that is below the $65,000 single threshold, so the cap is $4,000.
+    # Before the fix, ALD pulled in the full $14,000 raw amount.
+    capped_qualified_tuition_expenses_ald: 4_000
+    above_the_line_deductions: 4_000
+    adjusted_gross_income: 40_000
+
+- name: Capped tuition ALD is zero above the $80k MAGI phase-out for a 2020 single filer (issue #1318)
+  period: 2020
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 25
+        employment_income: 100_000
+        qualified_tuition_expenses: 5_000
+        is_eligible_for_american_opportunity_credit: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    capped_qualified_tuition_expenses_ald: 0
+    above_the_line_deductions: 0
+
+- name: Capped tuition ALD is zero starting 2021 after the statute was repealed (issue #1318)
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 25
+        employment_income: 44_000
+        qualified_tuition_expenses: 14_000
+        is_eligible_for_american_opportunity_credit: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    capped_qualified_tuition_expenses_ald: 0
+    above_the_line_deductions: 0
+
+- name: Capped tuition ALD is zero for married filing separately (issue #1318)
+  period: 2020
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 25
+        employment_income: 44_000
+        qualified_tuition_expenses: 14_000
+        is_eligible_for_american_opportunity_credit: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SEPARATE
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    capped_qualified_tuition_expenses_ald: 0

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/capped_qualified_tuition_expenses_ald.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/capped_qualified_tuition_expenses_ald.py
@@ -1,0 +1,55 @@
+from policyengine_us.model_api import *
+
+
+class capped_qualified_tuition_expenses_ald(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Qualified tuition expenses above-the-line deduction (capped)"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "Tuition and fees above-the-line deduction from IRS Form 8917 "
+        "(pre-2021 only). Applies the IRC 222(b)(2) cap using a locally "
+        "computed MAGI to avoid a circular dependency on "
+        "`adjusted_gross_income`."
+    )
+    reference = (
+        "https://www.irs.gov/pub/irs-pdf/f8917.pdf#page=2"
+        # Law was repealed starting tax year 2021.
+        "https://irc.bloombergtax.com/public/uscode/doc/irc/section_222"
+    )
+
+    def formula(tax_unit, period, parameters):
+        # This variable contributes to the ALD list only in years when
+        # `capped_qualified_tuition_expenses_ald` is listed in
+        # `gov.irs.ald.deductions`. If a reform removes it, return 0.
+        all_alds = parameters(period).gov.irs.ald.deductions
+        if "capped_qualified_tuition_expenses_ald" not in all_alds:
+            return 0
+        # Married filing separately cannot take the tuition deduction.
+        filing_status = tax_unit("filing_status", period)
+        separate = filing_status == filing_status.possible_values.SEPARATE
+        qualified_tuition_expenses = add(
+            tax_unit, period, ["qualified_tuition_expenses"]
+        )
+        # Build a simple MAGI from non-dependent person-level income sources,
+        # excluding sources that depend on MAGI themselves (taxable SS, UI).
+        irs = parameters(period).gov.irs
+        gross_income_sources = irs.gross_income.sources
+        person = tax_unit.members
+        not_dependent = ~person("is_tax_unit_dependent", period)
+        cycle_sources = {
+            "taxable_social_security",
+            "taxable_unemployment_compensation",
+        }
+        safe_sources = [src for src in gross_income_sources if src not in cycle_sources]
+        if "taxable_unemployment_compensation" in gross_income_sources:
+            safe_sources.append("unemployment_compensation")
+        magi = 0
+        for source in safe_sources:
+            magi += not_dependent * max_(0, add(person, period, [source]))
+        magi = tax_unit.sum(magi)
+        p = parameters(period).gov.irs.deductions.tuition_and_fees
+        joint = filing_status == filing_status.possible_values.JOINT
+        cap = where(joint, p.joint.calc(magi), p.non_joint.calc(magi))
+        return where(separate, 0, min_(qualified_tuition_expenses, cap))


### PR DESCRIPTION
## Summary

- Apply the IRS Form 8917 cap to the pre-2021 qualified-tuition above-the-line deduction
- Previously, raw `qualified_tuition_expenses` flowed into `above_the_line_deductions` uncapped; a filer with $14k in tuition could take a $14k deduction even though Form 8917 caps it at $4k and phases it out entirely above $80k/$160k AGI per IRC 222(b)(2)
- Replaces `qualified_tuition_expenses` with a new `capped_qualified_tuition_expenses_ald` in the 2010 and 2018 ALD lists (2021+ already excluded tuition after statutory repeal)

## Changes

- New variable `capped_qualified_tuition_expenses_ald` (TaxUnit, USD) applies the Form 8917 cap using a locally computed MAGI to avoid a circular dependency with `adjusted_gross_income` (following the same pattern as `student_loan_interest_ald_magi`)
- `parameters/gov/irs/ald/deductions.yaml` swaps `qualified_tuition_expenses` for the new variable in the 2010 and 2018 lists

## Test plan

- [x] New YAML regression tests in `above_the_line_deductions/capped_qualified_tuition_expenses_ald.yaml` cover the low-AGI cap (issue #1318), the above-phase-out zero case, the 2021 repeal, and married-filing-separately ineligibility
- [x] Tests failed on upstream/main baseline (confirmed TDD) and pass with the fix
- [x] All 83 tests under `taxable_income/adjusted_gross_income` pass locally
- [ ] Full CI on PolicyEngine CI runners

Closes #1318

---

Generated with [Claude Code](https://claude.com/claude-code)
