### PR TITLE
Fix OH senior citizen credit to check spouse's age

### DIFF
--- a/changelog.d/fix-oh-senior-credit-spouse-age.fixed.md
+++ b/changelog.d/fix-oh-senior-credit-spouse-age.fixed.md
@@ -1,0 +1,1 @@
+Fixed OH senior citizen credit to check both head and spouse age per ORC 5747.055.

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/credits/oh_senior_citizen_credit.yaml
@@ -145,3 +145,80 @@
         oh_income_tax_before_non_refundable_credits: 1000000
   output:
     oh_senior_citizen_credit: 50
+
+- name: Issue 8121 - spouse is 65+, head is not
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 62
+        oh_has_taken_oh_lump_sum_credits: false
+      person2:
+        is_tax_unit_spouse: true
+        age: 67
+        oh_has_taken_oh_lump_sum_credits: false
+    households:
+      household:
+        members: [person1, person2]
+        state_code: OH
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        oh_modified_agi: 90_000
+        oh_personal_exemptions: 0
+        oh_income_tax_before_non_refundable_credits: 1_000_000
+  output:
+    oh_senior_citizen_credit: 50
+
+- name: Spouse is 65+ but took lump sum, head is 62
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 62
+        oh_has_taken_oh_lump_sum_credits: false
+      person2:
+        is_tax_unit_spouse: true
+        age: 67
+        oh_has_taken_oh_lump_sum_credits: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: OH
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        oh_modified_agi: 90_000
+        oh_personal_exemptions: 0
+        oh_income_tax_before_non_refundable_credits: 1_000_000
+  output:
+    # Spouse is 65+ but took lump sum — excluded. Head is 62 — not 65+.
+    oh_senior_citizen_credit: 0
+
+- name: Both spouses 65+, head took lump sum, spouse did not
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        oh_has_taken_oh_lump_sum_credits: true
+      person2:
+        is_tax_unit_spouse: true
+        age: 68
+        oh_has_taken_oh_lump_sum_credits: false
+    households:
+      household:
+        members: [person1, person2]
+        state_code: OH
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        oh_modified_agi: 90_000
+        oh_personal_exemptions: 0
+        oh_income_tax_before_non_refundable_credits: 1_000_000
+  output:
+    # Head 66 took lump sum (excluded), but spouse 68 didn't — eligible
+    oh_senior_citizen_credit: 50

--- a/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit_potential.py
+++ b/policyengine_us/variables/gov/states/oh/tax/income/credits/oh_senior_citizen_credit_potential.py
@@ -17,16 +17,20 @@ class oh_senior_citizen_credit_potential(Variable):
         p = parameters(period).gov.states.oh.tax.income.credits.senior_citizen
         person = tax_unit.members
         head = person("is_tax_unit_head", period)
-        head_has_not_taken_lump_sum_distribution = (
-            ~person("oh_has_taken_oh_lump_sum_credits", period) * head
-        )
+        spouse = person("is_tax_unit_spouse", period)
+        has_not_taken_lump_sum = ~person("oh_has_taken_oh_lump_sum_credits", period)
+        # Per ORC 5747.055 and IT 1040 Schedule of Credits Line 4:
+        # credit applies if either taxpayer or spouse is 65+ and has
+        # not taken the lump-sum distribution credit.
         age_head = tax_unit("age_head", period)
+        age_spouse = tax_unit("age_spouse", period)
         elderly_head = age_head >= p.age_threshold
-        eligible_head = (
-            tax_unit.any(head_has_not_taken_lump_sum_distribution) & elderly_head
-        )
+        elderly_spouse = age_spouse >= p.age_threshold
+        head_eligible = elderly_head & tax_unit.any(head & has_not_taken_lump_sum)
+        spouse_eligible = elderly_spouse & tax_unit.any(spouse & has_not_taken_lump_sum)
+        eligible = head_eligible | spouse_eligible
         agi = tax_unit("oh_modified_agi", period)
         exemptions = tax_unit("oh_personal_exemptions", period)
         applicable_income = max_(agi - exemptions, 0)
         credit_amount = p.amount.calc(applicable_income)
-        return eligible_head * credit_amount
+        return eligible * credit_amount


### PR DESCRIPTION
## Summary
- Fixes `oh_senior_citizen_credit_potential` to check both head's and spouse's age per ORC 5747.055
- Previously only checked `age_head >= 65`, missing cases where only the spouse is 65+
- Now checks each person independently: if either head or spouse is 65+ AND hasn't taken the lump-sum distribution credit, the credit applies

Closes #8121

## Test plan
- [x] All 9 existing OH senior credit tests pass (no regressions)
- [x] Added 3 new test cases:
  - Spouse 67, head 62 → $50 credit (was $0 before fix)
  - Spouse 67 took lump sum, head 62 → $0 (correctly excluded)
  - Both 65+, head took lump sum, spouse didn't → $50 (spouse qualifies)
- [x] All 232 Ohio tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)