### PR TITLE
Remove ct_child_tax_rebate from state_ctcs catalog

### DIFF
--- a/changelog.d/fix-8146-remove-ct-child-tax-rebate-from-state-ctcs.fixed.md
+++ b/changelog.d/fix-8146-remove-ct-child-tax-rebate-from-state-ctcs.fixed.md
@@ -1,0 +1,1 @@
+Removed the one-time Connecticut child tax rebate from the ongoing state Child Tax Credits catalog, eliminating a phantom $250 per child value in taxsim state CTC output for 2023-2026.

--- a/policyengine_us/parameters/gov/states/household/state_ctcs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_ctcs.yaml
@@ -30,7 +30,6 @@ values:
     - az_dependent_tax_credit
     - ca_yctc
     - co_ctc
-    - ct_child_tax_rebate
     - id_ctc
     - ma_child_and_family_credit_or_dependent_care_credit
     - md_ctc
@@ -45,7 +44,6 @@ values:
     - az_dependent_tax_credit
     - ca_yctc
     - co_ctc
-    - ct_child_tax_rebate
     - id_ctc
     - ma_child_and_family_credit_or_dependent_care_credit
     - md_ctc
@@ -64,7 +62,6 @@ values:
     - ca_yctc
     - co_ctc
     - co_family_affordability_credit
-    - ct_child_tax_rebate
     - id_ctc
     - il_ctc
     - ma_child_and_family_credit_or_dependent_care_credit
@@ -86,7 +83,6 @@ values:
     - ca_yctc
     - co_ctc
     - co_family_affordability_credit
-    - ct_child_tax_rebate
     - dc_ctc
     - ga_ctc
     - id_ctc


### PR DESCRIPTION
Closes #8146.

## Summary

Remove \`ct_child_tax_rebate\` from \`parameters/gov/states/household/state_ctcs.yaml\` at all year entries (2022, 2023, 2024, 2026).

## Why

The Connecticut Child Tax Rebate was a **one-time 2022 program** under Public Act 22-118 §410 — mailed checks based on 2021 returns, later repealed. It is not an ongoing state Child Tax Credit and does not belong in the CTC catalog parameter.

Its presence produced **phantom values** in 2023+ via \`taxsim_state_ctc\` (which aggregates \`gov.states.household.state_ctcs\`), surfacing as incorrect \`sctc\` output in \`policyengine-taxsim\` for CT filers — reported in [policyengine-taxsim#849](https://github.com/PolicyEngine/policyengine-taxsim/issues/849).

## Verification

Confirmed with a CT joint 2025 filer with two children:

| Variable | Before | After |
|---|---|---|
| \`taxsim_state_ctc\` | \$500 (phantom) | **\$0** ✓ |
| \`ct_child_tax_rebate\` (standalone) | \$500 | \$500 |

The standalone \`ct_child_tax_rebate\` variable still computes its result (the rebate parameter still has a 2022 value); only the catalog entry is removed, which is what the issue asks for. CT's actual \`ct_income_tax\` is unaffected — \`ct_child_tax_rebate\` was only ever in \`ct/tax/income/credits/non_refundable.yaml\` for 2022 and correctly dropped for 2023+.

## Related cleanup (not in this PR)

Per the issue: \`parameters/gov/states/ct/tax/income/rebate/amount.yaml\` could add \`2023-01-01: 0\` so the \`ct_child_tax_rebate\` variable itself returns \$0 post-2022. Flagged as non-blocking in the issue and can be done as a follow-up.

## Test plan

- [x] 3 existing \`ct_child_tax_rebate.yaml\` tests still pass
- [x] \`make format\` clean
- [x] End-to-end verification: \`taxsim_state_ctc\` for CT 2025 = \$0 (previously \$500 phantom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)