### PR TITLE
Fix unsubsidized Marketplace net premiums

### DIFF
--- a/changelog.d/marketplace-net-premium-unsubsidized.fixed.md
+++ b/changelog.d/marketplace-net-premium-unsubsidized.fixed.md
@@ -1,0 +1,1 @@
+Fix Marketplace selected-plan and net premiums for unsubsidized households.

--- a/policyengine_us/parameters/gov/household/household_health_costs.yaml
+++ b/policyengine_us/parameters/gov/household/household_health_costs.yaml
@@ -2,6 +2,7 @@ description: The government counts these sources as household health out-of-pock
 values:
   2022-01-01:
     - chip_premium
+    - marketplace_net_premium
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/marketplace_net_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/marketplace_net_premium.yaml
@@ -21,3 +21,23 @@
     used_aca_ptc: 3_000
   output:
     marketplace_net_premium: 0
+
+- name: High-income Marketplace household pays the full selected plan premium when PTC-ineligible.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    age: 40
+    aca_magi_fraction: 5
+    is_medicaid_eligible: false
+    is_chip_eligible: false
+    is_basic_health_program_eligible: false
+    is_aca_eshi_eligible: false
+    is_medicare_eligible: false
+    slcsp: 10_000
+    selected_marketplace_plan_benchmark_ratio: 0.8
+  output:
+    pays_aca_premium: true
+    is_aca_ptc_eligible: false
+    selected_marketplace_plan_premium_proxy: 8_000
+    used_aca_ptc: 0
+    marketplace_net_premium: 8_000

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/selected_marketplace_plan_premium_proxy.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/selected_marketplace_plan_premium_proxy.yaml
@@ -2,7 +2,7 @@
   absolute_error_margin: 0.01
   period: 2025
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
@@ -14,7 +14,7 @@
   absolute_error_margin: 0.01
   period: 2025
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     slcsp: 10_000
     aca_magi: 20_000
     aca_required_contribution_percentage: 0.04
@@ -23,17 +23,17 @@
   output:
     selected_marketplace_plan_premium_proxy: 8_000
 
-- name: Case 3, selected plan proxy is zero when no ACA PTC is available.
+- name: Case 3, selected plan proxy remains gross premium when no ACA PTC is available.
   absolute_error_margin: 0.01
   period: 2025
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.05
     selected_marketplace_plan_benchmark_ratio: 0.8
   output:
-    selected_marketplace_plan_premium_proxy: 0
+    selected_marketplace_plan_premium_proxy: 960
 
 - name: Case 4, selected plan proxy is zero when the tax unit does not take up ACA.
   absolute_error_margin: 0.01
@@ -45,3 +45,21 @@
     takes_up_aca_if_eligible: false
   output:
     selected_marketplace_plan_premium_proxy: 0
+
+- name: Case 5, high-income Marketplace household keeps selected plan proxy when PTC-ineligible.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    age: 40
+    aca_magi_fraction: 5
+    is_medicaid_eligible: false
+    is_chip_eligible: false
+    is_basic_health_program_eligible: false
+    is_aca_eshi_eligible: false
+    is_medicare_eligible: false
+    slcsp: 10_000
+    selected_marketplace_plan_benchmark_ratio: 0.8
+  output:
+    pays_aca_premium: true
+    is_aca_ptc_eligible: false
+    selected_marketplace_plan_premium_proxy: 8_000

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/used_aca_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/used_aca_ptc.yaml
@@ -3,6 +3,7 @@
   period: 2025
   input:
     is_aca_ptc_eligible: true
+    pays_aca_premium: true
     slcsp: 1_200
     aca_magi: 25_000
     aca_required_contribution_percentage: 0.04
@@ -17,6 +18,7 @@
   period: 2025
   input:
     is_aca_ptc_eligible: true
+    pays_aca_premium: true
     slcsp: 10_000
     aca_magi: 20_000
     aca_required_contribution_percentage: 0.04

--- a/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_category.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_category.yaml
@@ -4,7 +4,7 @@
     people:
       person1:
         age: 30
-        is_aca_ptc_eligible: true   
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1]
@@ -22,10 +22,10 @@
     people:
       person1:
         age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person2:
         age: 32
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2]
@@ -43,13 +43,13 @@
     people:
       person1:
         age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person2:
         age: 32
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person3:
         age: 35
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
@@ -67,10 +67,10 @@
     people:
       person1:
         age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person2:
         age: 5
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2]
@@ -88,13 +88,13 @@
     people:
       person1:
         age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person2:
         age: 32
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person3:
         age: 5
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
@@ -112,7 +112,7 @@
     people:
       person1:
         age: 15
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1]
@@ -130,7 +130,7 @@
     people:
       person1:
         age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1]
@@ -148,13 +148,13 @@
     people:
       person1:
         age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person2:
         age: 32
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person3:
         age: 5
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
@@ -165,6 +165,31 @@
         state_fips: 50
   output:
     slcsp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+
+- name: NY high-income adult uses family tier category even when PTC-ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 5
+    households:
+      household:
+        members: [person1]
+        state_code_str: NY
+        state_fips: 36
+  output:
+    pays_aca_premium: true
+    is_aca_ptc_eligible: false
+    slcsp_family_tier_category: ONE_ADULT
 
 - name: Non-family tier state uses individual age rating
   period: 2023

--- a/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_integration.yaml
@@ -5,7 +5,7 @@
       person1:
         age: 30
         monthly_age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1]
@@ -28,15 +28,15 @@
       person1:
         age: 35
         monthly_age: 35
-        is_aca_ptc_eligible: true 
+        pays_aca_premium: true
       person2:
         age: 32
         monthly_age: 32
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person3:
         age: 5
         monthly_age: 5
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
@@ -59,7 +59,7 @@
       person1:
         age: 30
         monthly_age: 30
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1]
@@ -82,15 +82,15 @@
       person1:
         age: 40
         monthly_age: 40
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person2:
         age: 10
         monthly_age: 10
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person3:
         age: 8
         monthly_age: 8
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
@@ -113,11 +113,11 @@
       person1:
         age: 17
         monthly_age: 17
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
       person2:
         age: 15
         monthly_age: 15
-        is_aca_ptc_eligible: true
+        pays_aca_premium: true
     tax_units:
       tax_unit:
         members: [person1, person2]
@@ -132,6 +132,52 @@
     slcsp_family_tier_category: CHILD_ONLY
     slcsp_family_tier_multiplier: 0.412
     slcsp: 230.72  # 560 * 0.412
+
+- name: VT high-income family still has gross family-tier SLCSP in 2026
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 35
+        monthly_age: 35
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+      person2:
+        age: 32
+        monthly_age: 32
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+      person3:
+        age: 5
+        monthly_age: 5
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        aca_magi_fraction: 5
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: VT
+        state_fips: 50
+        slcsp_rating_area: 1
+        slcsp_age_0: 1_277
+  output:
+    pays_aca_premium: [true, true, true]
+    is_aca_ptc_eligible: [false, false, false]
+    slcsp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+    slcsp_family_tier_multiplier: 2.81
+    slcsp: 3_588.37  # 1,277 * 2.81
 
 - name: Regular age rating state like CA
   period: 2023-01

--- a/policyengine_us/tests/policy/baseline/gov/aca/slcsp/slcsp_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/slcsp/slcsp_person.yaml
@@ -2,7 +2,7 @@
   period: 2023-01
   absolute_error_margin: 0.1
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     state_code_str: AL
     monthly_age: 15
     slcsp_age_0: 270
@@ -13,7 +13,7 @@
   period: 2023-01
   absolute_error_margin: 0.1
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     state_code_str: DC
     monthly_age: 55
     slcsp_age_0: 388
@@ -24,7 +24,7 @@
   period: 2023-01
   absolute_error_margin: 0.1
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     state_code_str: UT
     monthly_age: 26
     slcsp_age_0: 371
@@ -35,7 +35,7 @@
   period: 2023-01
   absolute_error_margin: 0.1
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     state_code_str: MN
     monthly_age: 40
     slcsp_age_0: 252
@@ -46,7 +46,7 @@
   period: 2023-01
   absolute_error_margin: 0.1
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     state_code_str: MS
     monthly_age: 33
     slcsp_age_0: 240
@@ -57,7 +57,7 @@
   period: 2023-01
   absolute_error_margin: 0.1
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     state_code_str: WV
     monthly_age: 62
     slcsp_age_0: 561
@@ -68,9 +68,28 @@
   period: 2025-01
   absolute_error_margin: 0.1
   input:
-    is_aca_ptc_eligible: true
+    pays_aca_premium: true
     state_code_str: CA
     monthly_age: 15
     slcsp_age_0: 244
   output:
     slcsp_age_curve_amount_person: 265.69
+
+- name: High-income California adult still has gross SLCSP in 2026
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age: 40
+    monthly_age: 40
+    state_code_str: CA
+    aca_magi_fraction: 5
+    is_medicaid_eligible: false
+    is_chip_eligible: false
+    is_basic_health_program_eligible: false
+    is_aca_eshi_eligible: false
+    is_medicare_eligible: false
+    slcsp_age_0: 244
+  output:
+    pays_aca_premium: true
+    is_aca_ptc_eligible: false
+    slcsp_age_curve_amount_person: 407.63

--- a/policyengine_us/tests/policy/baseline/household/income/household/household_health_costs.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/household/household_health_costs.yaml
@@ -22,3 +22,32 @@
     marketplace_net_premium: 2_000
   output:
     household_health_costs: 2_360
+
+- name: Household health costs include computed unsubsidized Marketplace net premium.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    gov.simulation.include_health_benefits_in_net_income: true
+    people:
+      person:
+        age: 40
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person]
+        aca_magi_fraction: 5
+        slcsp: 10_000
+        selected_marketplace_plan_benchmark_ratio: 0.8
+    households:
+      household:
+        members: [person]
+  output:
+    pays_aca_premium: true
+    is_aca_ptc_eligible: false
+    selected_marketplace_plan_premium_proxy: 8_000
+    marketplace_net_premium: 8_000
+    household_health_costs: 8_000

--- a/policyengine_us/tests/policy/baseline/household/income/household/household_health_costs.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/household/household_health_costs.yaml
@@ -14,3 +14,11 @@
   output:
     household_health_costs: 360
 
+- name: Household health costs include Marketplace net premium when health benefits are included in net income.
+  period: 2024
+  input:
+    gov.simulation.include_health_benefits_in_net_income: true
+    chip_premium: 360
+    marketplace_net_premium: 2_000
+  output:
+    household_health_costs: 2_360

--- a/policyengine_us/variables/gov/aca/ptc/selected_marketplace_plan_premium_proxy.py
+++ b/policyengine_us/variables/gov/aca/ptc/selected_marketplace_plan_premium_proxy.py
@@ -10,9 +10,10 @@ class selected_marketplace_plan_premium_proxy(Variable):
 
     def formula(tax_unit, period, parameters):
         takes_up_aca_if_eligible = tax_unit("takes_up_aca_if_eligible", period)
-        aca_ptc = tax_unit("aca_ptc", period)
+        person = tax_unit.members
+        pays_marketplace_premium = tax_unit.sum(person("pays_aca_premium", period)) > 0
         return where(
-            takes_up_aca_if_eligible & (aca_ptc > 0),
+            takes_up_aca_if_eligible & pays_marketplace_premium,
             tax_unit("slcsp", period)
             * tax_unit("selected_marketplace_plan_benchmark_ratio", period),
             0,

--- a/policyengine_us/variables/gov/aca/slspc/slcsp_age_curve_amount_person.py
+++ b/policyengine_us/variables/gov/aca/slspc/slcsp_age_curve_amount_person.py
@@ -7,7 +7,7 @@ class slcsp_age_curve_amount_person(Variable):
     label = "Second-lowest ACA silver-plan cost, for people in age curve states"
     unit = USD
     definition_period = MONTH
-    defined_for = "is_aca_ptc_eligible"
+    defined_for = "pays_aca_premium"
 
     def formula(person, period, parameters):
         state_code = person.household("state_code_str", period)

--- a/policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_category.py
+++ b/policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_category.py
@@ -43,11 +43,11 @@ class slcsp_family_tier_category(Variable):
         member_ages = person("monthly_age", period)
 
         # Define adult status using the parameter instead of hardcoded value
-        is_aca_ptc_eligible = person("is_aca_ptc_eligible", period)
-        is_eligible_adult = (member_ages > max_child_age) & is_aca_ptc_eligible
-        eligible_adult_count = tax_unit.sum(is_eligible_adult)
+        pays_premium = person("pays_aca_premium", period)
+        is_premium_paying_adult = (member_ages > max_child_age) & pays_premium
+        eligible_adult_count = tax_unit.sum(is_premium_paying_adult)
         # More efficient than recounting: total - adults = children
-        eligible_people = tax_unit.sum(is_aca_ptc_eligible)
+        eligible_people = tax_unit.sum(pays_premium)
         eligible_child_count = eligible_people - eligible_adult_count
 
         # Common conditions for both states


### PR DESCRIPTION
## Summary
- Use `pays_aca_premium` rather than PTC eligibility for gross SLCSP age-curve and NY/VT family-tier premiums.
- Gate `selected_marketplace_plan_premium_proxy` on ACA premium payment/takeup instead of `aca_ptc > 0`, so high-income unsubsidized Marketplace households keep a gross selected-plan premium and net premium.
- Include `marketplace_net_premium` in `household_health_costs` when health benefits are included in net income.

## Notes
This intentionally does not add Marketplace premiums to SPM MOOP yet; that path needs imputed-premium residual work to avoid broad baseline double counting. This is the household-net-income side of #8095 plus the unsubsidized gross-premium fix.

## Tests
- `uv run ruff format --check policyengine_us/variables/gov/aca/slspc/slcsp_age_curve_amount_person.py policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_category.py policyengine_us/variables/gov/aca/ptc/selected_marketplace_plan_premium_proxy.py`
- `uv run ruff check policyengine_us/variables/gov/aca/slspc/slcsp_age_curve_amount_person.py policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_category.py policyengine_us/variables/gov/aca/ptc/selected_marketplace_plan_premium_proxy.py`
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/aca --batches 1`
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/household/income/household/household_health_costs.yaml --batches 1`
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/household/household_health_benefits.yaml --batches 1`
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/household/household_net_income_including_health_benefits.yaml --batches 1`

I also tried `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/household --batches 1`; it stayed CPU-bound for about 9 minutes without test output, so I stopped it and used the narrower household tests above.