### PR TITLE
Exclude children with ESI from CHIP eligibility

### DIFF
--- a/changelog.d/codex-issue-6910-chip-esi.fixed.md
+++ b/changelog.d/codex-issue-6910-chip-esi.fixed.md
@@ -1,0 +1,1 @@
+Exclude children with employer-sponsored insurance from CHIP eligibility.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/chip/is_chip_eligible_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/chip/is_chip_eligible_child.yaml
@@ -29,3 +29,71 @@
         members: [head]
   output:
     is_chip_eligible_child: False
+
+- name: TX child without ESI qualifies for CHIP
+  period: 2023
+  input:
+    people:
+      head:
+        age: 10
+        immigration_status: CITIZEN
+        is_medicaid_eligible: False
+        medicaid_income_level: 2.0
+        has_esi: False
+    households:
+      household:
+        state_code: TX
+        members: [head]
+  output:
+    is_chip_eligible_child: True
+
+- name: TX child with ESI is not eligible for CHIP
+  period: 2023
+  input:
+    people:
+      head:
+        age: 10
+        immigration_status: CITIZEN
+        is_medicaid_eligible: False
+        medicaid_income_level: 2.0
+        has_esi: True
+    households:
+      household:
+        state_code: TX
+        members: [head]
+  output:
+    is_chip_eligible_child: False
+
+- name: TX adult is not a CHIP-eligible child
+  period: 2023
+  input:
+    people:
+      head:
+        age: 20
+        immigration_status: CITIZEN
+        is_medicaid_eligible: False
+        medicaid_income_level: 2.0
+        has_esi: False
+    households:
+      household:
+        state_code: TX
+        members: [head]
+  output:
+    is_chip_eligible_child: False
+
+- name: TX Medicaid-eligible child is not CHIP-eligible
+  period: 2023
+  input:
+    people:
+      head:
+        age: 10
+        immigration_status: CITIZEN
+        is_medicaid_eligible: True
+        medicaid_income_level: 1.0
+        has_esi: False
+    households:
+      household:
+        state_code: TX
+        members: [head]
+  output:
+    is_chip_eligible_child: False

--- a/policyengine_us/variables/gov/hhs/chip/is_chip_eligible_child.py
+++ b/policyengine_us/variables/gov/hhs/chip/is_chip_eligible_child.py
@@ -12,6 +12,7 @@ class is_chip_eligible_child(Variable):
     reference = (
         "https://www.ssa.gov/OP_Home/ssact/title21/2110.htm",
         "https://www.medicaid.gov/medicaid/national-medicaid-chip-program-information/medicaid-childrens-health-insurance-program-basic-health-program-eligibility-levels",
+        "https://www.healthcare.gov/medicaid-chip/childrens-health-insurance-program/",
     )
 
     def formula(person, period, parameters):
@@ -43,10 +44,13 @@ class is_chip_eligible_child(Variable):
         income_ratio = person("medicaid_income_level", period)
         income_eligible = income_ratio <= income_limit
 
+        has_esi = person("has_esi", period)
+
         return (
             is_age_eligible
             & state_has_chip
             & immigration_eligible
             & ~medicaid_eligible
             & income_eligible
+            & ~has_esi
         )


### PR DESCRIPTION
Fixes #6910

Supersedes #7007.

This updates child CHIP eligibility to exclude children with employer-sponsored insurance and adds targeted CHIP child eligibility tests plus a changelog fragment.

Verification:
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/chip/is_chip_eligible_child.yaml -c policyengine_us`

Note:
- `make format` did not complete in the fresh worktree environment because `uv run ruff format .` could not find `ruff`, but `git diff --check` is clean.