### PR TITLE
Stop misclassifying AK SSP couples where both spouses qualify

### DIFF
--- a/changelog.d/fix-ak-ssp-claim-type-both-eligible.fixed.md
+++ b/changelog.d/fix-ak-ssp-claim-type-both-eligible.fixed.md
@@ -1,0 +1,1 @@
+Stop classifying both spouses as COUPLE_ONE_ELIGIBLE for Alaska Adult Public Assistance when both are individually ABD-eligible but not jointly claiming.

--- a/policyengine_us/tests/policy/baseline/gov/states/ak/dpa/ssp/ak_ssp_claim_type.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ak/dpa/ssp/ak_ssp_claim_type.yaml
@@ -48,3 +48,29 @@
   output:
     # select picks first True condition; joint_claim is checked first
     ak_ssp_claim_type: COUPLE_BOTH_ELIGIBLE
+
+- name: Case 5, both spouses individually ABD but not jointly claiming.
+  period: 2011
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_aged_blind_disabled: true
+        ssi_claim_is_joint: false
+      person2:
+        age: 68
+        is_ssi_aged_blind_disabled: true
+        ssi_claim_is_joint: false
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AK
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+  output:
+    # Both spouses are individually eligible. Neither should be
+    # treated as COUPLE_ONE_ELIGIBLE, because neither has an
+    # ineligible spouse. With joint_claim false, they fall back to
+    # INDIVIDUAL claims for purposes of the AK SSP classification.
+    ak_ssp_claim_type: [INDIVIDUAL, INDIVIDUAL]

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_claim_type.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_claim_type.py
@@ -54,8 +54,19 @@ class ak_ssp_claim_type(Variable):
             )
         )
         is_eligible_individual = person("is_ssi_aged_blind_disabled", period)
+        # COUPLE_ONE_ELIGIBLE requires exactly one spouse to be
+        # individually ABD-eligible. If both spouses qualify but they
+        # are not jointly claiming, they should not be misclassified
+        # as a one-eligible couple.
+        spouse_is_eligible = (
+            person.marital_unit.sum(is_eligible_individual.astype(int))
+            - is_eligible_individual.astype(int)
+        ) > 0
         one_eligible_couple = (
-            ~joint_claim & is_eligible_individual & (marital_unit_size == 2)
+            ~joint_claim
+            & is_eligible_individual
+            & ~spouse_is_eligible
+            & (marital_unit_size == 2)
         )
         couple_both_eligible = joint_claim & shared_living_arrangement
         return select(


### PR DESCRIPTION
## Summary

Follow-up to #7998. `ak_ssp_claim_type` assigned `COUPLE_ONE_ELIGIBLE` whenever `ssi_claim_is_joint` was `False`, the person was individually ABD-eligible, and the marital unit size was 2 - without checking the other spouse's eligibility. Two spouses who both qualified individually but were not jointly claiming would both be tagged as `COUPLE_ONE_ELIGIBLE`, which is semantically wrong (neither has an "ineligible spouse") and would route both through the with-ineligible-spouse grant pathway downstream.

### Changes

- `policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_claim_type.py`: require the other spouse to be individually ineligible before assigning `COUPLE_ONE_ELIGIBLE`; the both-eligible-but-not-joint scenario falls through to the `INDIVIDUAL` default.
- `ak_ssp_claim_type.yaml`: new Case 5 covering the both-individually-eligible, non-joint-claim scenario.

## Test plan

- [x] New regression case (`Case 5, both spouses individually ABD but not jointly claiming`) fails before the fix and passes after.
- [x] All 157 tests under `policyengine_us/tests/policy/baseline/gov/states/ak/` pass.
