### PR TITLE
Use rules-based Medicare Part B in SPM medical out-of-pocket expenses

### DIFF
--- a/changelog.d/medicare-part-b-in-spm.changed.md
+++ b/changelog.d/medicare-part-b-in-spm.changed.md
@@ -1,0 +1,1 @@
+SPM unit medical out-of-pocket expenses now uses rules-based `income_adjusted_part_b_premium` (base + IRMAA) in place of the imputed `medicare_part_b_premiums`, so reforms to the Medicare Part B base premium or IRMAA thresholds propagate through SPM resources.

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses_medicare_part_b.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses_medicare_part_b.yaml
@@ -1,0 +1,45 @@
+- name: SPM unit MOOP swaps imputed Medicare Part B for the rules-based computation at the base premium.
+  period: 2024
+  input:
+    people:
+      retiree:
+        age: 70
+        is_medicare_eligible: true
+        medical_out_of_pocket_expenses: 2_000
+        medicare_part_b_premiums: 1_500
+        income_adjusted_part_b_premium: 2_220
+    tax_units:
+      tax_unit:
+        members: [retiree]
+    spm_units:
+      spm_unit:
+        members: [retiree]
+    households:
+      household:
+        members: [retiree]
+        state_code: CA
+  output:
+    spm_unit_medical_out_of_pocket_expenses: 2_720
+
+- name: SPM unit MOOP reflects IRMAA surcharge for high-income Medicare household.
+  period: 2024
+  input:
+    people:
+      retiree:
+        age: 70
+        is_medicare_eligible: true
+        medical_out_of_pocket_expenses: 2_000
+        medicare_part_b_premiums: 1_500
+        income_adjusted_part_b_premium: 5_028
+    tax_units:
+      tax_unit:
+        members: [retiree]
+    spm_units:
+      spm_unit:
+        members: [retiree]
+    households:
+      household:
+        members: [retiree]
+        state_code: CA
+  output:
+    spm_unit_medical_out_of_pocket_expenses: 5_528

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.py
@@ -10,20 +10,19 @@ class spm_unit_medical_out_of_pocket_expenses(Variable):
     documentation = (
         "Total medical out-of-pocket expenses at the SPM unit level, "
         "combining person-level imputed `medical_out_of_pocket_expenses` "
-        "with rules-based premium variables that are defined at higher "
-        "entities (e.g. `chip_premium` at the tax unit level). Used by "
-        "`spm_unit_spm_expenses` for SPM resource accounting. For the "
-        "person-level imputed figure alone, consumers that don't need "
-        "rules-based premium additions should read "
-        "`medical_out_of_pocket_expenses` directly."
+        "with rules-based premium variables (CHIP premium, Medicare Part B "
+        "with IRMAA). The imputed Medicare Part B (`medicare_part_b_premiums`) "
+        "that ships with person-level MOOP is subtracted out and replaced "
+        "with the rules-based `income_adjusted_part_b_premium`, so reforms "
+        "to the Medicare Part B base premium or IRMAA thresholds propagate "
+        "through SPM resources. Consumers reading person-level "
+        "`medical_out_of_pocket_expenses` directly (SNAP excess medical "
+        "deduction, state itemized medical deductions) are unaffected."
     )
 
     def formula(spm_unit, period, parameters):
-        return add(
-            spm_unit,
-            period,
-            [
-                "medical_out_of_pocket_expenses",
-                "chip_premium",
-            ],
-        )
+        imputed_moop = add(spm_unit, period, ["medical_out_of_pocket_expenses"])
+        imputed_part_b = add(spm_unit, period, ["medicare_part_b_premiums"])
+        computed_part_b = add(spm_unit, period, ["income_adjusted_part_b_premium"])
+        chip_premium = add(spm_unit, period, ["chip_premium"])
+        return imputed_moop - imputed_part_b + computed_part_b + chip_premium


### PR DESCRIPTION
Closes half of #8095.

## Context

PolicyEngine-US already has a **rules-based** Medicare Part B premium variable: `income_adjusted_part_b_premium` (base premium + IRMAA surcharge by MAGI from 2 years prior, per filing status). It lives in \`variables/gov/hhs/medicare/eligibility/part_b/\`.

But it's currently orphaned — nothing consumes it. The imputed \`medicare_part_b_premiums\` is what flows into \`medical_out_of_pocket_expenses\` via \`health_insurance_premiums\`.

## Fix

In \`spm_unit_medical_out_of_pocket_expenses\` (the SPM-unit-level wrapper introduced by #8103), subtract the imputed figure and add the rules-based one:

\`\`\`python
return (
    imputed_moop
    - imputed_medicare_part_b_premiums
    + computed_income_adjusted_part_b_premium
    + chip_premium
)
\`\`\`

Baseline SPM now uses statute-driven Part B premium rather than CPS-imputed (removes per-family CPS noise). Reforms to the base premium or IRMAA thresholds propagate through SPM poverty measurement — previously they affected computed \`income_adjusted_part_b_premium\` but that variable was unused.

Person-level \`medical_out_of_pocket_expenses\` is untouched, so state itemized medical deductions and SNAP excess medical continue to see the imputed CPS figure.

## Testing

- 2 new tests in \`spm_unit_medical_out_of_pocket_expenses_medicare_part_b.yaml\`: base-premium scenario and IRMAA surcharge scenario
- Existing SPM wrapper tests unaffected
- 6/6 SPM-MOOP tests pass locally

## Caveats

This does **not** yet touch the Person-level \`medical_out_of_pocket_expenses\`. Doing so would swap the imputed figure for rules-based across all consumers (state deductions, SNAP, etc.), which is a larger change and warrants a separate PR once we confirm the rules-based figure matches CMS-aggregate calibration for baseline.

## Test plan

- [x] Local tests pass
- [x] \`make format\` / \`ruff check\` clean
- [ ] CI passes