### PR TITLE
Require head/spouse for NJ CCAP activity eligibility

### DIFF
--- a/changelog.d/fix-nj-ccap-activity-no-parent.fixed.md
+++ b/changelog.d/fix-nj-ccap-activity-no-parent.fixed.md
@@ -1,0 +1,1 @@
+Require the presence of at least one head/spouse for New Jersey CCAP activity eligibility so units with only dependents no longer vacuously pass the test.

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_activity_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_activity_eligible.yaml
@@ -1,0 +1,133 @@
+# New Jersey CCAP activity eligibility tests
+# Per N.J.A.C. 10:15-5.2, each head/spouse in the CCAP unit must
+# independently qualify (work hours above the weekly threshold or
+# full-time study) unless the family is otherwise covered by a
+# CCDF-recognized fallback activity (TANF, CP&P, etc.).
+#
+# The test also must not vacuously pass for an SPM unit that contains
+# no head/spouse (e.g. an unaccompanied-minor unit): activity eligibility
+# requires at least one head/spouse in the unit.
+
+- name: Case 1, working parent meets activity requirement.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        weekly_hours_worked: 35
+      person2:
+        age: 4
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ccap_activity_eligible: true
+
+- name: Case 2, parent below hour threshold fails.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        weekly_hours_worked: 20
+        is_full_time_student: false
+      person2:
+        age: 4
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    # Default fallback CCDF activity test is false, no exemption path
+    nj_ccap_activity_eligible: false
+
+- name: Case 3, full-time student parent meets requirement.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 22
+        weekly_hours_worked: 0
+        is_full_time_student: true
+      person2:
+        age: 2
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ccap_activity_eligible: true
+
+- name: Case 4, two parents where one fails hour threshold.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 35
+        weekly_hours_worked: 40
+      person2:
+        age: 33
+        weekly_hours_worked: 10
+        is_full_time_student: false
+      person3:
+        age: 4
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: NJ
+  output:
+    # Every head/spouse must independently qualify; default fallback false
+    nj_ccap_activity_eligible: false
+
+- name: Case 5, SPM unit with only dependents has no activity-eligible parent.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 16
+        is_tax_unit_dependent: true
+      person2:
+        age: 10
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    # No head/spouse in the unit -> must not vacuously pass the test
+    nj_ccap_activity_eligible: false

--- a/policyengine_us/variables/gov/states/nj/njdhs/ccap/eligibility/nj_ccap_activity_eligible.py
+++ b/policyengine_us/variables/gov/states/nj/njdhs/ccap/eligibility/nj_ccap_activity_eligible.py
@@ -22,9 +22,11 @@ class nj_ccap_activity_eligible(Variable):
         is_student = person("is_full_time_student", period.this_year)
         individually_eligible = meets_work_requirement | is_student
         # Each parent must independently qualify (N.J.A.C. 10:15-5.2).
+        # Require at least one head/spouse in the unit so an SPM unit
+        # containing only dependents does not vacuously pass.
         n_parents = spm_unit.sum(is_head_or_spouse)
         n_qualifying = spm_unit.sum(is_head_or_spouse & individually_eligible)
-        all_parents_qualify = n_qualifying >= n_parents
+        all_parents_qualify = (n_parents >= 1) & (n_qualifying >= n_parents)
         # Fallback for non-derivable activities (TANF recipients,
         # CP&P cases, job training combos).
         fallback = spm_unit("meets_ccdf_activity_test", period.this_year)


### PR DESCRIPTION
## Summary

Follow-up to #7811. `nj_ccap_activity_eligible` treated an SPM unit with zero heads/spouses as satisfying the activity test: `n_qualifying (0) >= n_parents (0)` evaluates to `True`. A unit composed only of dependents would vacuously pass.

This adds `n_parents >= 1` to the head/spouse qualification rule from N.J.A.C. 10:15-5.2, matching the fix applied to SC CCAP activity eligibility.

### Changes

- `policyengine_us/variables/gov/states/nj/njdhs/ccap/eligibility/nj_ccap_activity_eligible.py`: require `n_parents >= 1` alongside `n_qualifying >= n_parents`.
- New `nj_ccap_activity_eligible.yaml` test suite covering work hours, student exemption, multi-parent gating, and the orphaned-minors regression case.

## Test plan

- [x] New regression case (`Case 5, SPM unit with only dependents`) fails before the fix and passes after.
- [x] All 455 tests under `policyengine_us/tests/policy/baseline/gov/states/nj/` pass.
