### PR TITLE
Mint GitHub App token in weekly-uv-lock workflow

### DIFF
--- a/.github/workflows/weekly-uv-lock.yaml
+++ b/.github/workflows/weekly-uv-lock.yaml
@@ -13,11 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'PolicyEngine/policyengine-us'
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -58,7 +65,7 @@ jobs:
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Check if PR already exists
           EXISTING_PR=$(gh pr list --head bot/weekly-uv-lock-update --json number --jq '.[0].number' || echo "")

--- a/changelog.d/migrate-to-app-token.fixed.md
+++ b/changelog.d/migrate-to-app-token.fixed.md
@@ -1,0 +1,1 @@
+Migrate weekly-uv-lock workflow to GitHub App token (POLICYENGINE_GITHUB PAT expired).


### PR DESCRIPTION
## Summary

The org-level PAT `POLICYENGINE_GITHUB` expired on 2026-01-12, which broke the `weekly-uv-lock` workflow at checkout time with "could not read Username for 'https://github.com'". This PR swaps both uses of the PAT in `.github/workflows/weekly-uv-lock.yaml` for a short-lived token minted by the existing PolicyEngine GitHub App (already used in `push.yaml`).

## Changes

- Add a `Generate GitHub App token` step using `actions/create-github-app-token@v1` with `APP_ID` / `APP_PRIVATE_KEY` (org-level secrets, same App installation as `push.yaml`).
- `actions/checkout@v4` now consumes `${{ steps.app-token.outputs.token }}`.
- `gh pr create` step consumes the same token via its `GH_TOKEN` env var.

## Context

This mirrors the migrations already merged into sibling repos:
- `policyengine-core` PR #470
- `microdf` PR #296
- `policyengine-api` (same pattern)

Closes the last remaining consumer of `POLICYENGINE_GITHUB` in this repo outside of `push.yaml` (which is already on the App).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/weekly-uv-lock.yaml'))"` succeeds
- [ ] CI passes on this PR
- [ ] Next Wednesday 22:00 UTC cron run succeeds (or `workflow_dispatch` smoke test after merge)