### PR TITLE
Mark 7 SSI state supplements as complete in programs.yaml

### DIFF
--- a/changelog.d/fix-programs-yaml-ssp-status.fixed.md
+++ b/changelog.d/fix-programs-yaml-ssp-status.fixed.md
@@ -1,0 +1,1 @@
+Update SSI state supplement program registry to mark CT, DC, ID, IN, NM, SC, and TX as complete.

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -599,18 +599,20 @@ programs:
         full_name: California State Supplementary Payment
         variable: ca_state_supplement
       - state: CT
-        status: in_progress
+        status: complete
         name: Connecticut SSP
         full_name: Connecticut State Supplement Program
+        variable: ct_ssp
       - state: CO
         status: complete
         name: Colorado SSP
         full_name: Colorado State Supplementary Payment
         variable: co_state_supplement
       - state: DC
-        status: in_progress
+        status: complete
         name: DC OSSP
         full_name: DC Optional State Supplemental Payment
+        variable: dc_ossp
       - state: DE
         status: complete
         name: Delaware SSP
@@ -634,13 +636,15 @@ programs:
         name: Iowa SSP
         full_name: Iowa State Supplemental Payment
       - state: ID
-        status: in_progress
+        status: complete
         name: Idaho AABD
         full_name: Idaho AABD cash assistance
+        variable: id_aabd
       - state: IN
-        status: in_progress
+        status: complete
         name: Indiana SSP
         full_name: Indiana State Supplementary Payment
+        variable: in_ssp
       - state: MA
         status: complete
         name: Massachusetts SSP
@@ -656,17 +660,20 @@ programs:
         full_name: Illinois Aid to the Aged, Blind or Disabled
         variable: il_aabd
       - state: NM
-        status: in_progress
+        status: complete
         name: New Mexico SSI supplement
         full_name: New Mexico SSI state supplement
+        variable: nm_ssi_state_supplement
       - state: SC
-        status: in_progress
+        status: complete
         name: South Carolina SSI supplement
         full_name: South Carolina SSI state supplement
+        variable: sc_ssi_state_supplement
       - state: TX
-        status: in_progress
+        status: complete
         name: Texas SSI supplement
         full_name: Texas SSI state supplement
+        variable: tx_ssi_state_supplement
 
   - id: social_security
     name: Social Security


### PR DESCRIPTION
## Summary
`programs.yaml` listed CT, DC, ID, IN, NM, SC, and TX as `in_progress` with no `variable:` field, but their SSI state supplement variables are already implemented and registered in `household_state_benefits.yaml` and `spm_unit_benefits.py`. This PR updates those 7 entries to `status: complete` and adds the variable reference.

## Changes
| State | Variable added |
|---|---|
| CT | `ct_ssp` |
| DC | `dc_ossp` |
| ID | `id_aabd` |
| IN | `in_ssp` |
| NM | `nm_ssi_state_supplement` |
| SC | `sc_ssi_state_supplement` |
| TX | `tx_ssi_state_supplement` |

No code changes — registry metadata only.

## Test plan
- [x] `make format` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)