### PR TITLE
Add marketplace_net_premium variable (Marketplace premium net of PTC)

### DIFF
--- a/changelog.d/marketplace-net-premium.added.md
+++ b/changelog.d/marketplace-net-premium.added.md
@@ -1,0 +1,1 @@
+Added `marketplace_net_premium` variable — annual Marketplace plan premium net of applied PTC.

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/marketplace_net_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/marketplace_net_premium.yaml
@@ -1,0 +1,23 @@
+- name: Marketplace net premium equals plan cost minus used PTC.
+  period: 2024
+  input:
+    selected_marketplace_plan_premium_proxy: 6_000
+    used_aca_ptc: 4_000
+  output:
+    marketplace_net_premium: 2_000
+
+- name: Marketplace net premium is zero when the household does not take up coverage.
+  period: 2024
+  input:
+    selected_marketplace_plan_premium_proxy: 0
+    used_aca_ptc: 0
+  output:
+    marketplace_net_premium: 0
+
+- name: Marketplace net premium floors at zero when PTC exceeds plan cost.
+  period: 2024
+  input:
+    selected_marketplace_plan_premium_proxy: 2_000
+    used_aca_ptc: 3_000
+  output:
+    marketplace_net_premium: 0

--- a/policyengine_us/variables/gov/aca/ptc/marketplace_net_premium.py
+++ b/policyengine_us/variables/gov/aca/ptc/marketplace_net_premium.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class marketplace_net_premium(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Marketplace plan net premium after PTC"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "Annual net premium paid by a tax unit for its selected Marketplace "
+        "plan, after the advance premium tax credit is applied. Equal to "
+        "the plan premium proxy minus the PTC actually used. Zero for "
+        "households not taking up Marketplace coverage."
+    )
+    reference = "https://www.law.cornell.edu/uscode/text/26/36B"
+
+    def formula(tax_unit, period, parameters):
+        plan_cost = tax_unit("selected_marketplace_plan_premium_proxy", period)
+        used_ptc = tax_unit("used_aca_ptc", period)
+        return max_(plan_cost - used_ptc, 0)


### PR DESCRIPTION
Partially addresses #8095.

## What

New variable \`marketplace_net_premium\` = \`selected_marketplace_plan_premium_proxy − used_aca_ptc\`.

The net out-of-pocket Marketplace premium a tax unit pays after the advance PTC is applied. Rules-based counterpart to the CPS-imputed Marketplace portion of \`health_insurance_premiums_without_medicare_part_b\`.

## Why not wire into SPM MOOP yet

The SPM MOOP wrapper (#8103) swaps imputed Medicare Part B for rules-based Medicare Part B cleanly because there's a dedicated imputed variable (\`medicare_part_b_premiums\`) that can be subtracted.

For Marketplace, the CPS-imputed Marketplace net premium is commingled inside \`health_insurance_premiums_without_medicare_part_b\` along with employer-sponsored insurance premiums, small Medicaid/CHIP premium receipts, etc. We can't cleanly subtract the Marketplace share without either:
1. A per-household "takes up Marketplace" flag in the CPS imputation, or
2. A reform-delta-only application pattern (only add the difference between reform and baseline computed values).

Either is a us-data-side change. Filing the wiring as a follow-up once the isolation mechanism is in place.

## Meanwhile

- \`marketplace_net_premium\` is available for consumers that want rules-based Marketplace net cost (cliff calculators, affordability analyses, reform studies). The variable moves with PTC reforms and benchmark changes.

## Testing

3/3 tests pass: normal case, no-takeup case, PTC-exceeds-premium zero-floor case.

## Test plan

- [x] Local tests pass
- [x] \`make format\` / \`ruff check\` clean
- [ ] CI passes