### PR TITLE
Fix business income SECA and LSR inputs

### DIFF
--- a/changelog.d/business-income-seca-lsr.fixed
+++ b/changelog.d/business-income-seca-lsr.fixed
@@ -1,0 +1,1 @@
+Fix farm operations income, business self-employment tax, and labor supply response inputs.

--- a/policyengine_us/parameters/gov/household/market_income_sources.yaml
+++ b/policyengine_us/parameters/gov/household/market_income_sources.yaml
@@ -6,7 +6,7 @@ values:
   - sstb_self_employment_income
   - partnership_s_corp_income
   - gi_cash_assistance
-  - farm_income
+  - farm_operations_income
   - farm_rent_income
   - capital_gains
   - interest_income

--- a/policyengine_us/parameters/gov/local/ca/riv/general_relief/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/local/ca/riv/general_relief/income/sources/unearned.yaml
@@ -1,7 +1,7 @@
 description: Riverside County counts these income sources as unearned income under General Relief.
 values:
   2020-01-01:
-    - farm_income
+    - farm_operations_income
     - interest_income
     - social_security
     - ca_state_disability_insurance

--- a/policyengine_us/parameters/gov/states/al/tax/income/agi/gross_income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/al/tax/income/agi/gross_income_sources.yaml
@@ -15,7 +15,7 @@ values:
     - rental_income
     - capital_gains
     - partnership_s_corp_income
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
 
 metadata:

--- a/policyengine_us/parameters/gov/states/ca/cpuc/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cpuc/income_sources.yaml
@@ -15,7 +15,7 @@ values:
   # Self-employment
   - self_employment_income
   - partnership_s_corp_income
-  - farm_income
+  - farm_operations_income
   # Interest
   - interest_income
   # Dividends

--- a/policyengine_us/parameters/gov/states/co/ccap/income/countable_income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/co/ccap/income/countable_income/sources.yaml
@@ -4,7 +4,7 @@ values:
     # Earned income
     - employment_income
     - self_employment_income
-    - farm_income
+    - farm_operations_income
     # Unearned income
     - social_security
     - pension_income

--- a/policyengine_us/parameters/gov/states/ct/oec/c4k/income/earned_sources.yaml
+++ b/policyengine_us/parameters/gov/states/ct/oec/c4k/income/earned_sources.yaml
@@ -3,7 +3,7 @@ values:
   2020-01-01:
     - employment_income
     - self_employment_income
-    - farm_income
+    - farm_operations_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ia/tax/income/gross_income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/gross_income/sources.yaml
@@ -10,7 +10,7 @@ values:
     - taxable_pension_income
     - partnership_s_corp_income
     - rental_income
-    - farm_income
+    - farm_operations_income
     - taxable_unemployment_compensation
     - miscellaneous_income
 

--- a/policyengine_us/parameters/gov/states/il/dhs/aabd/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/aabd/income/sources/unearned.yaml
@@ -15,7 +15,7 @@ values:
     - dividend_income
     - interest_income
     #- rental_income # considered earned income if the individual is actively engaged in the management of the property
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
     - capital_gains
     - debt_relief

--- a/policyengine_us/parameters/gov/states/il/dhs/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/tanf/income/sources/unearned.yaml
@@ -9,7 +9,7 @@ values:
     - alimony_income
     - dividend_income
     - interest_income
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
     - capital_gains
     - debt_relief

--- a/policyengine_us/parameters/gov/states/il/hfs/hbwd/eligibility/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/il/hfs/hbwd/eligibility/income/sources/unearned.yaml
@@ -10,7 +10,7 @@ values:
     - dividend_income
     - interest_income
     - capital_gains
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
     - debt_relief
     - illicit_income

--- a/policyengine_us/parameters/gov/states/me/dhhs/ccap/income/countable_income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/me/dhhs/ccap/income/countable_income/sources.yaml
@@ -4,7 +4,7 @@ values:
     # Earned income (Rule §2.C.3)
     - employment_income
     - self_employment_income
-    - farm_income
+    - farm_operations_income
     - rental_income
     # Unearned income (Rule §2.C.4)
     - social_security

--- a/policyengine_us/parameters/gov/states/mi/tax/income/household_resources.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/household_resources.yaml
@@ -5,7 +5,7 @@ values:
     - strike_benefits
     - dividend_income
     - interest_income
-    - farm_income
+    - farm_operations_income
     - total_self_employment_income
     - partnership_s_corp_income
     - rental_income

--- a/policyengine_us/parameters/gov/states/ms/tax/income/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/income_sources.yaml
@@ -6,7 +6,7 @@ values:
     - partnership_s_corp_income
     - loss_limited_net_capital_gains_person
     - rental_income
-    - farm_income
+    - farm_operations_income
     - interest_income
     - qualified_dividend_income
     - alimony_income

--- a/policyengine_us/parameters/gov/states/nh/dhhs/ccap/income/countable_income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/nh/dhhs/ccap/income/countable_income/sources.yaml
@@ -4,7 +4,7 @@ values:
     # Earned income
     - employment_income
     - self_employment_income
-    - farm_income
+    - farm_operations_income
     # Unearned income
     - social_security
     - pension_income

--- a/policyengine_us/parameters/gov/states/nj/tax/income/gross_income/loss_eligible_categories/category_b.yaml
+++ b/policyengine_us/parameters/gov/states/nj/tax/income/gross_income/loss_eligible_categories/category_b.yaml
@@ -2,7 +2,7 @@ description: New Jersey combines self-employment and farm income into Category (
 values:
   2021-01-01:
     - self_employment_income  # Line 18: Net business profits
-    - farm_income  # Line 18: Farm income
+    - farm_operations_income  # Line 18: Farm income
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/ok/tax/income/credits/gross_income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/ok/tax/income/credits/gross_income_sources.yaml
@@ -4,7 +4,7 @@ values:
     - irs_employment_income
     - self_employment_income
     - partnership_s_corp_income
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
     - short_term_capital_gains
     - long_term_capital_gains

--- a/policyengine_us/parameters/gov/states/sc/dss/ccap/income/countable_income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/sc/dss/ccap/income/countable_income/sources.yaml
@@ -3,7 +3,7 @@ values:
   2022-10-01:
     - employment_income
     - self_employment_income
-    - farm_income
+    - farm_operations_income
     - social_security
     - pension_income
     - unemployment_compensation

--- a/policyengine_us/parameters/gov/states/sc/tanf/income/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/sc/tanf/income/unearned.yaml
@@ -2,7 +2,7 @@ description: South Carolina counts these income sources as unearned income under
 values:
   1996-07-01:
     - partnership_s_corp_income
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
     - capital_gains
     - taxable_interest_income

--- a/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
@@ -11,7 +11,7 @@ values:
     - alimony_income
     - dividend_income
     - interest_income
-    - farm_income
+    - farm_operations_income
     - farm_rent_income
     - capital_gains
     - miscellaneous_income

--- a/policyengine_us/parameters/gov/states/wi/tax/income/credits/homestead/eligible/earnings_sources.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/credits/homestead/eligible/earnings_sources.yaml
@@ -12,4 +12,4 @@ values:
     - irs_employment_income
     - self_employment_income
     - partnership_s_corp_income
-    - farm_income
+    - farm_operations_income

--- a/policyengine_us/parameters/gov/states/wi/tax/income/credits/married_couple/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/credits/married_couple/income_sources.yaml
@@ -20,4 +20,4 @@ values:
     - irs_employment_income
     - self_employment_income
     - partnership_s_corp_income
-    - farm_income
+    - farm_operations_income

--- a/policyengine_us/parameters/gov/territories/pr/tax/income/gross_income/sources.yaml
+++ b/policyengine_us/parameters/gov/territories/pr/tax/income/gross_income/sources.yaml
@@ -22,7 +22,7 @@ values:
     # distributions due to disaster declared by PR
     # gain or loss from manufacturing
     # gain or loss from sale of goods
-    - farm_income # gain or loss from farming
+    - farm_operations_income # gain or loss from farming
     # gain or loss from services rendered
     - rental_income # gain or loss from rental business
 

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -158,10 +158,18 @@ class Simulation(CoreSimulation):
             employment_income.delete_arrays(known_period)
 
         self_employment_income = self.get_holder("self_employment_income")
-        for known_period in employment_income.get_known_periods():
+        for known_period in self_employment_income.get_known_periods():
             array = self_employment_income.get_array(known_period)
             self.set_input("self_employment_income_before_lsr", known_period, array)
             self_employment_income.delete_arrays(known_period)
+
+        sstb_self_employment_income = self.get_holder("sstb_self_employment_income")
+        for known_period in sstb_self_employment_income.get_known_periods():
+            array = sstb_self_employment_income.get_array(known_period)
+            self.set_input(
+                "sstb_self_employment_income_before_lsr", known_period, array
+            )
+            sstb_self_employment_income.delete_arrays(known_period)
 
         weekly_hours = self.get_holder("weekly_hours_worked")
         for known_period in weekly_hours.get_known_periods():
@@ -299,6 +307,14 @@ class Microsimulation(CoreMicrosimulation):
             self.set_input("self_employment_income_before_lsr", known_period, array)
             self_employment_income.delete_arrays(known_period)
 
+        sstb_self_employment_income = self.get_holder("sstb_self_employment_income")
+        for known_period in sstb_self_employment_income.get_known_periods():
+            array = sstb_self_employment_income.get_array(known_period)
+            self.set_input(
+                "sstb_self_employment_income_before_lsr", known_period, array
+            )
+            sstb_self_employment_income.delete_arrays(known_period)
+
         weekly_hours = self.get_holder("weekly_hours_worked")
         for known_period in weekly_hours.get_known_periods():
             array = weekly_hours.get_array(known_period)
@@ -322,12 +338,14 @@ class Microsimulation(CoreMicrosimulation):
             not in [
                 "employment_income",
                 "self_employment_income",
+                "sstb_self_employment_income",
                 "weekly_hours_worked",
                 "capital_gains",
             ]
         ] + [
             "employment_income_before_lsr",
             "self_employment_income_before_lsr",
+            "sstb_self_employment_income_before_lsr",
             "weekly_hours_worked_before_lsr",
             "long_term_capital_gains_before_response",
         ]

--- a/policyengine_us/tests/core/test_business_income_regressions.py
+++ b/policyengine_us/tests/core/test_business_income_regressions.py
@@ -1,0 +1,66 @@
+import pytest
+
+from policyengine_us import Simulation
+
+
+def test_simulation_moves_self_employment_input_before_lsr():
+    simulation = Simulation(
+        situation={
+            "people": {
+                "person": {
+                    "self_employment_income": 10_000,
+                },
+            },
+        },
+    )
+
+    assert simulation.calculate("self_employment_income_before_lsr", 2024)[0] == 10_000
+    assert simulation.calculate("self_employment_income", 2024)[0] == 10_000
+
+
+def test_simulation_moves_sstb_self_employment_input_before_lsr():
+    simulation = Simulation(
+        situation={
+            "people": {
+                "person": {
+                    "sstb_self_employment_income": 10_000,
+                },
+            },
+        },
+    )
+
+    assert (
+        simulation.calculate("sstb_self_employment_income_before_lsr", 2024)[0]
+        == 10_000
+    )
+    assert simulation.calculate("sstb_self_employment_income", 2024)[0] == 10_000
+
+
+def test_taxable_self_employment_income_uses_farm_operations_income():
+    simulation = Simulation(
+        situation={
+            "people": {
+                "person": {
+                    "farm_operations_income": 10_000,
+                },
+            },
+        },
+    )
+
+    assert simulation.calculate("taxable_self_employment_income", 2024)[
+        0
+    ] == pytest.approx(9_235)
+
+
+def test_taxable_self_employment_income_excludes_schedule_j_farm_income():
+    simulation = Simulation(
+        situation={
+            "people": {
+                "person": {
+                    "farm_income": 10_000,
+                },
+            },
+        },
+    )
+
+    assert simulation.calculate("taxable_self_employment_income", 2024)[0] == 0

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qbid/qualified_business_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qbid/qualified_business_income.yaml
@@ -71,6 +71,19 @@
     # Non-SSTB QBI = 30_000 - 0.3 * 1_000 = 29_700
     qualified_business_income: 29_700
 
+- name: Farm operations income is non-SSTB QBI
+  period: 2026
+  input:
+    farm_operations_income: 30_000
+    sstb_self_employment_income: 70_000
+    self_employment_tax_ald_person: 1_000
+    self_employed_health_insurance_ald_person: 0
+    self_employed_pension_contribution_ald_person: 0
+  output:
+    # Non-SSTB share = 30_000 / 100_000 = 0.3
+    # Non-SSTB QBI = 30_000 - 0.3 * 1_000 = 29_700
+    qualified_business_income: 29_700
+
 - name: Only SSTB SE income, non-SSTB QBI is zero
   period: 2026
   input:

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qbid/sstb_qualified_business_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qbid/sstb_qualified_business_income.yaml
@@ -43,6 +43,19 @@
     # SSTB QBI = 70_000 - 0.7 * 1_000 = 69_300
     sstb_qualified_business_income: 69_300
 
+- name: Farm operations income pro-rates deductions against SSTB QBI
+  period: 2026
+  input:
+    farm_operations_income: 30_000
+    sstb_self_employment_income: 70_000
+    self_employment_tax_ald_person: 1_000
+    self_employed_health_insurance_ald_person: 0
+    self_employed_pension_contribution_ald_person: 0
+  output:
+    # SSTB share = 70_000 / 100_000 = 0.7
+    # SSTB QBI = 70_000 - 0.7 * 1_000 = 69_300
+    sstb_qualified_business_income: 69_300
+
 - name: No SSTB SE income returns zero
   period: 2026
   input:

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_countable_income.yaml
@@ -138,7 +138,7 @@
         age: 30
         employment_income: 20_000
         self_employment_income: 5_000
-        farm_income: 2_000
+        farm_operations_income: 2_000
         social_security: 3_000
         pension_income: 1_000
         unemployment_compensation: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_family_fee.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_family_fee.yaml
@@ -296,6 +296,31 @@
     # Fee = 2,500 * 0.03 = 75.00
     ct_c4k_family_fee: 75.00
 
+- name: Farm operations income only, fee applies.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        farm_operations_income: 30_000
+      person2:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        ct_c4k_countable_income: 2_500
+        hhs_smi: 99_180
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CT
+  output:
+    # Farm operations income is earned income => fee applies
+    # Ratio: 2,500/8,265 = 0.3024 (20%-40% bracket)
+    # Fee = 2,500 * 0.03 = 75.00
+    ct_c4k_family_fee: 75.00
+
 - name: Case 13, zero SMI, fee is zero.
   period: 2025-01
   absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/gross_income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/gross_income/integration.yaml
@@ -83,7 +83,7 @@
       person:
         age: 40
         employment_income: 80_000
-        farm_income: -30_000
+        farm_operations_income: -30_000
     tax_units:
       tax_unit:
         members: [person]
@@ -155,7 +155,7 @@
         employment_income: 100_000
         self_employment_income: -20_000
         rental_income: -15_000
-        farm_income: -10_000
+        farm_operations_income: -10_000
     tax_units:
       tax_unit:
         members: [person]

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_household_resources.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_household_resources.yaml
@@ -54,6 +54,15 @@
   output:
     mi_household_resources: 50_000
 
+- name: Farm operations income counted as household resources
+  period: 2024
+  input:
+    farm_operations_income: 50_000
+    above_the_line_deductions: 0
+    state_code: MI
+  output:
+    mi_household_resources: 50_000
+
 - name: Negative rental income floored at 0
   period: 2024
   input:

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/taxable_income/nj_gross_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/taxable_income/nj_gross_income.yaml
@@ -83,7 +83,7 @@
   input:
     employment_income: 90_000
     self_employment_income: 10_000
-    farm_income: -25_000
+    farm_operations_income: -25_000
     state_code: NJ
   output:
     # Category b: 10,000 + (-25,000) = -15,000 -> 0

--- a/policyengine_us/tests/policy/baseline/household/income/household/household_market_income.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/household/household_market_income.yaml
@@ -46,6 +46,18 @@
   output:
     household_market_income: 50_000
 
+- name: Farm operations income is market income
+  period: 2026
+  input:
+    people:
+      person:
+        farm_operations_income: 50_000
+    households:
+      household:
+        members: [person]
+  output:
+    household_market_income: 50_000
+
 - name: Employment income plus UC does not double count
   period: 2026
   input:

--- a/policyengine_us/tests/policy/baseline/household/income/person/market_income.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/market_income.yaml
@@ -6,5 +6,6 @@
     dividend_income: 3
     interest_income: 4
     gi_cash_assistance: 5
+    farm_operations_income: 6
   output:
-    market_income: 1 + 2 + 3 + 4 + 5
+    market_income: 1 + 2 + 3 + 4 + 5 + 6

--- a/policyengine_us/tools/default_uprating.py
+++ b/policyengine_us/tools/default_uprating.py
@@ -61,7 +61,7 @@ INPUT_VARIABLES = [
     "non_sch_d_capital_gains",
     "spm_unit_state_tax_reported",
     "spm_unit_capped_work_childcare_expenses",
-    "farm_income",
+    "farm_operations_income",
     "taxable_403b_distributions",
     "qualified_tuition_expenses",
     "disability_benefits",

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/loss_ald.py
@@ -32,9 +32,9 @@ class loss_ald(Variable):
         self_employment_loss = tax_unit.sum(indiv_se_loss)
 
         # Schedule F farm business income/losses.
-        indiv_farm_income = max_(0, person("farm_operations_income", period))
+        indiv_farm_operations_income = max_(0, person("farm_operations_income", period))
         indiv_farm_loss = max_(0, -person("farm_operations_income", period))
-        farm_income = tax_unit.sum(indiv_farm_income)
+        farm_operations_income = tax_unit.sum(indiv_farm_operations_income)
         farm_loss = tax_unit.sum(indiv_farm_loss)
 
         # Schedule E rental, farm-rent, and estate/trust items.
@@ -66,7 +66,7 @@ class loss_ald(Variable):
         # Total business losses subject to Section 461(l) limitation
         total_business_income = (
             self_employment_income
-            + farm_income
+            + farm_operations_income
             + rental_income
             + farm_rent_income
             + estate_income

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/qualified_business_income.py
@@ -32,9 +32,10 @@ class qualified_business_income(Variable):
         positive_sstb_gross = max_(0, sstb_gross)
         positive_gross_total = positive_non_sstb_gross + positive_sstb_gross
         qbi_deductions = add(person, period, p.deduction_definition)
-        non_sstb_share = where(
-            positive_gross_total > 0,
-            positive_non_sstb_gross / positive_gross_total,
-            0,
+        non_sstb_share = np.divide(
+            positive_non_sstb_gross,
+            positive_gross_total,
+            out=np.zeros_like(positive_gross_total),
+            where=positive_gross_total > 0,
         )
         return max_(0, non_sstb_gross - qbi_deductions * non_sstb_share)

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/sstb_qualified_business_income.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction/sstb_qualified_business_income.py
@@ -34,9 +34,10 @@ class sstb_qualified_business_income(Variable):
         positive_sstb_gross = max_(0, sstb_gross)
         positive_gross_total = positive_non_sstb_gross + positive_sstb_gross
         qbi_deductions = add(person, period, p.deduction_definition)
-        sstb_share = where(
-            positive_gross_total > 0,
-            positive_sstb_gross / positive_gross_total,
-            0,
+        sstb_share = np.divide(
+            positive_sstb_gross,
+            positive_gross_total,
+            out=np.zeros_like(positive_gross_total),
+            where=positive_gross_total > 0,
         )
         return max_(0, sstb_gross - qbi_deductions * sstb_share)

--- a/policyengine_us/variables/gov/irs/tax/self_employment/taxable_self_employment_income.py
+++ b/policyengine_us/variables/gov/irs/tax/self_employment/taxable_self_employment_income.py
@@ -12,13 +12,13 @@ class taxable_self_employment_income(Variable):
     def formula(person, period, parameters):
         # Per 26 USC 1402(a), SE income includes:
         # - Schedule C net profit (self_employment_income, sstb_self_employment_income)
-        # - Schedule F net profit (farm_income)
+        # - Schedule F net profit (farm_operations_income)
         # - General partners' distributive share (partnership_se_income from K-1 Box 14)
         # S-corp distributions are NOT subject to SE tax.
         SEI_SOURCES = [
             "self_employment_income",
             "sstb_self_employment_income",
-            "farm_income",
+            "farm_operations_income",
             "partnership_se_income",
         ]
         gross_sei = add(person, period, SEI_SOURCES)

--- a/policyengine_us/variables/gov/simulation/labor_supply_response/self_employment_income_behavioral_response.py
+++ b/policyengine_us/variables/gov/simulation/labor_supply_response/self_employment_income_behavioral_response.py
@@ -21,9 +21,10 @@ class self_employment_income_behavioral_response(Variable):
         total_self_employment_income = (
             non_sstb_self_employment_income + sstb_self_employment_income
         )
-        non_sstb_share = where(
-            total_self_employment_income > 0,
-            non_sstb_self_employment_income / total_self_employment_income,
-            1,
+        non_sstb_share = np.divide(
+            non_sstb_self_employment_income,
+            total_self_employment_income,
+            out=np.ones_like(total_self_employment_income),
+            where=total_self_employment_income > 0,
         )
         return total_self_employment_response * non_sstb_share

--- a/policyengine_us/variables/gov/simulation/labor_supply_response/sstb_self_employment_income_behavioral_response.py
+++ b/policyengine_us/variables/gov/simulation/labor_supply_response/sstb_self_employment_income_behavioral_response.py
@@ -21,9 +21,10 @@ class sstb_self_employment_income_behavioral_response(Variable):
         total_self_employment_income = (
             non_sstb_self_employment_income + sstb_self_employment_income
         )
-        sstb_share = where(
-            total_self_employment_income > 0,
-            sstb_self_employment_income / total_self_employment_income,
-            0,
+        sstb_share = np.divide(
+            sstb_self_employment_income,
+            total_self_employment_income,
+            out=np.zeros_like(total_self_employment_income),
+            where=total_self_employment_income > 0,
         )
         return total_self_employment_response * sstb_share

--- a/policyengine_us/variables/gov/states/ct/oec/c4k/ct_c4k_family_fee.py
+++ b/policyengine_us/variables/gov/states/ct/oec/c4k/ct_c4k_family_fee.py
@@ -29,7 +29,7 @@ class ct_c4k_family_fee(Variable):
         earned_income = add(
             spm_unit,
             period,
-            ["employment_income", "self_employment_income", "farm_income"],
+            ["employment_income", "self_employment_income", "farm_operations_income"],
         )
         has_earned_income = earned_income > 0
         return where(has_earned_income, countable_income * fee_rate, 0)

--- a/policyengine_us/variables/gov/states/ma/tax/income/gross_income/ma_gross_income_loss_adjustment.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/gross_income/ma_gross_income_loss_adjustment.py
@@ -19,7 +19,7 @@ class ma_gross_income_loss_adjustment(Variable):
         # Line 6a: Business/profession loss (Schedule C)
         se_income = add(tax_unit, period, ["total_self_employment_income"])
         # Line 6b: Farm loss (Schedule F)
-        farm = add(tax_unit, period, ["farm_income"])
+        farm = add(tax_unit, period, ["farm_operations_income"])
         # Line 7: Rental, partnership, S-corp, farm rent losses
         rental = add(tax_unit, period, ["rental_income"])
         partnership = add(tax_unit, period, ["partnership_s_corp_income"])

--- a/policyengine_us/variables/gov/states/mi/tax/income/mi_household_resources.py
+++ b/policyengine_us/variables/gov/states/mi/tax/income/mi_household_resources.py
@@ -26,7 +26,7 @@ class mi_household_resources(Variable):
         # "Net business income (including net farm income). If negative, enter 0"
         # "Net royalty or rent income. If negative, enter 0"
         floored_sources = {
-            "farm_income",
+            "farm_operations_income",
             "total_self_employment_income",
             "partnership_s_corp_income",
             "rental_income",

--- a/policyengine_us/variables/household/income/person/general/market_income.py
+++ b/policyengine_us/variables/household/income/person/general/market_income.py
@@ -21,7 +21,7 @@ class market_income(Variable):
             "capital_gains",
             "rental_income",
             "illicit_income",
-            "farm_income",
+            "farm_operations_income",
             "miscellaneous_income",
             "retirement_distributions",
         ]


### PR DESCRIPTION
## Summary
- Copy direct self-employment and SSTB self-employment inputs into their before-LSR holders in household and microsimulation runs.
- Use Schedule F farm operations income, not Schedule J farm income, for taxable self-employment income, market income, and state/program income source lists.
- Add regression tests for the LSR wiring, farm SECA source behavior, farm operations market income, and affected MA/NJ/CT farm-income cases.
- Avoid eager divide-by-zero warnings in self-employment response and QBI/SSTB QBI allocation shares.

Companion data PR: PolicyEngine/policyengine-us-data#828

## Root cause
The household `Simulation` constructor iterated over the emptied employment-income holder when moving self-employment inputs into before-LSR storage. SSTB self-employment had before-LSR plumbing but no constructor transfer. SECA and multiple downstream income source lists also referenced the Schedule J-style `farm_income` input where they meant Schedule F `farm_operations_income`.

## Tests
- `ruff check` on touched Python files
- `.venv/bin/python -m pytest policyengine_us/tests/core/test_business_income_regressions.py policyengine_us/tests/test_parameter_files.py -q`
- `.venv/bin/python -m pytest policyengine_us/tests/core/test_business_income_regressions.py policyengine_us/tests/core/test_behavioral_response_measurements.py -q`
- `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/self_employment/taxable_self_employment_income.yaml policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qbid/qualified_business_income.yaml policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qbid/sstb_qualified_business_income.yaml policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qbid/qualified_business_income_deduction.yaml -c policyengine_us`
- `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/income/person/market_income.yaml policyengine_us/tests/policy/baseline/household/income/household/household_market_income.yaml -c policyengine_us`
- `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/gross_income/integration.yaml policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/taxable_income/nj_gross_income.yaml policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_countable_income.yaml policyengine_us/tests/policy/baseline/household/income/person/market_income.yaml policyengine_us/tests/policy/baseline/household/income/household/household_market_income.yaml -c policyengine_us`
- `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_family_fee.yaml policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_household_resources.yaml -c policyengine_us`
- `uv run python policyengine_us/tests/run_selective_tests.py --base-branch upstream/main --coverage`
- `.venv/bin/python -m pytest policyengine_us/tests/core -q`
- `uv run --extra dev towncrier check --compare-with upstream/main --staged`