### PR TITLE
Net chip_premium from household_net_income

### DIFF
--- a/changelog.d/chip-premium-net-income.added.md
+++ b/changelog.d/chip-premium-net-income.added.md
@@ -1,0 +1,1 @@
+Added `household_health_costs` aggregate; `chip_premium` now reduces `household_net_income` when health benefits are counted as income.

--- a/policyengine_us/parameters/gov/household/household_health_costs.yaml
+++ b/policyengine_us/parameters/gov/household/household_health_costs.yaml
@@ -1,0 +1,9 @@
+description: The government counts these sources as household health out-of-pocket costs.
+values:
+  2022-01-01:
+    - chip_premium
+
+metadata:
+  unit: list
+  period: year
+  label: Household health costs

--- a/policyengine_us/tests/policy/baseline/household/income/household/household_health_costs.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/household/household_health_costs.yaml
@@ -1,0 +1,16 @@
+- name: Household health costs are zero when health benefits are excluded from net income.
+  period: 2024
+  input:
+    gov.simulation.include_health_benefits_in_net_income: false
+    chip_premium: 360
+  output:
+    household_health_costs: 0
+
+- name: Household health costs pick up chip_premium when health benefits are included in net income.
+  period: 2024
+  input:
+    gov.simulation.include_health_benefits_in_net_income: true
+    chip_premium: 360
+  output:
+    household_health_costs: 360
+

--- a/policyengine_us/variables/household/income/household/household_health_costs.py
+++ b/policyengine_us/variables/household/income/household/household_health_costs.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class household_health_costs(Variable):
+    value_type = float
+    entity = Household
+    label = "Household health costs"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "Household out-of-pocket health costs such as CHIP premiums. Included "
+        "in net income only when health benefits are counted as income, so "
+        "that the costs and benefits are accounted for symmetrically."
+    )
+
+    def formula(household, period, parameters):
+        p = parameters(period)
+        if p.gov.simulation.include_health_benefits_in_net_income:
+            return add(household, period, p.gov.household.household_health_costs)
+        return 0

--- a/policyengine_us/variables/household/income/household/household_net_income.py
+++ b/policyengine_us/variables/household/income/household/household_net_income.py
@@ -12,4 +12,7 @@ class household_net_income(Variable):
         "household_benefits",
         "household_refundable_tax_credits",
     ]
-    subtracts = ["household_tax_before_refundable_credits"]
+    subtracts = [
+        "household_tax_before_refundable_credits",
+        "household_health_costs",
+    ]


### PR DESCRIPTION
Follow-up to #8086.

## Problem

`chip_premium` (added in #8086) is a real household out-of-pocket cost but is not wired into `household_net_income`. Combined with the existing behavior — `household_health_benefits` adds `chip` (gross CHIP spending via `per_capita_chip`) to net income when `gov.simulation.include_health_benefits_in_net_income` is on — this means CHIP families currently look richer than they are, by the premium amount.

## Change

Mirrors the existing `household_health_benefits` list pattern on the cost side:

- **`gov/household/household_health_costs.yaml`** — a parameter list of household out-of-pocket health costs. Starts with `[chip_premium]` and can grow to include Marketplace premiums, employer-plan premiums, copays, etc. in later PRs.
- **`household_health_costs`** — Household-level variable, gated on the same `gov.simulation.include_health_benefits_in_net_income` flag so the cost and benefit sides are symmetric (both on, or both off).
- **`household_net_income`** — adds `household_health_costs` to its `subtracts` list.

## Calibration

No change needed to `policyengine-us-data`. The CHIP calibration target is MACPAC's Exhibit 33 "CHIP Spending by State" — federal + state program outlays (gross). Premium revenue is separately tracked and doesn't net against the spending line. `per_capita_chip` = gross benefit value, `chip_premium` = separate household cost. Adding the subtraction on the net-income side doesn't affect government-spending targets.

## Testing

- `household_health_costs = 0` when `include_health_benefits_in_net_income` is false (even with a positive `chip_premium` input).
- `household_health_costs = chip_premium` when the flag is true.
- Existing `household_health_benefits` tests still pass.

4/4 tests pass locally. `make format` / `ruff check` clean.

## Test plan

- [x] Local tests pass
- [x] Formatter / linter pass
- [ ] CI passes
