### PR TITLE
Model Basic Health Program as separate coverage

### DIFF
--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/active_states.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/active_states.yaml
@@ -1,0 +1,33 @@
+description: The Department of Health and Human Services treats these states as offering Basic Health Program coverage under this model.
+
+values:
+  2015-01-01:
+    - MN
+  2015-04-01:
+    - MN
+    - NY
+  2024-07-01:
+    - MN
+    - NY
+    - OR
+  2026-01-01:
+    - MN
+    - NY
+    - OR
+    - DC
+
+metadata:
+  unit: list
+  period: year
+  label: Basic Health Program active states
+  reference:
+    - title: Basic Health Program | Medicaid
+      href: https://www.medicaid.gov/basic-health-program
+    - title: MinnesotaCare | Minnesota Department of Human Services
+      href: https://mn.gov/dhs/people-we-serve/adults/health-care/health-care-programs/programs-and-services/minnesotacare.jsp
+    - title: Essential Plan Information | NY State of Health
+      href: https://info.nystateofhealth.ny.gov/EssentialPlan
+    - title: Oregon Health Plan (OHP) Bridge | Oregon Health Authority
+      href: https://www.oregon.gov/oha/ohp/pages/bridge.aspx
+    - title: Basic Health Plan | DC Health Benefit Exchange Authority
+      href: https://hbx.dc.gov/page/basic-health-plan

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/active_states.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/active_states.yaml
@@ -6,6 +6,9 @@ values:
   2015-04-01:
     - MN
     - NY
+  # New York's Essential Plan moved to a section 1332 waiver path on
+  # 2024-04-01. We keep it in this modeled BHP-like coverage path for
+  # continuity, and CMS later approved BHP reinstatement effective 2026-07-01.
   2024-07-01:
     - MN
     - NY
@@ -27,6 +30,10 @@ metadata:
       href: https://mn.gov/dhs/people-we-serve/adults/health-care/health-care-programs/programs-and-services/minnesotacare.jsp
     - title: Essential Plan Information | NY State of Health
       href: https://info.nystateofhealth.ny.gov/EssentialPlan
+    - title: New York BHP suspension approval letter | CMS
+      href: https://www.medicaid.gov/basic-health-program/downloads/ny-bhp-suspension-appvl-ltr-mar-2024.pdf
+    - title: New York BHP Blueprint revision | CMS
+      href: https://www.medicaid.gov/basic-health-program/downloads/ny-bhp-blueprint-revision-feb2026.pdf
     - title: Oregon Health Plan (OHP) Bridge | Oregon Health Authority
       href: https://www.oregon.gov/oha/ohp/pages/bridge.aspx
     - title: Basic Health Plan | DC Health Benefit Exchange Authority

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit.yaml
@@ -1,0 +1,14 @@
+description: The Department of Health and Human Services limits Basic Health Program income to this share of the federal poverty guidelines under the expanded coverage path.
+
+values:
+  2015-01-01: 2.5
+
+metadata:
+  unit: /1
+  period: year
+  label: Expanded Basic Health Program income limit
+  reference:
+    - title: Essential Plan Information | NY State of Health
+      href: https://info.nystateofhealth.ny.gov/EssentialPlan
+    - title: New York State Department of Health and NY State of Health Announce the Essential Plan Expansion Increasing Access to Affordable Health Insurance Begins Today
+      href: https://healthweb-back.health.ny.gov/press/releases/2024/2024-04-01_affordable_health_insurance.htm

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit.yaml
@@ -12,3 +12,7 @@ metadata:
       href: https://info.nystateofhealth.ny.gov/EssentialPlan
     - title: New York State Department of Health and NY State of Health Announce the Essential Plan Expansion Increasing Access to Affordable Health Insurance Begins Today
       href: https://healthweb-back.health.ny.gov/press/releases/2024/2024-04-01_affordable_health_insurance.htm
+    - title: New York BHP suspension approval letter | CMS
+      href: https://www.medicaid.gov/basic-health-program/downloads/ny-bhp-suspension-appvl-ltr-mar-2024.pdf
+    - title: New York BHP Blueprint revision | CMS
+      href: https://www.medicaid.gov/basic-health-program/downloads/ny-bhp-blueprint-revision-feb2026.pdf

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit_states.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit_states.yaml
@@ -1,0 +1,17 @@
+description: These states use the expanded Basic Health Program income limit under this model.
+
+values:
+  2015-01-01:
+    []
+  2024-04-01:
+    - NY
+
+metadata:
+  unit: list
+  period: year
+  label: Basic Health Program expanded-income states
+  reference:
+    - title: Essential Plan Information | NY State of Health
+      href: https://info.nystateofhealth.ny.gov/EssentialPlan
+    - title: New York State Department of Health and NY State of Health Announce the Essential Plan Expansion Increasing Access to Affordable Health Insurance Begins Today
+      href: https://healthweb-back.health.ny.gov/press/releases/2024/2024-04-01_affordable_health_insurance.htm

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit_states.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/expanded_income_limit_states.yaml
@@ -3,6 +3,9 @@ description: These states use the expanded Basic Health Program income limit und
 values:
   2015-01-01:
     []
+  # New York's 250% FPL Essential Plan expansion begins 2024-04-01 under
+  # the approved section 1332 waiver. The model carries that expanded ceiling
+  # forward in this BHP-like path, even though the formal BHP restarts later.
   2024-04-01:
     - NY
 
@@ -15,3 +18,7 @@ metadata:
       href: https://info.nystateofhealth.ny.gov/EssentialPlan
     - title: New York State Department of Health and NY State of Health Announce the Essential Plan Expansion Increasing Access to Affordable Health Insurance Begins Today
       href: https://healthweb-back.health.ny.gov/press/releases/2024/2024-04-01_affordable_health_insurance.htm
+    - title: New York BHP suspension approval letter | CMS
+      href: https://www.medicaid.gov/basic-health-program/downloads/ny-bhp-suspension-appvl-ltr-mar-2024.pdf
+    - title: New York BHP Blueprint revision | CMS
+      href: https://www.medicaid.gov/basic-health-program/downloads/ny-bhp-blueprint-revision-feb2026.pdf

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/income_limit.yaml
@@ -1,0 +1,18 @@
+description: The Department of Health and Human Services limits Basic Health Program income to this share of the federal poverty guidelines under the standard coverage path.
+
+values:
+  2015-01-01: 2
+
+metadata:
+  unit: /1
+  period: year
+  label: Basic Health Program income limit
+  reference:
+    - title: Basic Health Program | Medicaid
+      href: https://www.medicaid.gov/basic-health-program
+    - title: MinnesotaCare | Minnesota Department of Human Services
+      href: https://mn.gov/dhs/people-we-serve/adults/health-care/health-care-programs/programs-and-services/minnesotacare.jsp
+    - title: Oregon Health Plan (OHP) Bridge | Oregon Health Authority
+      href: https://www.oregon.gov/oha/ohp/pages/bridge.aspx
+    - title: DC Health Benefit Exchange Authority Healthy DC Plan Overview - October 2025
+      href: https://hbx.dc.gov/sites/default/files/dc/sites/hbx/page_content/attachments/Healthy%20DC%20Plan%20Overview%20-%20October%202025.pdf

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/max_age.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/max_age.yaml
@@ -1,0 +1,14 @@
+description: The Department of Health and Human Services limits Basic Health Program coverage to people below this age in this model.
+
+values:
+  2015-01-01: 65
+
+metadata:
+  unit: year
+  period: year
+  label: Basic Health Program maximum age
+  reference:
+    - title: Essential Plan Information | NY State of Health
+      href: https://info.nystateofhealth.ny.gov/EssentialPlan
+    - title: Oregon Health Plan (OHP) Bridge | Oregon Health Authority
+      href: https://www.oregon.gov/oha/ohp/pages/bridge.aspx

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/min_age.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/min_age.yaml
@@ -1,0 +1,14 @@
+description: The Department of Health and Human Services limits Basic Health Program coverage to people at or above this age in this model.
+
+values:
+  2015-01-01: 19
+
+metadata:
+  unit: year
+  period: year
+  label: Basic Health Program minimum age
+  reference:
+    - title: Essential Plan Information | NY State of Health
+      href: https://info.nystateofhealth.ny.gov/EssentialPlan
+    - title: Oregon Health Plan (OHP) Bridge | Oregon Health Authority
+      href: https://www.oregon.gov/oha/ohp/pages/bridge.aspx

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/adult/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/adult/income_limit.yaml
@@ -13,6 +13,8 @@ metadata:
       href: https://www.medicaid.gov/medicaid/national-medicaid-chip-program-information/medicaid-childrens-health-insurance-program-basic-health-program-eligibility-levels/index.html
     - title: Medicaid and CHIP Eligibility, Enrollment, Renewal, and Cost Sharing Policies as of January 2018
       href: https://files.kff.org/attachment/Report-Medicaid-and-CHIP-Eligibility-Enrollment-Renewal-and-Cost-Sharing-Policies-as-of-January-2018#page=36
+    - title: Proposed Extension of Existing Loss of Medicaid SEP | DC Health Benefit Exchange Authority
+      href: https://hbx.dc.gov/sites/default/files/dc/sites/hbx/event_content/attachments/PROPOSED%20EXTENSION%20OF%20LOSS%20OF%20MEDICAID%20SEP%20Nov%202025_0.pdf
 AK:
   2021-01-01: 1.38
 AL:
@@ -29,6 +31,7 @@ CT:
   2021-01-01: 1.38
 DC:
   2021-01-01: 2.15
+  2026-01-01: 1.38
 DE:
   2021-01-01: 1.38
 FL:
@@ -63,7 +66,7 @@ ME:
 MI:
   2021-01-01: 1.38
 MN:
-  2021-01-01: 2.00
+  2021-01-01: 1.38
 MO:
   2018-01-01: -.inf
   2021-01-01: 1.38
@@ -88,7 +91,7 @@ NM:
 NV:
   2021-01-01: 1.38
 NY:
-  2021-01-01: 2.00
+  2021-01-01: 1.38
 OH:
   2021-01-01: 1.38
 OK:

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
@@ -13,6 +13,8 @@ metadata:
       href: https://www.medicaid.gov/medicaid/national-medicaid-chip-program-information/medicaid-childrens-health-insurance-program-basic-health-program-eligibility-levels/index.html
     - title: Medicaid and CHIP Eligibility, Enrollment, Renewal, and Cost Sharing Policies as of January 2018
       href: https://files.kff.org/attachment/Report-Medicaid-and-CHIP-Eligibility-Enrollment-Renewal-and-Cost-Sharing-Policies-as-of-January-2018#page=36
+    - title: Proposed Extension of Existing Loss of Medicaid SEP | DC Health Benefit Exchange Authority
+      href: https://hbx.dc.gov/sites/default/files/dc/sites/hbx/event_content/attachments/PROPOSED%20EXTENSION%20OF%20LOSS%20OF%20MEDICAID%20SEP%20Nov%202025_0.pdf
 AK:
   2018-01-01: 1.39
   2021-01-01: 1.36
@@ -35,6 +37,7 @@ CT:
   2021-01-01: 1.60
 DC:
   2018-01-01: 2.21
+  2026-01-01: 1.38
 DE:
   2018-01-01: 0.87
   2021-01-01: 0.92

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
@@ -63,6 +63,18 @@
   output:
      is_aca_ptc_eligible: false
 
+- name: is_aca_ptc_eligible unit test 6b --- basic health program coverage
+  period: 2025
+  input:
+    is_medicaid_eligible: false
+    is_aca_eshi_eligible: false
+    is_medicare_eligible: false
+    is_chip_eligible: false
+    is_basic_health_program_eligible: true
+    aca_magi_fraction: 2.50
+  output:
+     is_aca_ptc_eligible: false
+
 - name: is_aca_ptc_eligible unit test 7 --- max three children pay ACA premium
   period: 2022
   input:

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
@@ -75,6 +75,31 @@
   output:
      is_aca_ptc_eligible: false
 
+- name: is_aca_ptc_eligible unit test 6c --- New York Essential Plan derived from program rules
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: CITIZEN
+        medicaid_income_level: 2.3
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+        is_chip_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.3
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+     is_medicaid_eligible: [false]
+     is_basic_health_program_eligible: [true]
+     is_aca_ptc_eligible: [false]
+
 - name: is_aca_ptc_eligible unit test 7 --- max three children pay ACA premium
   period: 2022
   input:

--- a/policyengine_us/tests/policy/baseline/gov/hhs/basic_health_program/is_basic_health_program_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/basic_health_program/is_basic_health_program_eligible.yaml
@@ -64,7 +64,6 @@
         age: 34
         immigration_status: CITIZEN
         medicaid_income_level: 1.7
-        is_medicaid_eligible: false
         is_chip_eligible: false
         is_aca_eshi_eligible: false
         is_medicare_eligible: false
@@ -73,6 +72,7 @@
         members: [person]
         state_code: DC
   output:
+    is_medicaid_eligible: [false]
     is_basic_health_program_eligible: [true]
 
 - name: California does not have a Basic Health Program path
@@ -93,3 +93,23 @@
         state_code: CA
   output:
     is_basic_health_program_eligible: [false]
+
+- name: Minnesota adult above Medicaid ceiling moves to the Basic Health Program path
+  period: 2025
+  input:
+    people:
+      person:
+        age: 30
+        immigration_status: CITIZEN
+        medicaid_income_level: 1.5
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: MN
+  output:
+    is_adult_for_medicaid: [false]
+    is_medicaid_eligible: [false]
+    is_basic_health_program_eligible: [true]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/basic_health_program/is_basic_health_program_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/basic_health_program/is_basic_health_program_eligible.yaml
@@ -1,0 +1,95 @@
+- name: Minnesota Basic Health Program eligibility above Medicaid range
+  period: 2025
+  input:
+    people:
+      person:
+        age: 30
+        immigration_status: CITIZEN
+        medicaid_income_level: 1.5
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: MN
+  output:
+    is_basic_health_program_eligible: [true]
+    basic_health_program_enrolled: [true]
+
+- name: New York expanded Basic Health Program range uses 250 percent FPL ceiling
+  period: 2025
+  input:
+    people:
+      person:
+        age: 40
+        immigration_status: CITIZEN
+        medicaid_income_level: 2.3
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: NY
+  output:
+    is_basic_health_program_eligible: [true]
+
+- name: Oregon Basic Health Program is active after the 2024 launch
+  period: 2025
+  input:
+    people:
+      person:
+        age: 45
+        immigration_status: CITIZEN
+        medicaid_income_level: 1.8
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: OR
+  output:
+    is_basic_health_program_eligible: [true]
+
+- name: DC Basic Health Program is active in 2026
+  period: 2026
+  input:
+    people:
+      person:
+        age: 34
+        immigration_status: CITIZEN
+        medicaid_income_level: 1.7
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: DC
+  output:
+    is_basic_health_program_eligible: [true]
+
+- name: California does not have a Basic Health Program path
+  period: 2025
+  input:
+    people:
+      person:
+        age: 30
+        immigration_status: CITIZEN
+        medicaid_income_level: 1.7
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: CA
+  output:
+    is_basic_health_program_eligible: [false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_adult_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_adult_for_medicaid.yaml
@@ -36,4 +36,45 @@
     medicaid_income_level: 1.38
   output:
     is_adult_for_medicaid: true
-    
+
+- name: MinnesotaCare range is above the Medicaid adult ceiling
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 30
+        medicaid_income_level: 1.5
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    is_adult_for_medicaid: [false]
+
+- name: Essential Plan range is above the Medicaid adult ceiling
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        medicaid_income_level: 2.3
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    is_adult_for_medicaid: [false]
+
+- name: Healthy DC Plan range is above the Medicaid adult ceiling after 2026
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 34
+        medicaid_income_level: 1.7
+    households:
+      household:
+        members: [person1]
+        state_code: DC
+  output:
+    is_adult_for_medicaid: [false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_parent_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_parent_for_medicaid.yaml
@@ -20,3 +20,21 @@
     medicaid_income_level: 1.15
   output:
     is_parent_for_medicaid: false
+
+- name: DC parent above the Medicaid ceiling is not parent-eligible after Healthy DC Plan starts
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 34
+        medicaid_income_level: 1.5
+    tax_units:
+      tax_unit:
+        members: [person1]
+        tax_unit_count_dependents: 1
+    households:
+      household:
+        members: [person1]
+        state_code: DC
+  output:
+    is_parent_for_medicaid: [false]

--- a/policyengine_us/variables/gov/aca/eligibility/is_aca_ptc_eligible.py
+++ b/policyengine_us/variables/gov/aca/eligibility/is_aca_ptc_eligible.py
@@ -19,6 +19,7 @@ class is_aca_ptc_eligible(Variable):
         INELIGIBLE_COVERAGE = [
             "is_medicaid_eligible",
             "is_chip_eligible",
+            "is_basic_health_program_eligible",
             "is_aca_eshi_eligible",
             "is_medicare_eligible",
         ]

--- a/policyengine_us/variables/gov/hhs/basic_health_program/basic_health_program_enrolled.py
+++ b/policyengine_us/variables/gov/hhs/basic_health_program/basic_health_program_enrolled.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class basic_health_program_enrolled(Variable):
+    value_type = bool
+    entity = Person
+    label = "Basic Health Program enrolled"
+    definition_period = YEAR
+    reference = "https://www.medicaid.gov/basic-health-program"
+    defined_for = "is_basic_health_program_eligible"
+    adds = ["takes_up_basic_health_program_if_eligible"]

--- a/policyengine_us/variables/gov/hhs/basic_health_program/is_basic_health_program_eligible.py
+++ b/policyengine_us/variables/gov/hhs/basic_health_program/is_basic_health_program_eligible.py
@@ -1,0 +1,61 @@
+from policyengine_us.model_api import *
+
+
+class is_basic_health_program_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Basic Health Program coverage"
+    definition_period = YEAR
+    reference = (
+        "https://www.medicaid.gov/basic-health-program",
+        "https://mn.gov/dhs/people-we-serve/adults/health-care/health-care-programs/programs-and-services/minnesotacare.jsp",
+        "https://info.nystateofhealth.ny.gov/EssentialPlan",
+        "https://www.oregon.gov/oha/ohp/pages/bridge.aspx",
+        "https://hbx.dc.gov/page/basic-health-plan",
+    )
+    documentation = """
+    First slice of Basic Health Program modeling.
+
+    This models the adult public-coverage path that substitutes for Marketplace
+    coverage in states with BHP-like programs. It uses one common program path
+    for MinnesotaCare, New York's Essential Plan, Oregon OHP Bridge, and DC's
+    Healthy DC Plan so ACA interactions can be modeled consistently.
+
+    Child-specific and funding-mechanism nuances remain a follow-up.
+    """
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.hhs.basic_health_program.eligibility
+
+        state = person.household("state_code_str", period)
+        in_effect = np.isin(state, p.active_states)
+
+        age = person("age", period)
+        age_eligible = (age >= p.min_age) & (age < p.max_age)
+
+        medicaid_eligible = person("is_medicaid_eligible", period)
+        chip_eligible = person("is_chip_eligible", period)
+        esi_eligible = person("is_aca_eshi_eligible", period)
+        medicare_eligible = person("is_medicare_eligible", period)
+        immigration_eligible = person(
+            "is_aca_ptc_immigration_status_eligible", period
+        )
+
+        income_level = person("medicaid_income_level", period)
+        expanded_limit_state = np.isin(state, p.expanded_income_limit_states)
+        income_limit = where(
+            expanded_limit_state,
+            p.expanded_income_limit,
+            p.income_limit,
+        )
+
+        return (
+            in_effect
+            & age_eligible
+            & immigration_eligible
+            & ~medicaid_eligible
+            & ~chip_eligible
+            & ~esi_eligible
+            & ~medicare_eligible
+            & (income_level <= income_limit)
+        )

--- a/policyengine_us/variables/gov/hhs/basic_health_program/takes_up_basic_health_program_if_eligible.py
+++ b/policyengine_us/variables/gov/hhs/basic_health_program/takes_up_basic_health_program_if_eligible.py
@@ -1,0 +1,9 @@
+from policyengine_us.model_api import *
+
+
+class takes_up_basic_health_program_if_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether an eligible person takes up Basic Health Program coverage"
+    definition_period = YEAR
+    default_value = True


### PR DESCRIPTION
## Summary
- add a separate `gov/hhs/basic_health_program` program path with core eligibility and enrollment variables
- exclude BHP coverage from ACA premium tax credit eligibility
- move MN and NY adult Medicaid limits back to Medicaid-only ceilings, and model DC's 2026 adult and parent transition into Healthy DC Plan
- document New York's 250% FPL Essential Plan / BHP transition timeline in the eligibility parameters

## Testing
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/hhs/basic_health_program --batches 1`
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/hhs/medicaid --batches 1`
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/aca/eligibility --batches 1`

Refs #8112