### PR TITLE
Add California AB 2591: standard deduction at federal poverty line

### DIFF
--- a/changelog.d/ca-ab2591.added.md
+++ b/changelog.d/ca-ab2591.added.md
@@ -1,0 +1,1 @@
+Add California AB 2591 contributed reform: standard deduction at the federal poverty line.

--- a/policyengine_us/parameters/gov/contrib/states/ca/ab2591/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ca/ab2591/in_effect.yaml
@@ -1,0 +1,12 @@
+description: California AB 2591 sets the state standard deduction equal to the federal poverty line for the filer's household size if this is true.
+
+values:
+  0000-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: California AB 2591 federal poverty line standard deduction in effect
+  reference:
+    - title: California AB 2591 (2025-2026), Sec. 2 amending R&TC 17073.5(b)
+      href: https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260AB2591

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -200,6 +200,9 @@ from .states.nj.anchor import (
 )
 
 
+from .states.ca.ab2591 import (
+    create_ca_ab2591_reform,
+)
 from .states.ga.sb520 import (
     create_ga_sb520_reform,
 )
@@ -420,6 +423,7 @@ def create_structural_reforms_from_parameters(parameters, period):
     al_hb527_overtime_deduction = create_al_hb527_overtime_deduction_reform(
         parameters, period
     )
+    ca_ab2591 = create_ca_ab2591_reform(parameters, period)
     ga_sb520 = create_ga_sb520_reform(parameters, period)
     hi_hb2306_cdcc = create_hi_hb2306_cdcc_reform(parameters, period)
     nc_eitc = create_nc_eitc_reform(parameters, period)
@@ -531,6 +535,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         ct_sb100,
         ct_tax_rebate_2026,
         al_hb527_overtime_deduction,
+        ca_ab2591,
         ga_sb520,
         hi_hb2306_cdcc,
         nc_eitc,

--- a/policyengine_us/reforms/states/ca/__init__.py
+++ b/policyengine_us/reforms/states/ca/__init__.py
@@ -1,0 +1,1 @@
+from .ab2591 import create_ca_ab2591_reform

--- a/policyengine_us/reforms/states/ca/ab2591/__init__.py
+++ b/policyengine_us/reforms/states/ca/ab2591/__init__.py
@@ -1,0 +1,5 @@
+from .ab2591 import (
+    create_ca_ab2591,
+    create_ca_ab2591_reform,
+    ca_ab2591,
+)

--- a/policyengine_us/reforms/states/ca/ab2591/ab2591.py
+++ b/policyengine_us/reforms/states/ca/ab2591/ab2591.py
@@ -1,0 +1,86 @@
+from policyengine_us.model_api import *
+from policyengine_core.periods import period as period_
+
+
+def create_ca_ab2591() -> Reform:
+    class ca_standard_deduction(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "California standard deduction"
+        unit = USD
+        definition_period = YEAR
+        reference = (
+            "https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260AB2591",
+        )
+        defined_for = StateCode.CA
+
+        def formula(tax_unit, period, parameters):
+            p = parameters(period).gov.states.ca.tax.income.deductions.standard
+            p_ab2591 = parameters(period).gov.contrib.states.ca.ab2591
+            filing_status = tax_unit("filing_status", period)
+            statuses = filing_status.possible_values
+
+            baseline_deduction = p.amount[filing_status]
+
+            # AB 2591 allows an election of the federal poverty line as the
+            # standard deduction. For single / married-filing-separately, the
+            # deduction equals the FPL for a one-person household. For head of
+            # household, the FPL for a two-person household. For joint and
+            # surviving-spouse filers, the FPL adjusted for the actual number of
+            # persons in the household.
+            p_fpg = parameters(period).gov.hhs.fpg
+            state_group = tax_unit.household("state_group_str", period)
+            first_person = p_fpg.first_person[state_group]
+            additional_person = p_fpg.additional_person[state_group]
+
+            household_size = tax_unit("tax_unit_size", period)
+            # Bill Sec. 2, R&TC 17073.5(b)(2) sets HoH to the two-person FPL.
+            # Bill Sec. 2, R&TC 17073.5(b)(1) sets single / separate to the
+            # one-person FPL.
+            is_joint_or_ss = (filing_status == statuses.JOINT) | (
+                filing_status == statuses.SURVIVING_SPOUSE
+            )
+            is_hoh = filing_status == statuses.HEAD_OF_HOUSEHOLD
+            fpl_household_size = where(
+                is_joint_or_ss,
+                household_size,
+                where(is_hoh, 2, 1),
+            )
+            fpl_deduction = first_person + additional_person * (fpl_household_size - 1)
+
+            # Taxpayer election: higher of FPL-based amount or baseline
+            # statutory standard deduction.
+            elected_deduction = max_(fpl_deduction, baseline_deduction)
+
+            return where(p_ab2591.in_effect, elected_deduction, baseline_deduction)
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(ca_standard_deduction)
+
+    return reform
+
+
+def create_ca_ab2591_reform(parameters, period, bypass: bool = False):
+    if bypass:
+        return create_ca_ab2591()
+
+    p = parameters.gov.contrib.states.ca.ab2591
+
+    reform_active = False
+    current_period = period_(period)
+
+    for _ in range(5):
+        p_at_period = p(current_period)
+        if p_at_period.in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
+        return create_ca_ab2591()
+    else:
+        return None
+
+
+ca_ab2591 = create_ca_ab2591_reform(None, None, bypass=True)

--- a/policyengine_us/tests/policy/contrib/states/ca/ab2591/ca_ab2591.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ca/ab2591/ca_ab2591.yaml
@@ -1,0 +1,208 @@
+# California AB 2591 - Taxing Californians into Poverty Protection Act
+# Allows taxpayers to elect a standard deduction equal to the federal
+# poverty line for their household size.
+# Effective for taxable years beginning on or after July 1, 2027.
+# 2027 federal poverty guidelines (CONTIGUOUS_US):
+#   first person = $16,334
+#   additional person = $5,813
+#   1-person FPL  = $16,334
+#   2-person FPL  = $22,147
+#   4-person FPL  = $33,774
+
+- name: Single filer uses one-person FPL.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: true
+    people:
+      person1:
+        age: 35
+        employment_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    ca_standard_deduction: 16_334
+
+- name: Head of household with one child uses two-person FPL.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: true
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+        employment_income: 60_000
+      person2:
+        age: 8
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CA
+  output:
+    ca_standard_deduction: 22_147
+
+- name: Head of household with two children still uses two-person FPL.
+  # Bill R&TC 17073.5(b)(2) fixes HoH at the two-person FPL regardless of size.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: true
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+        employment_income: 60_000
+      person2:
+        age: 10
+        is_tax_unit_dependent: true
+      person3:
+        age: 7
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: CA
+  output:
+    ca_standard_deduction: 22_147
+
+- name: Joint filers with no children use two-person FPL.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: true
+    people:
+      person1:
+        age: 38
+        is_tax_unit_head: true
+        employment_income: 80_000
+      person2:
+        age: 36
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CA
+  output:
+    ca_standard_deduction: 22_147
+
+- name: Joint filers with two children use four-person FPL.
+  # Bill R&TC 17073.5(b)(3) scales joint FPL with the number of persons in the household.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: true
+    people:
+      person1:
+        age: 38
+        is_tax_unit_head: true
+        employment_income: 90_000
+      person2:
+        age: 36
+        is_tax_unit_spouse: true
+      person3:
+        age: 10
+        is_tax_unit_dependent: true
+      person4:
+        age: 7
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: CA
+  output:
+    ca_standard_deduction: 33_774
+
+- name: Married filing separately uses one-person FPL.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: true
+    people:
+      person1:
+        age: 35
+        is_tax_unit_head: true
+        employment_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SEPARATE
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    ca_standard_deduction: 16_334
+
+- name: Reform inactive leaves baseline CA standard deduction unchanged.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: false
+    people:
+      person1:
+        age: 35
+        employment_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    # 2025 indexed CA standard deduction value (still $5,706 in 2027 absent uprating)
+    ca_standard_deduction: 5_706
+
+- name: Non-California filer unaffected by the reform.
+  period: 2027
+  absolute_error_margin: 1
+  reforms: policyengine_us.reforms.states.ca.ab2591.ab2591.ca_ab2591
+  input:
+    gov.contrib.states.ca.ab2591.in_effect: true
+    people:
+      person1:
+        age: 35
+        employment_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    # ca_standard_deduction is defined_for=CA, so non-CA returns 0
+    ca_standard_deduction: 0


### PR DESCRIPTION
# California AB 2591 — Taxing Californians into Poverty Protection Act

## Summary

Implements [California AB 2591 (Bains, 2025-2026)](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260AB2591), which amends R&TC 17073.5 to let taxpayers elect a state standard deduction equal to the federal poverty line for their household size, operative for taxable years beginning on or after July 1, 2027.

Closes #8135

## Reform mechanics

Per R&TC 17073.5(b):

| Filing status | FPL basis |
|---|---|
| Single, separate | 1-person FPL |
| Head of household | 2-person FPL |
| Joint, surviving spouse | FPL scaled by tax unit size |

Since FPL exceeds the statutory CA standard deduction for every filing status, the bill effectively sets the CA standard deduction to the FPL amount. The reform returns `max(FPL-based, baseline)` to explicitly implement the taxpayer election rather than hard-coding the direction.

## Files

### New
- `policyengine_us/parameters/gov/contrib/states/ca/ab2591/in_effect.yaml` — boolean toggle, default false
- `policyengine_us/reforms/states/ca/ab2591/ab2591.py` — overrides `ca_standard_deduction`
- `policyengine_us/reforms/states/ca/ab2591/__init__.py`
- `policyengine_us/reforms/states/ca/__init__.py`
- `policyengine_us/tests/policy/contrib/states/ca/ab2591/ca_ab2591.yaml` — 8 test cases
- `changelog.d/ca-ab2591.added.md`

### Modified
- `policyengine_us/reforms/reforms.py` — register reform

## Test coverage

8 YAML cases covering:
- Single filer → 1-person FPL ($16,334 in 2027)
- Head of household (2 members) → 2-person FPL ($22,147)
- Head of household (3 members) → 2-person FPL (fixed, per bill)
- Joint no children → 2-person FPL
- Joint family of four → 4-person FPL ($33,774)
- Separate → 1-person FPL
- Reform inactive → baseline CA standard deduction
- Non-CA filer → zero (defined_for=CA)

All 8 tests pass.

## Usage

```yaml
gov.contrib.states.ca.ab2591.in_effect: true
```

## References

- [Bill text](https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202520260AB2591)
- [Assembly Revenue and Taxation committee analysis (FTB fiscal note)](https://trackbill.com/s3/bills/CA/2025/AB/2591/analyses/assembly-revenue-and-taxation.pdf) — FTB estimates -\$7B/yr after full effect