### PR TITLE
Scale NJ CCAP copay by children actually in care

### DIFF
--- a/changelog.d/fix-nj-ccap-copay-attending-children.fixed.md
+++ b/changelog.d/fix-nj-ccap-copay-attending-children.fixed.md
@@ -1,0 +1,1 @@
+Scale the New Jersey CCAP family co-payment by children actually receiving care, not just all eligible children.

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_copay.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_copay.yaml
@@ -396,3 +396,82 @@
         state_code: NJ
   output:
     nj_ccap_copay: 0
+
+- name: Case 11, two eligible children but only one attending uses first-child rate.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 31_000
+        immigration_status: CITIZEN
+      kid_in_care:
+        age: 4
+        is_tax_unit_dependent: true
+        immigration_status: CITIZEN
+        childcare_hours_per_week: 35
+        nj_ccap_provider_type: LICENSED_CENTER
+        nj_ccap_grow_nj_kids_rating: NONE
+      kid_not_in_care:
+        age: 6
+        is_tax_unit_dependent: true
+        immigration_status: CITIZEN
+        childcare_hours_per_week: 0
+        nj_ccap_provider_type: LICENSED_CENTER
+        nj_ccap_grow_nj_kids_rating: NONE
+    tax_units:
+      tax_unit:
+        members: [parent, kid_in_care, kid_not_in_care]
+    spm_units:
+      spm_unit:
+        members: [parent, kid_in_care, kid_not_in_care]
+    households:
+      household:
+        members: [parent, kid_in_care, kid_not_in_care]
+        state_code: NJ
+  output:
+    # Copay scales with children actually attending care, not just those
+    # eligible. FPG family of 3 = 27_320; FPL ratio = 31_000/27_320 = 1.134.
+    # 1 child FT in care at 101-200% FPL -> first child FT rate 2%.
+    # monthly copay = 31_000 * 0.02 / 12 = 51.67
+    nj_ccap_copay: 51.67
+
+- name: Case 12, two eligible children with only one PT attending uses first-child PT rate.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 40_000
+        immigration_status: CITIZEN
+      kid_in_care:
+        age: 4
+        is_tax_unit_dependent: true
+        immigration_status: CITIZEN
+        childcare_hours_per_week: 20
+        nj_ccap_provider_type: LICENSED_CENTER
+        nj_ccap_grow_nj_kids_rating: NONE
+      kid_not_in_care:
+        age: 7
+        is_tax_unit_dependent: true
+        immigration_status: CITIZEN
+        childcare_hours_per_week: 0
+        nj_ccap_provider_type: LICENSED_CENTER
+        nj_ccap_grow_nj_kids_rating: NONE
+    tax_units:
+      tax_unit:
+        members: [parent, kid_in_care, kid_not_in_care]
+    spm_units:
+      spm_unit:
+        members: [parent, kid_in_care, kid_not_in_care]
+    households:
+      household:
+        members: [parent, kid_in_care, kid_not_in_care]
+        state_code: NJ
+  output:
+    # FPG family of 3 = 27_320; FPL ratio = 40_000/27_320 = 1.464.
+    # Only one attending child (PT) -> first child PT rate 1%.
+    # monthly copay = 40_000 * 0.01 / 12 = 33.33
+    nj_ccap_copay: 33.33

--- a/policyengine_us/variables/gov/states/nj/njdhs/ccap/copay/nj_ccap_copay.py
+++ b/policyengine_us/variables/gov/states/nj/njdhs/ccap/copay/nj_ccap_copay.py
@@ -26,10 +26,16 @@ class nj_ccap_copay(Variable):
         is_eligible_child = person("nj_ccap_eligible_child", period)
         time_category = person("nj_ccap_time_category", period)
         is_ft = time_category == NJCCAPTimeCategory.FULL_TIME
+        # Copay scales with children actually receiving care, not merely
+        # those who would be eligible. Follows the VA CCSP (va_ccsp_copay)
+        # and SC CCAP (sc_ccap_copay) pattern of gating the child count on
+        # an "in care" flag.
+        in_care = person("childcare_hours_per_week", period.this_year) > 0
+        is_paying_child = is_eligible_child & in_care
 
-        n_eligible = spm_unit.sum(is_eligible_child)
-        n_ft = spm_unit.sum(is_eligible_child & is_ft)
-        has_second_child = n_eligible >= 2
+        n_paying = spm_unit.sum(is_paying_child)
+        n_ft = spm_unit.sum(is_paying_child & is_ft)
+        has_second_child = n_paying >= 2
 
         # First child rate: use FT rate if any child is FT, else PT
         first_child_rate = where(


### PR DESCRIPTION
## Summary

Follow-up to #7811. The New Jersey CCAP copay schedule (CC-236) scales the family co-payment by the number of children actually receiving subsidized care, applying a first-child rate for one child in care and a first + second rate for two in care. The initial implementation counted all age- and immigration-eligible children, so a family with two eligible children but only one in subsidized care would be charged at the two-child rate instead of the one-child rate.

The fix gates the per-child count on an "in care" signal (`childcare_hours_per_week > 0`, evaluated at the year), following the existing pattern in `va_ccsp_copay.py` and `sc_ccap_copay.py`. The CPS-exemption check still references `is_eligible_child`, so the protective-services waiver is unchanged.

## Regulatory authority

- N.J.A.C. 10:15-9.1 -- Co-payment requirements (per-child rates apply to children receiving care).
- CC-236 Copayment Schedule -- first-child / second-child rates.
- See #7811 for the full program description.

## Regression tests

Added two cases to `nj_ccap_copay.yaml`:

- **Case 11**: two eligible children, only one FT in care, income in the 101-200% FPL tier -- now returns the 1-child FT rate (2%) -> $51.67/mo, not the 2-child FT rate (3%) -> $77.50/mo.
- **Case 12**: two eligible children, only one PT in care -- now returns the 1-child PT rate (1%) -> $33.33/mo.

Both tests fail on `main` and pass after this change. All 126 NJ CCAP tests and all 450 NJ-state tests pass.

## Test plan

- [x] New regression cases fail without the fix
- [x] New regression cases pass with the fix
- [x] All NJ CCAP tests pass (126/126)
- [x] All NJ state tests pass (450/450)
