### PR TITLE
Exclude minor child earnings from VA CCSP countable income

### DIFF
--- a/changelog.d/fix-8074-va-child-income.fixed.md
+++ b/changelog.d/fix-8074-va-child-income.fixed.md
@@ -1,0 +1,1 @@
+Excluded earnings of VA CCSP household members under 18 from countable income, per 8VAC20-790-40(H).

--- a/policyengine_us/parameters/gov/states/va/dss/ccsp/income/countable_income/earned_sources.yaml
+++ b/policyengine_us/parameters/gov/states/va/dss/ccsp/income/countable_income/earned_sources.yaml
@@ -1,0 +1,15 @@
+description: Virginia counts these earned income sources as countable income under the Child Care Subsidy Program. Per 8VAC20-790-40(H), earnings of a family member younger than 18 years of age are excluded, so these sources are summed only for household members aged 18 or older.
+values:
+  2023-01-01:
+    - employment_income
+    - self_employment_income
+
+metadata:
+  unit: list
+  period: year
+  label: Virginia CCSP countable earned income sources (subject to child-under-18 exclusion)
+  reference:
+    - title: 8VAC20-790-40(H) Excluded income
+      href: https://law.lis.virginia.gov/admincode/title8/agency20/chapter790/section40/
+    - title: Virginia Child Care Subsidy Program Guidance Manual Section 3.4 E
+      href: https://ris.dls.virginia.gov/uploads/22VAC40/dibr/VDOE%20Child%20Care%20Program%20Guidance%20Manual%205.3.2023-20240822104447.pdf#page=63

--- a/policyengine_us/parameters/gov/states/va/dss/ccsp/income/countable_income/unearned_sources.yaml
+++ b/policyengine_us/parameters/gov/states/va/dss/ccsp/income/countable_income/unearned_sources.yaml
@@ -1,8 +1,6 @@
-description: Virginia counts these income sources as countable income under the Child Care Subsidy Program.
+description: Virginia counts these unearned income sources as countable income under the Child Care Subsidy Program. These sources are summed across all household members because 8VAC20-790-40(H)'s "earnings of a child younger than 18" exclusion applies only to earned income (wages and self-employment).
 values:
   2023-01-01:
-    - employment_income
-    - self_employment_income
     - child_support_received
     - social_security
     - pension_income
@@ -14,20 +12,20 @@ values:
     - dividend_income
     - rental_income
     - alimony_income
-    # The following are excluded income per 8VAC20-790-40(C)(1):
+    # The following are excluded income per 8VAC20-790-40(H):
     # ssi, tanf, snap, school meals, eitc, lump sums,
     # education scholarships/loans/grants, tax refunds,
     # monetary gifts, vendor payments, loans, capital gains,
     # GI Bill benefits, reimbursements, Holocaust restitution,
     # Agent Orange settlements, temporary census earnings,
-    # earnings of child under 18, earnings under $25/month
+    # earnings under $25/month.
 
 metadata:
   unit: list
   period: year
-  label: Virginia CCSP countable income sources
+  label: Virginia CCSP countable unearned income sources
   reference:
-    - title: 8VAC20-790-40(C)(1)
+    - title: 8VAC20-790-40(H) Excluded income
       href: https://law.lis.virginia.gov/admincode/title8/agency20/chapter790/section40/
     - title: Virginia Child Care Subsidy Program Guidance Manual Section 3.4 E
       href: https://ris.dls.virginia.gov/uploads/22VAC40/dibr/VDOE%20Child%20Care%20Program%20Guidance%20Manual%205.3.2023-20240822104447.pdf#page=63

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_countable_income.yaml
@@ -112,3 +112,80 @@
   output:
     # (30,000 + 24,000) / 12 = 4,500
     va_ccsp_countable_income: 4_500
+
+# Cases 6-8 exercise 8VAC20-790-40(H): "earnings of a child younger than
+# 18 years of age" are excluded from countable income. The exclusion
+# covers earned income only (wages and self-employment); unearned income
+# for household members under 18 (e.g. a child's SSA survivor benefit)
+# remains countable.
+- name: Case 6, working teen's employment income is excluded.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 40
+        employment_income: 36_000
+      teen:
+        age: 16
+        employment_income: 6_000
+      young_child:
+        age: 4
+    spm_units:
+      spm_unit:
+        members: [parent, teen, young_child]
+    households:
+      household:
+        members: [parent, teen, young_child]
+        state_code: VA
+  output:
+    # Parent earnings count: 36,000 / 12 = 3,000/month
+    # Teen's $6,000 employment_income is excluded (age 16 < 18)
+    va_ccsp_countable_income: 3_000
+
+- name: Case 7, minor child's self-employment income is excluded.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+      child_entrepreneur:
+        age: 15
+        self_employment_income: 12_000
+    spm_units:
+      spm_unit:
+        members: [parent, child_entrepreneur]
+    households:
+      household:
+        members: [parent, child_entrepreneur]
+        state_code: VA
+  output:
+    # Only parent's earned income counts: 24,000 / 12 = 2,000/month
+    va_ccsp_countable_income: 2_000
+
+- name: Case 8, minor child's unearned income is still countable.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+      child:
+        age: 10
+        social_security: 6_000
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: VA
+  output:
+    # Parent earnings 24,000 + child SSA survivor benefit 6,000 = 30,000
+    # Monthly: 30,000 / 12 = 2,500
+    # Only earnings (wages/self-employment) of children <18 are excluded;
+    # unearned income (e.g. social_security) of minors is still countable.
+    va_ccsp_countable_income: 2_500

--- a/policyengine_us/variables/gov/states/va/dss/ccsp/income/va_ccsp_countable_income.py
+++ b/policyengine_us/variables/gov/states/va/dss/ccsp/income/va_ccsp_countable_income.py
@@ -13,5 +13,18 @@ class va_ccsp_countable_income(Variable):
         "https://doe.virginia.gov/home/showpublisheddocument/56270#page=63",
     )
 
-    adds = "gov.states.va.dss.ccsp.income.countable_income.sources"
-    subtracts = "gov.states.va.dss.ccsp.income.countable_income.subtracts"
+    def formula(spm_unit, period, parameters):
+        p = parameters(period).gov.states.va.dss.ccsp.income.countable_income
+        # Per 8VAC20-790-40(H), earnings of a family member younger than 18
+        # years of age are excluded from countable income. We sum earned
+        # income (wages and self-employment) for adult (18+) members only,
+        # and sum unearned income across all members.
+        person = spm_unit.members
+        # `age` is a YEAR-defined variable; use period.this_year so the
+        # monthly formula picks up the annual age rather than age/12.
+        is_adult = person("age", period.this_year) >= 18
+        earned_per_person = sum(person(source, period) for source in p.earned_sources)
+        adult_earned_income = spm_unit.sum(earned_per_person * is_adult)
+        unearned_income = add(spm_unit, period, p.unearned_sources)
+        deductions = add(spm_unit, period, p.subtracts)
+        return adult_earned_income + unearned_income - deductions


### PR DESCRIPTION
## Summary
- Refs #8074 (Cluster B, VA).
- Implements the statutory exclusion in `8VAC20-790-40(H)` that "earnings of a child younger than 18 years of age" are excluded from countable income under the Virginia Child Care Subsidy Program.

## Changes
- Split `countable_income.sources` into:
  - `earned_sources`: `employment_income`, `self_employment_income` (summed only for members aged 18 or older, per the statute).
  - `unearned_sources`: all other previously listed sources (`child_support_received`, `social_security`, `pension_income`, `unemployment_compensation`, `workers_compensation`, `veterans_benefits`, `disability_benefits`, `interest_income`, `dividend_income`, `rental_income`, `alimony_income`), summed across all members because the exclusion in the statute applies only to earned income.
- Replace `va_ccsp_countable_income`'s declarative `adds=/subtracts=` with a formula that applies the adult filter.
- Add 3 YAML regression tests: working teen's wages excluded, minor child entrepreneur's self-employment excluded, minor's social-security unearned income still countable.

## Statutory reference
- `8VAC20-790-40(H)` Excluded income: https://law.lis.virginia.gov/admincode/title8/agency20/chapter790/section40/
- VDOE CCSP Guidance Manual Section 3.4 E: https://ris.dls.virginia.gov/uploads/22VAC40/dibr/VDOE%20Child%20Care%20Program%20Guidance%20Manual%205.3.2023-20240822104447.pdf#page=63

## Test plan
- [x] `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/ -c policyengine_us` — 151 passed (all CCSP tests green, including 3 new child-earnings cases).
- [ ] CI green.
