### PR TITLE
Include chip_premium in SPM expenses so reforms propagate

### DIFF
--- a/changelog.d/chip-premium-moop.changed.md
+++ b/changelog.d/chip-premium-moop.changed.md
@@ -1,0 +1,1 @@
+Include `chip_premium` in `spm_unit_spm_expenses` so CHIP premium reforms propagate to SPM resources.

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_spm_expenses_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_spm_expenses_chip_premium.yaml
@@ -1,0 +1,51 @@
+- name: CHIP premium adds to SPM expenses.
+  period: 2024
+  input:
+    people:
+      parent:
+        is_chip_eligible: false
+        child_support_expense: 0
+        medical_out_of_pocket_expenses: 0
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+        child_support_expense: 0
+        medical_out_of_pocket_expenses: 0
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        tax_unit_medicaid_income_level: 1.70
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+        spm_unit_capped_work_childcare_expenses: 0
+    households:
+      household:
+        members: [parent, child]
+        state_code: TX
+  output:
+    spm_unit_spm_expenses: 35
+
+- name: No CHIP premium when household is outside any implemented CHIP premium state.
+  period: 2024
+  input:
+    people:
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+        child_support_expense: 0
+        medical_out_of_pocket_expenses: 0
+    tax_units:
+      tax_unit:
+        members: [child]
+        tax_unit_medicaid_income_level: 1.70
+    spm_units:
+      spm_unit:
+        members: [child]
+        spm_unit_capped_work_childcare_expenses: 0
+    households:
+      household:
+        members: [child]
+        state_code: VA
+  output:
+    spm_unit_spm_expenses: 0

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
@@ -8,9 +8,14 @@ class spm_unit_spm_expenses(Variable):
     definition_period = YEAR
     unit = USD
 
-    adds = [
-        "child_support_expense",
-        "medical_out_of_pocket_expenses",
-        "spm_unit_capped_work_childcare_expenses",
-        "chip_premium",
-    ]
+    def formula(spm_unit, period, parameters):
+        return add(
+            spm_unit,
+            period,
+            [
+                "child_support_expense",
+                "medical_out_of_pocket_expenses",
+                "spm_unit_capped_work_childcare_expenses",
+                "chip_premium",
+            ],
+        )

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
@@ -12,4 +12,5 @@ class spm_unit_spm_expenses(Variable):
         "child_support_expense",
         "medical_out_of_pocket_expenses",
         "spm_unit_capped_work_childcare_expenses",
+        "chip_premium",
     ]


### PR DESCRIPTION
Addresses the us-model half of #8089.

## Summary

Adds `chip_premium` to `spm_unit_spm_expenses.adds`, so CHIP premium reforms propagate to SPM resources.

```python
adds = [
    "child_support_expense",
    "medical_out_of_pocket_expenses",
    "spm_unit_capped_work_childcare_expenses",
    "chip_premium",  # new
]
```

This follows the existing precedent for TaxUnit-level variables reaching SPM-unit aggregates via `add()` (e.g. `premium_tax_credit` → `spm_unit_benefits`).

## Why this is the model side only

The full fix also needs a data-side change so baseline doesn't double-count. Today, `health_insurance_premiums_without_medicare_part_b` is pure CPS-imputed and already includes the CHIP premium a respondent reported paying. Adding the computed `chip_premium` on top double-counts at baseline.

The architectural plan (#8089) is:

1. **us-model (this PR)** — wire `chip_premium` into `spm_unit_spm_expenses` so reforms move SPM resources.
2. **us-data (follow-up)** — during data construction, compute each CPS record's baseline CHIP premium using the `chip_premium` variable at the reference year's rules (**2024, encoded here in us-model**), and subtract it from the imputed `health_insurance_premiums_without_medicare_part_b`. Baseline reconciles exactly after this.

Keeping the 2024 rules in policyengine-us (this PR's foundation, shipped in #8086) is the right location — us-data imports `chip_premium` at `period=2024` for each record.

## Reform behavior today (baseline double-count acknowledged)

- Reform that eliminates CHIP premiums: `chip_premium` drops to 0, SPM expenses fall → SPM resources rise. ✓
- Reform that raises a state's CHIP premium: `chip_premium` rises, SPM expenses rise → SPM resources fall. ✓
- Baseline absolute value is overstated by roughly 1× computed CHIP premium among CHIP families, pending #8089 item 2.

## Testing

- `spm_unit_spm_expenses = 35` when a Texas CHIP-eligible child's tax unit has `tax_unit_medicaid_income_level = 1.70` (other expenses zeroed).
- `spm_unit_spm_expenses = 0` for the same inputs with `state_code = VA` (no CHIP premium modeled).

Both pass locally. `make format` / `ruff check` clean.

## Test plan

- [x] Tests pass locally
- [x] Format / lint clean
- [ ] CI passes
