### PR TITLE
Add education credit eligibility inputs

### DIFF
--- a/changelog.d/aotc-student-eligibility.added.md
+++ b/changelog.d/aotc-student-eligibility.added.md
@@ -1,0 +1,1 @@
+Add statutory American Opportunity Credit student eligibility inputs and compute eligibility from those inputs.

--- a/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/amount.yaml
@@ -19,4 +19,4 @@ metadata:
   threshold_unit: currency-USD
   reference:
     - title: 26 U.S. Code § 25A(b)(1)
-      url: https://www.law.cornell.edu/uscode/text/26/25A#b_1
+      url: https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A

--- a/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/eligibility/requires_1098_t_or_exception.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/eligibility/requires_1098_t_or_exception.yaml
@@ -1,0 +1,13 @@
+description: The IRS requires a Form 1098-T payee statement, or an exception allowed by the Secretary, to claim education credits if this is true.
+values:
+  0000-01-01: false
+  2016-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: American Opportunity Credit Form 1098-T requirement applies
+  reference:
+    - title: 26 U.S. Code § 25A(g)(8)
+      href: https://www.law.cornell.edu/uscode/text/26/25A#g_8
+    - title: 26 U.S. Code § 25A effective date notes
+      href: https://www.law.cornell.edu/uscode/text/26/25A#notes

--- a/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/eligibility/requires_institution_ein.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/eligibility/requires_institution_ein.yaml
@@ -1,0 +1,13 @@
+description: The IRS requires the employer identification number of the educational institution to claim the American Opportunity Credit if this is true.
+values:
+  0000-01-01: false
+  2016-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: American Opportunity Credit institution EIN requirement applies
+  reference:
+    - title: 26 U.S. Code § 25A(g)(1)(B)
+      href: https://www.law.cornell.edu/uscode/text/26/25A#g_1_B
+    - title: 26 U.S. Code § 25A effective date notes
+      href: https://www.law.cornell.edu/uscode/text/26/25A#notes

--- a/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/eligibility/requires_qualifying_ssn.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/eligibility/requires_qualifying_ssn.yaml
@@ -1,0 +1,13 @@
+description: The IRS requires a qualifying Social Security number, rather than any taxpayer identification number, for American Opportunity Credit identification if this is true.
+values:
+  0000-01-01: false
+  2026-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: American Opportunity Credit qualifying SSN requirement applies
+  reference:
+    - title: 26 U.S. Code § 25A(g)(1)
+      href: https://www.law.cornell.edu/uscode/text/26/25A#g_1
+    - title: 26 U.S. Code § 24(h)(7)
+      href: https://www.law.cornell.edu/uscode/text/26/24#h_7

--- a/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/refundability.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/american_opportunity_credit/refundability.yaml
@@ -6,4 +6,4 @@ metadata:
   label: American Opportunity Credit refundable percentage
   reference:
     - title: 26 U.S. Code § 25A
-      url: https://www.law.cornell.edu/uscode/text/26/25A#i
+      url: https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A

--- a/policyengine_us/parameters/gov/irs/credits/education/lifetime_learning_credit/eligibility/requires_1098_t_or_exception.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/lifetime_learning_credit/eligibility/requires_1098_t_or_exception.yaml
@@ -1,0 +1,13 @@
+description: The IRS requires a Form 1098-T payee statement, or an exception allowed by the Secretary, to claim the Lifetime Learning Credit if this is true.
+values:
+  0000-01-01: false
+  2016-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: Lifetime Learning Credit Form 1098-T requirement applies
+  reference:
+    - title: 26 U.S. Code § 25A(g)(8)
+      href: https://www.law.cornell.edu/uscode/text/26/25A#g_8
+    - title: 26 U.S. Code § 25A effective date notes
+      href: https://www.law.cornell.edu/uscode/text/26/25A#notes

--- a/policyengine_us/parameters/gov/irs/credits/education/lifetime_learning_credit/eligibility/requires_qualifying_ssn.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/education/lifetime_learning_credit/eligibility/requires_qualifying_ssn.yaml
@@ -1,0 +1,13 @@
+description: The IRS requires a qualifying Social Security number, rather than any taxpayer identification number, for Lifetime Learning Credit identification if this is true.
+values:
+  0000-01-01: false
+  2026-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: Lifetime Learning Credit qualifying SSN requirement applies
+  reference:
+    - title: 26 U.S. Code § 25A(g)(1)
+      href: https://www.law.cornell.edu/uscode/text/26/25A#g_1
+    - title: 26 U.S. Code § 24(h)(7)
+      href: https://www.law.cornell.edu/uscode/text/26/24#h_7

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/education/american_opportunity_credit/american_opportunity_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/education/american_opportunity_credit/american_opportunity_credit.yaml
@@ -14,6 +14,19 @@
   output:
     american_opportunity_credit: 1_000
 
+- name: Eligibility formula, under first threshold of expenses
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    qualified_tuition_expenses: 1_000
+  output:
+    is_eligible_for_american_opportunity_credit: true
+    american_opportunity_credit: 1_000
+
 - name: Over phase_out, no entitlement
   period: 2020
   input:

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/education/american_opportunity_credit/is_eligible_for_american_opportunity_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/education/american_opportunity_credit/is_eligible_for_american_opportunity_credit.yaml
@@ -1,0 +1,179 @@
+- name: Meets American Opportunity Credit student eligibility requirements
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: true
+
+- name: Student must pursue a recognized credential
+  period: 2024
+  input:
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student must attend an eligible educational institution
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student must be enrolled at least half-time
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student cannot have completed the first four postsecondary years
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_completed_first_four_years_of_postsecondary_education: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student cannot have four prior AOTC or Hope Credit claim years
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    american_opportunity_credit_claimed_prior_years: 4
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student cannot have a felony drug conviction
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_felony_drug_conviction: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student must have Form 1098-T or an exception
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student must have a TIN before 2026
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: false
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Student must have a qualifying SSN starting in 2026
+  period: 2026
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+    ssn_card_type: NONE
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Filer must provide the institution EIN
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Form 1098-T and institution EIN requirements do not apply before 2016
+  period: 2015
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: true
+
+- name: Nonresident alien taxpayers cannot claim the AOTC
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+    is_nonresident_alien_for_american_opportunity_credit: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Taxpayers barred due to improper claims cannot claim the AOTC
+  period: 2024
+  input:
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+    is_barred_from_american_opportunity_credit_due_to_improper_claims: true
+  output:
+    is_eligible_for_american_opportunity_credit: false
+
+- name: Married filing separately cannot claim the AOTC
+  period: 2024
+  input:
+    filing_status: SEPARATE
+    is_pursuing_credential_for_american_opportunity_credit: true
+    attends_eligible_educational_institution_for_american_opportunity_credit: true
+    is_enrolled_at_least_half_time_for_american_opportunity_credit: true
+    has_american_opportunity_credit_1098_t_or_exception: true
+    has_american_opportunity_credit_institution_ein: true
+    has_tin: true
+  output:
+    is_eligible_for_american_opportunity_credit: false

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/is_eligible_for_lifetime_learning_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/is_eligible_for_lifetime_learning_credit.yaml
@@ -1,0 +1,72 @@
+- name: Student at eligible institution with TIN can qualify for LLC
+  period: 2024
+  input:
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
+  output:
+    is_eligible_for_lifetime_learning_credit: true
+
+- name: Student must attend an eligible educational institution for LLC
+  period: 2024
+  input:
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
+  output:
+    is_eligible_for_lifetime_learning_credit: false
+
+- name: LLC requires Form 1098-T or an exception starting in 2016
+  period: 2024
+  input:
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_tin: true
+  output:
+    is_eligible_for_lifetime_learning_credit: false
+
+- name: LLC Form 1098-T requirement does not apply before 2016
+  period: 2015
+  input:
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_tin: true
+  output:
+    is_eligible_for_lifetime_learning_credit: true
+
+- name: LLC accepts TIN before 2026
+  period: 2025
+  input:
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
+    ssn_card_type: NONE
+  output:
+    is_eligible_for_lifetime_learning_credit: true
+
+- name: LLC requires qualifying SSN starting in 2026
+  period: 2026
+  input:
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
+    ssn_card_type: NONE
+  output:
+    is_eligible_for_lifetime_learning_credit: false
+
+- name: Nonresident alien taxpayers cannot claim LLC
+  period: 2024
+  input:
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
+    is_nonresident_alien_for_lifetime_learning_credit: true
+  output:
+    is_eligible_for_lifetime_learning_credit: false
+
+- name: Married filing separately cannot claim LLC
+  period: 2024
+  input:
+    filing_status: SEPARATE
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
+  output:
+    is_eligible_for_lifetime_learning_credit: false

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit_potential.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit_potential.yaml
@@ -9,6 +9,9 @@
   period: 2020
   input:
     qualified_tuition_expenses: 1_000
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
   output:
     lifetime_learning_credit_potential: 200
 
@@ -16,6 +19,9 @@
   period: 2020
   input:
     qualified_tuition_expenses: 1_000
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
     is_eligible_for_american_opportunity_credit: true
   output:
     lifetime_learning_credit_potential: 0
@@ -24,6 +30,9 @@
   period: 2020
   input:
     qualified_tuition_expenses: 1_000
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
     adjusted_gross_income: 90_000
   output:
     lifetime_learning_credit_potential: 0

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit_pre_2021_phase_out.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit_pre_2021_phase_out.yaml
@@ -15,6 +15,9 @@
     qualified_tuition_expenses: 4_000
     filing_status: JOINT
     tax_unit_is_joint: true
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
     is_eligible_for_american_opportunity_credit: false
   output:
     # Joint LLC phase-out in 2020: starts $118k, ends $138k.
@@ -31,6 +34,9 @@
     qualified_tuition_expenses: 5_000
     filing_status: SINGLE
     tax_unit_is_joint: false
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
     is_eligible_for_american_opportunity_credit: false
   output:
     # Single LLC phase-out in 2020: starts $59k, ends $69k.
@@ -46,6 +52,9 @@
     qualified_tuition_expenses: 4_000
     filing_status: JOINT
     tax_unit_is_joint: true
+    attends_eligible_educational_institution_for_lifetime_learning_credit: true
+    has_lifetime_learning_credit_1098_t_or_exception: true
+    has_tin: true
     is_eligible_for_american_opportunity_credit: false
   output:
     # Starting 2021, LLC and AOC share phase-out ($160k/$180k joint).

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/american_opportunity_credit.py
@@ -8,7 +8,7 @@ class american_opportunity_credit(Variable):
     unit = USD
     documentation = "Total value of the American Opportunity Credit"
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/26/25A#b"
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"
 
     def formula(tax_unit, period, parameters):
         education = parameters(period).gov.irs.credits.education

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/american_opportunity_credit_claimed_prior_years.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/american_opportunity_credit_claimed_prior_years.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class american_opportunity_credit_claimed_prior_years(Variable):
+    value_type = int
+    entity = Person
+    label = "Prior years claiming the American Opportunity or Hope Credit"
+    documentation = "Number of prior tax years for which the American Opportunity Credit or former Hope Credit was claimed for the student."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/attends_eligible_educational_institution_for_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/attends_eligible_educational_institution_for_american_opportunity_credit.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class attends_eligible_educational_institution_for_american_opportunity_credit(
+    Variable
+):
+    value_type = bool
+    entity = Person
+    label = "Attends an AOTC eligible educational institution"
+    documentation = "Whether the student attends a post-secondary educational institution eligible to participate in a US Department of Education student aid program for American Opportunity Credit purposes."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/filer_meets_american_opportunity_credit_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/filer_meets_american_opportunity_credit_identification_requirements.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class filer_meets_american_opportunity_credit_identification_requirements(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Filer meets American Opportunity Credit identification requirements"
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        meets_identification_requirements = person(
+            "meets_american_opportunity_credit_identification_requirements",
+            period,
+        )
+        return tax_unit.all(~head_or_spouse | meets_identification_requirements)

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_american_opportunity_credit_1098_t_or_exception.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_american_opportunity_credit_1098_t_or_exception.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class has_american_opportunity_credit_1098_t_or_exception(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has Form 1098-T or an AOTC exception"
+    documentation = "Whether the student received Form 1098-T or meets an exception allowing the American Opportunity Credit to be claimed with substantiated qualified expenses."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_american_opportunity_credit_institution_ein.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_american_opportunity_credit_institution_ein.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class has_american_opportunity_credit_institution_ein(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has institution EIN for American Opportunity Credit"
+    documentation = "Whether the filer includes the employer identification number of the eligible educational institution for this student's American Opportunity Credit expenses."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_completed_first_four_years_of_postsecondary_education.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_completed_first_four_years_of_postsecondary_education.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class has_completed_first_four_years_of_postsecondary_education(Variable):
+    value_type = bool
+    entity = Person
+    label = "Completed the first four years of postsecondary education"
+    documentation = "Whether the student completed the first four years of postsecondary education before the beginning of the tax year."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_felony_drug_conviction.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/has_felony_drug_conviction.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class has_felony_drug_conviction(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has a felony drug conviction"
+    documentation = "Whether the person has been convicted of a Federal or State felony offense consisting of the possession or distribution of a controlled substance before the end of the tax year."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_barred_from_american_opportunity_credit_due_to_improper_claims.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_barred_from_american_opportunity_credit_due_to_improper_claims.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class is_barred_from_american_opportunity_credit_due_to_improper_claims(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Barred from American Opportunity Credit due to improper claims"
+    documentation = "Whether the taxpayer is barred from the American Opportunity Credit due to prior fraudulent, reckless, intentional-disregard, or deficiency-denied claims."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_eligible_for_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_eligible_for_american_opportunity_credit.py
@@ -7,4 +7,62 @@ class is_eligible_for_american_opportunity_credit(Variable):
     label = "Eligible for American Opportunity Credit"
     documentation = "Whether the person is eligible for the AOC in respect of qualified tuition expenses for this tax year. The expenses must be for one of the first four years of post-secondary education, and the person must not have claimed the AOC for any four previous tax years."
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/26/25A#b_2"
+    reference = [
+        "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A",
+        "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title20-section1091",
+    ]
+
+    def formula(person, period, parameters):
+        tax_unit = person.tax_unit
+        filing_status = tax_unit("filing_status", period)
+        filing_status_values = filing_status.possible_values
+        filing_status_eligible = filing_status != filing_status_values.SEPARATE
+        requires_1098_t = period.start.year >= 2016
+        has_1098_t_or_exception = (
+            person("has_american_opportunity_credit_1098_t_or_exception", period)
+            if requires_1098_t
+            else True
+        )
+        requires_institution_ein = period.start.year >= 2016
+        has_institution_ein = (
+            person("has_american_opportunity_credit_institution_ein", period)
+            if requires_institution_ein
+            else True
+        )
+
+        return (
+            person("is_pursuing_credential_for_american_opportunity_credit", period)
+            & person(
+                "attends_eligible_educational_institution_for_american_opportunity_credit",
+                period,
+            )
+            & person(
+                "is_enrolled_at_least_half_time_for_american_opportunity_credit",
+                period,
+            )
+            & ~person(
+                "has_completed_first_four_years_of_postsecondary_education",
+                period,
+            )
+            & (person("american_opportunity_credit_claimed_prior_years", period) < 4)
+            & ~person("has_felony_drug_conviction", period)
+            & has_1098_t_or_exception
+            & has_institution_ein
+            & person(
+                "meets_american_opportunity_credit_identification_requirements",
+                period,
+            )
+            & tax_unit(
+                "filer_meets_american_opportunity_credit_identification_requirements",
+                period,
+            )
+            & ~tax_unit(
+                "is_nonresident_alien_for_american_opportunity_credit",
+                period,
+            )
+            & ~tax_unit(
+                "is_barred_from_american_opportunity_credit_due_to_improper_claims",
+                period,
+            )
+            & filing_status_eligible
+        )

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_eligible_for_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_eligible_for_american_opportunity_credit.py
@@ -13,17 +13,18 @@ class is_eligible_for_american_opportunity_credit(Variable):
     ]
 
     def formula(person, period, parameters):
+        aoc = parameters(period).gov.irs.credits.education.american_opportunity_credit
         tax_unit = person.tax_unit
         filing_status = tax_unit("filing_status", period)
         filing_status_values = filing_status.possible_values
         filing_status_eligible = filing_status != filing_status_values.SEPARATE
-        requires_1098_t = period.start.year >= 2016
+        requires_1098_t = aoc.eligibility.requires_1098_t_or_exception
         has_1098_t_or_exception = (
             person("has_american_opportunity_credit_1098_t_or_exception", period)
             if requires_1098_t
             else True
         )
-        requires_institution_ein = period.start.year >= 2016
+        requires_institution_ein = aoc.eligibility.requires_institution_ein
         has_institution_ein = (
             person("has_american_opportunity_credit_institution_ein", period)
             if requires_institution_ein

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_enrolled_at_least_half_time_for_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_enrolled_at_least_half_time_for_american_opportunity_credit.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class is_enrolled_at_least_half_time_for_american_opportunity_credit(Variable):
+    value_type = bool
+    entity = Person
+    label = "Enrolled at least half-time for the American Opportunity Credit"
+    documentation = "Whether the student is enrolled at least half-time for at least one academic period beginning in the tax year for American Opportunity Credit purposes."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_nonresident_alien_for_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_nonresident_alien_for_american_opportunity_credit.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class is_nonresident_alien_for_american_opportunity_credit(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Nonresident alien for American Opportunity Credit"
+    documentation = "Whether the taxpayer is a nonresident alien for American Opportunity Credit purposes and is not treated as a resident alien under section 6013(g) or 6013(h)."
+    definition_period = YEAR
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_pursuing_credential_for_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/is_pursuing_credential_for_american_opportunity_credit.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class is_pursuing_credential_for_american_opportunity_credit(Variable):
+    value_type = bool
+    entity = Person
+    label = "Pursuing a credential for the American Opportunity Credit"
+    documentation = "Whether the student is pursuing a degree, certificate, or other recognized educational credential for American Opportunity Credit purposes."
+    definition_period = YEAR
+    reference = [
+        "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A",
+        "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title20-section1091",
+    ]

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/meets_american_opportunity_credit_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/meets_american_opportunity_credit_identification_requirements.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class meets_american_opportunity_credit_identification_requirements(Variable):
+    value_type = bool
+    entity = Person
+    label = "Meets American Opportunity Credit identification requirements"
+    documentation = "Whether the person has the taxpayer identification required for the American Opportunity Credit. For tax years beginning after 2025, the required identification is a Social Security number as defined in section 24(h)(7)."
+    definition_period = YEAR
+    reference = [
+        "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A",
+        "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section24",
+    ]
+
+    def formula(person, period, parameters):
+        if period.start.year <= 2025:
+            return person("has_tin", period)
+
+        ssn_card_type = person("ssn_card_type", period)
+        ssn_card_types = ssn_card_type.possible_values
+        citizen = ssn_card_type == ssn_card_types.CITIZEN
+        non_citizen_valid_ead = ssn_card_type == ssn_card_types.NON_CITIZEN_VALID_EAD
+        return citizen | non_citizen_valid_ead

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/meets_american_opportunity_credit_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/meets_american_opportunity_credit_identification_requirements.py
@@ -13,7 +13,8 @@ class meets_american_opportunity_credit_identification_requirements(Variable):
     ]
 
     def formula(person, period, parameters):
-        if period.start.year <= 2025:
+        aoc = parameters(period).gov.irs.credits.education.american_opportunity_credit
+        if not aoc.eligibility.requires_qualifying_ssn:
             return person("has_tin", period)
 
         ssn_card_type = person("ssn_card_type", period)

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/non_refundable_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/non_refundable_american_opportunity_credit.py
@@ -10,7 +10,7 @@ class non_refundable_american_opportunity_credit(Variable):
         "Value of the non-refundable portion of the American Opportunity Credit"
     )
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/26/25A#i"
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"
 
     def formula(tax_unit, period, parameters):
         credit_limit = tax_unit(

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/non_refundable_american_opportunity_credit_credit_limit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/non_refundable_american_opportunity_credit_credit_limit.py
@@ -10,7 +10,7 @@ class non_refundable_american_opportunity_credit_credit_limit(Variable):
         "Value of the non-refundable portion of the American Opportunity Credit"
     )
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/26/25A#i"
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"
 
     def formula(tax_unit, period, parameters):
         income_tax_before_credits = tax_unit("income_tax_before_credits", period)

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/non_refundable_american_opportunity_credit_potential.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/non_refundable_american_opportunity_credit_potential.py
@@ -10,7 +10,7 @@ class non_refundable_american_opportunity_credit_potential(Variable):
         "Value of the non-refundable portion of the American Opportunity Credit"
     )
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/26/25A#i"
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"
 
     adds = ["american_opportunity_credit"]
     subtracts = ["refundable_american_opportunity_credit"]

--- a/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/refundable_american_opportunity_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/american_opportunity_credit/refundable_american_opportunity_credit.py
@@ -8,7 +8,7 @@ class refundable_american_opportunity_credit(Variable):
     unit = USD
     documentation = "Value of the refundable portion of the American Opportunity Credit"
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/26/25A#i"
+    reference = "https://uscode.house.gov/view.xhtml?edition=prelim&num=0&req=granuleid%3AUSC-prelim-title26-section25A"
 
     def formula(tax_unit, period, parameters):
         aoc = parameters(period).gov.irs.credits.education.american_opportunity_credit

--- a/policyengine_us/variables/gov/irs/credits/education/attends_eligible_educational_institution_for_lifetime_learning_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/attends_eligible_educational_institution_for_lifetime_learning_credit.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class attends_eligible_educational_institution_for_lifetime_learning_credit(Variable):
+    value_type = bool
+    entity = Person
+    label = "Attends an eligible educational institution for Lifetime Learning Credit"
+    documentation = "Whether the person is enrolled at an eligible educational institution for Lifetime Learning Credit purposes."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#f_2"

--- a/policyengine_us/variables/gov/irs/credits/education/filer_meets_lifetime_learning_credit_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/education/filer_meets_lifetime_learning_credit_identification_requirements.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class filer_meets_lifetime_learning_credit_identification_requirements(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Filer meets Lifetime Learning Credit identification requirements"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#g_1"
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        meets_identification_requirements = person(
+            "meets_lifetime_learning_credit_identification_requirements",
+            period,
+        )
+        return tax_unit.all(~head_or_spouse | meets_identification_requirements)

--- a/policyengine_us/variables/gov/irs/credits/education/has_lifetime_learning_credit_1098_t_or_exception.py
+++ b/policyengine_us/variables/gov/irs/credits/education/has_lifetime_learning_credit_1098_t_or_exception.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class has_lifetime_learning_credit_1098_t_or_exception(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has Form 1098-T or an LLC exception"
+    documentation = "Whether the student received Form 1098-T or meets an exception allowing the Lifetime Learning Credit to be claimed with substantiated qualified expenses."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#g_8"

--- a/policyengine_us/variables/gov/irs/credits/education/is_eligible_for_lifetime_learning_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/is_eligible_for_lifetime_learning_credit.py
@@ -1,0 +1,48 @@
+from policyengine_us.model_api import *
+
+
+class is_eligible_for_lifetime_learning_credit(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Lifetime Learning Credit"
+    documentation = "Whether the person is eligible for the Lifetime Learning Credit in respect of qualified tuition expenses for this tax year."
+    definition_period = YEAR
+    reference = [
+        "https://www.law.cornell.edu/uscode/text/26/25A#c",
+        "https://www.law.cornell.edu/uscode/text/26/25A#f",
+        "https://www.law.cornell.edu/uscode/text/26/25A#g",
+    ]
+
+    def formula(person, period, parameters):
+        llc = parameters(period).gov.irs.credits.education.lifetime_learning_credit
+        tax_unit = person.tax_unit
+        filing_status = tax_unit("filing_status", period)
+        filing_status_values = filing_status.possible_values
+        filing_status_eligible = filing_status != filing_status_values.SEPARATE
+        requires_1098_t = llc.eligibility.requires_1098_t_or_exception
+        has_1098_t_or_exception = (
+            person("has_lifetime_learning_credit_1098_t_or_exception", period)
+            if requires_1098_t
+            else True
+        )
+
+        return (
+            person(
+                "attends_eligible_educational_institution_for_lifetime_learning_credit",
+                period,
+            )
+            & has_1098_t_or_exception
+            & person(
+                "meets_lifetime_learning_credit_identification_requirements",
+                period,
+            )
+            & tax_unit(
+                "filer_meets_lifetime_learning_credit_identification_requirements",
+                period,
+            )
+            & ~tax_unit(
+                "is_nonresident_alien_for_lifetime_learning_credit",
+                period,
+            )
+            & filing_status_eligible
+        )

--- a/policyengine_us/variables/gov/irs/credits/education/is_nonresident_alien_for_lifetime_learning_credit.py
+++ b/policyengine_us/variables/gov/irs/credits/education/is_nonresident_alien_for_lifetime_learning_credit.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class is_nonresident_alien_for_lifetime_learning_credit(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Nonresident alien for Lifetime Learning Credit"
+    documentation = "Whether the taxpayer is a nonresident alien for Lifetime Learning Credit purposes and is not treated as a resident alien under section 6013(g) or 6013(h)."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#g_7"

--- a/policyengine_us/variables/gov/irs/credits/education/lifetime_learning_credit_potential.py
+++ b/policyengine_us/variables/gov/irs/credits/education/lifetime_learning_credit_potential.py
@@ -15,8 +15,11 @@ class lifetime_learning_credit_potential(Variable):
         llc = education.lifetime_learning_credit
         person = tax_unit.members
         is_aoc_eligible = person("is_eligible_for_american_opportunity_credit", period)
+        is_llc_eligible = person("is_eligible_for_lifetime_learning_credit", period)
         eligible_expenses = tax_unit.sum(
-            person("qualified_tuition_expenses", period) * ~is_aoc_eligible
+            person("qualified_tuition_expenses", period)
+            * is_llc_eligible
+            * ~is_aoc_eligible
         )
         capped_expenses = min_(llc.expense_limit, eligible_expenses)
         maximum_amount = llc.rate * capped_expenses

--- a/policyengine_us/variables/gov/irs/credits/education/meets_lifetime_learning_credit_identification_requirements.py
+++ b/policyengine_us/variables/gov/irs/credits/education/meets_lifetime_learning_credit_identification_requirements.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class meets_lifetime_learning_credit_identification_requirements(Variable):
+    value_type = bool
+    entity = Person
+    label = "Meets Lifetime Learning Credit identification requirements"
+    documentation = "Whether the person has the taxpayer identification required for the Lifetime Learning Credit. For tax years beginning after 2025, the required identification is a Social Security number as defined in section 24(h)(7)."
+    definition_period = YEAR
+    reference = [
+        "https://www.law.cornell.edu/uscode/text/26/25A#g_1",
+        "https://www.law.cornell.edu/uscode/text/26/24#h_7",
+    ]
+
+    def formula(person, period, parameters):
+        llc = parameters(period).gov.irs.credits.education.lifetime_learning_credit
+        if not llc.eligibility.requires_qualifying_ssn:
+            return person("has_tin", period)
+
+        ssn_card_type = person("ssn_card_type", period)
+        ssn_card_types = ssn_card_type.possible_values
+        citizen = ssn_card_type == ssn_card_types.CITIZEN
+        non_citizen_valid_ead = ssn_card_type == ssn_card_types.NON_CITIZEN_VALID_EAD
+        return citizen | non_citizen_valid_ead


### PR DESCRIPTION
## Summary
- add lower-level American Opportunity Credit eligibility inputs for the statutory student, documentation, institution, identification, residency, improper-claim, and filing-status predicates
- compute `is_eligible_for_american_opportunity_credit` from those predicates instead of leaving it as an unpopulated input
- gate AOTC Form 1098-T/payee-statement, institution-EIN, and qualifying-SSN requirements with time-varying eligibility parameters
- add lower-level Lifetime Learning Credit predicates for eligible-institution attendance, Form 1098-T/exception, taxpayer/student identification, nonresident-alien disallowance, and MFS disallowance
- gate LLC qualified tuition through `is_eligible_for_lifetime_learning_credit` while continuing to exclude AOTC-eligible students from LLC expenses

## Primary Sources
- [26 U.S.C. § 25A(b)](https://www.law.cornell.edu/uscode/text/26/25A#b) for AOTC amount, refundability cross-reference, and eligible-student rules
- [26 U.S.C. § 25A(c)](https://www.law.cornell.edu/uscode/text/26/25A#c) for the Lifetime Learning Credit amount
- [26 U.S.C. § 25A(f)](https://www.law.cornell.edu/uscode/text/26/25A#f) for qualified tuition, eligible educational institutions, and the no-double-benefit rule between education credits
- [26 U.S.C. § 25A(g)(1)](https://www.law.cornell.edu/uscode/text/26/25A#g_1) and [26 U.S.C. § 24(h)(7)](https://www.law.cornell.edu/uscode/text/26/24#h_7) for the post-2025 qualifying-SSN identification rule
- [26 U.S.C. § 25A(g)(7)](https://www.law.cornell.edu/uscode/text/26/25A#g_7) for the nonresident-alien disallowance
- [26 U.S.C. § 25A(g)(8)](https://www.law.cornell.edu/uscode/text/26/25A#g_8) for the Form 1098-T/payee-statement requirement
- [20 U.S.C. § 1091(a)(1)](https://www.law.cornell.edu/uscode/text/20/1091#a_1), incorporated by 26 U.S.C. § 25A(b)(3)(A), for the recognized-credential enrollment rule

## Tests
- `uv run ruff format policyengine_us/variables/gov/irs/credits/education policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit`
- `uv run ruff check policyengine_us/variables/gov/irs/credits/education policyengine_us/tests/policy/baseline/gov/irs/credits/education/lifetime_learning_credit`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/credits/education -c policyengine_us`

Follow-up data PR: PolicyEngine/policyengine-us-data#843
