### PR TITLE
Add stillbirth tax provisions for CT, NE, and ND

### DIFF
--- a/changelog.d/stillbirth-credits-ct-ne-nd.added.md
+++ b/changelog.d/stillbirth-credits-ct-ne-nd.added.md
@@ -1,0 +1,1 @@
+Connecticut, Nebraska, and North Dakota stillbirth tax provisions effective 2022.

--- a/policyengine_us/parameters/gov/states/ct/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ct/tax/income/credits/non_refundable.yaml
@@ -10,5 +10,7 @@ values:
   2022-01-01:
     - ct_property_tax_credit
     - ct_child_tax_rebate
+    - ct_stillborn_credit
   2023-01-01:
     - ct_property_tax_credit
+    - ct_stillborn_credit

--- a/policyengine_us/parameters/gov/states/ct/tax/income/credits/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/ct/tax/income/credits/stillborn.yaml
@@ -1,0 +1,15 @@
+description: Connecticut provides this non-refundable credit for each delivery of a fetus born dead for which a fetal death certificate has been filed.
+values:
+  2021-01-01: 0
+  2022-01-01: 2_500
+metadata:
+  unit: currency-USD
+  period: year
+  label: Connecticut stillborn credit amount
+  reference:
+    - title: Conn. Gen. Stat. § 12-704i - Credit for delivery of a fetus born dead for which a fetal death certificate has been filed
+      href: https://www.cga.ct.gov/current/pub/chap_229.htm#sec_12-704i
+    - title: Connecticut Public Act No. 22-118, § 411 (effective July 1, 2022, applicable to taxable years commencing on or after January 1, 2022)
+      href: https://www.cga.ct.gov/2022/act/pa/pdf/2022PA-00118-R00SB-00005-PA.pdf
+    - title: Connecticut Public Act No. 23-31 (amendment effective June 7, 2023, applicable to taxable years commencing on or after January 1, 2022)
+      href: https://www.cga.ct.gov/2023/act/pa/pdf/2023PA-00031-R00HB-06680-PA.pdf

--- a/policyengine_us/parameters/gov/states/ct/tax/income/credits/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/ct/tax/income/credits/stillborn.yaml
@@ -13,3 +13,5 @@ metadata:
       href: https://www.cga.ct.gov/2022/act/pa/pdf/2022PA-00118-R00SB-00005-PA.pdf
     - title: Connecticut Public Act No. 23-31, § 10 (amended section 12-704i, effective June 7, 2023, applicable to taxable years commencing on or after January 1, 2022)
       href: https://www.cga.ct.gov/2023/act/pa/pdf/2023PA-00031-R00HB-06680-PA.pdf
+    - title: 2022 Schedule CT-IT Credit, Line 4 - Birth of a Stillborn Child Tax Credit
+      href: https://portal.ct.gov/-/media/drs/forms/2022/income/schedule-ct-it-credit_1222.pdf

--- a/policyengine_us/parameters/gov/states/ct/tax/income/credits/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/ct/tax/income/credits/stillborn.yaml
@@ -9,7 +9,7 @@ metadata:
   reference:
     - title: Conn. Gen. Stat. § 12-704i - Credit for delivery of a fetus born dead for which a fetal death certificate has been filed
       href: https://www.cga.ct.gov/current/pub/chap_229.htm#sec_12-704i
-    - title: Connecticut Public Act No. 22-118, § 411 (effective July 1, 2022, applicable to taxable years commencing on or after January 1, 2022)
+    - title: Connecticut Public Act No. 22-118, § 412 (enacted section 12-704i, effective July 1, 2022, applicable to taxable years commencing on or after January 1, 2022)
       href: https://www.cga.ct.gov/2022/act/pa/pdf/2022PA-00118-R00SB-00005-PA.pdf
-    - title: Connecticut Public Act No. 23-31 (amendment effective June 7, 2023, applicable to taxable years commencing on or after January 1, 2022)
+    - title: Connecticut Public Act No. 23-31, § 10 (amended section 12-704i, effective June 7, 2023, applicable to taxable years commencing on or after January 1, 2022)
       href: https://www.cga.ct.gov/2023/act/pa/pdf/2023PA-00031-R00HB-06680-PA.pdf

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
@@ -7,6 +7,7 @@ values:
     - taxable_social_security
     - military_retirement_pay
     - nd_529_deduction
+    - nd_stillborn_subtraction
 
   2022-01-01:
     - us_govt_interest

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
@@ -8,19 +8,29 @@ values:
     - military_retirement_pay
     - nd_529_deduction
 
+  2022-01-01:
+    - us_govt_interest
+    - nd_ltcg_subtraction  # long-term capital gains
+    - nd_qdiv_subtraction  # qualified dividends
+    - taxable_social_security
+    - military_retirement_pay
+    - nd_529_deduction
+    - nd_stillborn_subtraction
+
   2023-01-01:
     - us_govt_interest
     - nd_ltcg_subtraction  # long-term capital gains
     - nd_qdiv_subtraction  # qualified dividends
     - taxable_social_security
     - military_retirement_pay
-    - military_service_income # military pay exculsion
+    - military_service_income  # military pay exclusion
     - nd_529_deduction
+    - nd_stillborn_subtraction
 
 metadata:
-  unit: list  
-  period: year  
-  label: North Dakota subtractions from federal taxable income  
+  unit: list
+  period: year
+  label: North Dakota subtractions from federal taxable income
   reference:
   - title: 2021 North Dakota income tax form
     href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2021-iit/form-nd-1-2021.pdf#page=1
@@ -38,5 +48,5 @@ metadata:
     href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2024-iit/2024-individual-income-tax-booklet.pdf#page=14
   - title: 2025 North Dakota income tax instructions
     href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2025-iit/2025-individual-income-tax-booklet.pdf#page=14
-  - title: North Dakota Century Code Title 57 - Taxation Chapter 57-38 - Income Tax, 57-38-30.3 (2) 
+  - title: North Dakota Century Code Title 57 - Taxation Chapter 57-38 - Income Tax, 57-38-30.3 (2)
     href: https://law.justia.com/codes/north-dakota/2022/title-57/chapter-57-38/

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/stillborn.yaml
@@ -1,6 +1,6 @@
 description: North Dakota provides this subtraction from federal taxable income for each child who was stillborn during the tax year, provided a Fetal Death Record was filed with the North Dakota Division of Vital Records and the child would have been a dependent. The amount is adjusted annually for inflation.
 values:
-  2021-01-01: 0
+  2021-01-01: 4_310
   2022-01-01: 4_530
   2023-01-01: 4_892
   2024-01-01: 5_088
@@ -9,12 +9,15 @@ metadata:
   unit: currency-USD
   period: year
   label: North Dakota stillborn child subtraction amount
+  # ND indexes to Midwest CPI-U; IRS uprating is a proxy until available.
   uprating: gov.irs.uprating
   reference:
     - title: N.D.C.C. § 57-38-30.3(2) - Individual income tax - Subtraction for stillborn child
       href: https://ndlegis.gov/cencode/t57c38.pdf#nameddest=57-38-30p3
     - title: N.D.C.C. § 57-38-30.3(2) (Casetext rendering)
       href: https://casetext.com/statute/north-dakota-century-code/title-57-taxation/chapter-57-38-income-tax/section-57-38-303-individual-estate-and-trust-income-tax
+    - title: 2021 North Dakota Individual Income Tax Booklet, page 15, Line 8 instructions
+      href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2021-iit/individual-income-tax-booklet-2021.pdf#page=15
     - title: 2022 Schedule ND-1SA Statutory Adjustments, Line 5 instructions
       href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2022-iit/schedule-nd-1sa-2022.pdf#page=2
     - title: 2023 Schedule ND-1SA Statutory Adjustments, Line 8 instructions

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/stillborn.yaml
@@ -1,18 +1,27 @@
-description: North Dakota provides this deduction from federal taxable income for each child who was stillborn during the tax year, provided a Fetal Death Record was filed with the North Dakota Division of Vital Records and the child would have been a dependent. The amount is adjusted annually for inflation.
+description: North Dakota provides this subtraction from federal taxable income for each child who was stillborn during the tax year, provided a Fetal Death Record was filed with the North Dakota Division of Vital Records and the child would have been a dependent. The amount is adjusted annually for inflation.
 values:
   2021-01-01: 0
   2022-01-01: 4_530
   2023-01-01: 4_892
+  2024-01-01: 5_088
+  2025-01-01: 5_241
 metadata:
   unit: currency-USD
   period: year
-  label: North Dakota stillborn child deduction amount
+  label: North Dakota stillborn child subtraction amount
+  uprating: gov.irs.uprating
   reference:
-    - title: N.D.C.C. § 57-38-30.3(2) - Individual income tax - Deduction for stillborn child
+    - title: N.D.C.C. § 57-38-30.3(2) - Individual income tax - Subtraction for stillborn child
       href: https://ndlegis.gov/cencode/t57c38.pdf#nameddest=57-38-30p3
+    - title: N.D.C.C. § 57-38-30.3(2) (Casetext rendering)
+      href: https://casetext.com/statute/north-dakota-century-code/title-57-taxation/chapter-57-38-income-tax/section-57-38-303-individual-estate-and-trust-income-tax
     - title: 2022 Schedule ND-1SA Statutory Adjustments, Line 5 instructions
       href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2022-iit/schedule-nd-1sa-2022.pdf#page=2
     - title: 2023 Schedule ND-1SA Statutory Adjustments, Line 8 instructions
       href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2023-iit/schedule-nd-1sa-2023.pdf#page=2
+    - title: 2024 Schedule ND-1SA Statutory Adjustments, Line 8 instructions
+      href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2024-iit/28710-schedule-nd-1sa-2024.pdf#page=2
+    - title: 2025 Schedule ND-1SA Statutory Adjustments, Line 8 instructions
+      href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2025-iit/28710-schedule-nd-1sa-2025.pdf#page=2
     - title: 2022 North Dakota Individual Income Tax Booklet, page 17 "REMINDER - Deduction available to parents of stillborn child"
       href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2022-iit/2022-individual-income-tax-booklet.pdf#page=17

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/stillborn.yaml
@@ -1,0 +1,18 @@
+description: North Dakota provides this deduction from federal taxable income for each child who was stillborn during the tax year, provided a Fetal Death Record was filed with the North Dakota Division of Vital Records and the child would have been a dependent. The amount is adjusted annually for inflation.
+values:
+  2021-01-01: 0
+  2022-01-01: 4_530
+  2023-01-01: 4_892
+metadata:
+  unit: currency-USD
+  period: year
+  label: North Dakota stillborn child deduction amount
+  reference:
+    - title: N.D.C.C. § 57-38-30.3(2) - Individual income tax - Deduction for stillborn child
+      href: https://ndlegis.gov/cencode/t57c38.pdf#nameddest=57-38-30p3
+    - title: 2022 Schedule ND-1SA Statutory Adjustments, Line 5 instructions
+      href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2022-iit/schedule-nd-1sa-2022.pdf#page=2
+    - title: 2023 Schedule ND-1SA Statutory Adjustments, Line 8 instructions
+      href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2023-iit/schedule-nd-1sa-2023.pdf#page=2
+    - title: 2022 North Dakota Individual Income Tax Booklet, page 17 "REMINDER - Deduction available to parents of stillborn child"
+      href: https://www.tax.nd.gov/sites/www/files/documents/forms/individual/2022-iit/2022-individual-income-tax-booklet.pdf#page=17

--- a/policyengine_us/parameters/gov/states/ne/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/credits/refundable.yaml
@@ -3,10 +3,16 @@ values:
   2021-01-01:
     - ne_cdcc_refundable
     - ne_eitc
-  
+
+  2022-01-01:
+    - ne_cdcc_refundable
+    - ne_eitc
+    - ne_stillborn_credit
+
   2024-01-01:
     - ne_cdcc_refundable
     - ne_eitc
+    - ne_stillborn_credit
     - ne_refundable_ctc
     - ne_school_readiness_credit
 

--- a/policyengine_us/parameters/gov/states/ne/tax/income/credits/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/credits/stillborn.yaml
@@ -9,7 +9,7 @@ metadata:
   reference:
     - title: Neb. Rev. Stat. § 77-2715.07(9) (stillborn child tax credit)
       href: https://nebraskalegislature.gov/laws/statutes.php?statute=77-2715.07
-    - title: Nebraska LB 432 (2021), § 26 (enacting legislation)
+    - title: Nebraska LB 432 (2021), § 11 (enacting legislation)
       href: https://nebraskalegislature.gov/FloorDocs/107/PDF/Slip/LB432.pdf
     - title: 2022 Nebraska Individual Income Tax Booklet (Form 1040N, line 38 instructions)
       href: https://revenue.nebraska.gov/sites/revenue.nebraska.gov/files/doc/2022_Ne_Individual_Income_Tax_Booklet_8-307-2022_final_8.pdf#page=12

--- a/policyengine_us/parameters/gov/states/ne/tax/income/credits/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/credits/stillborn.yaml
@@ -1,0 +1,17 @@
+description: Nebraska provides this refundable credit for each stillborn child for whom a Birth Resulting in Stillbirth Certificate has been issued, where the stillbirth occurred at or after the twentieth week of gestation and the child would have been a dependent.
+values:
+  2021-01-01: 0
+  2022-01-01: 2_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Nebraska stillborn child tax credit amount
+  reference:
+    - title: Nebraska LB 432 (2021), § 26 (stillborn child tax credit, codified at Neb. Rev. Stat. § 77-2715.07)
+      href: https://nebraskalegislature.gov/FloorDocs/107/PDF/Slip/LB432.pdf
+    - title: 2022 Nebraska Individual Income Tax Booklet (Form 1040N, line 38 instructions)
+      href: https://revenue.nebraska.gov/sites/revenue.nebraska.gov/files/doc/2022_Ne_Individual_Income_Tax_Booklet_8-307-2022_final_8.pdf#page=12
+    - title: 2023 Nebraska Individual Income Tax Booklet (Form 1040N, line 39 instructions)
+      href: https://revenue.nebraska.gov/sites/revenue.nebraska.gov/files/doc/tax-forms/2023/incometax/f_1040n_booklet_2023_Final.pdf#page=14
+    - title: 2024 Nebraska Individual Income Tax Booklet (Form 1040N, line 45 instructions)
+      href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2024/f_Individual_Income_Tax_Booklet.pdf#page=16

--- a/policyengine_us/parameters/gov/states/ne/tax/income/credits/stillborn.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/credits/stillborn.yaml
@@ -7,7 +7,9 @@ metadata:
   period: year
   label: Nebraska stillborn child tax credit amount
   reference:
-    - title: Nebraska LB 432 (2021), § 26 (stillborn child tax credit, codified at Neb. Rev. Stat. § 77-2715.07)
+    - title: Neb. Rev. Stat. § 77-2715.07(9) (stillborn child tax credit)
+      href: https://nebraskalegislature.gov/laws/statutes.php?statute=77-2715.07
+    - title: Nebraska LB 432 (2021), § 26 (enacting legislation)
       href: https://nebraskalegislature.gov/FloorDocs/107/PDF/Slip/LB432.pdf
     - title: 2022 Nebraska Individual Income Tax Booklet (Form 1040N, line 38 instructions)
       href: https://revenue.nebraska.gov/sites/revenue.nebraska.gov/files/doc/2022_Ne_Individual_Income_Tax_Booklet_8-307-2022_final_8.pdf#page=12

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/ct_stillborn_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/ct_stillborn_credit.yaml
@@ -1,0 +1,39 @@
+- name: No stillborn children, no credit
+  period: 2023
+  input:
+    state_code: CT
+    tax_unit_stillborn_children: 0
+  output:
+    ct_stillborn_credit: 0
+
+- name: One stillborn child, $2,500 credit
+  period: 2023
+  input:
+    state_code: CT
+    tax_unit_stillborn_children: 1
+  output:
+    ct_stillborn_credit: 2_500
+
+- name: Two stillborn children, $5,000 credit
+  period: 2023
+  input:
+    state_code: CT
+    tax_unit_stillborn_children: 2
+  output:
+    ct_stillborn_credit: 5_000
+
+- name: Pre-effective year 2021, credit is zero
+  period: 2021
+  input:
+    state_code: CT
+    tax_unit_stillborn_children: 1
+  output:
+    ct_stillborn_credit: 0
+
+- name: Effective year 2022, $2,500 per stillborn child
+  period: 2022
+  input:
+    state_code: CT
+    tax_unit_stillborn_children: 1
+  output:
+    ct_stillborn_credit: 2_500

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/ct_stillborn_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/ct_stillborn_credit.yaml
@@ -37,3 +37,11 @@
     tax_unit_stillborn_children: 1
   output:
     ct_stillborn_credit: 2_500
+
+- name: Non-CT filer with stillborn child receives no CT credit
+  period: 2023
+  input:
+    state_code: CA
+    tax_unit_stillborn_children: 1
+  output:
+    ct_stillborn_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.yaml
@@ -1,0 +1,39 @@
+- name: No stillborn children, no deduction
+  period: 2023
+  input:
+    state_code: ND
+    tax_unit_stillborn_children: 0
+  output:
+    nd_stillborn_subtraction: 0
+
+- name: One stillborn child in 2022, $4,530 deduction
+  period: 2022
+  input:
+    state_code: ND
+    tax_unit_stillborn_children: 1
+  output:
+    nd_stillborn_subtraction: 4_530
+
+- name: Two stillborn children in 2022, $9,060 deduction
+  period: 2022
+  input:
+    state_code: ND
+    tax_unit_stillborn_children: 2
+  output:
+    nd_stillborn_subtraction: 9_060
+
+- name: One stillborn child in 2023, $4,892 deduction
+  period: 2023
+  input:
+    state_code: ND
+    tax_unit_stillborn_children: 1
+  output:
+    nd_stillborn_subtraction: 4_892
+
+- name: Pre-effective year 2021, deduction is zero
+  period: 2021
+  input:
+    state_code: ND
+    tax_unit_stillborn_children: 1
+  output:
+    nd_stillborn_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.yaml
@@ -1,4 +1,4 @@
-- name: No stillborn children, no deduction
+- name: No stillborn children, no subtraction
   period: 2023
   input:
     state_code: ND
@@ -6,7 +6,7 @@
   output:
     nd_stillborn_subtraction: 0
 
-- name: One stillborn child in 2022, $4,530 deduction
+- name: One stillborn child in 2022, $4,530 subtraction
   period: 2022
   input:
     state_code: ND
@@ -14,7 +14,7 @@
   output:
     nd_stillborn_subtraction: 4_530
 
-- name: Two stillborn children in 2022, $9,060 deduction
+- name: Two stillborn children in 2022, $9,060 subtraction
   period: 2022
   input:
     state_code: ND
@@ -22,7 +22,7 @@
   output:
     nd_stillborn_subtraction: 9_060
 
-- name: One stillborn child in 2023, $4,892 deduction
+- name: One stillborn child in 2023, $4,892 subtraction
   period: 2023
   input:
     state_code: ND
@@ -30,10 +30,34 @@
   output:
     nd_stillborn_subtraction: 4_892
 
-- name: Pre-effective year 2021, deduction is zero
+- name: One stillborn child in 2024, $5,088 subtraction
+  period: 2024
+  input:
+    state_code: ND
+    tax_unit_stillborn_children: 1
+  output:
+    nd_stillborn_subtraction: 5_088
+
+- name: One stillborn child in 2025, $5,241 subtraction
+  period: 2025
+  input:
+    state_code: ND
+    tax_unit_stillborn_children: 1
+  output:
+    nd_stillborn_subtraction: 5_241
+
+- name: Pre-effective year 2021, subtraction is zero
   period: 2021
   input:
     state_code: ND
+    tax_unit_stillborn_children: 1
+  output:
+    nd_stillborn_subtraction: 0
+
+- name: Non-ND filer with stillborn child receives no ND subtraction
+  period: 2023
+  input:
+    state_code: CA
     tax_unit_stillborn_children: 1
   output:
     nd_stillborn_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.yaml
@@ -46,13 +46,13 @@
   output:
     nd_stillborn_subtraction: 5_241
 
-- name: Pre-effective year 2021, subtraction is zero
+- name: One stillborn child in 2021, $4,310 subtraction
   period: 2021
   input:
     state_code: ND
     tax_unit_stillborn_children: 1
   output:
-    nd_stillborn_subtraction: 0
+    nd_stillborn_subtraction: 4_310
 
 - name: Non-ND filer with stillborn child receives no ND subtraction
   period: 2023

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ne_stillborn_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ne_stillborn_credit.yaml
@@ -37,3 +37,11 @@
     tax_unit_stillborn_children: 1
   output:
     ne_stillborn_credit: 2_000
+
+- name: Non-NE filer with stillborn child receives no NE credit
+  period: 2023
+  input:
+    state_code: CA
+    tax_unit_stillborn_children: 1
+  output:
+    ne_stillborn_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ne_stillborn_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ne_stillborn_credit.yaml
@@ -1,0 +1,39 @@
+- name: No stillborn children, no credit
+  period: 2023
+  input:
+    state_code: NE
+    tax_unit_stillborn_children: 0
+  output:
+    ne_stillborn_credit: 0
+
+- name: One stillborn child, $2,000 refundable credit
+  period: 2023
+  input:
+    state_code: NE
+    tax_unit_stillborn_children: 1
+  output:
+    ne_stillborn_credit: 2_000
+
+- name: Two stillborn children, $4,000 credit
+  period: 2023
+  input:
+    state_code: NE
+    tax_unit_stillborn_children: 2
+  output:
+    ne_stillborn_credit: 4_000
+
+- name: Pre-effective year 2021, credit is zero
+  period: 2021
+  input:
+    state_code: NE
+    tax_unit_stillborn_children: 1
+  output:
+    ne_stillborn_credit: 0
+
+- name: Effective year 2022, $2,000 per stillborn child
+  period: 2022
+  input:
+    state_code: NE
+    tax_unit_stillborn_children: 1
+  output:
+    ne_stillborn_credit: 2_000

--- a/policyengine_us/variables/gov/states/ct/tax/income/credits/ct_stillborn_credit.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/credits/ct_stillborn_credit.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class ct_stillborn_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Connecticut stillborn credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.CT
+    reference = "https://www.cga.ct.gov/current/pub/chap_229.htm#sec_12-704i"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ct.tax.income.credits
+        stillborn = tax_unit("tax_unit_stillborn_children", period)
+        return stillborn * p.stillborn

--- a/policyengine_us/variables/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.py
+++ b/policyengine_us/variables/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class nd_stillborn_subtraction(Variable):
     value_type = float
     entity = TaxUnit
-    label = "North Dakota stillborn child deduction"
+    label = "North Dakota stillborn child subtraction"
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.ND

--- a/policyengine_us/variables/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.py
+++ b/policyengine_us/variables/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class nd_stillborn_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Dakota stillborn child deduction"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.ND
+    reference = "https://ndlegis.gov/cencode/t57c38.pdf#nameddest=57-38-30p3"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(
+            period
+        ).gov.states.nd.tax.income.taxable_income.subtractions
+        stillborn = tax_unit("tax_unit_stillborn_children", period)
+        return stillborn * p.stillborn

--- a/policyengine_us/variables/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.py
+++ b/policyengine_us/variables/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.py
@@ -11,8 +11,6 @@ class nd_stillborn_subtraction(Variable):
     reference = "https://ndlegis.gov/cencode/t57c38.pdf#nameddest=57-38-30p3"
 
     def formula(tax_unit, period, parameters):
-        p = parameters(
-            period
-        ).gov.states.nd.tax.income.taxable_income.subtractions
+        p = parameters(period).gov.states.nd.tax.income.taxable_income.subtractions
         stillborn = tax_unit("tax_unit_stillborn_children", period)
         return stillborn * p.stillborn

--- a/policyengine_us/variables/gov/states/ne/tax/income/credits/ne_stillborn_credit.py
+++ b/policyengine_us/variables/gov/states/ne/tax/income/credits/ne_stillborn_credit.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class ne_stillborn_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Nebraska stillborn child tax credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.NE
+    reference = (
+        "https://nebraskalegislature.gov/FloorDocs/107/PDF/Slip/LB432.pdf"
+    )
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.ne.tax.income.credits
+        stillborn = tax_unit("tax_unit_stillborn_children", period)
+        return stillborn * p.stillborn

--- a/policyengine_us/variables/gov/states/ne/tax/income/credits/ne_stillborn_credit.py
+++ b/policyengine_us/variables/gov/states/ne/tax/income/credits/ne_stillborn_credit.py
@@ -8,9 +8,7 @@ class ne_stillborn_credit(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.NE
-    reference = (
-        "https://nebraskalegislature.gov/FloorDocs/107/PDF/Slip/LB432.pdf"
-    )
+    reference = "https://nebraskalegislature.gov/FloorDocs/107/PDF/Slip/LB432.pdf"
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.ne.tax.income.credits

--- a/policyengine_us/variables/gov/states/ne/tax/income/credits/ne_stillborn_credit.py
+++ b/policyengine_us/variables/gov/states/ne/tax/income/credits/ne_stillborn_credit.py
@@ -8,7 +8,7 @@ class ne_stillborn_credit(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.NE
-    reference = "https://nebraskalegislature.gov/FloorDocs/107/PDF/Slip/LB432.pdf"
+    reference = "https://nebraskalegislature.gov/laws/statutes.php?statute=77-2715.07"
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.ne.tax.income.credits


### PR DESCRIPTION
## Summary

Implements three state stillbirth tax provisions enacted for the 2022 tax year, all reusing the existing `tax_unit_stillborn_children` input variable:

- **Connecticut**: $2,500 nonrefundable credit per stillbirth for a fetus with a filed fetal death certificate.
- **Nebraska**: $2,000 refundable credit per stillborn child (≥20th week of gestation, would have been a dependent).
- **North Dakota**: Inflation-adjusted subtraction from federal taxable income — $4,530 (2022), $4,892 (2023), $5,088 (2024), $5,241 (2025); uprated via `gov.irs.uprating` for future years.

Closes #4966, closes #5010, closes #5016.

## Regulatory authority

| State | Statute | Form | Amount | Mechanism |
|---|---|---|---|---|
| CT | [Conn. Gen. Stat. § 12-704i](https://www.cga.ct.gov/current/pub/chap_229.htm#sec_12-704i) (PA 22-118, § 412; amended PA 23-31, § 10) | CT-1040 | $2,500 | Nonrefundable credit |
| NE | [Neb. Rev. Stat. § 77-2715.07(9)](https://nebraskalegislature.gov/laws/statutes.php?statute=77-2715.07) (enacted by LB 432 (2021) § 26) | Form 1040N, Line 38/39/45 | $2,000 | Refundable credit |
| ND | [N.D.C.C. § 57-38-30.3(2)](https://ndlegis.gov/cencode/t57c38.pdf#nameddest=57-38-30p3) | Schedule ND-1SA, Line 8 | $4,530 (2022), $4,892 (2023), $5,088 (2024), $5,241 (2025) | Subtraction from federal taxable income (inflation-adjusted) |

## Statutory eligibility per state

**Connecticut** — From Conn. Gen. Stat. § 12-704i: a taxpayer is allowed a credit of \$2,500 \"for the delivery of a fetus born dead for which a fetal death certificate has been filed, provided such child would have been a dependent on such taxpayer's federal income tax return. The credit shall be allowed for the taxable year for which a fetal death occurred.\" Enacted by PA 22-118, § 412 (effective July 1, 2022, applicable to taxable years commencing on or after January 1, 2022); amended by PA 23-31, § 10 (effective June 7, 2023). Integrated into `ct_non_refundable_credits` via the `gov.states.ct.tax.income.credits.non_refundable` list parameter.

**Nebraska** — Neb. Rev. Stat. § 77-2715.07(9) allows a \$2,000 refundable credit per stillborn child for taxable years beginning on or after January 1, 2022, when: (a) the parent would have been eligible to claim the stillborn child as a dependent, (b) the stillbirth occurred at or after the twentieth week of gestation, and (c) a fetal death certificate under Neb. Rev. Stat. § 71-606(1) was filed. Only one credit is allowed per stillborn child. Integrated into `ne_refundable_credits` via the `gov.states.ne.tax.income.credits.refundable` list parameter.

**North Dakota** — From N.D.C.C. § 57-38-30.3(2) and the 2022–2025 Schedule ND-1SA Line 8 instructions: a subtraction from federal taxable income is allowed to the parent of a child stillborn during the tax year who (a) obtained a certified Fetal Death Record from the ND Division of Vital Records and (b) would have been eligible to claim the child as a dependent on their federal return. The amount is adjusted annually for inflation. Integrated into `nd_subtractions` via the `gov.states.nd.tax.income.taxable_income.subtractions.sources` list parameter; future years uprate via `gov.irs.uprating`.

## Implementation approach

All three states follow the same pattern as the existing Arizona stillborn exemption (`policyengine_us/variables/gov/states/az/tax/income/exemptions/az_stillborn_exemption.py`):

1. A single per-stillbirth amount parameter, modeled from 2021-01-01 with `0` pre-effective-date and the statutory value from 2022-01-01 onward.
2. A tax-unit-level formula variable computed as `tax_unit_stillborn_children × per_stillbirth_amount`.
3. The new variable is added to the relevant state's existing credit or subtraction list parameter, preserving the existing chain integration (no new wrapper variables).

## Files added

**Parameters**
- `policyengine_us/parameters/gov/states/ct/tax/income/credits/stillborn.yaml`
- `policyengine_us/parameters/gov/states/ne/tax/income/credits/stillborn.yaml`
- `policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/stillborn.yaml`

**Variables**
- `policyengine_us/variables/gov/states/ct/tax/income/credits/ct_stillborn_credit.py`
- `policyengine_us/variables/gov/states/ne/tax/income/credits/ne_stillborn_credit.py`
- `policyengine_us/variables/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.py`

**Tests** (6 cases for CT/NE, 8 cases for ND; 20 total including cross-state isolation and ND 2024/2025)
- `policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/ct_stillborn_credit.yaml`
- `policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ne_stillborn_credit.yaml`
- `policyengine_us/tests/policy/baseline/gov/states/nd/tax/income/subtractions/nd_stillborn_subtraction.yaml`

**Integration (modified list parameters)**
- `policyengine_us/parameters/gov/states/ct/tax/income/credits/non_refundable.yaml`
- `policyengine_us/parameters/gov/states/ne/tax/income/credits/refundable.yaml`
- `policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml`

## Test plan

- [x] 20 unit tests cover: no stillbirth, one stillbirth, two stillbirths, pre-effective year (2021), first effective year (2022), cross-state isolation (CA filer); ND additionally covers 2023, 2024, and 2025 inflation-adjusted values
- [x] Full state test suites pass locally
- [x] `make format` clean
- [ ] CI green
- [ ] Reviewer verifies statutory citations and dollar amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
