### PR TITLE
Implement Louisiana State Supplementary Payment (SSP)

### DIFF
--- a/changelog.d/la-ssp.added.md
+++ b/changelog.d/la-ssp.added.md
@@ -1,0 +1,1 @@
+Implement Louisiana Optional State Supplement (OSS).

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -55,6 +55,8 @@ values:
     - ks_sspp
     # Hawaii benefits
     - hi_oss
+    # Louisiana benefits
+    - la_oss
   2024-01-01:
     # Delaware benefits
     - de_ssp
@@ -112,6 +114,8 @@ values:
     - ks_sspp
     # Hawaii benefits
     - hi_oss
+    # Louisiana benefits
+    - la_oss
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/la/hhs/oss/maximum_payment.yaml
+++ b/policyengine_us/parameters/gov/states/la/hhs/oss/maximum_payment.yaml
@@ -9,11 +9,9 @@ metadata:
   period: month
   label: Louisiana OSS maximum monthly payment
   reference:
-    - title: SSA Publication No. 13-11975, State Assistance Programs for SSI Recipients, January 2011 - Louisiana, Table 1
-      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/la.html
     - title: LDH Medicaid Eligibility Manual Z-700, Personal Care Maintenance Needs Allowance and OSS Chart
       href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/Z-700.pdf#page=2
     - title: LDH Medicaid Eligibility Manual J-300, Optional State Supplement Payment
       href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/J-0000.pdf#page=2
-    - title: Louisiana State Plan Amendment 25-0013, Personal Needs Allowance (effective July 1, 2025)
-      href: https://ldh.la.gov/medicaid/medicaid-state-plan-amendments-2025
+    - title: SSA Publication No. 13-11975, State Assistance Programs for SSI Recipients, January 2011 - Louisiana, Table 1
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/la.html

--- a/policyengine_us/parameters/gov/states/la/hhs/oss/maximum_payment.yaml
+++ b/policyengine_us/parameters/gov/states/la/hhs/oss/maximum_payment.yaml
@@ -1,0 +1,19 @@
+description: Louisiana provides this maximum monthly Optional State Supplement payment to aged, blind, or disabled individuals residing in non-psychiatric Medicaid long-term care facilities.
+
+values:
+  2011-01-01: 8
+  2025-07-01: 15
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Louisiana OSS maximum monthly payment
+  reference:
+    - title: SSA Publication No. 13-11975, State Assistance Programs for SSI Recipients, January 2011 - Louisiana, Table 1
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/la.html
+    - title: LDH Medicaid Eligibility Manual Z-700, Personal Care Maintenance Needs Allowance and OSS Chart
+      href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/Z-700.pdf#page=2
+    - title: LDH Medicaid Eligibility Manual J-300, Optional State Supplement Payment
+      href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/J-0000.pdf#page=2
+    - title: Louisiana State Plan Amendment 25-0013, Personal Needs Allowance (effective July 1, 2025)
+      href: https://ldh.la.gov/medicaid/medicaid-state-plan-amendments-2025

--- a/policyengine_us/parameters/gov/states/la/hhs/oss/personal_care_needs_allowance.yaml
+++ b/policyengine_us/parameters/gov/states/la/hhs/oss/personal_care_needs_allowance.yaml
@@ -9,11 +9,15 @@ metadata:
   period: month
   label: Louisiana OSS personal care needs allowance
   reference:
-    - title: SSA Publication No. 13-11975, State Assistance Programs for SSI Recipients, January 2011 - Louisiana, Table 1
-      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/la.html
     - title: LDH Medicaid Eligibility Manual Z-700, Personal Care Maintenance Needs Allowance and OSS Chart
       href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/Z-700.pdf#page=2
-    - title: LDH Medicaid Eligibility Manual H-831.6, Personal Care Needs Allowance
-      href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/H-800.pdf#page=14
     - title: LDH Medicaid Eligibility Manual J-300, Optional State Supplement Payment Formula
       href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/J-0000.pdf#page=2
+    - title: LDH Medicaid Eligibility Manual H-831.6, Personal Care Needs Allowance
+      href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/H-800.pdf#page=14
+    - title: Louisiana SPA 25-0013, Approved Attachment 2.6-A page 4a (effective July 1, 2025)
+      href: https://ldh.la.gov/assets/medicaid/StatePlan/Amend2025/25-0013/25-0013-CMS-Approval.pdf#page=4
+    - title: Louisiana SPA 25-0013, Supplement 12 to Attachment 2.6-A (Redlined)
+      href: https://ldh.la.gov/assets/medicaid/StatePlan/Amend2025/25-0013/Supplement-12-to-Attachment-2.6-A-Redlined.pdf
+    - title: SSA Publication No. 13-11975, State Assistance Programs for SSI Recipients, January 2011 - Louisiana, Table 1
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/la.html

--- a/policyengine_us/parameters/gov/states/la/hhs/oss/personal_care_needs_allowance.yaml
+++ b/policyengine_us/parameters/gov/states/la/hhs/oss/personal_care_needs_allowance.yaml
@@ -1,0 +1,19 @@
+description: Louisiana provides this monthly personal care needs allowance as the state payment standard from which the federal Supplemental Security Income institutional payment and countable income are deducted to compute the Optional State Supplement for residents of Medicaid long-term care facilities.
+
+values:
+  2011-01-01: 38
+  2025-07-01: 45
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Louisiana OSS personal care needs allowance
+  reference:
+    - title: SSA Publication No. 13-11975, State Assistance Programs for SSI Recipients, January 2011 - Louisiana, Table 1
+      href: https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/la.html
+    - title: LDH Medicaid Eligibility Manual Z-700, Personal Care Maintenance Needs Allowance and OSS Chart
+      href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/Z-700.pdf#page=2
+    - title: LDH Medicaid Eligibility Manual H-831.6, Personal Care Needs Allowance
+      href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/H-800.pdf#page=14
+    - title: LDH Medicaid Eligibility Manual J-300, Optional State Supplement Payment Formula
+      href: https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/J-0000.pdf#page=2

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -656,6 +656,11 @@ programs:
         name: Kansas SSPP
         full_name: Kansas State Supplemental Payment Program
         variable: ks_sspp
+      - state: LA
+        status: complete
+        name: Louisiana OSS
+        full_name: Louisiana Optional State Supplement
+        variable: la_oss
       - state: IL
         status: complete
         name: Illinois AABD

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/integration.yaml
@@ -1,0 +1,256 @@
+# Integration tests for Louisiana Optional State Supplement (OSS).
+# End-to-end scenarios with full household setup.
+#
+# Eligibility: aged/blind/disabled AND in a Medicaid LTC facility AND in Louisiana.
+# Formula: la_oss (monthly) = min(max(PNA - federal_institutional_SSI - ssi_countable_income, 0), max_payment).
+#
+# Pre-July-2025: PNA = $38, max payment = $8/month.
+# From July 1, 2025: PNA = $45, max payment = $15/month.
+# Federal institutional SSI rate = $30/month (since 1988).
+#
+# Reference: LDH J-300, Z-700; SSA Publication 13-11975 (2011) - Louisiana, Table 1.
+
+- name: Scenario 1, aged SSI recipient in LA Medicaid LTC facility (2024-01).
+  # 70-year-old aged person with no countable income gets the max OSS.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: true
+    # Monthly: max(38 - 30 - 0, 0) = 8, capped at 8.
+    la_oss: 8
+
+- name: Scenario 2, disabled adult in LA ICF/IID facility (2024-01).
+  # 45-year-old disabled SSI recipient in an ICF/IID facility.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 45
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: true
+    la_oss: 8
+
+- name: Scenario 3, eligible individual NOT in Medicaid LTC facility.
+  # SSI recipient living in the community gets no OSS.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: false
+        ssi_countable_income: 0
+        ssi: 11_928
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false
+    la_oss: 0
+
+- name: Scenario 4, person in Medicaid LTC facility but NOT aged/blind/disabled.
+  # Categorical requirement fails so no OSS.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 50
+        is_ssi_aged_blind_disabled: false
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 0
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false
+    la_oss: 0
+
+- name: Scenario 5, eligible individual in Medicaid LTC facility but in Texas.
+  # defined_for StateCode.LA filters out non-LA residents.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 68
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    la_oss_eligible: false
+    la_oss: 0
+
+- name: Scenario 6, post-July-2025 eligible individual gets higher max OSS (2026-01).
+  # PNA increases to $45 and max payment to $15 from July 1, 2025.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 72
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: true
+    # Monthly: max(45 - 30 - 0, 0) = 15, capped at 15.
+    la_oss: 15
+
+- name: Scenario 7, couple both aged in LA Medicaid LTC facility (2024-01).
+  # Each spouse receives the per-person individual rate (REQ-014).
+  # SSA 2011 Table 1 confirms couple = 2 x individual.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 72
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+      person2:
+        age: 70
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1, person2]
+        state_code: LA
+  output:
+    la_oss_eligible: [true, true]
+    # Each person: monthly max(38 - 30 - 0, 0) = 8.
+    la_oss: [8, 8]
+
+- name: Scenario 8, disabled child in LA Medicaid LTC facility (REQ-017).
+  # Children are eligible (no minimum age) per SSA 2011 report.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 10
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: true
+    la_oss: 8
+
+- name: Scenario 9, eligible adjacent-state resident in MS gets nothing (defined_for filter).
+  # Mississippi shares a border with Louisiana but defined_for excludes non-LA residents.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 70
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1]
+        state_code: MS
+  output:
+    la_oss_eligible: false
+    la_oss: 0
+
+- name: Scenario 10, person with zero SSI and zero income but no SSI categorical status.
+  # Without aged/blind/disabled status, no payment regardless of income or LTC residence.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 40
+        is_ssi_aged_blind_disabled: false
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 0
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false
+    la_oss: 0
+
+- name: Scenario 11, mixed couple - one eligible, one not (asymmetric eligibility).
+  # Only the LTC-residing spouse gets OSS; the community-residing spouse gets zero.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 72
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+      person2:
+        age: 70
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: false
+        ssi_countable_income: 0
+        ssi: 11_928
+    households:
+      household:
+        members: [person1, person2]
+        state_code: LA
+  output:
+    la_oss_eligible: [true, false]
+    # person1: monthly 8. person2: not in LTC, so 0.
+    la_oss: [8, 0]
+
+- name: Scenario 12, pre-July-2025 monthly snapshot in LA (2025-01).
+  # 2025-01 falls before the July 2025 PNA/max increase, so the old amounts apply.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 75
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+        ssi_countable_income: 0
+        ssi: 360
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: true
+    la_oss: 8

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/integration.yaml
@@ -2,11 +2,12 @@
 # End-to-end scenarios with full household setup.
 #
 # Eligibility: aged/blind/disabled AND in a Medicaid LTC facility AND in Louisiana.
-# Formula: la_oss (monthly) = min(max(PNA - federal_institutional_SSI - ssi_countable_income, 0), max_payment).
+# Formula: la_oss (monthly) = min(max(PNA - ssi - ssi_countable_income, 0), max_payment).
+# Both ssi and ssi_countable_income are YEAR-period; PolicyEngine divides by 12
+# when the formula reads them at MONTH.
 #
-# Pre-July-2025: PNA = $38, max payment = $8/month.
+# Pre-July-2025: PNA = $38, max payment = $8/month. Federal SSI institutional FBR = $30/mo.
 # From July 1, 2025: PNA = $45, max payment = $15/month.
-# Federal institutional SSI rate = $30/month (since 1988).
 #
 # Reference: LDH J-300, Z-700; SSA Publication 13-11975 (2011) - Louisiana, Table 1.
 
@@ -18,7 +19,7 @@
       person1:
         age: 70
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:
@@ -38,7 +39,7 @@
       person1:
         age: 45
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:
@@ -57,7 +58,7 @@
       person1:
         age: 70
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: false
+        ssi_federal_living_arrangement: OWN_HOUSEHOLD
         ssi_countable_income: 0
         ssi: 11_928
     households:
@@ -76,7 +77,7 @@
       person1:
         age: 50
         is_ssi_aged_blind_disabled: false
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 0
     households:
@@ -95,7 +96,7 @@
       person1:
         age: 68
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:
@@ -114,7 +115,7 @@
       person1:
         age: 72
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:
@@ -135,13 +136,13 @@
       person1:
         age: 72
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
       person2:
         age: 70
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:
@@ -161,7 +162,7 @@
       person1:
         age: 10
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:
@@ -180,7 +181,7 @@
       person1:
         age: 70
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:
@@ -199,7 +200,7 @@
       person1:
         age: 40
         is_ssi_aged_blind_disabled: false
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 0
     households:
@@ -218,13 +219,13 @@
       person1:
         age: 72
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
       person2:
         age: 70
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: false
+        ssi_federal_living_arrangement: OWN_HOUSEHOLD
         ssi_countable_income: 0
         ssi: 11_928
     households:
@@ -244,7 +245,7 @@
       person1:
         age: 75
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
         ssi: 360
     households:

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss.yaml
@@ -1,18 +1,23 @@
 # Unit tests for Louisiana Optional State Supplement (OSS) benefit amount.
-# Formula (monthly): la_oss = min(max(PNA - federal_institutional_SSI - ssi_countable_income, 0), max_payment)
-# ssi_countable_income is YEAR-period; reading at MONTH yields annual / 12.
+# Formula (monthly): la_oss = min(max(PNA - ssi - ssi_countable_income, 0), max_payment)
+# Both ssi and ssi_countable_income are YEAR-period; reading at MONTH yields annual / 12.
 #
-# Pre-July-2025: PNA = $38, federal institutional SSI = $30, max payment = $8.
-# From July 1, 2025: PNA = $45, max payment = $15. Federal institutional rate stays $30.
+# Pre-July-2025: PNA = $38, max payment = $8. Federal SSI institutional FBR = $30.
+# From July 1, 2025: PNA = $45, max payment = $15.
+#
+# Test inputs pass annual ssi and ssi_countable_income directly so that the
+# SSI formula chain doesn't recompute them. SSI institutional rate is $30/mo
+# = $360/yr; SSI = max(FBR - countable, 0) when SSI is being received.
 #
 # Reference: LDH J-300, Z-700; SSA 2011 State Assistance Programs - Louisiana, Table 1.
 
-- name: Case 1, eligible individual with zero countable income (2024-01).
+- name: Case 1, eligible individual receiving full institutional SSI with no other income (2024-01).
   period: 2024-01
   input:
     people:
       person1:
         la_oss_eligible: true
+        ssi: 360  # full institutional FBR ($30/month)
         ssi_countable_income: 0
     households:
       household:
@@ -41,6 +46,7 @@
     people:
       person1:
         la_oss_eligible: true
+        ssi: 360  # full institutional FBR ($30/month)
         ssi_countable_income: 0
     households:
       household:
@@ -50,28 +56,32 @@
     # Monthly: max(45 - 30 - 0, 0) = 15, capped at 15.
     la_oss: 15
 
-- name: Case 4, eligible individual with countable income that reduces supplement (2024-01).
-  # Annual ssi_countable_income of 60 -> 5/month; 38 - 30 - 5 = 3.
+- name: Case 4, partial SSI recipient with low countable income still gets full state cap (2024-01).
+  # Annual countable 60 -> 5/month; SSI reduced to 25/month (FBR 30 - countable 5).
+  # Formula: 38 - 25 - 5 = 8, capped at 8.
   period: 2024-01
   input:
     people:
       person1:
         la_oss_eligible: true
+        ssi: 300  # 25/month (reduced by countable income)
         ssi_countable_income: 60
     households:
       household:
         members: [person1]
         state_code: LA
   output:
-    la_oss: 3
+    la_oss: 8
 
-- name: Case 5, eligible individual with countable income that fully offsets supplement (2024-01).
-  # Annual 1200 -> 100/month; 38 - 30 - 100 < 0, floored at 0.
+- name: Case 5, non-SSI recipient with countable income above PNA receives zero (2024-01).
+  # Annual countable 1200 -> 100/month; SSI = 0 (countable > FBR).
+  # Formula: max(38 - 0 - 100, 0) = 0.
   period: 2024-01
   input:
     people:
       person1:
         la_oss_eligible: true
+        ssi: 0
         ssi_countable_income: 1_200
     households:
       household:
@@ -80,44 +90,50 @@
   output:
     la_oss: 0
 
-- name: Case 6, countable income exactly equals PNA minus federal institutional rate (boundary, 2024-01).
-  # Annual 96 -> 8/month; 38 - 30 - 8 = 0.
+- name: Case 6, non-SSI recipient with countable income at FBR receives full cap (2024-01).
+  # Annual countable 360 -> 30/month (= FBR boundary); SSI = 0.
+  # Formula: 38 - 0 - 30 = 8, capped at 8.
   period: 2024-01
   input:
     people:
       person1:
         la_oss_eligible: true
-        ssi_countable_income: 96
+        ssi: 0
+        ssi_countable_income: 360
     households:
       household:
         members: [person1]
         state_code: LA
   output:
-    la_oss: 0
+    la_oss: 8
 
-- name: Case 7, countable income just below boundary yields tiny positive supplement (2024-01).
-  # Annual 84 -> 7/month; 38 - 30 - 7 = 1.
+- name: Case 7, non-SSI recipient with countable income just above FBR receives partial supplement (2024-01).
+  # Annual countable 372 -> 31/month; SSI = 0.
+  # Formula: 38 - 0 - 31 = 7.
   period: 2024-01
   input:
     people:
       person1:
         la_oss_eligible: true
-        ssi_countable_income: 84
+        ssi: 0
+        ssi_countable_income: 372
     households:
       household:
         members: [person1]
         state_code: LA
   output:
-    la_oss: 1
+    la_oss: 7
 
-- name: Case 8, countable income one cent above monthly boundary clips to zero (2024-01).
-  # Annual 96.12 -> 8.01/month; 38 - 30 - 8.01 < 0.
+- name: Case 8, non-SSI recipient with countable income at PNA receives zero (2024-01).
+  # Annual countable 456 -> 38/month (= PNA boundary); SSI = 0.
+  # Formula: 38 - 0 - 38 = 0.
   period: 2024-01
   input:
     people:
       person1:
         la_oss_eligible: true
-        ssi_countable_income: 96.12
+        ssi: 0
+        ssi_countable_income: 456
     households:
       household:
         members: [person1]
@@ -133,13 +149,14 @@
     people:
       person1:
         la_oss_eligible: true
+        ssi: 0
         ssi_countable_income: -1_000_000
     households:
       household:
         members: [person1]
         state_code: LA
   output:
-    # Monthly: min(max(38 - 30 - (-monthly), 0), 8) = 8.
+    # Monthly: min(max(38 - 0 - (-monthly), 0), 8) = 8.
     la_oss: 8
 
 - name: Case 10, pre-July-2025 monthly period uses old PNA and max (2025-01).
@@ -148,6 +165,7 @@
     people:
       person1:
         la_oss_eligible: true
+        ssi: 360
         ssi_countable_income: 0
     households:
       household:
@@ -162,23 +180,26 @@
     people:
       person1:
         la_oss_eligible: true
+        ssi: 0
         ssi_countable_income: -1_000_000
     households:
       household:
         members: [person1]
         state_code: LA
   output:
-    # Monthly: min(max(45 - 30 - (-monthly), 0), 15) = 15.
+    # Monthly: min(max(45 - 0 - (-monthly), 0), 15) = 15.
     la_oss: 15
 
-- name: Case 12, post-July-2025 countable income at new boundary yields zero (2026-01).
-  # Annual 180 -> 15/month; 45 - 30 - 15 = 0.
+- name: Case 12, post-July-2025 non-SSI recipient with countable income at new PNA receives zero (2026-01).
+  # Annual countable 540 -> 45/month (= new PNA); SSI = 0.
+  # Formula: 45 - 0 - 45 = 0.
   period: 2026-01
   input:
     people:
       person1:
         la_oss_eligible: true
-        ssi_countable_income: 180
+        ssi: 0
+        ssi_countable_income: 540
     households:
       household:
         members: [person1]
@@ -186,17 +207,19 @@
   output:
     la_oss: 0
 
-- name: Case 13, post-July-2025 countable income just below new boundary yields tiny supplement (2026-01).
-  # Annual 168 -> 14/month; 45 - 30 - 14 = 1.
+- name: Case 13, post-July-2025 non-SSI recipient with countable income at FBR receives new cap (2026-01).
+  # Annual countable 360 -> 30/month (= FBR); SSI = 0.
+  # Formula: 45 - 0 - 30 = 15, capped at 15.
   period: 2026-01
   input:
     people:
       person1:
         la_oss_eligible: true
-        ssi_countable_income: 168
+        ssi: 0
+        ssi_countable_income: 360
     households:
       household:
         members: [person1]
         state_code: LA
   output:
-    la_oss: 1
+    la_oss: 15

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss.yaml
@@ -1,0 +1,202 @@
+# Unit tests for Louisiana Optional State Supplement (OSS) benefit amount.
+# Formula (monthly): la_oss = min(max(PNA - federal_institutional_SSI - ssi_countable_income, 0), max_payment)
+# ssi_countable_income is YEAR-period; reading at MONTH yields annual / 12.
+#
+# Pre-July-2025: PNA = $38, federal institutional SSI = $30, max payment = $8.
+# From July 1, 2025: PNA = $45, max payment = $15. Federal institutional rate stays $30.
+#
+# Reference: LDH J-300, Z-700; SSA 2011 State Assistance Programs - Louisiana, Table 1.
+
+- name: Case 1, eligible individual with zero countable income (2024-01).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    # Monthly: max(38 - 30 - 0, 0) = 8, capped at 8.
+    la_oss: 8
+
+- name: Case 2, not eligible receives zero.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: false
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 0
+
+- name: Case 3, eligible individual post-July-2025 (2026-01 has new PNA and max in effect).
+  period: 2026-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    # Monthly: max(45 - 30 - 0, 0) = 15, capped at 15.
+    la_oss: 15
+
+- name: Case 4, eligible individual with countable income that reduces supplement (2024-01).
+  # Annual ssi_countable_income of 60 -> 5/month; 38 - 30 - 5 = 3.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 60
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 3
+
+- name: Case 5, eligible individual with countable income that fully offsets supplement (2024-01).
+  # Annual 1200 -> 100/month; 38 - 30 - 100 < 0, floored at 0.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 1_200
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 0
+
+- name: Case 6, countable income exactly equals PNA minus federal institutional rate (boundary, 2024-01).
+  # Annual 96 -> 8/month; 38 - 30 - 8 = 0.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 96
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 0
+
+- name: Case 7, countable income just below boundary yields tiny positive supplement (2024-01).
+  # Annual 84 -> 7/month; 38 - 30 - 7 = 1.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 84
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 1
+
+- name: Case 8, countable income one cent above monthly boundary clips to zero (2024-01).
+  # Annual 96.12 -> 8.01/month; 38 - 30 - 8.01 < 0.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 96.12
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 0
+
+- name: Case 9, extreme negative countable income clips to maximum payment (2024-01).
+  # Verifies the rate cap engages so a very negative ssi_countable_income
+  # can never inflate the supplement above the max payment.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: -1_000_000
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    # Monthly: min(max(38 - 30 - (-monthly), 0), 8) = 8.
+    la_oss: 8
+
+- name: Case 10, pre-July-2025 monthly period uses old PNA and max (2025-01).
+  period: 2025-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 0
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 8
+
+- name: Case 11, eligible with extreme negative countable income post-July-2025 clips to new max (2026-01).
+  period: 2026-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: -1_000_000
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    # Monthly: min(max(45 - 30 - (-monthly), 0), 15) = 15.
+    la_oss: 15
+
+- name: Case 12, post-July-2025 countable income at new boundary yields zero (2026-01).
+  # Annual 180 -> 15/month; 45 - 30 - 15 = 0.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 180
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 0
+
+- name: Case 13, post-July-2025 countable income just below new boundary yields tiny supplement (2026-01).
+  # Annual 168 -> 14/month; 45 - 30 - 14 = 1.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        la_oss_eligible: true
+        ssi_countable_income: 168
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss: 1

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss_eligible.yaml
@@ -1,0 +1,87 @@
+# Unit tests for Louisiana OSS eligibility.
+# Eligible if: aged/blind/disabled AND in a Medicaid LTC facility AND in Louisiana.
+# Reference: LDH J-300, H-831.2, H-831.6; SSA 2011 State Assistance Programs - Louisiana.
+
+- name: Case 1, aged person in Medicaid LTC facility in Louisiana.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: true
+
+- name: Case 2, aged/blind/disabled but NOT in Medicaid LTC facility.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: false
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false
+
+- name: Case 3, in Medicaid LTC facility but NOT aged/blind/disabled.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: false
+        is_in_medicaid_facility: true
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false
+
+- name: Case 4, meets all criteria but in Texas (defined_for filters by state).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    la_oss_eligible: false
+
+- name: Case 5, meets all criteria but in Mississippi (adjacent state, defined_for filters).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: true
+        is_in_medicaid_facility: true
+    households:
+      household:
+        members: [person1]
+        state_code: MS
+  output:
+    la_oss_eligible: false
+
+- name: Case 6, neither aged/blind/disabled nor in LTC facility in Louisiana.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: false
+        is_in_medicaid_facility: false
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss_eligible.yaml
@@ -85,3 +85,39 @@
         state_code: LA
   output:
     la_oss_eligible: false
+
+- name: Case 7, ABD in LTC facility but fails the SSI resource test.
+  # Countable resources of $5k exceed the $2k individual SSI limit, so
+  # is_ssi_eligible is false even though the categorical and living
+  # arrangement gates pass.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
+        ssi_countable_resources: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false
+
+- name: Case 8, ABD in LTC facility but fails SSI immigration status.
+  # Undocumented immigration status fails the SSI nonfinancial gate, so
+  # OSS eligibility fails even though the categorical and living
+  # arrangement gates pass.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        is_ssi_aged_blind_disabled: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
+        immigration_status: UNDOCUMENTED
+    households:
+      household:
+        members: [person1]
+        state_code: LA
+  output:
+    la_oss_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss_eligible.yaml
@@ -1,5 +1,5 @@
 # Unit tests for Louisiana OSS eligibility.
-# Eligible if: aged/blind/disabled AND in a Medicaid LTC facility AND in Louisiana.
+# Eligible if: aged/blind/disabled AND ssi_federal_living_arrangement == MEDICAL_TREATMENT_FACILITY AND in Louisiana.
 # Reference: LDH J-300, H-831.2, H-831.6; SSA 2011 State Assistance Programs - Louisiana.
 
 - name: Case 1, aged person in Medicaid LTC facility in Louisiana.
@@ -8,7 +8,7 @@
     people:
       person1:
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
     households:
       household:
         members: [person1]
@@ -22,7 +22,7 @@
     people:
       person1:
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: false
+        ssi_federal_living_arrangement: OWN_HOUSEHOLD
     households:
       household:
         members: [person1]
@@ -36,7 +36,7 @@
     people:
       person1:
         is_ssi_aged_blind_disabled: false
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
     households:
       household:
         members: [person1]
@@ -50,7 +50,7 @@
     people:
       person1:
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
     households:
       household:
         members: [person1]
@@ -64,7 +64,7 @@
     people:
       person1:
         is_ssi_aged_blind_disabled: true
-        is_in_medicaid_facility: true
+        ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
     households:
       household:
         members: [person1]
@@ -78,7 +78,7 @@
     people:
       person1:
         is_ssi_aged_blind_disabled: false
-        is_in_medicaid_facility: false
+        ssi_federal_living_arrangement: OWN_HOUSEHOLD
     households:
       household:
         members: [person1]

--- a/policyengine_us/variables/gov/states/la/hhs/oss/la_oss.py
+++ b/policyengine_us/variables/gov/states/la/hhs/oss/la_oss.py
@@ -14,13 +14,15 @@ class la_oss(Variable):
     )
 
     def formula(person, period, parameters):
-        # OSS = personal care needs allowance (state standard) - federal SSI
-        # institutional payment - countable income, floored at zero and capped
-        # at the maximum payment.
+        # Per SSA 2011 LA report: state supplement = state standard - federal
+        # SSI payment - countable income. The federal payment is the actual
+        # `ssi` (post-reduction for institutional residents), not the constant
+        # institutional FBR — using the constant under-pays people with
+        # low-but-positive countable income still receiving partial SSI, and
+        # also under-pays non-SSI recipients in LTC. J-300's $1.00 floor and
+        # $0.50/$0.49 round-up rule are not modeled at the moment.
         p = parameters(period).gov.states.la.hhs.oss
-        federal_institutional = parameters(
-            period
-        ).gov.ssa.ssi.amount.institutional.individual
+        ssi = person("ssi", period)
         countable_income = person("ssi_countable_income", period)
-        raw = p.personal_care_needs_allowance - federal_institutional - countable_income
+        raw = p.personal_care_needs_allowance - ssi - countable_income
         return min_(max_(raw, 0), p.maximum_payment)

--- a/policyengine_us/variables/gov/states/la/hhs/oss/la_oss.py
+++ b/policyengine_us/variables/gov/states/la/hhs/oss/la_oss.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class la_oss(Variable):
+    value_type = float
+    entity = Person
+    label = "Louisiana Optional State Supplement (OSS)"
+    unit = USD
+    definition_period = MONTH
+    defined_for = "la_oss_eligible"
+    reference = (
+        "https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/J-0000.pdf#page=2",
+        "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/la.html",
+    )
+
+    def formula(person, period, parameters):
+        # OSS = personal care needs allowance (state standard) - federal SSI
+        # institutional payment - countable income, floored at zero and capped
+        # at the maximum payment.
+        p = parameters(period).gov.states.la.hhs.oss
+        federal_institutional = parameters(
+            period
+        ).gov.ssa.ssi.amount.institutional.individual
+        countable_income = person("ssi_countable_income", period)
+        raw = p.personal_care_needs_allowance - federal_institutional - countable_income
+        return min_(max_(raw, 0), p.maximum_payment)

--- a/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
+++ b/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.ssa.ssi.eligibility.status.ssi_federal_living_arrangement import (
+    SSIFederalLivingArrangement,
+)
 
 
 class la_oss_eligible(Variable):
@@ -8,11 +11,7 @@ class la_oss_eligible(Variable):
     documentation = (
         "Eligible if the person is aged, blind, or disabled and resides in a "
         "non-psychiatric Medicaid long-term care facility (federal Code D living "
-        "arrangement: nursing facility or ICF/IID) in Louisiana. We don't track "
-        "Medicare SNF coverage, MAGI vs. non-MAGI Medicaid pathway, transfer-of-"
-        "resource or home-equity penalties, temporary (<=3 month) institutional "
-        "stays, or HCBS waiver enrollment at the moment, so the corresponding "
-        "regulatory exclusions are not applied."
+        "arrangement: nursing facility or ICF/IID) in Louisiana "
     )
     definition_period = MONTH
     defined_for = StateCode.LA
@@ -22,6 +21,13 @@ class la_oss_eligible(Variable):
     )
 
     def formula(person, period, parameters):
+        # Tie eligibility to the same federal SSI living-arrangement enum
+        # that triggers the $30 institutional FBR. This keeps OSS coherent
+        # with the federal SSI calculation: the population getting the
+        # reduced institutional SSI is the same population getting OSS.
         aged_blind_disabled = person("is_ssi_aged_blind_disabled", period)
-        in_ltc_facility = person("is_in_medicaid_facility", period)
-        return aged_blind_disabled & in_ltc_facility
+        arrangement = person("ssi_federal_living_arrangement", period)
+        in_medical_facility = (
+            arrangement == SSIFederalLivingArrangement.MEDICAL_TREATMENT_FACILITY
+        )
+        return aged_blind_disabled & in_medical_facility

--- a/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
+++ b/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class la_oss_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Louisiana Optional State Supplement (OSS)"
+    documentation = (
+        "Eligible if the person is aged, blind, or disabled and resides in a "
+        "non-psychiatric Medicaid long-term care facility (federal Code D living "
+        "arrangement: nursing facility or ICF/IID) in Louisiana. We don't track "
+        "Medicare SNF coverage, MAGI vs. non-MAGI Medicaid pathway, transfer-of-"
+        "resource or home-equity penalties, temporary (<=3 month) institutional "
+        "stays, or HCBS waiver enrollment at the moment, so the corresponding "
+        "regulatory exclusions are not applied."
+    )
+    definition_period = MONTH
+    defined_for = StateCode.LA
+    reference = (
+        "https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/J-0000.pdf#page=2",
+        "https://ldh.la.gov/assets/medicaid/MedicaidEligibilityPolicy/H-800.pdf#page=9",
+    )
+
+    def formula(person, period, parameters):
+        aged_blind_disabled = person("is_ssi_aged_blind_disabled", period)
+        in_ltc_facility = person("is_in_medicaid_facility", period)
+        return aged_blind_disabled & in_ltc_facility

--- a/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
+++ b/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
@@ -8,11 +8,6 @@ class la_oss_eligible(Variable):
     value_type = bool
     entity = Person
     label = "Eligible for Louisiana Optional State Supplement (OSS)"
-    documentation = (
-        "Eligible if the person is aged, blind, or disabled and resides in a "
-        "non-psychiatric Medicaid long-term care facility (federal Code D living "
-        "arrangement: nursing facility or ICF/IID) in Louisiana "
-    )
     definition_period = MONTH
     defined_for = StateCode.LA
     reference = (

--- a/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
+++ b/policyengine_us/variables/gov/states/la/hhs/oss/la_oss_eligible.py
@@ -22,12 +22,15 @@ class la_oss_eligible(Variable):
 
     def formula(person, period, parameters):
         # Tie eligibility to the same federal SSI living-arrangement enum
-        # that triggers the $30 institutional FBR. This keeps OSS coherent
-        # with the federal SSI calculation: the population getting the
-        # reduced institutional SSI is the same population getting OSS.
-        aged_blind_disabled = person("is_ssi_aged_blind_disabled", period)
+        # that triggers the $30 institutional FBR. `is_ssi_eligible` covers
+        # the categorical (aged/blind/disabled), resource, and nonfinancial
+        # (immigration/residency) gates without imposing the federal income
+        # test — which is what we want, since LA OSS also reaches non-SSI
+        # LTC residents whose countable income sits above the FBR but below
+        # the PNA.
+        ssi_eligible = person("is_ssi_eligible", period)
         arrangement = person("ssi_federal_living_arrangement", period)
         in_medical_facility = (
             arrangement == SSIFederalLivingArrangement.MEDICAL_TREATMENT_FACILITY
         )
-        return aged_blind_disabled & in_medical_facility
+        return ssi_eligible & in_medical_facility

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -23,6 +23,7 @@ class spm_unit_benefits(Variable):
             "fl_oss",
             "ks_sspp",  # Kansas benefits
             "hi_oss",
+            "la_oss",  # Louisiana benefits
             "ma_state_supplement",  # Massachusetts benefits
             # California programs.
             "ca_cvrp",  # California Clean Vehicle Rebate Project.


### PR DESCRIPTION
## Summary
Implements Louisiana's Optional State Supplement (OSS) — a state-administered SSI supplement paid to aged, blind, and disabled persons (including children) residing in non-psychiatric Medicaid long-term care facilities.

Closes #8171

## Regulatory Authority
- LDH J-300 / J-0000 (current OSS rules and amount)
- LDH H-800 / H-831.6 (personal care needs allowance / Medicaid LTC eligibility)
- LDH Z-700 (rate chart with historical OSS table)
- SSA 2011 State Assistance Programs Report — Louisiana
- SPA 25-0013 (July 2025 increase)

## Program Overview
- **Administration**: State-administered (Louisiana Department of Health, Bureau of Health Services Financing)
- **Funding**: State funds
- **Effective date**: March 1, 1982 (Senate Concurrent Resolution No. 133, 1980)
- **Current caseload**: 4,539 recipients (1,115 aged, 33 blind, 3,391 disabled) per January 2011 SSA report — most recent verified count

## Eligibility
| Requirement | Source | How Modeled |
|---|---|---|
| Aged, blind, or disabled + SSI resource and nonfinancial gates | LDH H-831.2; SSA 2011 report; SSA POMS | `is_ssi_eligible` (categorical + resource + immigration/residency, excludes income test so non-SSI LTC residents in the $30–$38 countable-income band are still reachable) |
| Resides in a federal Code D living arrangement (Medicaid-paid medical treatment facility) | LDH J-300 #page=2; SSA POMS SI 00520.011 | `ssi_federal_living_arrangement == MEDICAL_TREATMENT_FACILITY` (same enum that triggers the $30 institutional FBR) |
| Louisiana resident | LDH J-300 | `defined_for = StateCode.LA` |
| Not Medicare SNF beneficiary | LDH J-300 #page=2 | Not modeled (Medicare SNF coverage not tracked at the moment) |
| Not MAGI-based LTC beneficiary | LDH J-300 #page=2 | Not modeled (Medicaid eligibility track not modeled at the moment) |
| Not subject to transfer-of-resource penalty | LDH J-300 pp.2-3 | Not modeled (Medicaid penalty rules not modeled at the moment) |
| Not temporary (≤3-month) institutional stay | LDH J-300 #page=3 | Not modeled (institutional stay duration not tracked at the moment) |
| Not HCBS beneficiary | LDH J-300 #page=3 | Not modeled (HCBS waiver enrollment not tracked at the moment) |

**Note on facility scope**: LA law (J-300, H-831.6) limits OSS to non-psychiatric Medicaid LTC residents (NF or ICF/IID), but PolicyEngine doesn't distinguish facility type below the federal `MEDICAL_TREATMENT_FACILITY` enum. We treat the federal enum as equivalent to the LA scope.

## Benefit Amounts (LDH Z-700 / SPA 25-0013)
| Category | Effective Date | Maximum OSS | Personal Care Needs Allowance |
|---|---|---|---|
| All eligible | 2011-01-01 | $8.00 | $38.00 |
| All eligible | 2025-07-01 | $15.00 | $45.00 |

**Couple treatment**: Per-person rate (couple = 2 × individual; SSA 2011 Table 1 shows $16/$76 couple = 2 × $8/$38)
**COLA**: None — flat amount, last increase July 2025 via SPA 25-0013

## Benefit Calculation
Formula (per LDH J-300, SSA 2011 LA report):
```
OSS = min(max(personal_care_needs_allowance − ssi − ssi_countable_income, 0), maximum_payment)
```
- Uses the actual federal SSI payment (`ssi`), not the institutional FBR constant — this correctly handles partial-SSI recipients whose federal payment is reduced by countable income, and reaches non-SSI LTC residents whose countable income sits between the FBR ($30) and the PNA ($38 / $45).
- Pre-July 2025: $38 − ssi − countable, capped at $8
- Post-July 2025: $45 − ssi − countable, capped at $15

## Requirements Coverage
12 of 12 in-scope requirements implemented; 7 NOT-MODELED exclusions documented.

**Covered (11 + registry):**
- REQ-001 LA residency — `defined_for = StateCode.LA`
- REQ-002 Aged/blind/disabled categorical — via `is_ssi_eligible`
- REQ-003 Medicaid LTC facility — `ssi_federal_living_arrangement == MEDICAL_TREATMENT_FACILITY`
- REQ-009 Federal SSI resource limits — via `is_ssi_eligible`
- REQ-010 Federal SSI income exclusions — `ssi_countable_income`
- REQ-011 Top-up formula (PNA − ssi − countable, capped)
- REQ-012 Maximum OSS ($8 → $15 on 2025-07-01)
- REQ-013 Personal care needs allowance ($38 → $45 on 2025-07-01)
- REQ-014 Couple treatment (per-person Person variable)
- REQ-017 Children eligible (no age gate)
- REQ-018 No COLA / not auto-indexed
- REQ-020 Registry (spm_unit_benefits.py + household_state_benefits.yaml + programs.yaml)

**NOT-MODELED (documented):** REQ-004, 005, 006, 007, 008 (narrow Medicaid-track exclusions); REQ-015, 016 (cents-level rounding rule).

## Not Modeled (by design)
| What | Source | Why Excluded |
|---|---|---|
| Medicare SNF / MAGI LTC / transfer-of-resource / temp stays / HCBS exclusions | LDH J-300 | These narrow exclusion conditions require Medicaid eligibility tracking we don't have at the moment |
| $1.00 floor when raw amount is $0.50–$1.00, $0 when ≤$0.49 | LDH J-300 #page=2 | Cents-level administrative rule with no material impact on whole-dollar formulas |
| Pre-2011 backdating | — | Earliest verified value is January 2011 SSA report; pre-2011 amounts not directly verified |

## Files
```
policyengine_us/parameters/gov/states/la/hhs/oss/
  ├── maximum_payment.yaml ($8 → $15 on 2025-07-01)
  └── personal_care_needs_allowance.yaml ($38 → $45 on 2025-07-01)

policyengine_us/variables/gov/states/la/hhs/oss/
  ├── la_oss_eligible.py
  └── la_oss.py

policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/
  ├── la_oss_eligible.yaml (8 cases)
  ├── la_oss.yaml (13 cases)
  └── integration.yaml (12 cases)

# Registry
policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py (add la_oss)
policyengine_us/parameters/gov/household/household_state_benefits.yaml (add la_oss to both date entries)
policyengine_us/programs.yaml (add LA SSP state implementation entry)
```

## Historical Notes
- Maximum OSS was static at $8/month for 15+ years (at least 2010 through June 30, 2025), then increased to $15/month effective July 1, 2025 via SPA 25-0013 (approved Nov 3, 2025).
- Personal care needs allowance moved $38 → $45 on the same date.
- Program inception: March 1, 1982 per SCR 133/1980 — but no verified historical values for early years.

## Verification TODO
- [ ] Verify payment amounts against LDH J-300 / Z-700 (current)
- [ ] Verify eligibility logic against LDH H-831.2 / J-300
- [ ] Verify amounts current as of 2011-2025
- [ ] CI passes

## Test plan
- [x] 33 tests pass locally (la_oss_eligible: 8, la_oss: 13, integration: 12)
- [ ] CI passes
