### PR TITLE
Add North Carolina Child and Dependent Care Tax Credit contrib reform

### DIFF
--- a/changelog.d/nc-cdcc.added.md
+++ b/changelog.d/nc-cdcc.added.md
@@ -1,0 +1,1 @@
+North Carolina Child and Dependent Care Credit contrib reform (refundable, 30% match of federal credit, 2026+).

--- a/policyengine_us/parameters/gov/contrib/states/nc/cdcc/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nc/cdcc/in_effect.yaml
@@ -1,0 +1,12 @@
+description: North Carolina applies a refundable state Child and Dependent Care Credit as a match of the federal credit if this is true.
+
+values:
+  0000-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: North Carolina Child and Dependent Care Credit in effect
+  reference:
+    - title: North Carolina Governor's Recommended Budget, FY 2026-27, p. 69
+      href: https://www.osbm.nc.gov/fy2026-27-budget-rec-budget-book/open#page=69

--- a/policyengine_us/parameters/gov/contrib/states/nc/cdcc/match.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nc/cdcc/match.yaml
@@ -1,0 +1,12 @@
+description: North Carolina Child and Dependent Care Credit match rate as a fraction of the federal credit.
+
+values:
+  2026-01-01: 0.3
+
+metadata:
+  unit: /1
+  period: year
+  label: North Carolina Child and Dependent Care Credit match rate
+  reference:
+    - title: North Carolina Governor's Recommended Budget, FY 2026-27, p. 69
+      href: https://www.osbm.nc.gov/fy2026-27-budget-rec-budget-book/open#page=69

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -209,6 +209,9 @@ from .states.hi.hb2306_cdcc import (
 from .states.nc.eitc import (
     create_nc_eitc_reform,
 )
+from .states.nc.cdcc import (
+    create_nc_cdcc_reform,
+)
 from .states.mi.ctc import (
     create_mi_ctc_reform,
 )
@@ -424,6 +427,7 @@ def create_structural_reforms_from_parameters(parameters, period):
     ga_sb520 = create_ga_sb520_reform(parameters, period)
     hi_hb2306_cdcc = create_hi_hb2306_cdcc_reform(parameters, period)
     nc_eitc = create_nc_eitc_reform(parameters, period)
+    nc_cdcc = create_nc_cdcc_reform(parameters, period)
     mi_ctc = create_mi_ctc_reform(parameters, period)
     watca = create_watca_reform(parameters, period)
     al_eitc = create_al_eitc_reform(parameters, period)
@@ -535,6 +539,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         ga_sb520,
         hi_hb2306_cdcc,
         nc_eitc,
+        nc_cdcc,
         mi_ctc,
         watca,
         al_eitc,

--- a/policyengine_us/reforms/states/nc/cdcc/__init__.py
+++ b/policyengine_us/reforms/states/nc/cdcc/__init__.py
@@ -1,0 +1,5 @@
+from .nc_cdcc_reform import (
+    create_nc_cdcc,
+    create_nc_cdcc_reform,
+    nc_cdcc,
+)

--- a/policyengine_us/reforms/states/nc/cdcc/nc_cdcc_reform.py
+++ b/policyengine_us/reforms/states/nc/cdcc/nc_cdcc_reform.py
@@ -25,7 +25,14 @@ def create_nc_cdcc() -> Reform:
         defined_for = StateCode.NC
 
         def formula(tax_unit, period, parameters):
-            return tax_unit("nc_cdcc", period)
+            # Stack with nc_eitc when the NC EITC contrib reform is also
+            # active, so enabling both NC contrib credits sums rather than
+            # overwrites.
+            total = tax_unit("nc_cdcc", period)
+            variables = tax_unit.simulation.tax_benefit_system.variables
+            if "nc_eitc" in variables:
+                total = total + tax_unit("nc_eitc", period)
+            return total
 
     class nc_income_tax(Variable):
         value_type = float

--- a/policyengine_us/reforms/states/nc/cdcc/nc_cdcc_reform.py
+++ b/policyengine_us/reforms/states/nc/cdcc/nc_cdcc_reform.py
@@ -1,0 +1,80 @@
+from policyengine_us.model_api import *
+from policyengine_core.periods import period as period_
+
+
+def create_nc_cdcc() -> Reform:
+    class nc_cdcc(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "North Carolina Child and Dependent Care Credit"
+        unit = USD
+        definition_period = YEAR
+        defined_for = StateCode.NC
+
+        def formula(tax_unit, period, parameters):
+            p = parameters(period).gov.contrib.states.nc.cdcc
+            federal_cdcc = tax_unit("cdcc_potential", period)
+            return federal_cdcc * p.match
+
+    class nc_refundable_credits(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "North Carolina refundable credits"
+        unit = USD
+        definition_period = YEAR
+        defined_for = StateCode.NC
+
+        def formula(tax_unit, period, parameters):
+            return tax_unit("nc_cdcc", period)
+
+    class nc_income_tax(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "North Carolina income tax"
+        unit = USD
+        definition_period = YEAR
+        defined_for = StateCode.NC
+
+        def formula(tax_unit, period, parameters):
+            tax_before_credits = add(
+                tax_unit, period, ["nc_income_tax_before_credits", "nc_use_tax"]
+            )
+            non_refundable_credits = tax_unit("nc_non_refundable_credits", period)
+            tax_before_refundable = max_(0, tax_before_credits - non_refundable_credits)
+
+            refundable_credits = tax_unit("nc_refundable_credits", period)
+
+            return tax_before_refundable - refundable_credits
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(nc_cdcc)
+            self.update_variable(nc_refundable_credits)
+            self.update_variable(nc_income_tax)
+
+    return reform
+
+
+def create_nc_cdcc_reform(parameters, period, bypass: bool = False):
+    if bypass:
+        return create_nc_cdcc()
+
+    p = parameters.gov.contrib.states.nc.cdcc
+
+    reform_active = False
+    current_period = period_(period)
+
+    for _ in range(5):
+        p_at_period = p(current_period)
+        if p_at_period.in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
+        return create_nc_cdcc()
+    else:
+        return None
+
+
+nc_cdcc = create_nc_cdcc_reform(None, None, bypass=True)

--- a/policyengine_us/tests/policy/contrib/states/nc/cdcc/nc_cdcc.yaml
+++ b/policyengine_us/tests/policy/contrib/states/nc/cdcc/nc_cdcc.yaml
@@ -1,0 +1,63 @@
+- name: NC CDCC with 30% default match
+  period: 2026
+  reforms: policyengine_us.reforms.states.nc.cdcc.nc_cdcc
+  input:
+    gov.contrib.states.nc.cdcc.in_effect: true
+    state_code: NC
+    cdcc_potential: 1_000
+  output:
+    nc_cdcc: 300
+    nc_refundable_credits: 300
+
+- name: NC CDCC with custom 50% match
+  period: 2026
+  reforms: policyengine_us.reforms.states.nc.cdcc.nc_cdcc
+  input:
+    gov.contrib.states.nc.cdcc.in_effect: true
+    gov.contrib.states.nc.cdcc.match: 0.5
+    state_code: NC
+    cdcc_potential: 2_000
+  output:
+    nc_cdcc: 1_000
+    nc_refundable_credits: 1_000
+
+- name: NC income tax reduced by CDCC refundable credit
+  period: 2026
+  reforms: policyengine_us.reforms.states.nc.cdcc.nc_cdcc
+  input:
+    gov.contrib.states.nc.cdcc.in_effect: true
+    state_code: NC
+    cdcc_potential: 1_000
+    nc_income_tax_before_credits: 500
+    nc_use_tax: 0
+    nc_non_refundable_credits: 0
+  output:
+    nc_cdcc: 300
+    nc_refundable_credits: 300
+    nc_income_tax: 200
+
+- name: NC CDCC creates refund when credit exceeds tax liability
+  period: 2026
+  reforms: policyengine_us.reforms.states.nc.cdcc.nc_cdcc
+  input:
+    gov.contrib.states.nc.cdcc.in_effect: true
+    gov.contrib.states.nc.cdcc.match: 0.5
+    state_code: NC
+    cdcc_potential: 6_000
+    nc_income_tax_before_credits: 1_000
+    nc_use_tax: 0
+    nc_non_refundable_credits: 500
+  output:
+    nc_cdcc: 3_000
+    nc_refundable_credits: 3_000
+    nc_income_tax: -2_500
+
+- name: Non-NC filer receives no NC CDCC
+  period: 2026
+  reforms: policyengine_us.reforms.states.nc.cdcc.nc_cdcc
+  input:
+    gov.contrib.states.nc.cdcc.in_effect: true
+    state_code: CA
+    cdcc_potential: 1_000
+  output:
+    nc_cdcc: 0

--- a/policyengine_us/tests/policy/contrib/states/nc/cdcc/nc_cdcc.yaml
+++ b/policyengine_us/tests/policy/contrib/states/nc/cdcc/nc_cdcc.yaml
@@ -52,6 +52,26 @@
     nc_refundable_credits: 3_000
     nc_income_tax: -2_500
 
+- name: NC CDCC stacks with NC EITC contrib when both are active
+  period: 2026
+  reforms:
+    - policyengine_us.reforms.states.nc.eitc.nc_eitc
+    - policyengine_us.reforms.states.nc.cdcc.nc_cdcc
+  input:
+    gov.contrib.states.nc.eitc.match: 0.1
+    gov.contrib.states.nc.cdcc.in_effect: true
+    state_code: NC
+    eitc: 2_000
+    cdcc_potential: 1_000
+    nc_income_tax_before_credits: 1_000
+    nc_use_tax: 0
+    nc_non_refundable_credits: 0
+  output:
+    nc_eitc: 200
+    nc_cdcc: 300
+    nc_refundable_credits: 500
+    nc_income_tax: 500
+
 - name: Non-NC filer receives no NC CDCC
   period: 2026
   reforms: policyengine_us.reforms.states.nc.cdcc.nc_cdcc


### PR DESCRIPTION
# North Carolina Child and Dependent Care Tax Credit

## Summary

Establishes a refundable North Carolina Child and Dependent Care Tax Credit (CDCC) starting in 2026, equal to 30% of the federal CDCC (`cdcc_potential`). Proposed in the [North Carolina Governor's Recommended Budget, FY 2026-27, p. 69](https://www.osbm.nc.gov/fy2026-27-budget-rec-budget-book/open#page=69).

Closes #8141

## Reform mechanics

- `nc_cdcc = cdcc_potential * match`, where `match = 0.30` starting 2026-01-01.
- Fully refundable — introduces `nc_refundable_credits` (NC currently has no refundable income tax credits in baseline) and updates `nc_income_tax` to subtract it after non-refundable credits.
- Gated by `gov.contrib.states.nc.cdcc.in_effect` (default `false`) via the dispatcher in `reforms.py`.

## Files

### New
- `policyengine_us/parameters/gov/contrib/states/nc/cdcc/in_effect.yaml` — bool toggle, default false
- `policyengine_us/parameters/gov/contrib/states/nc/cdcc/match.yaml` — 0.30 starting 2026
- `policyengine_us/reforms/states/nc/cdcc/nc_cdcc_reform.py` — adds `nc_cdcc`, `nc_refundable_credits`; overrides `nc_income_tax`
- `policyengine_us/reforms/states/nc/cdcc/__init__.py`
- `policyengine_us/tests/policy/contrib/states/nc/cdcc/nc_cdcc.yaml` — 5 test cases
- `changelog.d/nc-cdcc.added.md`

### Modified
- `policyengine_us/reforms/reforms.py` — register reform

## Pattern

- Contrib scaffolding (in_effect gate, 5-year lookahead, registration) mirrors #8137 (CA AB 2591), with `for _ in range(5)` rather than `for i in range(5)`.
- Federal-match variable structure mirrors `pa_cdcc` — multiplies `cdcc_potential` (federal CDCC before tax-liability limit) by a state match rate.
- Refundable-credits wiring mirrors the NC EITC contrib reform.

## Test coverage

5 YAML cases (all pass):
- NC CDCC with 30% default match
- NC CDCC with custom 50% match
- NC income tax reduced by CDCC refundable credit
- NC CDCC creates refund when credit exceeds tax liability
- Non-NC filer receives no NC CDCC (`defined_for=NC`)

## Usage

```yaml
gov.contrib.states.nc.cdcc.in_effect: true
```

## References

- [North Carolina Governor's Recommended Budget, FY 2026-27, p. 69](https://www.osbm.nc.gov/fy2026-27-budget-rec-budget-book/open#page=69)

🤖 Generated with [Claude Code](https://claude.com/claude-code)