### PR TITLE
Encode historical MO and NY CHIP premium schedules for 2020-2026

### DIFF
--- a/changelog.d/chip-2024-rules.fixed.md
+++ b/changelog.d/chip-2024-rules.fixed.md
@@ -1,0 +1,1 @@
+Added historical effective-date brackets for MO and NY CHIP premium schedules so `chip_premium` returns accurate 2020-2026 values for the 2024 data-imputation baseline anchor.

--- a/policyengine_us/parameters/gov/states/mo/hhs/chip/premium/tier_1.yaml
+++ b/policyengine_us/parameters/gov/states/mo/hhs/chip/premium/tier_1.yaml
@@ -6,40 +6,61 @@ metadata:
   period: month
   label: Missouri CHIP premium tier 1 (above 150 through 185 percent FPL)
   reference:
-    - title: Missouri DSS Appendix E - CHIP Premium Schedule
+    - title: Missouri DSS Appendix E IM-4(PRM) - CHIP Premium Schedule
       href: https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
     - title: Missouri DSS CHIP Premium Chart
       href: https://mydss.mo.gov/childrens-health-insurance-program-chip-premium-chart
+    - title: Appendix E (04-20), effective April 1, 2020
+      href: https://web.archive.org/web/20210226122055/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: IM-4(PRM) (07-24), effective July 1, 2024
+      href: https://web.archive.org/web/20250202220119/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: IM-4(PRM) (07-25), effective July 1, 2025
+      href: https://web.archive.org/web/20250623210133/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
 brackets:
   - threshold:
-      2021-01-01: 1
+      2020-01-01: 1
     amount:
-      2021-01-01: 18
+      2020-01-01: 15
+      2024-07-01: 18
   - threshold:
-      2021-01-01: 2
+      2020-01-01: 2
     amount:
-      2021-01-01: 25
+      2020-01-01: 20
+      2024-07-01: 24
+      2025-07-01: 25
   - threshold:
-      2021-01-01: 3
+      2020-01-01: 3
     amount:
-      2021-01-01: 31
+      2020-01-01: 25
+      2024-07-01: 30
+      2025-07-01: 31
   - threshold:
-      2021-01-01: 4
+      2020-01-01: 4
     amount:
-      2021-01-01: 38
+      2020-01-01: 30
+      2024-07-01: 36
+      2025-07-01: 38
   - threshold:
-      2021-01-01: 5
+      2020-01-01: 5
     amount:
-      2021-01-01: 44
+      2020-01-01: 35
+      2024-07-01: 43
+      2025-07-01: 44
   - threshold:
-      2021-01-01: 6
+      2020-01-01: 6
     amount:
-      2021-01-01: 50
+      2020-01-01: 40
+      2024-07-01: 49
+      2025-07-01: 50
   - threshold:
-      2021-01-01: 7
+      2020-01-01: 7
     amount:
-      2021-01-01: 57
+      2020-01-01: 46
+      2024-07-01: 55
+      2025-07-01: 57
   - threshold:
-      2021-01-01: 8
+      2020-01-01: 8
     amount:
-      2021-01-01: 63
+      2020-01-01: 51
+      2024-07-01: 62
+      2025-07-01: 63

--- a/policyengine_us/parameters/gov/states/mo/hhs/chip/premium/tier_2.yaml
+++ b/policyengine_us/parameters/gov/states/mo/hhs/chip/premium/tier_2.yaml
@@ -6,38 +6,60 @@ metadata:
   period: month
   label: Missouri CHIP premium tier 2 (above 185 through 225 percent FPL)
   reference:
-    - title: Missouri DSS Appendix E - CHIP Premium Schedule
+    - title: Missouri DSS Appendix E IM-4(PRM) - CHIP Premium Schedule
       href: https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: Appendix E (04-20), effective April 1, 2020
+      href: https://web.archive.org/web/20210226122055/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: IM-4(PRM) (07-24), effective July 1, 2024
+      href: https://web.archive.org/web/20250202220119/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: IM-4(PRM) (07-25), effective July 1, 2025
+      href: https://web.archive.org/web/20250623210133/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
 brackets:
   - threshold:
-      2021-01-01: 1
+      2020-01-01: 1
     amount:
-      2021-01-01: 60
+      2020-01-01: 48
+      2024-07-01: 58
+      2025-07-01: 60
   - threshold:
-      2021-01-01: 2
+      2020-01-01: 2
     amount:
-      2021-01-01: 81
+      2020-01-01: 65
+      2024-07-01: 78
+      2025-07-01: 81
   - threshold:
-      2021-01-01: 3
+      2020-01-01: 3
     amount:
-      2021-01-01: 102
+      2020-01-01: 82
+      2024-07-01: 99
+      2025-07-01: 102
   - threshold:
-      2021-01-01: 4
+      2020-01-01: 4
     amount:
-      2021-01-01: 124
+      2020-01-01: 99
+      2024-07-01: 119
+      2025-07-01: 124
   - threshold:
-      2021-01-01: 5
+      2020-01-01: 5
     amount:
-      2021-01-01: 144
+      2020-01-01: 115
+      2024-07-01: 141
+      2025-07-01: 144
   - threshold:
-      2021-01-01: 6
+      2020-01-01: 6
     amount:
-      2021-01-01: 165
+      2020-01-01: 132
+      2024-07-01: 161
+      2025-07-01: 165
   - threshold:
-      2021-01-01: 7
+      2020-01-01: 7
     amount:
-      2021-01-01: 187
+      2020-01-01: 150
+      2024-07-01: 181
+      2025-07-01: 187
   - threshold:
-      2021-01-01: 8
+      2020-01-01: 8
     amount:
-      2021-01-01: 207
+      2020-01-01: 167
+      2024-07-01: 203
+      2025-07-01: 207

--- a/policyengine_us/parameters/gov/states/mo/hhs/chip/premium/tier_3.yaml
+++ b/policyengine_us/parameters/gov/states/mo/hhs/chip/premium/tier_3.yaml
@@ -6,38 +6,60 @@ metadata:
   period: month
   label: Missouri CHIP premium tier 3 (above 225 through 300 percent FPL)
   reference:
-    - title: Missouri DSS Appendix E - CHIP Premium Schedule
+    - title: Missouri DSS Appendix E IM-4(PRM) - CHIP Premium Schedule
       href: https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: Appendix E (04-20), effective April 1, 2020
+      href: https://web.archive.org/web/20210226122055/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: IM-4(PRM) (07-24), effective July 1, 2024
+      href: https://web.archive.org/web/20250202220119/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
+    - title: IM-4(PRM) (07-25), effective July 1, 2025
+      href: https://web.archive.org/web/20250623210133/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf
 brackets:
   - threshold:
-      2021-01-01: 1
+      2020-01-01: 1
     amount:
-      2021-01-01: 147
+      2020-01-01: 117
+      2024-07-01: 141
+      2025-07-01: 147
   - threshold:
-      2021-01-01: 2
+      2020-01-01: 2
     amount:
-      2021-01-01: 198
+      2020-01-01: 159
+      2024-07-01: 192
+      2025-07-01: 198
   - threshold:
-      2021-01-01: 3
+      2020-01-01: 3
     amount:
-      2021-01-01: 250
+      2020-01-01: 200
+      2024-07-01: 242
+      2025-07-01: 250
   - threshold:
-      2021-01-01: 4
+      2020-01-01: 4
     amount:
-      2021-01-01: 301
+      2020-01-01: 241
+      2024-07-01: 293
+      2025-07-01: 301
   - threshold:
-      2021-01-01: 5
+      2020-01-01: 5
     amount:
-      2021-01-01: 353
+      2020-01-01: 283
+      2024-07-01: 343
+      2025-07-01: 353
   - threshold:
-      2021-01-01: 6
+      2020-01-01: 6
     amount:
-      2021-01-01: 405
+      2020-01-01: 324
+      2024-07-01: 393
+      2025-07-01: 405
   - threshold:
-      2021-01-01: 7
+      2020-01-01: 7
     amount:
-      2021-01-01: 456
+      2020-01-01: 366
+      2024-07-01: 444
+      2025-07-01: 456
   - threshold:
-      2021-01-01: 8
+      2020-01-01: 8
     amount:
-      2021-01-01: 508
+      2020-01-01: 407
+      2024-07-01: 494
+      2025-07-01: 508

--- a/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
+++ b/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
@@ -6,26 +6,48 @@ metadata:
   period: month
   label: New York Child Health Plus monthly premium family cap
   reference:
-    - title: New York State Department of Health - Child Health Plus Eligibility and Cost
+    - title: New York State Department of Health - Child Health Plus Eligibility and Cost (current)
       href: https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: Child Health Plus page captured January 2020 (pre-2023 schedule with $27 cap at 160-222 percent FPL)
+      href: https://web.archive.org/web/20200118155511/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: Child Health Plus page captured February 2023 (restructured schedule)
+      href: https://web.archive.org/web/20230207084107/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
 brackets:
   - threshold:
-      2021-01-01: -.inf
+      2020-01-01: -.inf
     amount:
-      2021-01-01: 0
+      2020-01-01: 0
   - threshold:
-      2021-01-01: 2.23
+      2020-01-01: 1.60
+      2023-02-01: 2.22
+      2026-02-17: 2.23
     amount:
-      2021-01-01: 45
+      2020-01-01: 27
+      2023-02-01: 45
   - threshold:
-      2021-01-01: 2.51
+      2020-01-01: 2.22
+      2023-02-01: 2.50
+      2026-02-17: 2.51
     amount:
-      2021-01-01: 90
+      2020-01-01: 45
+      2023-02-01: 90
   - threshold:
-      2021-01-01: 3.01
+      2020-01-01: 2.50
+      2023-02-01: 3.00
+      2026-02-17: 3.01
     amount:
-      2021-01-01: 135
+      2020-01-01: 90
+      2023-02-01: 135
   - threshold:
-      2021-01-01: 3.51
+      2020-01-01: 3.00
+      2023-02-01: 3.50
+      2026-02-17: 3.51
     amount:
-      2021-01-01: 180
+      2020-01-01: 135
+      2023-02-01: 180
+  - threshold:
+      2020-01-01: 3.50
+      2023-02-01: 4.00
+    amount:
+      2020-01-01: 180
+      2023-02-01: 0

--- a/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/per_child.yaml
+++ b/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/per_child.yaml
@@ -6,26 +6,50 @@ metadata:
   period: month
   label: New York Child Health Plus monthly premium per child
   reference:
-    - title: New York State Department of Health - Child Health Plus Eligibility and Cost
+    - title: New York State Department of Health - Child Health Plus Eligibility and Cost (current)
       href: https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: Child Health Plus page captured January 2020 (pre-2023 schedule with $9 tier at 160-222 percent FPL)
+      href: https://web.archive.org/web/20200118155511/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: Child Health Plus page captured February 2023 (restructured schedule, $9 tier eliminated, free threshold raised to 222 percent FPL)
+      href: https://web.archive.org/web/20230207084107/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: Child Health Plus page captured February 2024 (first page using "Effective for applications received on or after" caption)
+      href: https://web.archive.org/web/20240229061759/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
 brackets:
   - threshold:
-      2021-01-01: -.inf
+      2020-01-01: -.inf
     amount:
-      2021-01-01: 0
+      2020-01-01: 0
   - threshold:
-      2021-01-01: 2.23
+      2020-01-01: 1.60
+      2023-02-01: 2.22
+      2026-02-17: 2.23
     amount:
-      2021-01-01: 15
+      2020-01-01: 9
+      2023-02-01: 15
   - threshold:
-      2021-01-01: 2.51
+      2020-01-01: 2.22
+      2023-02-01: 2.50
+      2026-02-17: 2.51
     amount:
-      2021-01-01: 30
+      2020-01-01: 15
+      2023-02-01: 30
   - threshold:
-      2021-01-01: 3.01
+      2020-01-01: 2.50
+      2023-02-01: 3.00
+      2026-02-17: 3.01
     amount:
-      2021-01-01: 45
+      2020-01-01: 30
+      2023-02-01: 45
   - threshold:
-      2021-01-01: 3.51
+      2020-01-01: 3.00
+      2023-02-01: 3.50
+      2026-02-17: 3.51
     amount:
-      2021-01-01: 60
+      2020-01-01: 45
+      2023-02-01: 60
+  - threshold:
+      2020-01-01: 3.50
+      2023-02-01: 4.00
+    amount:
+      2020-01-01: 60
+      2023-02-01: 0

--- a/policyengine_us/tests/policy/baseline/gov/hhs/chip/chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/chip/chip_premium.yaml
@@ -73,4 +73,4 @@
         members: [p, c1, c2]
         state_code: MO
   output:
-    chip_premium: 372
+    chip_premium: 300

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/hhs/chip/mo_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/hhs/chip/mo_chip_premium.yaml
@@ -1,4 +1,4 @@
-- name: Missouri tier 1 family of 3 pays 31 dollars monthly.
+- name: Missouri tier 1 family of 3 in 2024 uses the pre-July 2024 schedule (25 dollars monthly).
   period: 2024
   input:
     people:
@@ -19,9 +19,9 @@
         members: [parent, child1, child2]
         state_code: MO
   output:
-    mo_chip_premium: 372
+    mo_chip_premium: 300
 
-- name: Missouri tier 2 family of 4 pays 124 dollars monthly.
+- name: Missouri tier 2 family of 4 in 2024 uses the pre-July 2024 schedule (99 dollars monthly).
   period: 2024
   input:
     people:
@@ -44,7 +44,30 @@
         members: [p1, p2, c1, c2]
         state_code: MO
   output:
-    mo_chip_premium: 1488
+    mo_chip_premium: 1188
+
+- name: Missouri tier 1 family of 3 in 2026 uses the post-July 2025 schedule (31 dollars monthly).
+  period: 2026
+  input:
+    people:
+      parent:
+        is_chip_eligible: false
+      child1:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+      child2:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [parent, child1, child2]
+        tax_unit_medicaid_income_level: 1.70
+    households:
+      household:
+        members: [parent, child1, child2]
+        state_code: MO
+  output:
+    mo_chip_premium: 372
 
 - name: Missouri below 151 percent FPL owes no premium.
   period: 2024

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
@@ -1,4 +1,22 @@
-- name: New York Child Health Plus below 223 percent FPL owes no premium.
+- name: New York Child Health Plus in 2022 charges 9 dollars per child between 160 and 222 percent FPL.
+  period: 2022
+  input:
+    people:
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [child]
+        tax_unit_medicaid_income_level: 1.80
+    households:
+      household:
+        members: [child]
+        state_code: NY
+  output:
+    ny_chip_premium: 108
+
+- name: New York Child Health Plus below 223 percent FPL owes no premium in 2024 after 9 dollar tier elimination.
   period: 2024
   input:
     people:


### PR DESCRIPTION
Follow-up to #8086.

## Problem

The CHIP premium parameters for Missouri and New York were dated `2021-01-01` with the most-recent (2025–2026) dollar amounts, so `chip_premium` at `period=2024` returned modern values rather than the historically accurate 2024 amounts. This matters for the us-data MOOP imputation subtraction described in #8089: `chip_premium` evaluated at the CPS reference year (2024) needs to return what CPS respondents actually paid in 2024.

## Changes

### Missouri (MO HealthNet for Kids, Appendix E / IM-4(PRM))

Three effective-dated schedules encoded in `premium/tier_1.yaml`, `tier_2.yaml`, `tier_3.yaml`:

| Period | Family-size-1 premium (tier 1 / 2 / 3) | Source |
|--------|-----------------------------------------|--------|
| 2020-01-01 – 2024-06-30 | $15 / $48 / $117 | [Appendix E (04-20)](https://web.archive.org/web/20210226122055/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf) |
| 2024-07-01 – 2025-06-30 | $18 / $58 / $141 | [IM-4(PRM) (07-24)](https://web.archive.org/web/20250202220119/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf) |
| 2025-07-01 onward | $18 / $60 / $147 | [IM-4(PRM) (07-25)](https://web.archive.org/web/20250623210133/https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf) |

The 2020 schedule was stable through June 2024 (confirmed by archived 2020 and 2022 charts showing identical dollars, and a Missouri Budget Project November 2023 brief citing the same $82 value for a family of 3 at 201% FPL).

### New York (Child Health Plus)

Restructured `premium/per_child.yaml` and `premium/family_cap.yaml`:

| Period | Structure | Per-child rates | Source |
|--------|-----------|-----------------|--------|
| pre 2023-02-01 | 6 brackets, free below 160% FPL | $0/$9/$15/$30/$45/$60 | [2020 snapshot](https://web.archive.org/web/20200118155511/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm) |
| 2023-02-01 onward | 5 brackets, free below 222% FPL ($9 tier eliminated) | $0/$15/$30/$45/$60 | [Feb 2023 snapshot](https://web.archive.org/web/20230207084107/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm) |
| 2026-02-17 onward | Same rates, thresholds micro-shifted (2.22→2.23 etc.) reflecting FPL rounding | $0/$15/$30/$45/$60 | [current page](https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm) |

### Wisconsin

No change. The per-child table has been stable since Release 19-01 (April 2019); only the 5%-of-income family cap amounts have moved release-to-release, and that cap isn't implemented in the model yet. Existing `2021-01-01` entries are historically accurate for 2024.

## Tests

Existing MO and NY tests at `period=2024` updated to reflect actual 2024 values (e.g., MO family of 3 tier 1 = $25/mo = $300/yr pre-July 2024, not the $31/mo = $372/yr July-2025 rate). Added `period=2026` MO test and `period=2022` NY test to verify transitions.

**70/70 CHIP tests pass locally.** `make format` / `ruff check` clean.

## Not included

- **Missouri April 2021 and April 2023 charts** — not archived on archive.org or mo.gov; evidence (identical dollar amounts in the 2020 and 2022 captures; Missouri Budget Project Nov 2023 brief citing matching numbers) indicates the premium dollar amounts were stable. Only the annual FPL refresh changed. Flagged as inferred in the parameter comments.
- **Wisconsin release history** — confirmed unchanged but not encoded as separate date entries since the per-child table didn't change.

## Test plan

- [x] 70 CHIP tests pass locally
- [x] Format / lint clean
- [ ] CI passes
