### PR TITLE
Remove ri_child_tax_rebate from state_ctcs catalog

### DIFF
--- a/changelog.d/fix-8149-remove-ri-child-tax-rebate-from-state-ctcs.fixed.md
+++ b/changelog.d/fix-8149-remove-ri-child-tax-rebate-from-state-ctcs.fixed.md
@@ -1,0 +1,1 @@
+Removed the one-time Rhode Island child tax rebate from the ongoing state Child Tax Credits catalog, eliminating a phantom $250 per child value in taxsim state CTC output for 2023 onward.

--- a/policyengine_us/parameters/gov/states/household/state_ctcs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_ctcs.yaml
@@ -25,7 +25,6 @@ values:
     - nc_ctc
     - ny_ctc
     - taxsim_ok_child_tax_credit_component
-    - ri_child_tax_rebate
   2022-01-01:
     - az_dependent_tax_credit
     - ca_yctc
@@ -38,7 +37,6 @@ values:
     - nj_ctc
     - ny_ctc
     - taxsim_ok_child_tax_credit_component
-    - ri_child_tax_rebate
     - vt_ctc
   2023-01-01:
     - az_dependent_tax_credit
@@ -55,7 +53,6 @@ values:
     - ny_ctc
     - taxsim_ok_child_tax_credit_component
     - or_ctc
-    - ri_child_tax_rebate
     - vt_ctc
   2024-01-01:
     - az_dependent_tax_credit
@@ -75,7 +72,6 @@ values:
     - ny_ctc
     - taxsim_ok_child_tax_credit_component
     - or_ctc
-    - ri_child_tax_rebate
     - ut_ctc
     - vt_ctc
   2026-01-01:
@@ -98,7 +94,6 @@ values:
     - ny_ctc
     - taxsim_ok_child_tax_credit_component
     - or_ctc
-    - ri_child_tax_rebate
     - ut_ctc
     - vt_ctc
 


### PR DESCRIPTION
Closes #8149.

## Summary

Remove \`ri_child_tax_rebate\` from \`parameters/gov/states/household/state_ctcs.yaml\` at all year entries (2021, 2022, 2023, 2024, 2026).

## Why

The Rhode Island Child Tax Rebate was a **one-time 2022 program** under [R.I. Gen. Laws § 44-30-103](https://webserver.rilegislature.gov/Statutes/TITLE44/44-30/44-VI/44-30-103.htm) — checks based on 2021 returns, not an ongoing tax credit. It does not belong in the ongoing state CTC catalog parameter.

Its presence produced **phantom values** in 2023+ via \`taxsim_state_ctc\` (which aggregates \`gov.states.household.state_ctcs\`), surfacing as incorrect \`sctc\` output in \`policyengine-taxsim\`. Same pattern as #8146 (CT child tax rebate, fixed via #8147).

## Verification

Confirmed with an RI joint 2025 filer with two children:

| Variable | Before | After |
|---|---|---|
| \`taxsim_state_ctc\` | \$500 (phantom) | **\$0** ✓ |
| \`ri_child_tax_rebate\` (standalone) | \$500 | \$500 |

The standalone \`ri_child_tax_rebate\` variable still computes its result; only the catalog entry is removed, matching the issue's ask.

## Related cleanup (not in this PR, per issue)

- Add \`2023-01-01: 0\` to \`parameters/gov/states/ri/tax/income/credits/child_tax_rebate/amount.yaml\` so the variable returns \$0 post-2022.
- Consider whether the start date should be 2022-01-01 rather than 2021-01-01 (the parameter's own reference comment notes "The child tax rebate was introduced in 2022").

Flagged as non-blocking in the issue; can be a follow-up.

## Test plan

- [x] \`make format\` clean
- [x] End-to-end verification: \`taxsim_state_ctc\` for RI 2025 = \$0 (previously \$500 phantom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)