### PR TITLE
Fix state benchmark tests with Medicare enrollment inputs

### DIFF
--- a/changelog.d/8189.fixed.md
+++ b/changelog.d/8189.fixed.md
@@ -1,0 +1,1 @@
+Fix state benchmark tests affected by modeled Medicare enrollment inputs.

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/exclusions/nj_other_retirement_income_exclusion.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/exclusions/nj_other_retirement_income_exclusion.yaml
@@ -40,6 +40,7 @@
     people:
       person1:
         age: 68
+        medicare_enrolled: false
         employment_income: 0.0
         ssi: 0
         wic: 0
@@ -53,6 +54,7 @@
         is_tax_unit_head: true
       person2:
         age: 67
+        medicare_enrolled: false
         employment_income: 0.0
         ssi: 0
         wic: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/integration.yaml
@@ -143,6 +143,7 @@
     people:
       person1:
         age: 71
+        medicare_enrolled: false
         taxable_interest_income: 104_762
         is_tax_unit_head: true
     tax_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/subtractions/nj_social_security_exclusion.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/subtractions/nj_social_security_exclusion.yaml
@@ -11,6 +11,7 @@
     people:
       person1:
         age: 75
+        medicare_enrolled: false
         employment_income: 37_274
         social_security: 27_262
         is_tax_unit_head: true

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/integration.yaml
@@ -62,6 +62,7 @@
     people:
       person1:
         age: 70
+        medicare_enrolled: false
         employment_income: 200_000
         ssi: 0
         ma_state_supplement: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/integration.yaml
@@ -130,6 +130,7 @@
     people:
       person1:
         age: 70
+        medicare_enrolled: false
         employment_income: 10000.0
         ssi: 0
         wic: 0
@@ -141,6 +142,7 @@
         is_tax_unit_head: true
       person2:
         age: 70
+        medicare_enrolled: false
         employment_income: 10000.0
         ssi: 0
         wic: 0


### PR DESCRIPTION
## Summary

- Mark TAXSIM-style NJ, NM, and OH state test households as not Medicare-enrolled where expected values assume no Medicare Part B premium expense.
- Preserve the new MOOP decomposition behavior while making the benchmark inputs explicit.

## Tests

- `.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/exclusions/nj_other_retirement_income_exclusion.yaml policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/integration.yaml policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/subtractions/nj_social_security_exclusion.yaml policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/integration.yaml policyengine_us/tests/policy/baseline/gov/states/oh/tax/income/integration.yaml -c policyengine_us`

The targeted test command was run after applying the same `branch_to_determine_itemization: false` setting used by CI.
