### PR TITLE
Add medicaid_premium with Indiana HIP POWER Account contribution

### DIFF
--- a/changelog.d/medicaid-expansion-premium.added.md
+++ b/changelog.d/medicaid-expansion-premium.added.md
@@ -1,0 +1,1 @@
+Added `medicaid_premium` federal aggregator variable plus Indiana HIP POWER Account contribution (`in_hip_power_account_contribution`), and wired `medicaid_premium` into `spm_unit_medical_out_of_pocket_expenses`. Collection is currently paused in Indiana; the encoded schedule is reform-ready.

--- a/policyengine_us/parameters/gov/states/in/fssa/hip/power_account/active.yaml
+++ b/policyengine_us/parameters/gov/states/in/fssa/hip/power_account/active.yaml
@@ -1,0 +1,11 @@
+description: Indiana collects Healthy Indiana Plan (HIP) POWER Account contributions only when this flag is true. Contributions have been suspended since 2020-03-01 under the COVID-19 public health emergency and remain paused after a 2024-06-27 federal court ruling (Rose v. Becerra) vacated CMS's HIP waiver approval.
+metadata:
+  unit: bool
+  period: year
+  label: Indiana HIP POWER Account contributions active
+  reference:
+    - title: Indiana Primary Care Association announcement (HIP cost-sharing paused)
+      href: https://www.indianapca.org/cost-sharing-for-hip-program-to-remain-paused-at-this-time/
+values:
+  2015-02-01: true
+  2020-03-01: false

--- a/policyengine_us/parameters/gov/states/in/fssa/hip/power_account/contribution_amount.yaml
+++ b/policyengine_us/parameters/gov/states/in/fssa/hip/power_account/contribution_amount.yaml
@@ -1,0 +1,33 @@
+description: Indiana charges this monthly Healthy Indiana Plan (HIP) POWER Account contribution per adult enrollee, tiered by FPL. Contribution is paused since the public health emergency and remains paused through 2025 following a June 27, 2024 federal court ruling.
+metadata:
+  type: single_amount
+  threshold_unit: /1
+  amount_unit: currency-USD
+  period: month
+  label: Indiana HIP POWER Account monthly contribution per enrollee
+  reference:
+    - title: Indiana FSSA HIP POWER Accounts
+      href: https://www.in.gov/fssa/hip/about-hip/power-accounts/
+    - title: Indiana HIP Section 1115 Waiver Special Terms and Conditions
+      href: https://www.medicaid.gov/medicaid/section-1115-demonstrations/downloads/in-healthy-indiana-plan-support-20-ca-20230321.pdf
+brackets:
+  - threshold:
+      2015-02-01: -.inf
+    amount:
+      2015-02-01: 1
+  - threshold:
+      2015-02-01: 0.23
+    amount:
+      2015-02-01: 5
+  - threshold:
+      2015-02-01: 0.51
+    amount:
+      2015-02-01: 10
+  - threshold:
+      2015-02-01: 0.76
+    amount:
+      2015-02-01: 15
+  - threshold:
+      2015-02-01: 1.01
+    amount:
+      2015-02-01: 20

--- a/policyengine_us/tests/policy/baseline/gov/states/in/fssa/hip/in_hip_power_account_contribution.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/fssa/hip/in_hip_power_account_contribution.yaml
@@ -1,0 +1,74 @@
+- name: Indiana HIP POWER Account contribution is zero in 2024 because collection is paused.
+  period: 2024
+  input:
+    people:
+      adult:
+        age: 30
+        is_hip_eligible_adult: true
+    tax_units:
+      tax_unit:
+        members: [adult]
+        tax_unit_medicaid_income_level: 0.80
+    households:
+      household:
+        members: [adult]
+        state_code: IN
+  output:
+    in_hip_power_account_contribution: 0
+
+- name: Indiana HIP POWER Account contribution in 2019 single adult at 80 percent FPL pays 15 dollars monthly.
+  period: 2019
+  input:
+    people:
+      adult:
+        age: 30
+        is_hip_eligible_adult: true
+    tax_units:
+      tax_unit:
+        members: [adult]
+        tax_unit_medicaid_income_level: 0.80
+    households:
+      household:
+        members: [adult]
+        state_code: IN
+  output:
+    in_hip_power_account_contribution: 180
+
+- name: Indiana HIP POWER Account contribution in 2019 two adults at 120 percent FPL pays 40 dollars monthly combined.
+  period: 2019
+  input:
+    people:
+      adult1:
+        age: 34
+        is_hip_eligible_adult: true
+      adult2:
+        age: 33
+        is_hip_eligible_adult: true
+    tax_units:
+      tax_unit:
+        members: [adult1, adult2]
+        tax_unit_medicaid_income_level: 1.20
+    households:
+      household:
+        members: [adult1, adult2]
+        state_code: IN
+  output:
+    in_hip_power_account_contribution: 480
+
+- name: Non-Indiana household owes no HIP contribution.
+  period: 2019
+  input:
+    people:
+      adult:
+        age: 30
+        is_hip_eligible_adult: true
+    tax_units:
+      tax_unit:
+        members: [adult]
+        tax_unit_medicaid_income_level: 0.80
+    households:
+      household:
+        members: [adult]
+        state_code: IL
+  output:
+    in_hip_power_account_contribution: 0

--- a/policyengine_us/variables/gov/hhs/medicaid/medicaid_premium.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/medicaid_premium.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class medicaid_premium(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Medicaid premium"
+    unit = USD
+    documentation = (
+        "Annual household-paid Medicaid premium or premium-like contribution "
+        "(e.g. Indiana HIP POWER Account, Michigan Healthy Michigan Plan "
+        "contributions, Montana HELP premiums). Zero by default; state-level "
+        "variables add their contributions. Michigan Healthy Michigan "
+        "contributions were eliminated 2024-01-01 and Montana HELP premiums "
+        "were eliminated 2023-01-01; Indiana HIP POWER Account contributions "
+        "have been paused since 2020-03-01. Schedules are still encoded for "
+        "reform analysis."
+    )
+    definition_period = YEAR
+    reference = "https://www.medicaid.gov/medicaid/section-1115-demonstrations/"
+    adds = ["in_hip_power_account_contribution"]

--- a/policyengine_us/variables/gov/states/in/fssa/hip/in_hip_power_account_contribution.py
+++ b/policyengine_us/variables/gov/states/in/fssa/hip/in_hip_power_account_contribution.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class in_hip_power_account_contribution(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Indiana HIP POWER Account annual contribution"
+    unit = USD
+    documentation = (
+        "Annual Indiana Healthy Indiana Plan (HIP) POWER Account contribution "
+        "paid by the tax unit. Monthly per-adult tier keyed on the tax unit's "
+        "income as a fraction of the federal poverty line, multiplied by the "
+        "count of HIP-eligible adults and by twelve months. Returns zero when "
+        "the collection flag is false (true value since 2020-03-01 per the "
+        "COVID-19 public health emergency and continued suspension after the "
+        "2024 court ruling)."
+    )
+    definition_period = YEAR
+    defined_for = StateCode.IN
+    reference = "https://www.in.gov/fssa/hip/about-hip/power-accounts/"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states["in"].fssa.hip.power_account
+        if not p.active:
+            return 0
+        n_hip_adults = tax_unit.sum(tax_unit.members("is_hip_eligible_adult", period))
+        income_level = tax_unit("tax_unit_medicaid_income_level", period)
+        monthly_per_adult = p.contribution_amount.calc(income_level)
+        return monthly_per_adult * n_hip_adults * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/in/fssa/hip/is_hip_eligible_adult.py
+++ b/policyengine_us/variables/gov/states/in/fssa/hip/is_hip_eligible_adult.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class is_hip_eligible_adult(Variable):
+    value_type = bool
+    entity = Person
+    label = "Indiana HIP-eligible adult"
+    definition_period = YEAR
+    documentation = (
+        "Adult enrolled in Indiana's Healthy Indiana Plan Medicaid expansion "
+        "(aged 19 through 64). POWER Account contributions apply only to "
+        "these members."
+    )
+    defined_for = StateCode.IN
+
+    def formula(person, period, parameters):
+        age = person("age", period)
+        return (age >= 19) & (age < 65)

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_medical_out_of_pocket_expenses.py
@@ -25,4 +25,11 @@ class spm_unit_medical_out_of_pocket_expenses(Variable):
         imputed_part_b = add(spm_unit, period, ["medicare_part_b_premiums"])
         computed_part_b = add(spm_unit, period, ["income_adjusted_part_b_premium"])
         chip_premium = add(spm_unit, period, ["chip_premium"])
-        return imputed_moop - imputed_part_b + computed_part_b + chip_premium
+        medicaid_premium = add(spm_unit, period, ["medicaid_premium"])
+        return (
+            imputed_moop
+            - imputed_part_b
+            + computed_part_b
+            + chip_premium
+            + medicaid_premium
+        )


### PR DESCRIPTION
Addresses part of #8102.

## Summary

Introduces a federal \`medicaid_premium\` tax-unit aggregator (parallel to \`chip_premium\`) and encodes Indiana's Healthy Indiana Plan POWER Account monthly contribution as the first state implementation. Also wires \`medicaid_premium\` into \`spm_unit_medical_out_of_pocket_expenses\`.

## Indiana HIP POWER Account

Per-enrollee monthly contribution, FPL-tiered (with tobacco surcharge and spouse-split simplifications omitted):

| FPL band | Monthly per adult |
|---|---:|
| ≤22% | \$1 |
| >22 – 50% | \$5 |
| >50 – 75% | \$10 |
| >75 – 100% | \$15 |
| >100% | \$20 |

Total = per-tier amount × count of HIP-eligible adults (19-64) × 12.

### Suspension

Collection has been paused since 2020-03-01 under the COVID-19 public health emergency and remains paused after the June 27, 2024 \`Rose v. Becerra\` federal court ruling vacated CMS's HIP waiver approval. The \`power_account.active\` parameter flag is \`false\` from 2020-03-01 onward. The tiered schedule is still encoded so a reform restoring collections (or a court decision reinstating the waiver) propagates naturally.

## MI and MT

Not encoded in this PR:
- Michigan Healthy Michigan Plan contributions were **eliminated 2024-01-01** per MDHHS Bulletin MMP 23-71
- Montana HELP premiums were **eliminated 2023-01-01** per CMS direction

Neither state has a current schedule to encode. Follow-up PRs can add the historical 2% rates if reform-reinstatement analysis becomes useful.

## SPM wiring

\`spm_unit_medical_out_of_pocket_expenses\` now includes \`medicaid_premium\` alongside \`chip_premium\` and the rules-based Medicare Part B computation. Person-level \`medical_out_of_pocket_expenses\` unchanged.

## Testing

- 4 tests for Indiana HIP: current-year zero (paused), 2019 single adult at 80% FPL, 2019 two adults at 120% FPL, non-Indiana household
- 19 existing SPM-unit tests still pass

## Sources

- https://www.in.gov/fssa/hip/about-hip/power-accounts/
- https://www.medicaid.gov/medicaid/section-1115-demonstrations/downloads/in-healthy-indiana-plan-support-20-ca-20230321.pdf
- https://www.indianapca.org/cost-sharing-for-hip-program-to-remain-paused-at-this-time/
- https://www.michigan.gov/mdhhs/-/media/Project/Websites/mdhhs/Assistance-Programs/Medicaid-BPHASA/2023-Bulletins/Final-Bulletin-MMP-23-71-HMP.pdf
- https://dphhs.mt.gov/assets/2025Legislature/MedicaidReport2025.pdf

## Test plan

- [x] Local tests pass
- [x] make format / ruff check clean
- [ ] CI passes