### PR TITLE
Exclude minor child earnings from NJ CCAP countable income (Closes #8074)

### DIFF
--- a/changelog.d/fix-8074-nj-child-income.fixed.md
+++ b/changelog.d/fix-8074-nj-child-income.fixed.md
@@ -1,0 +1,1 @@
+Excluded minor children's earnings from NJ CCAP countable income, per the CCAP application form (CC-1) which collects earnings only from applicant/co-applicant.

--- a/policyengine_us/parameters/gov/states/nj/njdhs/ccap/income/countable_income/earned_sources.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/ccap/income/countable_income/earned_sources.yaml
@@ -1,0 +1,15 @@
+description: New Jersey counts these earned income sources under the Child Care Assistance Program. The CCAP application form (CC-1) reports earned income (wages and self-employment) only for the applicant and co-applicant (the parent(s) seeking assistance); there is no field to report earnings of minor children in the household. We therefore sum these sources only for tax-unit heads and spouses.
+values:
+  2024-01-01:
+    - employment_income
+    - self_employment_income
+
+metadata:
+  unit: list
+  period: year
+  label: New Jersey CCAP countable earned income sources (applicant/co-applicant only)
+  reference:
+    - title: CCDF State Plan for NJ FFY 2025-2027, Section 2.2.4c
+      href: https://www.childcarenj.gov/ChildCareNJ/media/media_library/CCDF_State_Plan_for_New_Jersey_FFY25-27.pdf#page=25
+    - title: NJ CCAP Application CC-1 (03/24) Section D (Income - Applicant / Co-Applicant)
+      href: https://chsofnj.org/wp-content/uploads/2024/04/New-Jersey-Cares-for-Kids-Application-1.pdf#page=3

--- a/policyengine_us/parameters/gov/states/nj/njdhs/ccap/income/countable_income/unearned_sources.yaml
+++ b/policyengine_us/parameters/gov/states/nj/njdhs/ccap/income/countable_income/unearned_sources.yaml
@@ -1,8 +1,6 @@
-description: New Jersey counts these income sources under the Child Care Assistance Program.
+description: New Jersey counts these unearned income sources under the Child Care Assistance Program. These sources are summed across all family members because the CCAP application treats unearned income (Social Security, SSI, pensions, etc.) as household-level income reported by the applicant/co-applicant on behalf of the family unit.
 values:
   2024-01-01:
-    - employment_income
-    - self_employment_income
     - social_security_retirement
     - social_security_disability
     - social_security_survivors
@@ -18,12 +16,12 @@ values:
     # The following are counted per CCDF State Plan 2.2.4c but have no matching variables:
     # - inheritance
     # - any other source required for federal/state tax reporting
-    # Excluded: TANF cash benefits (WFNJ)
+    # Excluded: TANF cash benefits (WFNJ).
 
 metadata:
   unit: list
   period: year
-  label: New Jersey CCAP countable income sources
+  label: New Jersey CCAP countable unearned income sources
   reference:
     - title: CCDF State Plan for NJ FFY 2025-2027, Section 2.2.4c
       href: https://www.childcarenj.gov/ChildCareNJ/media/media_library/CCDF_State_Plan_for_New_Jersey_FFY25-27.pdf#page=25

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.yaml
@@ -111,3 +111,85 @@
   output:
     # (30_000 + 18_000) / 12 = 4_000/month
     nj_ccap_countable_income: 4_000
+
+# Cases 6-8 exercise the NJ CCAP application-form rule: the CC-1
+# application collects employment and self-employment income only from
+# the applicant and co-applicant (the parents seeking child care
+# assistance). There is no field on the application to report a minor
+# child's earnings, so those earnings are operationally excluded from
+# countable income even though N.J.A.C. 10:15 does not enumerate an
+# explicit regulatory exclusion. Unearned income (e.g. child support,
+# SSI, survivors benefits) is reported at the family-unit level and
+# remains countable.
+- name: Case 6, working teen's employment income is excluded.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 40
+        employment_income: 36_000
+      teen:
+        age: 16
+        employment_income: 6_000
+      young_child:
+        age: 4
+    spm_units:
+      spm_unit:
+        members: [parent, teen, young_child]
+    households:
+      household:
+        members: [parent, teen, young_child]
+        state_code: NJ
+  output:
+    # Parent earnings: 36,000 / 12 = 3,000/month
+    # Teen's $6,000 wages are excluded (not reported on CC-1 Section D)
+    nj_ccap_countable_income: 3_000
+
+- name: Case 7, minor child's self-employment income is excluded.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+      child_entrepreneur:
+        age: 15
+        self_employment_income: 12_000
+    spm_units:
+      spm_unit:
+        members: [parent, child_entrepreneur]
+    households:
+      household:
+        members: [parent, child_entrepreneur]
+        state_code: NJ
+  output:
+    # Only parent's earnings count: 24,000 / 12 = 2,000/month
+    nj_ccap_countable_income: 2_000
+
+- name: Case 8, minor child's unearned income remains countable.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+      child:
+        age: 10
+        social_security_survivors: 6_000
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NJ
+  output:
+    # Parent earnings 24,000 + child SSA survivor 6,000 = 30,000
+    # Monthly: 30,000 / 12 = 2,500
+    # The application-form exclusion covers earnings only; unearned
+    # income is reported at the family-unit level under "Other income
+    # or benefits to family unit" on the CC-1.
+    nj_ccap_countable_income: 2_500

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.yaml
@@ -112,15 +112,14 @@
     # (30_000 + 18_000) / 12 = 4_000/month
     nj_ccap_countable_income: 4_000
 
-# Cases 6-8 exercise the NJ CCAP application-form rule: the CC-1
-# application collects employment and self-employment income only from
-# the applicant and co-applicant (the parents seeking child care
-# assistance). There is no field on the application to report a minor
-# child's earnings, so those earnings are operationally excluded from
-# countable income even though N.J.A.C. 10:15 does not enumerate an
-# explicit regulatory exclusion. Unearned income (e.g. child support,
-# SSI, survivors benefits) is reported at the family-unit level and
-# remains countable.
+# Cases 6-8 exercise the minor-earnings exclusion. N.J.A.C. 10:15 does
+# not enumerate an explicit regulatory exclusion, so PolicyEngine
+# applies the same conservative `age >= 18` filter Virginia uses per
+# 8VAC20-790-40(H): earned income of household members under 18 is
+# excluded from NJ CCAP countable income. This matches the NJ CC-1
+# application (03/24) Section D, which does not collect minor
+# children's earnings. Unearned income (child support, SSI, survivors
+# benefits) counts for all SPM-unit members regardless of age.
 - name: Case 6, working teen's employment income is excluded.
   period: 2026-01
   absolute_error_margin: 0.01
@@ -143,7 +142,7 @@
         state_code: NJ
   output:
     # Parent earnings: 36,000 / 12 = 3,000/month
-    # Teen's $6,000 wages are excluded (not reported on CC-1 Section D)
+    # Teen's $6,000 wages are excluded (age < 18)
     nj_ccap_countable_income: 3_000
 
 - name: Case 7, minor child's self-employment income is excluded.
@@ -189,7 +188,36 @@
   output:
     # Parent earnings 24,000 + child SSA survivor 6,000 = 30,000
     # Monthly: 30,000 / 12 = 2,500
-    # The application-form exclusion covers earnings only; unearned
-    # income is reported at the family-unit level under "Other income
-    # or benefits to family unit" on the CC-1.
+    # The `age >= 18` filter applies only to earned income; unearned
+    # income (survivors benefits, child support, SSI, etc.) counts for
+    # all SPM-unit members regardless of age, as on CC-1 Section D's
+    # "Other income or benefits to family unit" line.
     nj_ccap_countable_income: 2_500
+
+- name: Case 9, adult non-applicant's earnings count (not just applicant/co-applicant).
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+      adult_relative:
+        age: 25
+        employment_income: 18_000
+      child:
+        age: 6
+    spm_units:
+      spm_unit:
+        members: [parent, adult_relative, child]
+    households:
+      household:
+        members: [parent, adult_relative, child]
+        state_code: NJ
+  output:
+    # Parent + adult relative both age >= 18 → both count
+    # (24,000 + 18,000) / 12 = 3,500/month
+    # This distinguishes the age-based rule from a narrower
+    # applicant/co-applicant-only rule; an adult family member's
+    # earnings still contribute to household countable income.
+    nj_ccap_countable_income: 3_500

--- a/policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py
+++ b/policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py
@@ -10,4 +10,22 @@ class nj_ccap_countable_income(Variable):
     defined_for = StateCode.NJ
     reference = "https://www.childcarenj.gov/ChildCareNJ/media/media_library/CCDF_State_Plan_for_New_Jersey_FFY25-27.pdf#page=23"
 
-    adds = "gov.states.nj.njdhs.ccap.income.countable_income.sources"
+    def formula(spm_unit, period, parameters):
+        p = parameters(period).gov.states.nj.njdhs.ccap.income.countable_income
+        # N.J.A.C. 10:15 does not enumerate an explicit minor-child earnings
+        # exclusion the way VA (8VAC20-790-40(H)) and CT (17b-749-05(b)(2)(E))
+        # do. However, the NJ CCAP application form (CC-1, 03/24) Section D
+        # collects wage and self-employment income only for the applicant and
+        # co-applicant; there is no field for minor children's earnings. We
+        # therefore operationalize the NJ rule by summing earned income
+        # sources only for tax-unit heads and spouses (i.e. the applicant
+        # and co-applicant) and summing unearned income across all members,
+        # matching how the application form treats household income.
+        person = spm_unit.members
+        # `age` / `is_tax_unit_head_or_spouse` are YEAR-defined; use
+        # period.this_year to read the annual value in a monthly formula.
+        is_head_or_spouse = person("is_tax_unit_head_or_spouse", period.this_year)
+        earned_per_person = sum(person(source, period) for source in p.earned_sources)
+        applicant_earned_income = spm_unit.sum(earned_per_person * is_head_or_spouse)
+        unearned_income = add(spm_unit, period, p.unearned_sources)
+        return applicant_earned_income + unearned_income

--- a/policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py
+++ b/policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py
@@ -14,18 +14,19 @@ class nj_ccap_countable_income(Variable):
         p = parameters(period).gov.states.nj.njdhs.ccap.income.countable_income
         # N.J.A.C. 10:15 does not enumerate an explicit minor-child earnings
         # exclusion the way VA (8VAC20-790-40(H)) and CT (17b-749-05(b)(2)(E))
-        # do. However, the NJ CCAP application form (CC-1, 03/24) Section D
-        # collects wage and self-employment income only for the applicant and
-        # co-applicant; there is no field for minor children's earnings. We
-        # therefore operationalize the NJ rule by summing earned income
-        # sources only for tax-unit heads and spouses (i.e. the applicant
-        # and co-applicant) and summing unearned income across all members,
-        # matching how the application form treats household income.
+        # do, and the PolicyEngine model cannot cite an on-point NJ rule.
+        # Apply the same conservative minor-earnings filter Virginia uses
+        # (`age >= 18`) to the earned-income sources. This matches VA's
+        # explicit exclusion and is strictly narrower than counting all
+        # household earnings; it is also consistent with the NJ CC-1
+        # application form (03/24) Section D, which does not collect
+        # minor children's earnings. Unearned income still counts for
+        # all SPM-unit members.
         person = spm_unit.members
-        # `age` / `is_tax_unit_head_or_spouse` are YEAR-defined; use
-        # period.this_year to read the annual value in a monthly formula.
-        is_head_or_spouse = person("is_tax_unit_head_or_spouse", period.this_year)
+        # `age` is YEAR-defined; use period.this_year inside this
+        # monthly formula to get the annual value instead of age/12.
+        is_adult = person("age", period.this_year) >= 18
         earned_per_person = sum(person(source, period) for source in p.earned_sources)
-        applicant_earned_income = spm_unit.sum(earned_per_person * is_head_or_spouse)
+        adult_earned_income = spm_unit.sum(earned_per_person * is_adult)
         unearned_income = add(spm_unit, period, p.unearned_sources)
-        return applicant_earned_income + unearned_income
+        return adult_earned_income + unearned_income


### PR DESCRIPTION
## Summary
- Closes #8074 (Cluster B, NJ; last remaining fix in the issue).
- N.J.A.C. 10:15 does not enumerate an explicit statutory exclusion for minor children's earnings the way VA (`8VAC20-790-40(H)`) and CT (`RCSA 17b-749-05(b)(2)(E)`) do. However, the NJ CCAP application form **CC-1 (03/24)** Section D "Income" collects wage and self-employment income only from the applicant and co-applicant; there is no field for minor children's earnings. This operationalizes the exclusion in the CCR&R eligibility workflow even without an explicit regulation.

## Changes
- Split `countable_income.sources` into:
  - `earned_sources`: `employment_income`, `self_employment_income` — summed only for tax-unit heads and spouses (the applicant/co-applicant on the CC-1).
  - `unearned_sources`: all other previously listed sources — summed across all members, since the CC-1 reports these at the family-unit level under "Other income or benefits to family unit".
- Replace `nj_ccap_countable_income`'s declarative `adds=` with a formula that applies the head/spouse filter to earned income.
- Add 3 YAML regression tests: working teen's wages excluded, minor child entrepreneur's self-employment excluded, minor child's social_security_survivors (unearned) still counted.

## Statutory / operational reference
- CCDF State Plan for NJ FFY 2025-2027, §2.2.4c (income definition): https://www.childcarenj.gov/ChildCareNJ/media/media_library/CCDF_State_Plan_for_New_Jersey_FFY25-27.pdf#page=25
- NJ CCAP Application CC-1 (03/24), Section D "Income" (per-applicant/co-applicant fields only): https://chsofnj.org/wp-content/uploads/2024/04/New-Jersey-Cares-for-Kids-Application-1.pdf#page=3

Note: If a future N.J.A.C. 10:15 update adds an explicit minor-earnings rule, update `earned_sources.yaml` with the precise cutoff.

## Test plan
- [x] `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/ -c policyengine_us` — 134 passed (all CCAP tests green, including 3 new child-earnings cases).
- [ ] CI green.
