### PR TITLE
Route chip_premium through spm_unit_medical_out_of_pocket_expenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ tmpclaude-*-cwd
 
 # Claude Code worktrees
 .claude/worktrees/
+.gitnexus/

--- a/changelog.d/spm-moop-wrapper.changed.md
+++ b/changelog.d/spm-moop-wrapper.changed.md
@@ -1,0 +1,1 @@
+Added `spm_unit_medical_out_of_pocket_expenses` that combines person-level imputed MOOP with rules-based tax-unit-level premiums (currently `chip_premium`). `spm_unit_spm_expenses` now reads the wrapper instead of listing MOOP and each premium separately.

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.yaml
@@ -1,0 +1,44 @@
+- name: SPM unit medical OOP sums person MOOP and tax unit CHIP premium.
+  period: 2024
+  input:
+    people:
+      parent:
+        medical_out_of_pocket_expenses: 500
+      child:
+        medical_out_of_pocket_expenses: 100
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        tax_unit_medicaid_income_level: 1.70
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: TX
+  output:
+    spm_unit_medical_out_of_pocket_expenses: 635
+
+- name: Non-CHIP state SPM unit medical OOP is just the sum of person MOOP.
+  period: 2024
+  input:
+    people:
+      parent:
+        medical_out_of_pocket_expenses: 500
+      child:
+        medical_out_of_pocket_expenses: 100
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: VA
+  output:
+    spm_unit_medical_out_of_pocket_expenses: 600

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class spm_unit_medical_out_of_pocket_expenses(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "SPM unit medical out-of-pocket expenses"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "Total medical out-of-pocket expenses at the SPM unit level, "
+        "combining person-level imputed `medical_out_of_pocket_expenses` "
+        "with rules-based premium variables that are defined at higher "
+        "entities (e.g. `chip_premium` at the tax unit level). Used by "
+        "`spm_unit_spm_expenses` for SPM resource accounting. For the "
+        "person-level imputed figure alone, consumers that don't need "
+        "rules-based premium additions should read "
+        "`medical_out_of_pocket_expenses` directly."
+    )
+
+    def formula(spm_unit, period, parameters):
+        return add(
+            spm_unit,
+            period,
+            [
+                "medical_out_of_pocket_expenses",
+                "chip_premium",
+            ],
+        )

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_expenses.py
@@ -14,8 +14,7 @@ class spm_unit_spm_expenses(Variable):
             period,
             [
                 "child_support_expense",
-                "medical_out_of_pocket_expenses",
+                "spm_unit_medical_out_of_pocket_expenses",
                 "spm_unit_capped_work_childcare_expenses",
-                "chip_premium",
             ],
         )


### PR DESCRIPTION
Addresses #8100.

## Summary

Introduces `spm_unit_medical_out_of_pocket_expenses` — an SPM-unit-level MOOP variable that combines person-level imputed `medical_out_of_pocket_expenses` with TaxUnit-level rules-based premium variables (currently just `chip_premium` from #8086; Marketplace / Medicare Part B / Medicaid-expansion premiums will slot in as #8095 and #8102 land).

`spm_unit_spm_expenses` refactored to read the wrapper rather than listing MOOP and premiums side-by-side.

## Why

#8090 added `chip_premium` as a *sibling* of `medical_out_of_pocket_expenses` inside `spm_unit_spm_expenses`. Functionally correct for SPM net income. Conceptually off — a CHIP premium IS a medical out-of-pocket expense. This PR puts it where it belongs. See #8100 for fuller rationale.

Person-level `medical_out_of_pocket_expenses` stays untouched, so state medical-expense deductions (AL, AR, HI, MT, NJ, NM, NY, MO, PR) and SNAP excess medical deduction are unaffected.

## Testing

- 2 new tests for the wrapper (TX tax unit owing an enrollment fee, VA tax unit owing nothing)
- Existing `spm_unit_spm_expenses_chip_premium` tests pass unchanged
- 4/4 passing locally, \`make format\` / \`ruff check\` clean

## Test plan

- [x] Tests pass locally
- [x] Format / lint clean
- [ ] CI passes