### PR TITLE
Document VA CCSP FDH rate structure (no age-group dimension)

### DIFF
--- a/changelog.d/fix-8074-va-fdh-docs.fixed.md
+++ b/changelog.d/fix-8074-va-fdh-docs.fixed.md
@@ -1,0 +1,1 @@
+Documented that VA CCSP family day home rates vary by region only, not by age group, with new regression tests.

--- a/policyengine_us/parameters/gov/states/va/dss/ccsp/maximum_reimbursement_rate/family_day_home.yaml
+++ b/policyengine_us/parameters/gov/states/va/dss/ccsp/maximum_reimbursement_rate/family_day_home.yaml
@@ -1,4 +1,12 @@
 description: Virginia sets this daily maximum reimbursement rate for family day homes under the Child Care Subsidy Program.
+# The VDOE Maximum Reimbursement Rates FY 2024 table publishes FDH rates by
+# region and by age group, but within each Ready Region every FDH age-group
+# column holds the same dollar value (e.g. Blue Ridge FDH Full Day is $53
+# for Infant / Toddler / 2-year-old / Preschool / School-Age; Capital Area
+# is $62 for every age). FDH rates therefore vary by region only, so this
+# parameter is correctly indexed by `va_ccsp_ready_region` alone and does
+# not require a `va_ccsp_care_age_group` breakdown. The center rate does
+# vary by age group and is indexed on both dimensions in `center.yaml`.
 
 metadata:
   period: day
@@ -9,6 +17,8 @@ metadata:
   reference:
     - title: VDOE Maximum Reimbursement Rates FY 2024
       href: https://data.virginia.gov/dataset/general-child-care-subsidy-program-maximum-reimbursement-rates
+    - title: FY 2024 CCSP Maximum Reimbursement Rates (PDF, page 2, Family Day Home columns)
+      href: https://data.virginia.gov/dataset/611027f1-99ee-42ec-94a9-7ec9a8153ef5/resource/e60334ca-53dc-4094-b16d-001851976f43/download/maximum-reimbursement-rates-by-localityeffective-832023.pdf
 
 BLUE_RIDGE:
   2023-08-01: 53

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_daily_mrr.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_daily_mrr.yaml
@@ -102,3 +102,93 @@
         va_ccsp_ready_region: NORTH_CENTRAL
   output:
     va_ccsp_daily_mrr: 55
+
+# Cases 7-11 lock in the researched behavior that Virginia's FDH rates vary
+# by Ready Region only and do NOT vary by age group. Per the VDOE FY 2024
+# MRR table, Capital Area FDH Full Day is $62 for every age (Infant through
+# School-Age). Running five cases across the age-group enum in the same
+# region asserts the flat-per-region structure is preserved.
+- name: Case 7, family day home infant in Capital Area matches flat regional rate.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 0
+        va_ccsp_provider_type: FAMILY_DAY_HOME
+        va_ccsp_is_full_day: true
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+        va_ccsp_ready_region: CAPITAL_AREA
+  output:
+    va_ccsp_daily_mrr: 62
+
+- name: Case 8, family day home toddler in Capital Area matches flat regional rate.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 1
+        va_ccsp_provider_type: FAMILY_DAY_HOME
+        va_ccsp_is_full_day: true
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+        va_ccsp_ready_region: CAPITAL_AREA
+  output:
+    va_ccsp_daily_mrr: 62
+
+- name: Case 9, family day home two-year-old in Capital Area matches flat regional rate.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 2
+        va_ccsp_provider_type: FAMILY_DAY_HOME
+        va_ccsp_is_full_day: true
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+        va_ccsp_ready_region: CAPITAL_AREA
+  output:
+    va_ccsp_daily_mrr: 62
+
+- name: Case 10, family day home preschooler in Capital Area matches flat regional rate.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 4
+        va_ccsp_provider_type: FAMILY_DAY_HOME
+        va_ccsp_is_full_day: true
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+        va_ccsp_ready_region: CAPITAL_AREA
+  output:
+    va_ccsp_daily_mrr: 62
+
+- name: Case 11, family day home school-age in Capital Area matches flat regional rate.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 8
+        va_ccsp_provider_type: FAMILY_DAY_HOME
+        va_ccsp_is_full_day: true
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+        va_ccsp_ready_region: CAPITAL_AREA
+  output:
+    va_ccsp_daily_mrr: 62

--- a/policyengine_us/variables/gov/states/va/dss/ccsp/rates/va_ccsp_daily_mrr.py
+++ b/policyengine_us/variables/gov/states/va/dss/ccsp/rates/va_ccsp_daily_mrr.py
@@ -22,6 +22,9 @@ class va_ccsp_daily_mrr(Variable):
 
         is_center = provider_type == provider_type.possible_values.CENTER
         center_rate = p.center[region][age_group]
+        # Per the VDOE FY 2024 MRR table, FDH rates vary by Ready Region only;
+        # within each region every age-group column carries the same rate, so
+        # the FDH parameter is indexed by region alone (no age_group lookup).
         fdh_rate = p.family_day_home[region]
         full_day_rate = where(is_center, center_rate, fdh_rate)
         return where(is_full_day, full_day_rate, full_day_rate * p.part_day_factor)


### PR DESCRIPTION
## Summary
- Refs #8074 (Cluster A).
- Researched the VDOE FY 2024 Maximum Reimbursement Rates table (https://data.virginia.gov/dataset/general-child-care-subsidy-program-maximum-reimbursement-rates). The published table breaks out Family Day Home (FDH) columns by age (Infant / Toddler / 2-year-old / Pre-School / School-Age), but within each Ready Region every FDH age column holds the same dollar value (e.g. Blue Ridge $53 for all ages; Capital Area $62 for all ages; Southwest $48 for all ages).
- FDH rates therefore vary by region only, so `family_day_home.yaml` is correctly indexed by `va_ccsp_ready_region` alone. This PR adds explanatory comments to the parameter YAML and the `va_ccsp_daily_mrr` formula documenting this observation, plus five new YAML regression tests that lock the flat-per-region structure in.

## Statutory reference
- VDOE FY 2024 CCSP Maximum Reimbursement Rates, Level 1 table, page 2 (Family Day Home columns): https://data.virginia.gov/dataset/611027f1-99ee-42ec-94a9-7ec9a8153ef5/resource/e60334ca-53dc-4094-b16d-001851976f43/download/maximum-reimbursement-rates-by-localityeffective-832023.pdf
- `8VAC20-790-80. Determining payment amount.` (rates established by type of care, level of regulatory oversight, age of child, and unit of service — VDOE's implementation flattens the age dimension for FDH.)

## Test plan
- [x] `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_daily_mrr.yaml -c policyengine_us` — 11 passed (6 existing + 5 new FDH age-invariance cases).
- [ ] CI green.
