### PR TITLE
Fix test_batched silently dropping --batches N and --exclude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ test-yaml-no-structural-states-ny:
 	# NY credits clone the tax_benefit_system per scenario (~12 GB) —
 	# split explicitly. Everything else under ny/ auto-fans out.
 	$(BATCH) $(TESTS)/policy/baseline/gov/states/ny/tax/income/credits --batches 3
-	$(BATCH) $(TESTS)/policy/baseline/gov/states/ny/tax/income/taxable_income --batches 1
-	$(BATCH) $(TESTS)/policy/baseline/gov/states/ny/tax/income --exclude credits,taxable_income --batches 1
+	$(BATCH) $(TESTS)/policy/baseline/gov/states/ny/tax/income --exclude credits --mode per-subdir
 	$(BATCH) $(TESTS)/policy/baseline/gov/states/ny --exclude tax --mode per-subdir
 test-yaml-no-structural-other:
 	$(BATCH) $(TESTS)/policy/baseline --batches 2 --exclude states

--- a/changelog.d/fix-batches-leaf-folders.fixed.md
+++ b/changelog.d/fix-batches-leaf-folders.fixed.md
@@ -1,0 +1,1 @@
+Fix `--batches N` silently collapsing to 1 batch for folders without subdirectories.

--- a/changelog.d/fix-batches-leaf-folders.fixed.md
+++ b/changelog.d/fix-batches-leaf-folders.fixed.md
@@ -1,1 +1,1 @@
-Fix `--batches N` silently collapsing to 1 batch for folders without subdirectories.
+Fix test_batched.py silently dropping `--batches N` and `--exclude` for folders without subdirectories, which caused duplicated and under-parallelized CI test runs.

--- a/policyengine_us/tests/test_batched.py
+++ b/policyengine_us/tests/test_batched.py
@@ -228,28 +228,45 @@ def split_into_batches(
 
             return batches
 
-    # Default: honor num_batches generically. If the caller asked for >1
-    # batch, split the recursive yaml list into that many chunks so any
-    # folder (leaf or otherwise) gets real subprocess isolation. Falling
-    # back to a single-path batch previously meant --batches N silently
-    # collapsed to 1 for folders that weren't matched by a special handler.
-    if num_batches > 1:
-        yaml_files = sorted(base_path.rglob("*.yaml"))
-        if not yaml_files:
-            return []
-        chunk_size = len(yaml_files) // num_batches
-        remainder = len(yaml_files) % num_batches
-        batches = []
-        start = 0
-        for i in range(num_batches):
-            end = start + chunk_size + (1 if i < remainder else 0)
-            chunk = [str(f) for f in yaml_files[start:end]]
-            if chunk:
-                batches.append(chunk)
-            start = end
-        return batches
+    # Default: honor num_batches and exclude generically. The cheapest
+    # common case (no chunking, no exclusion) returns the base_path as a
+    # single batch so policyengine-core walks the tree once. Otherwise we
+    # enumerate explicit paths — necessary because the test runner has no
+    # way to skip excluded subpaths on its own, and because splitting into
+    # multiple subprocesses requires discrete path lists.
+    if num_batches <= 1 and not exclude:
+        return [[str(base_path)]]
 
-    return [[str(base_path)]]
+    if exclude:
+        # Exclude applies to immediate children by name (same semantics as
+        # the special-branch excludes above). Previously, `--exclude` in
+        # the default branch was silently ignored, causing duplicated
+        # work — e.g. `ny --exclude tax` still re-ran every `tax/*` test.
+        paths = sorted(
+            str(item)
+            for item in base_path.iterdir()
+            if (item.is_dir() or item.suffix == ".yaml") and item.name not in exclude
+        )
+    else:
+        paths = sorted(str(f) for f in base_path.rglob("*.yaml"))
+
+    if not paths:
+        return []
+
+    if num_batches <= 1:
+        return [paths]
+
+    chunk_size = len(paths) // num_batches
+    remainder = len(paths) % num_batches
+    batches = []
+    start = 0
+    for i in range(num_batches):
+        end = start + chunk_size + (1 if i < remainder else 0)
+        chunk = paths[start:end]
+        if chunk:
+            batches.append(chunk)
+        start = end
+    return batches
 
 
 def run_batch(test_paths: List[str], batch_name: str) -> Dict:

--- a/policyengine_us/tests/test_batched.py
+++ b/policyengine_us/tests/test_batched.py
@@ -228,7 +228,27 @@ def split_into_batches(
 
             return batches
 
-    # Default: return the entire path as a single batch
+    # Default: honor num_batches generically. If the caller asked for >1
+    # batch, split the recursive yaml list into that many chunks so any
+    # folder (leaf or otherwise) gets real subprocess isolation. Falling
+    # back to a single-path batch previously meant --batches N silently
+    # collapsed to 1 for folders that weren't matched by a special handler.
+    if num_batches > 1:
+        yaml_files = sorted(base_path.rglob("*.yaml"))
+        if not yaml_files:
+            return []
+        chunk_size = len(yaml_files) // num_batches
+        remainder = len(yaml_files) % num_batches
+        batches = []
+        start = 0
+        for i in range(num_batches):
+            end = start + chunk_size + (1 if i < remainder else 0)
+            chunk = [str(f) for f in yaml_files[start:end]]
+            if chunk:
+                batches.append(chunk)
+            start = end
+        return batches
+
     return [[str(base_path)]]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2941,7 +2941,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-core"
-version = "3.25.1"
+version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpath" },
@@ -2967,14 +2967,14 @@ dependencies = [
     { name = "standard-imghdr" },
     { name = "wheel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/66/a858dcefd08d0146c12c5c1e28a7614ed1ed673c3a7bf8c342027d694368/policyengine_core-3.25.1.tar.gz", hash = "sha256:6ccb89469f30e6c02d57977aef1f5a2e2802c4c8f10b831529052fc8f1cb90a5", size = 464737, upload-time = "2026-04-18T12:30:27.982Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/ed/117c487e09bc2d5dae1d39baef2d317158433f66004f38f19f6ed82110eb/policyengine_core-3.25.2.tar.gz", hash = "sha256:de80b64b969e3c6b5a3046e29e5b9f2ce56c82f874064f65556fa60c8c423f17", size = 466431, upload-time = "2026-04-21T17:37:40.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/cf/4acec9277399ca9452bb66df796a07af90271355f7f8122fbc490603fed1/policyengine_core-3.25.1-py3-none-any.whl", hash = "sha256:196f26e067c1893aba6bde44ae4d1ede799fb6c0823866200500adcf4459d254", size = 230909, upload-time = "2026-04-18T12:30:25.525Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/22/b2297927a2091a22267c112e8d5d5d2b374d0f1ce67f257816fee1388170/policyengine_core-3.25.2-py3-none-any.whl", hash = "sha256:c884961937940e16730fb473d486728ed8c66250dc65df15257ad611e6655b09", size = 231186, upload-time = "2026-04-21T17:37:39.148Z" },
 ]
 
 [[package]]
 name = "policyengine-us"
-version = "1.659.1"
+version = "1.659.5"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
Two related silent bugs in `policyengine_us/tests/test_batched.py` that caused CI runners to do more or less work than their Makefile targets declared:

1. **`--batches N` ignored** for folders that didn't match any special-case handler (`gov/states`, `baseline`, `policy/contrib`, etc.). The default branch returned `[[base_path]]` — a single batch — no matter what `num_batches` was. This affected 3 live CI targets:
   - `ny/tax/income/credits --batches 3` → actually ran as 1 batch (NY CTC/EITC files that clone `tax_benefit_system` at ~12 GB each all ran in one subprocess, defeating the memory isolation goal)
   - `baseline/household --batches 2` → actually ran as 1 batch
   - `gov/ssa/revenue --batches 2` → actually ran as 1 batch
2. **`--exclude` ignored in the same default branch**. So `ny/tax/income --exclude credits,taxable_income --batches 1` silently re-ran the credits and taxable_income subdirectories that had already been covered by earlier invocations in the same Makefile target — the `states-ny` runner was double-testing those files.

## Fix
The default branch now honors both flags generically, with no new per-folder special cases:

- If no chunking or exclusion is requested, keep the cheap `[[base_path]]` return.
- Otherwise, enumerate the relevant paths (recursive yaml list when only `--batches N` applies; immediate children filtered by name when `--exclude` applies) and chunk into `num_batches` groups.

Also simplified the NY target from 4 Makefile calls to 3 — the `taxable_income` leaf call is unnecessary now that `--mode per-subdir` with `--exclude credits` on `ny/tax/income` naturally separates it.

## Verification
```
# Before the fix:
ny/tax/income/credits --batches 3   -> 1 batch (expected 3)
gov/ssa/revenue --batches 2         -> 1 batch (expected 2)
ny/tax/income --exclude credits     -> ran everything including credits

# After the fix:
ny/tax/income/credits --batches 3   -> 3 batches (7/6/6 yamls)
gov/ssa/revenue --batches 2         -> 2 batches (3/3 yamls)
ny/tax/income --exclude credits     -> excludes credits; taxable_income auto-routes as its own batch
```

Coverage audit on the new NY target: all 49 yamls under `ny/` run exactly once (zero duplicates, zero gaps).

`--batches 1` / no-exclude callers are unchanged — still return `[[base_path]]` as one batch.

## Test plan
- [ ] CI passes with real subprocess isolation on credits, household, and ssa/revenue
- [ ] `Baseline (states-ny)` runner time changes (expected: drop now that credits actually parallelizes)
- [ ] No regression on `--batches 1` callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)