### PR TITLE
Revert 2029 sunset from senior_deduction amount parameter

### DIFF
--- a/changelog.d/revert-senior-deduction-amount-sunset.fixed.md
+++ b/changelog.d/revert-senior-deduction-amount-sunset.fixed.md
@@ -1,0 +1,1 @@
+Reverted the 2029 sunset from `senior_deduction/amount.yaml` and removed its corresponding test — the sunset is handled at the deduction aggregator level, and zeroing the amount parameter broke the CRFB `senior_deduction_extension` tests.

--- a/policyengine_us/parameters/gov/irs/deductions/senior_deduction/amount.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/senior_deduction/amount.yaml
@@ -2,7 +2,6 @@ description: The IRS provides a deduction for seniors of this amount.
 
 values:
   2025-01-01: 6_000
-  2029-01-01: 0
 
 metadata:
   unit: currency-USD

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/senior_deduction/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/senior_deduction/integration.yaml
@@ -390,21 +390,3 @@
     # Total: $0 x 2 = $0
     additional_senior_deduction: 0
 
-- name: Senior deduction sunsets after 2028
-  period: 2029
-  input:
-    people:
-      person1:
-        age: 65
-        is_tax_unit_head_or_spouse: true
-        ssn_card_type: CITIZEN
-    tax_units:
-      tax_unit:
-        members: [person1]
-        adjusted_gross_income: 50_000
-        salt_deduction: 0
-        standard_deduction: 0
-  output:
-    # H.R.1 SEC. 70103 limits the deduction to tax years beginning before
-    # January 1, 2029. Parameter amount drops to  from 2029 onward.
-    additional_senior_deduction: 0


### PR DESCRIPTION
## Summary
- Follow-up to #8111 — removes the 2029 sunset entry from `senior_deduction/amount.yaml` and the corresponding baseline test case.
- Fixes 5 failing tests in `policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml`.

## Why
H.R.1 SEC. 70103's sunset is handled at the deduction **aggregator** level — `deductions_if_itemizing` and `deductions_if_not_itemizing` stop listing `additional_senior_deduction` after 2028, which takes it out of taxable income deductions. Setting `amount.yaml` to `2029-01-01: 0` in addition zeroes out the variable itself, which broke reforms like CRFB `senior_deduction_extension` that only restore the aggregator membership (not the amount).

The CRFB reform's tests expected `additional_senior_deduction: 12_000` for joint filers in 2029+ under the extension. With the amount parameter sunset, those returned `0` and all 5 CRFB tests failed.

## Changes
- `policyengine_us/parameters/gov/irs/deductions/senior_deduction/amount.yaml`: remove `2029-01-01: 0`
- `policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/senior_deduction/integration.yaml`: remove the 2029 sunset test (the aggregator-level sunset is already covered by the CRFB reform's tests)

## Test plan
- [x] `policyengine-core test policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml -c policyengine_us` — 5 passed
- [x] `policyengine-core test policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/senior_deduction/ -c policyengine_us` — 26 passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)