### PR TITLE
Prototype Quarto docs with MOOP and CHIP methodology pages

### DIFF
--- a/docs-quarto/.gitignore
+++ b/docs-quarto/.gitignore
@@ -1,0 +1,3 @@
+/.quarto/
+/_site/
+/_freeze/

--- a/docs-quarto/README.md
+++ b/docs-quarto/README.md
@@ -1,0 +1,46 @@
+# Quarto docs prototype
+
+A prototype for migrating PolicyEngine US documentation from Jupyter Book 2 to Quarto.
+
+## Why
+
+- **One source for docs and papers.** Quarto renders the same `.qmd` file to HTML (docs site) and PDF (working paper) from the same source. Methodology pages get reused as paper chapters; numeric results come from the same live simulation.
+- **Jupyter Book 2 drift.** The main Jupyter Book maintainer migrated the project to Quarto; JB2 has slower development and less academic adoption now.
+- **Reference auto-generation.** Quarto's computational blocks can call PolicyEngine US's metadata API to regenerate the variable catalog on each build.
+
+## Layout
+
+```
+docs-quarto/
+├── _quarto.yml
+├── index.qmd
+├── references.bib
+├── methodology/
+│   ├── index.qmd
+│   └── moop-decomposition.qmd
+├── programs/
+│   ├── index.qmd
+│   └── chip.qmd
+├── reference/
+│   └── index.qmd
+└── assets/
+    └── custom.scss
+```
+
+## Build
+
+```bash
+cd docs-quarto
+quarto render
+open _site/index.html
+```
+
+## Status
+
+This is a prototype — only two substantive content pages (MOOP decomposition, CHIP). The existing `docs/` Jupyter Book content has not been migrated. If this approach is approved, the next steps are:
+
+1. Migrate remaining methodology pages.
+2. Port program pages from `docs/gov/**`.
+3. Wire up the reference auto-generator.
+4. Add a paper output format (`--to pdf`) with journal template.
+5. Retire `docs/` and update CI.

--- a/docs-quarto/_quarto.yml
+++ b/docs-quarto/_quarto.yml
@@ -1,0 +1,48 @@
+project:
+  type: website
+  output-dir: _site
+  resources:
+    - "assets/**"
+
+website:
+  title: "PolicyEngine US"
+  description: "Methodology and reference for the US tax-benefit microsimulation model."
+  navbar:
+    left:
+      - href: index.qmd
+        text: Overview
+      - methodology/index.qmd
+      - programs/index.qmd
+      - reference/index.qmd
+  sidebar:
+    - id: methodology
+      title: "Methodology"
+      contents:
+        - methodology/index.qmd
+        - methodology/moop-decomposition.qmd
+    - id: programs
+      title: "Programs"
+      contents:
+        - programs/index.qmd
+        - programs/chip.qmd
+    - id: reference
+      title: "Reference"
+      contents:
+        - reference/index.qmd
+  page-footer:
+    center: "PolicyEngine — code at [github.com/PolicyEngine/policyengine-us](https://github.com/PolicyEngine/policyengine-us)."
+
+format:
+  html:
+    theme: [cosmo, assets/custom.scss]
+    toc: true
+    toc-depth: 3
+    code-copy: true
+    code-overflow: wrap
+    highlight-style: github
+    anchor-sections: true
+
+bibliography: references.bib
+
+execute:
+  freeze: auto

--- a/docs-quarto/assets/custom.scss
+++ b/docs-quarto/assets/custom.scss
@@ -1,0 +1,21 @@
+/*-- scss:defaults --*/
+
+$primary: #2C6496;
+$link-color: $primary;
+$body-bg: #ffffff;
+$body-color: #212529;
+$headings-color: #1a1a1a;
+
+/*-- scss:rules --*/
+
+.navbar-brand {
+  font-weight: 600;
+}
+
+h1, h2, h3 {
+  font-weight: 600;
+}
+
+table {
+  font-size: 0.95em;
+}

--- a/docs-quarto/index.qmd
+++ b/docs-quarto/index.qmd
@@ -1,0 +1,14 @@
+---
+title: "PolicyEngine US"
+subtitle: "Methodology and reference for the US tax-benefit microsimulation model"
+---
+
+PolicyEngine US is an open-source microsimulation model of the US tax and benefit system. It combines statutory rules encoded as Python formulas with a calibrated microdata foundation to answer policy questions at the household, state, and national level.
+
+This site covers:
+
+- **[Methodology](methodology/index.qmd)** — how the model is built: rules, data, calibration, and decompositions like medical out-of-pocket expenses.
+- **[Programs](programs/index.qmd)** — program-by-program writeups that trace eligibility, benefit value, and household-paid costs.
+- **[Reference](reference/index.qmd)** — auto-generated variable catalog pulled from the model's metadata API.
+
+The underlying code lives at [github.com/PolicyEngine/policyengine-us](https://github.com/PolicyEngine/policyengine-us). Every page here is reproducible — code blocks run against the installed model version when the site is built, so numeric results track the release rather than being pinned to whenever prose was written.

--- a/docs-quarto/methodology/index.qmd
+++ b/docs-quarto/methodology/index.qmd
@@ -1,0 +1,9 @@
+---
+title: "Methodology"
+---
+
+How PolicyEngine US is built and how to read its outputs.
+
+- [Medical out-of-pocket expense decomposition](moop-decomposition.qmd) — the architecture for layering rules-based premium computations on top of CPS-imputed medical costs.
+
+Planned sections (not yet written): microdata construction (enhanced CPS), calibration to administrative totals, behavioral responses, uprating, and validation against NBER TAXSIM and IRS SOI.

--- a/docs-quarto/methodology/moop-decomposition.qmd
+++ b/docs-quarto/methodology/moop-decomposition.qmd
@@ -1,0 +1,77 @@
+---
+title: "Medical out-of-pocket expense decomposition"
+subtitle: "Layering rules-based premium computations on CPS-imputed medical costs"
+---
+
+## Why a decomposition
+
+The Supplemental Poverty Measure subtracts medical out-of-pocket expenses (MOOP) from household resources. PolicyEngine US imports MOOP from the Current Population Survey's reported private health insurance premiums and other medical expenses. Imputed MOOP is accurate on average for the year the CPS was collected, but it does not respond to policy reform. If a user eliminates the ACA premium tax credit, simulated PTC goes to zero while imputed MOOP stays at the pre-reform value, understating the true cost to households.
+
+The fix is to decompose MOOP into a **rules-based** part (variables computable from statute) and an **imputed residual** (everything not modeled). Reforms move the rules-based part; the residual covers copays, over-the-counter costs, non-modeled employer premiums, etc.
+
+```
+medical_out_of_pocket_expenses
+    = imputed_residual
+    + computed_chip_premium
+    + computed_medicare_part_b_premium
+    + computed_marketplace_net_premium
+    + computed_medicaid_premium
+```
+
+with
+
+```
+imputed_residual = imputed_MOOP_total − baseline_computed_premium_sum
+```
+
+where `baseline_computed_premium_sum` is evaluated under the CPS reference year's rules during data construction, so baseline totals reconcile to CPS-reported MOOP while reforms propagate through the computed pieces.
+
+## What PolicyEngine US computes today
+
+| Component | Variable | Entity | Status |
+|---|---|---|---|
+| CHIP premium | `chip_premium` | TaxUnit | 17 states encoded (see [CHIP](../programs/chip.qmd)) |
+| Medicare Part B | `income_adjusted_part_b_premium` | Person | Rules-based (base + IRMAA tiers) |
+| Marketplace net premium | `marketplace_net_premium` | TaxUnit | `SLCSP × benchmark_ratio − used_PTC`; ratio imputed from CPS premium back-out |
+| Medicaid expansion premium | `medicaid_premium` | TaxUnit | IN HIP POWER Account (suspended since 2020, schedule reform-ready) |
+
+## The SPM-level wrapper
+
+At the SPM unit level, `spm_unit_medical_out_of_pocket_expenses` combines:
+
+```python
+def formula(spm_unit, period, parameters):
+    imputed_moop = add(spm_unit, period, ["medical_out_of_pocket_expenses"])
+    imputed_part_b = add(spm_unit, period, ["medicare_part_b_premiums"])
+    computed_part_b = add(
+        spm_unit, period, ["income_adjusted_part_b_premium"]
+    )
+    chip_premium = add(spm_unit, period, ["chip_premium"])
+    medicaid_premium = add(spm_unit, period, ["medicaid_premium"])
+    return (
+        imputed_moop
+        - imputed_part_b
+        + computed_part_b
+        + chip_premium
+        + medicaid_premium
+    )
+```
+
+Person-level `medical_out_of_pocket_expenses` is deliberately left untouched so downstream consumers that use it directly — SNAP excess medical deduction, state itemized medical deductions — continue to read the imputed figure. Only SPM resources see the decomposed value.
+
+## Why Marketplace net premium is layered differently
+
+CPS private-premium reports conflate Marketplace, employer, and direct-purchase coverage in a single aggregate. We populate `selected_marketplace_plan_benchmark_ratio` per tax unit via back-out from the reported premium, but the baseline subtraction of "imputed Marketplace premium" requires isolating the Marketplace share from the CPS aggregate — currently in-progress as a data-side follow-up. Until then, `marketplace_net_premium` is available as a variable but not wired into the SPM wrapper.
+
+## Gaps
+
+- **Copays** — the federal 5 % of income CHIP cost-sharing cap (42 CFR 457.560) binds on premiums + copays combined. Without copay modeling, the cap never bites on premium alone in realistic cases.
+- **Employer plan employee share** — stays in the imputed residual; employer plans aren't statutory and can't be computed from rules without a separate employer-plan model.
+- **Michigan and Montana historical Medicaid expansion premiums** — eliminated 2024-01-01 and 2023-01-01 respectively; historical schedules not yet encoded for reform analysis.
+
+## See also
+
+- [CHIP](../programs/chip.qmd) — state-by-state premium schedules.
+- GitHub issue [#8089](https://github.com/PolicyEngine/policyengine-us/issues/8089) — umbrella architecture issue.
+- GitHub issue [#8101](https://github.com/PolicyEngine/policyengine-us/issues/8101) — copay modeling and the 5 % cap.
+- GitHub issue [#8102](https://github.com/PolicyEngine/policyengine-us/issues/8102) — Medicaid expansion premium encoding.

--- a/docs-quarto/methodology/moop-decomposition.qmd
+++ b/docs-quarto/methodology/moop-decomposition.qmd
@@ -9,35 +9,9 @@ The Supplemental Poverty Measure subtracts medical out-of-pocket expenses (MOOP)
 
 The fix is to decompose MOOP into a **rules-based** part (variables computable from statute) and an **imputed residual** (everything not modeled). Reforms move the rules-based part; the residual covers copays, over-the-counter costs, non-modeled employer premiums, etc.
 
-```
-medical_out_of_pocket_expenses
-    = imputed_residual
-    + computed_chip_premium
-    + computed_medicare_part_b_premium
-    + computed_marketplace_net_premium
-    + computed_medicaid_premium
-```
+## What's shipped today
 
-with
-
-```
-imputed_residual = imputed_MOOP_total − baseline_computed_premium_sum
-```
-
-where `baseline_computed_premium_sum` is evaluated under the CPS reference year's rules during data construction, so baseline totals reconcile to CPS-reported MOOP while reforms propagate through the computed pieces.
-
-## What PolicyEngine US computes today
-
-| Component | Variable | Entity | Status |
-|---|---|---|---|
-| CHIP premium | `chip_premium` | TaxUnit | 17 states encoded (see [CHIP](../programs/chip.qmd)) |
-| Medicare Part B | `income_adjusted_part_b_premium` | Person | Rules-based (base + IRMAA tiers) |
-| Marketplace net premium | `marketplace_net_premium` | TaxUnit | `SLCSP × benchmark_ratio − used_PTC`; ratio imputed from CPS premium back-out |
-| Medicaid expansion premium | `medicaid_premium` | TaxUnit | IN HIP POWER Account (suspended since 2020, schedule reform-ready) |
-
-## The SPM-level wrapper
-
-At the SPM unit level, `spm_unit_medical_out_of_pocket_expenses` combines:
+The SPM-unit-level wrapper combines imputed and computed pieces:
 
 ```python
 def formula(spm_unit, period, parameters):
@@ -57,11 +31,48 @@ def formula(spm_unit, period, parameters):
     )
 ```
 
+| Component | How it flows | Double-count risk |
+|---|---|---|
+| Imputed person-level MOOP (private premiums + other medical) | In via `medical_out_of_pocket_expenses` | — |
+| Medicare Part B | Imputed subtracted, rules-based added (base + IRMAA) | No — clean swap |
+| CHIP premium (`chip_premium`) | Added on top of imputed MOOP | Yes — small overstatement for CHIP-paying families until CPS imputation strips the CHIP share at baseline |
+| Medicaid expansion premium (`medicaid_premium`) | Added on top of imputed MOOP | Yes — same pattern; IN HIP is the only state with a live (if currently suspended) schedule |
+| Marketplace net premium (`marketplace_net_premium`) | **Not wired in yet** | — |
+
 Person-level `medical_out_of_pocket_expenses` is deliberately left untouched so downstream consumers that use it directly — SNAP excess medical deduction, state itemized medical deductions — continue to read the imputed figure. Only SPM resources see the decomposed value.
+
+## The target architecture
+
+Once the CPS-imputation side strips each premium's baseline share from the reported aggregate, the wrapper becomes cleanly layered:
+
+```
+spm_unit_MOOP = imputed_residual
+              + computed_chip_premium
+              + computed_medicare_part_b_premium
+              + computed_marketplace_net_premium
+              + computed_medicaid_premium
+```
+
+with
+
+```
+imputed_residual = imputed_MOOP_total − baseline_computed_premium_sum
+```
+
+where `baseline_computed_premium_sum` is evaluated under the CPS reference year's rules during data construction. Baseline totals reconcile to CPS-reported MOOP exactly; reforms propagate through the computed pieces. Medicare Part B already works this way. CHIP and Medicaid will follow once per-household baseline premiums are pre-subtracted in `policyengine-us-data`.
+
+## Components computable today
+
+| Component | Variable | Entity | Status |
+|---|---|---|---|
+| CHIP premium | `chip_premium` | TaxUnit | 17 states encoded (see [CHIP](../programs/chip.qmd)) |
+| Medicare Part B | `income_adjusted_part_b_premium` | Person | Rules-based (base + IRMAA tiers); **fully swapped** in SPM wrapper |
+| Marketplace net premium | `marketplace_net_premium` | TaxUnit | `SLCSP × benchmark_ratio − used_PTC`; benchmark ratio imputed per-household via CPS back-out; not yet wired into the SPM wrapper |
+| Medicaid expansion premium | `medicaid_premium` | TaxUnit | IN HIP POWER Account (suspended since 2020, schedule reform-ready) |
 
 ## Why Marketplace net premium is layered differently
 
-CPS private-premium reports conflate Marketplace, employer, and direct-purchase coverage in a single aggregate. We populate `selected_marketplace_plan_benchmark_ratio` per tax unit via back-out from the reported premium, but the baseline subtraction of "imputed Marketplace premium" requires isolating the Marketplace share from the CPS aggregate — currently in-progress as a data-side follow-up. Until then, `marketplace_net_premium` is available as a variable but not wired into the SPM wrapper.
+CPS private-premium reports conflate Marketplace, employer, and direct-purchase coverage in a single aggregate. `selected_marketplace_plan_benchmark_ratio` is now populated per tax unit via back-out from the reported premium, but the baseline subtraction of "imputed Marketplace premium" requires isolating the Marketplace share from the CPS aggregate — in-progress as a data-side follow-up. Until then, `marketplace_net_premium` is available as a variable but not wired into the SPM wrapper.
 
 ## Gaps
 

--- a/docs-quarto/programs/chip.qmd
+++ b/docs-quarto/programs/chip.qmd
@@ -1,0 +1,82 @@
+---
+title: "CHIP"
+subtitle: "Children's Health Insurance Program"
+---
+
+PolicyEngine US models CHIP eligibility, per-capita benefit value, and household-paid premiums and enrollment fees for the 17 states that charge them.
+
+## Eligibility
+
+`is_chip_eligible` is true for a person if all of the following hold:
+
+- They are age-eligible: under the state's CHIP age cap (typically 18 or 19), or pregnant in FCEP / standard-pregnant-person states.
+- Household MAGI (as a fraction of the federal poverty line) is at or below the state's CHIP income limit. Limits vary from ~190 % in Idaho to ~405 % in New York.
+- They are not income-eligible for Medicaid.
+- Immigration status is eligible (not undocumented).
+
+State-specific eligibility is driven by `parameters/gov/hhs/chip/child/income_limit.yaml`.
+
+## Benefit value
+
+`per_capita_chip` is the state's net-of-cost-sharing spending per CHIP enrollee, from MACPAC Exhibit 33. `per_capita_chip_gross` adds back the state's CMS-21 cost-sharing offsets to recover the gross service value. `chip_gross` is the person-level analog summed within the household.
+
+## Premiums
+
+`chip_premium` is the annual household-paid premium or enrollment fee, at the tax unit level. It aggregates state-specific variables via
+
+```python
+adds = [
+    "al_chip_premium",
+    "ct_chip_premium",
+    "de_chip_premium",
+    "fl_chip_premium",
+    "ga_chip_premium",
+    "ia_chip_premium",
+    "id_chip_premium",
+    "il_chip_premium",
+    "in_chip_premium",
+    "ks_chip_premium",
+    "la_chip_premium",
+    "ma_chip_premium",
+    "mi_chip_premium",
+    "mo_chip_premium",
+    "ny_chip_premium",
+    "tx_chip_premium",
+    "wi_chip_premium",
+]
+```
+
+Each state uses one of four structural patterns:
+
+| Structure | States |
+|---|---|
+| Annual enrollment fee (per child, family cap) | AL, TX |
+| Monthly family flat fee by FPL band | CT, DE, FL, KS, LA, MI |
+| Monthly per-child with family cap | GA, IA, IL, MA, NY |
+| Monthly per-child without family cap | ID, WI |
+| Monthly per-child with 1-child vs 2+-child rates | IN |
+| Family-size × FPL tier matrix | MO |
+
+## States not encoded
+
+- **Nevada** — $25 / $50 / $80 quarterly family premium exists but the FPL tier boundaries are not published on primary state sources.
+- **Pennsylvania** — premium varies by chosen MCO across ~14 plans and tiers; PolicyEngine US doesn't currently model plan choice.
+- **North Dakota, New Jersey** — current status couldn't be verified from primary sources (NJ appears suspended).
+- **M-CHIP-funded pieces of MA, MI, NY, CT, DE** — cost-sharing offsets appear on Line 49 (Less Collection) of the Separate CHIP sheet for these combination-program states, not on the dedicated cost-sharing-offset lines. The Line 49 proxy is used in the gross reconstruction with a documented caveat about third-party liability noise.
+
+## SPM treatment
+
+`chip_premium` flows into `spm_unit_medical_out_of_pocket_expenses` (see [MOOP decomposition](../methodology/moop-decomposition.qmd)) and through `household_health_costs` into `household_net_income`, gated on the `gov.simulation.include_health_benefits_in_net_income` flag that already gates the benefit side.
+
+## Cost-sharing cap (not enforced)
+
+42 CFR 457.560 caps total CHIP cost sharing (premiums + copays) at 5 % of family income. PolicyEngine US does not currently enforce this cap. Enforcement on premiums alone would rarely bite because state schedules are designed below 5 % by construction; the cap mostly binds on premium + copay combinations, which require the copay modeling tracked in [issue #8101](https://github.com/PolicyEngine/policyengine-us/issues/8101).
+
+## Data sources
+
+Primary sources for state premium schedules vary by state. For each encoded state, the YAML parameter files cite the relevant state handbook, regulation, or Medicaid agency fee schedule. KFF's annual 50-state Medicaid and CHIP cost-sharing survey is the best cross-reference.
+
+## See also
+
+- [MOOP decomposition](../methodology/moop-decomposition.qmd)
+- GitHub issue [#5889](https://github.com/PolicyEngine/policyengine-us/issues/5889) — original framework request

--- a/docs-quarto/programs/index.qmd
+++ b/docs-quarto/programs/index.qmd
@@ -1,0 +1,23 @@
+---
+title: "Programs"
+---
+
+Program-by-program writeups tracing eligibility, benefit value, and household-paid costs.
+
+## Health
+
+- [CHIP](chip.qmd) — Children's Health Insurance Program
+
+Planned (not yet written): Medicaid, ACA premium tax credits, Medicare Part B.
+
+## Nutrition
+
+Planned: SNAP, WIC, free and reduced-price school meals.
+
+## Cash assistance
+
+Planned: TANF (federal and state variants), SSI, state SSPs.
+
+## Taxes
+
+Planned: federal income tax, state income taxes, payroll taxes, refundable credits.

--- a/docs-quarto/reference/index.qmd
+++ b/docs-quarto/reference/index.qmd
@@ -1,0 +1,9 @@
+---
+title: "Reference"
+---
+
+Placeholder for auto-generated variable catalog.
+
+Planned approach: build script pulls `/metadata` from a local Microsimulation, groups variables by `gov/agency/program` path, renders each as a `.qmd` page with label, entity, unit, documentation, and source references drawn directly from the Python class attributes. Pages regenerate on each release so reference docs never drift from the code.
+
+For now, the authoritative listing is `policyengine_us/programs.yaml` at the repo root.

--- a/docs-quarto/references.bib
+++ b/docs-quarto/references.bib
@@ -1,0 +1,6 @@
+@article{ghenis_woodruff_2024,
+  author = {Woodruff, Nikhil and Ghenis, Max},
+  title = {Enhancing Survey Microdata with Administrative Records: A Novel Approach to Microsimulation Dataset Construction},
+  year = {2024},
+  note = {Working paper}
+}


### PR DESCRIPTION
A **prototype** of migrating PolicyEngine US docs from Jupyter Book 2 to Quarto. Additive — existing \`docs/\` is untouched. If approved, a follow-up migrates the remaining content and retires Jupyter Book 2.

## What's here

\`\`\`
docs-quarto/
├── _quarto.yml           # site config, Cosmo theme, SCSS override
├── index.qmd             # landing page
├── references.bib
├── methodology/
│   ├── index.qmd
│   └── moop-decomposition.qmd     # substantive content
├── programs/
│   ├── index.qmd
│   └── chip.qmd                    # substantive content
├── reference/
│   └── index.qmd                   # placeholder for auto-generated variable catalog
└── assets/
    └── custom.scss
\`\`\`

Build works: \`cd docs-quarto && quarto render\` produces \`_site/index.html\`.

## Why Quarto

- **One source, multiple outputs** — same \`.qmd\` renders to HTML (docs site) and PDF (working paper) with journal-style citation and cross-reference support.
- **Computational blocks** — can run PolicyEngine US live during the build so numeric results track the release rather than going stale.
- **Adoption** — the main Jupyter Book maintainer moved the project to Quarto; JB2 is drifting.
- **Reference auto-generation path** — Python blocks can hit PolicyEngine's metadata API and emit one page per variable, grouped by \`gov/agency/program\`.

Alternative considered: MkDocs Material (docs) + Typst (paper). Simpler per tool but two sources to maintain; numbers can drift.

## Content choices for the prototype

The two substantive pages cover things just shipped this week:

- **methodology/moop-decomposition.qmd** — the imputed-plus-computed architecture: \`spm_unit_medical_out_of_pocket_expenses\` wrapper, rules-based Medicare Part B / CHIP / Medicaid-expansion / Marketplace premiums, and the CPS premium back-out for \`selected_marketplace_plan_benchmark_ratio\`.
- **programs/chip.qmd** — state-by-state schedule patterns (17 encoded), gross vs net benefit reconstruction, cost-sharing cap caveats, SPM wiring.

Both are self-contained; either could ship as-is to a user looking for the story behind the new variables.

## Next steps if approved

1. Port remaining methodology content from \`docs/analysis/\` and \`docs/validation/\`.
2. Convert \`docs/gov/hhs/medicaid.md\` and \`docs/gov/hhs/aca.md\` into Quarto programs pages alongside CHIP.
3. Wire up the reference auto-generator (Python block loops variables, emits \`.qmd\` per program).
4. Add \`--to pdf\` path for the methodology paper output, with a journal template (start with AEA template since that's where PolicyEngine papers have gone before).
5. CI: replace the \`myst build docs\` step with \`quarto render docs-quarto\` and GH Pages deployment.
6. Retire \`docs/\` once content is ported.

## Test plan

- [x] \`quarto render\` succeeds locally (6/6 pages)
- [ ] Subagent review on the approach and content fidelity