### PR TITLE
Apply CT C4K activity test to tax-unit head/spouse only

### DIFF
--- a/changelog.d/fix-ct-c4k-activity-test-head-filter.fixed.md
+++ b/changelog.d/fix-ct-c4k-activity-test-head-filter.fixed.md
@@ -1,0 +1,1 @@
+Apply the Connecticut Care 4 Kids activity test to the tax-unit head or spouse only, so a working dependent does not qualify the family.

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/eligibility/ct_c4k_meets_activity_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/eligibility/ct_c4k_meets_activity_test.yaml
@@ -117,3 +117,58 @@
   output:
     # Age 20 is NOT < 20 threshold, no employment, high income prevents TFA
     ct_c4k_meets_activity_test: false
+
+- name: Case 7, working teen dependent does not satisfy activity test for family.
+  period: 2025-01
+  input:
+    people:
+      parent:
+        age: 40
+        is_tax_unit_head: true
+        pension_income: 60_000
+      teen_dependent:
+        age: 17
+        is_tax_unit_dependent: true
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [parent, teen_dependent]
+    spm_units:
+      spm_unit:
+        members: [parent, teen_dependent]
+    households:
+      household:
+        members: [parent, teen_dependent]
+        state_code: CT
+  output:
+    # Activity test applies to applicant/caretaker (head or spouse) only.
+    # A working dependent (e.g., teen summer job) does not qualify the family.
+    # Parent has only pension income, no TFA, not a teen parent -> false.
+    ct_c4k_meets_activity_test: false
+
+- name: Case 8, self-employed teen dependent also excluded.
+  period: 2025-01
+  input:
+    people:
+      parent:
+        age: 45
+        is_tax_unit_head: true
+        pension_income: 60_000
+      teen_dependent:
+        age: 16
+        is_tax_unit_dependent: true
+        self_employment_income: 4_000
+    tax_units:
+      tax_unit:
+        members: [parent, teen_dependent]
+    spm_units:
+      spm_unit:
+        members: [parent, teen_dependent]
+    households:
+      household:
+        members: [parent, teen_dependent]
+        state_code: CT
+  output:
+    # Self-employment income of a dependent should also not satisfy the
+    # activity test; only the head/spouse's work activity counts.
+    ct_c4k_meets_activity_test: false

--- a/policyengine_us/variables/gov/states/ct/oec/c4k/eligibility/ct_c4k_meets_activity_test.py
+++ b/policyengine_us/variables/gov/states/ct/oec/c4k/eligibility/ct_c4k_meets_activity_test.py
@@ -12,8 +12,17 @@ class ct_c4k_meets_activity_test(Variable):
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.ct.oec.c4k.age_threshold
         person = spm_unit.members
-        employed = spm_unit.any(person("employment_income", period) > 0)
-        self_employed = spm_unit.any(person("self_employment_income", period) > 0)
+        # C4K activity test applies to the applicant/caretaker
+        # (tax-unit head or spouse) only. A working dependent (e.g., a
+        # teen with a summer job) does not satisfy the test for the
+        # family.
+        is_head_or_spouse = person("is_tax_unit_head_or_spouse", period.this_year)
+        employed = spm_unit.any(
+            is_head_or_spouse & (person("employment_income", period) > 0)
+        )
+        self_employed = spm_unit.any(
+            is_head_or_spouse & (person("self_employment_income", period) > 0)
+        )
         in_tfa = spm_unit("ct_tfa_eligible", period)
         teen_parent_in_school = spm_unit.any(
             person("is_parent", period.this_year)


### PR DESCRIPTION
## Summary

Follow-up to #7778. The Connecticut Care 4 Kids activity test (RCSA 17b-749-04) requires the *applicant* or *caretaker* to be employed, self-employed, receiving TFA, or a teen parent in school. The initial implementation checked whether *any* SPM-unit member had employment or self-employment income, so a working dependent (for example, a teen with a part-time or summer job) would make the whole family appear to meet the activity test.

Gating the earnings check on `is_tax_unit_head_or_spouse` restricts the activity test to the applicant/spouse, matching the statute. TFA eligibility and the teen-parent-in-school branches already reference the correct person, so they are unchanged.

## Regulatory authority

- RCSA 17b-749-04 -- Non-financial eligibility (activity requirement applies to parents/caretakers seeking the subsidy).
- See #7778 for the full rulemaking history.

## Regression tests

Added two cases to `ct_c4k_meets_activity_test.yaml`:

- **Case 7**: working teen dependent (age 17, $8,000 earnings), head has only pension income -- now returns `false`.
- **Case 8**: self-employed teen dependent (age 16), head has only pension income -- also returns `false`.

Both tests fail on `main` and pass after this change. All 135 CT C4K tests and all 456 CT-state tests pass.

## Test plan

- [x] New regression cases fail without the fix
- [x] New regression cases pass with the fix
- [x] All CT C4K tests pass (135/135)
- [x] All CT state tests pass (456/456)
