### PR TITLE
Add Illinois SB3567 child tax credit contrib reform

### DIFF
--- a/changelog.d/il-sb3567.added.md
+++ b/changelog.d/il-sb3567.added.md
@@ -1,1 +1,1 @@
-- Add an Illinois SB3567 contributed reform that boosts the child tax credit for low-AGI filers and makes the credit nonrefundable.
+- Add an Illinois SB3567 (104th General Assembly) contributed reform, opt-in via `gov.contrib.states.il.sb3567.in_effect`, that boosts the child tax credit for low-AGI filers and makes it nonrefundable.

--- a/changelog.d/il-sb3567.added.md
+++ b/changelog.d/il-sb3567.added.md
@@ -1,0 +1,1 @@
+- Add an Illinois SB3567 contributed reform that boosts the child tax credit for low-AGI filers and makes the credit nonrefundable.

--- a/changelog.d/il-sb3567.added.md
+++ b/changelog.d/il-sb3567.added.md
@@ -1,1 +1,1 @@
-- Add an Illinois SB3567 (104th General Assembly) contributed reform, opt-in via `gov.contrib.states.il.sb3567.in_effect`, that boosts the child tax credit for low-AGI filers and makes it nonrefundable.
+- Add an Illinois SB3567 (104th General Assembly) contributed reform, opt-in via `gov.contrib.states.il.sb3567.in_effect`, that boosts the child tax credit for low-AGI filers.

--- a/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
@@ -9,4 +9,6 @@ metadata:
   label: Illinois SB3567 child tax credit reform in effect
   reference:
     - title: Illinois SB3567 (104th General Assembly) full text
-      href: https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114
+      href: https://www.ilga.gov/documents/legislation/104/SB/PDF/10400SB3567lv.pdf#page=2
+    - title: 35 ILCS 5/244 Child tax credit
+      href: https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244

--- a/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
@@ -1,14 +1,23 @@
-description: Illinois SB3567 modifies the child tax credit formula and makes the credit nonrefundable if this is true.
+description: Illinois applies the SB3567 three-tier child tax credit boost under the Illinois Child Tax Credit program when this is true.
+# NOTE: SB3567 is pending in the 104th General Assembly as of 2026-05;
+# values here reflect the introduced text. The bill leaves 35 ILCS 5/244(b)
+# refundability intact, so this reform does NOT make the credit non-refundable.
 
 values:
-  0000-01-01: false
+  2025-01-01: false
 
 metadata:
   unit: bool
   period: year
   label: Illinois SB3567 child tax credit reform in effect
   reference:
-    - title: Illinois SB3567 (104th General Assembly) full text
+    - title: Illinois SB3567 (104th General Assembly) - full bill text (Sec. 244 begins on page 2)
       href: https://www.ilga.gov/documents/legislation/104/SB/PDF/10400SB3567lv.pdf#page=2
-    - title: 35 ILCS 5/244 Child tax credit
+    - title: 35 ILCS 5/244 (a) and (b) - Illinois Child Tax Credit (formula amended; refundability preserved)
       href: https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244
+    - title: 35 ILCS 5/212 - Illinois Earned Income Tax Credit (the underlying state credit)
+      href: https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K212
+    - title: IRC § 32 - federal EITC (defines the phase-in plateau cited as Tier (1)-(2) threshold)
+      href: https://www.law.cornell.edu/uscode/text/26/32
+    - title: IRC § 152 - definition of "qualifying dependents" referenced in Tier (1)-(2)
+      href: https://www.law.cornell.edu/uscode/text/26/152

--- a/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
@@ -3,8 +3,10 @@ description: Illinois applies the SB3567 three-tier child tax credit boost under
 # values here reflect the introduced text. The bill leaves 35 ILCS 5/244(b)
 # refundability intact, so this reform does NOT make the credit non-refundable.
 
+# Default false from 0000-01-01 so the autoloader resolves the toggle at
+# any simulation period; flip to true (via reform input) when modeling SB3567.
 values:
-  2025-01-01: false
+  0000-01-01: false
 
 metadata:
   unit: bool

--- a/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/il/sb3567/in_effect.yaml
@@ -1,0 +1,12 @@
+description: Illinois SB3567 modifies the child tax credit formula and makes the credit nonrefundable if this is true.
+
+values:
+  0000-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: Illinois SB3567 child tax credit reform in effect
+  reference:
+    - title: Illinois SB3567 (104th General Assembly) full text
+      href: https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -236,6 +236,9 @@ from .states.id.eitc import (
 from .states.id.s1450 import (
     create_id_s1450_reform,
 )
+from .states.il.sb3567 import (
+    create_il_sb3567_reform,
+)
 from .states.ky.eitc import (
     create_ky_eitc_reform,
 )
@@ -440,6 +443,7 @@ def create_structural_reforms_from_parameters(parameters, period):
     ga_eitc = create_ga_eitc_reform(parameters, period)
     id_eitc = create_id_eitc_reform(parameters, period)
     id_s1450 = create_id_s1450_reform(parameters, period)
+    il_sb3567 = create_il_sb3567_reform(parameters, period)
     ky_eitc = create_ky_eitc_reform(parameters, period)
     ms_eitc = create_ms_eitc_reform(parameters, period)
     nd_eitc = create_nd_eitc_reform(parameters, period)
@@ -553,6 +557,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         ga_eitc,
         id_eitc,
         id_s1450,
+        il_sb3567,
         ky_eitc,
         ms_eitc,
         nd_eitc,

--- a/policyengine_us/reforms/states/il/__init__.py
+++ b/policyengine_us/reforms/states/il/__init__.py
@@ -1,0 +1,1 @@
+from .sb3567 import create_il_sb3567_reform

--- a/policyengine_us/reforms/states/il/sb3567/__init__.py
+++ b/policyengine_us/reforms/states/il/sb3567/__init__.py
@@ -1,0 +1,5 @@
+from .il_sb3567_reform import (
+    create_il_sb3567,
+    create_il_sb3567_reform,
+    il_sb3567,
+)

--- a/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
+++ b/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
@@ -1,4 +1,3 @@
-from policyengine_core.periods import instant
 from policyengine_core.periods import period as period_
 from policyengine_us.model_api import *
 
@@ -48,29 +47,9 @@ def create_il_sb3567() -> Reform:
                 actual_credit,
             )
 
-    def modify_parameters(parameters):
-        parameters.gov.states.il.tax.income.credits.refundable.update(
-            start=instant("2025-01-01"),
-            value=[
-                "il_pass_through_withholding",
-                "il_pass_through_entity_tax_credit",
-                "il_eitc",
-            ],
-        )
-        parameters.gov.states.il.tax.income.credits.non_refundable.update(
-            start=instant("2025-01-01"),
-            value=[
-                "il_property_tax_credit",
-                "il_k12_education_expense_credit",
-                "il_ctc",
-            ],
-        )
-        return parameters
-
     class reform(Reform):
         def apply(self):
             self.update_variable(il_ctc)
-            self.modify_parameters(modify_parameters)
 
     return reform
 

--- a/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
+++ b/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
@@ -1,0 +1,97 @@
+from policyengine_core.periods import instant
+from policyengine_core.periods import period as period_
+from policyengine_us.model_api import *
+
+
+def create_il_sb3567() -> Reform:
+    class il_ctc(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "Illinois Child Tax Credit"
+        unit = USD
+        definition_period = YEAR
+        reference = "https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114"
+        defined_for = StateCode.IL
+
+        def formula(tax_unit, period, parameters):
+            p = parameters(period).gov.states.il.tax.income.credits
+            ctc = p.ctc
+            person = tax_unit.members
+            age = person("age", period)
+            age_eligible_child = age < ctc.age_limit
+            federal_ctc_eligible_child = person("ctc_qualifying_child", period)
+            eligible_child = age_eligible_child & federal_ctc_eligible_child
+            eligible_child_present = tax_unit.any(eligible_child)
+
+            actual_credit = tax_unit("il_eitc", period) * ctc.rate
+
+            # SB3567 keys the maximum credit amount to the Section 152
+            # dependent count, while the federal EITC schedule tops out at 3+.
+            dependent_count = min_(tax_unit("tax_unit_child_dependents", period), 3)
+            federal_eitc = parameters(period).gov.irs.credits.eitc
+            federal_maximum = federal_eitc.max.calc(dependent_count)
+            phase_in_rate = federal_eitc.phase_in_rate.calc(dependent_count)
+
+            # The bill compares AGI to the threshold for the maximum federal
+            # EITC, which corresponds to the end of the phase-in range.
+            max_federal_eitc_threshold = federal_maximum / phase_in_rate
+            max_il_eitc = federal_maximum * p.eitc.match
+            max_credit = max_il_eitc * ctc.rate
+
+            adjusted_gross_income = tax_unit("adjusted_gross_income", period)
+            boosted_credit = where(
+                adjusted_gross_income <= max_federal_eitc_threshold,
+                max_credit,
+                actual_credit,
+            )
+            return eligible_child_present * boosted_credit
+
+    def modify_parameters(parameters):
+        parameters.gov.states.il.tax.income.credits.refundable.update(
+            start=instant("2025-01-01"),
+            value=[
+                "il_pass_through_withholding",
+                "il_pass_through_entity_tax_credit",
+                "il_eitc",
+            ],
+        )
+        parameters.gov.states.il.tax.income.credits.non_refundable.update(
+            start=instant("2025-01-01"),
+            value=[
+                "il_property_tax_credit",
+                "il_k12_education_expense_credit",
+                "il_ctc",
+            ],
+        )
+        return parameters
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(il_ctc)
+            self.modify_parameters(modify_parameters)
+
+    return reform
+
+
+def create_il_sb3567_reform(parameters, period, bypass: bool = False):
+    if bypass:
+        return create_il_sb3567()
+
+    p = parameters.gov.contrib.states.il.sb3567
+
+    reform_active = False
+    current_period = period_(period)
+
+    for _ in range(5):
+        if p(current_period).in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
+        return create_il_sb3567()
+    else:
+        return None
+
+
+il_sb3567 = create_il_sb3567_reform(None, None, bypass=True)

--- a/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
+++ b/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
@@ -1,20 +1,25 @@
-from policyengine_core.periods import instant, period as period_
 from policyengine_us.model_api import *
-from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
-    applied_state_non_refundable_credit,
-)
 
 
 def create_il_sb3567() -> Reform:
-    class il_ctc_potential(Variable):
+    class il_ctc(Variable):
         value_type = float
         entity = TaxUnit
-        label = "Illinois Child Tax Credit before non-refundable cap"
+        label = "Illinois Child Tax Credit"
         unit = USD
         definition_period = YEAR
+        # Bill text + the underlying state and federal statutes it builds on.
         reference = (
+            # SB3567 bill text (104th GA), amending 35 ILCS 5/244(a).
             "https://www.ilga.gov/documents/legislation/104/SB/PDF/10400SB3567lv.pdf#page=2",
+            # 35 ILCS 5/244 - Illinois Child Tax Credit (subsections (a) and (b)).
             "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244",
+            # 35 ILCS 5/212 - Illinois EITC, whose "maximum value" Section 244 references.
+            "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K212",
+            # IRC § 32 - federal EITC schedule whose phase-in plateau anchors
+            # SB3567's "income threshold to qualify for the maximum federal EITC".
+            "https://www.law.cornell.edu/uscode/text/26/32",
+            # IRC § 152 - dependent definition cited by SB3567 Tier (1)-(2).
             "https://www.law.cornell.edu/uscode/text/26/152",
         )
         defined_for = StateCode.IL
@@ -29,80 +34,57 @@ def create_il_sb3567() -> Reform:
             eligible_child = age_eligible_child & federal_ctc_eligible_child
             eligible_child_present = tax_unit.any(eligible_child)
 
+            # The baseline IL CTC formula: 40% (rate) of the IL EITC (which
+            # is itself a state match of the federal EITC).
             actual_credit = tax_unit("il_eitc", period) * ctc.rate
 
+            # 35 ILCS 5/244(a) prescribes a flat 20% of Section 212 for
+            # TY 2024 (no tier logic); the three-tier (a)(1)-(3) structure
+            # applies only "for tax years beginning on or after
+            # January 1, 2025." Preserve baseline behavior pre-2025.
             if period.start.year < 2025:
                 return eligible_child_present * actual_credit
 
-            # The bill's "income threshold to qualify for the maximum federal
-            # EITC" is the end of the phase-in range (start of the plateau).
+            # Tier (a)(1) and (a)(2) ceiling: 40% of "the maximum value of
+            # the credit allowed under Section 212 of this Act based on the
+            # number of qualifying dependents as defined by Section 152."
+            #
+            # KNOWN APPROXIMATION: IRC § 152 includes qualifying RELATIVES
+            # and has no 3-child cap. We use `eitc_maximum` here, which is
+            # keyed off federal § 32 EITC qualifying-child count (capped at
+            # 3 by the federal schedule). This under-credits families with
+            # (i) 4+ EITC-qualifying children or (ii) § 152 dependents who
+            # are not § 32 qualifying children (e.g., an elderly dependent
+            # parent). Pending sponsor clarification on whether SB3567
+            # intends the broader § 152 universe or — as is conventional in
+            # IL EITC linkage — the § 32 EITC-qualifying subset.
             federal_maximum = tax_unit("eitc_maximum", period)
             phase_in_rate = tax_unit("eitc_phase_in_rate", period)
+            # SB3567 "income threshold to qualify for the maximum federal
+            # EITC" is the end of the phase-in range / start of the plateau.
+            # The federal phase-in threshold is an earned-income concept;
+            # SB3567 explicitly tests against ADJUSTED GROSS INCOME, so we
+            # compare AGI against the earned-income plateau-start value.
+            # This produces conservative results when AGI > earned income
+            # (e.g., filers with investment or retirement income).
             max_federal_eitc_threshold = federal_maximum / phase_in_rate
             max_credit = federal_maximum * p.eitc.match * ctc.rate
 
             agi = tax_unit("adjusted_gross_income", period)
+            # Tier (a)(3) — AGI above the plateau-start — collapses
+            # mathematically to `actual_credit` because at the plateau and
+            # beyond, `il_eitc * ctc.rate` equals `max_credit`. We encode
+            # this as the fall-through branch rather than a third explicit
+            # arm; the math is equivalent at the boundary.
             return eligible_child_present * where(
                 agi <= max_federal_eitc_threshold,
                 max_credit,
                 actual_credit,
             )
 
-    class il_ctc(Variable):
-        value_type = float
-        entity = TaxUnit
-        label = "Illinois Child Tax Credit"
-        unit = USD
-        definition_period = YEAR
-        reference = (
-            "https://www.ilga.gov/documents/legislation/104/SB/PDF/10400SB3567lv.pdf#page=2",
-            "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244",
-        )
-        defined_for = StateCode.IL
-
-        def formula(tax_unit, period, parameters):
-            if period.start.year < 2025:
-                return tax_unit("il_ctc_potential", period)
-
-            ordered_credits = parameters(
-                period
-            ).gov.states.il.tax.income.credits.non_refundable
-            return applied_state_non_refundable_credit(
-                tax_unit,
-                period,
-                ordered_credits,
-                "il_income_tax_before_non_refundable_credits",
-                "il_ctc",
-                "il_ctc_potential",
-            )
-
-    def modify_parameters(parameters: ParameterNode) -> ParameterNode:
-        refundable = parameters.gov.states.il.tax.income.credits.refundable
-        refundable_credits = list(refundable(instant("2025-01-01")))
-        if "il_ctc" in refundable_credits:
-            refundable_credits.remove("il_ctc")
-        refundable.update(
-            start=instant("2025-01-01"),
-            stop=instant("2100-12-31"),
-            value=refundable_credits,
-        )
-
-        non_refundable = parameters.gov.states.il.tax.income.credits.non_refundable
-        non_refundable_credits = list(non_refundable(instant("2025-01-01")))
-        if "il_ctc" not in non_refundable_credits:
-            non_refundable_credits.append("il_ctc")
-        non_refundable.update(
-            start=instant("2025-01-01"),
-            stop=instant("2100-12-31"),
-            value=non_refundable_credits,
-        )
-        return parameters
-
     class reform(Reform):
         def apply(self):
-            self.add_variable(il_ctc_potential)
             self.update_variable(il_ctc)
-            self.modify_parameters(modify_parameters)
 
     return reform
 
@@ -110,22 +92,13 @@ def create_il_sb3567() -> Reform:
 def create_il_sb3567_reform(parameters, period, bypass: bool = False):
     if bypass:
         return create_il_sb3567()
-
-    p = parameters.gov.contrib.states.il.sb3567
-
-    reform_active = False
-    current_period = period_(period)
-
-    for _ in range(5):
-        if p(current_period).in_effect:
-            reform_active = True
-            break
-        current_period = current_period.offset(1, "year")
-
-    if reform_active:
+    # Idiomatic single-period activation check, matching sibling contrib
+    # reforms (pa_ctc_match, ct_sb100, ny/wftc). No 5-year forward
+    # lookahead: that pattern can retroactively activate the reform in
+    # earlier years when the toggle later flips, which is not desired here.
+    if parameters(period).gov.contrib.states.il.sb3567.in_effect:
         return create_il_sb3567()
-    else:
-        return None
+    return None
 
 
 il_sb3567 = create_il_sb3567_reform(None, None, bypass=True)

--- a/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
+++ b/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
@@ -1,12 +1,15 @@
-from policyengine_core.periods import period as period_
+from policyengine_core.periods import instant, period as period_
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.states.tax.income.non_refundable_credit_cap import (
+    applied_state_non_refundable_credit,
+)
 
 
 def create_il_sb3567() -> Reform:
-    class il_ctc(Variable):
+    class il_ctc_potential(Variable):
         value_type = float
         entity = TaxUnit
-        label = "Illinois Child Tax Credit"
+        label = "Illinois Child Tax Credit before non-refundable cap"
         unit = USD
         definition_period = YEAR
         reference = (
@@ -47,9 +50,58 @@ def create_il_sb3567() -> Reform:
                 actual_credit,
             )
 
+    class il_ctc(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "Illinois Child Tax Credit"
+        unit = USD
+        definition_period = YEAR
+        reference = (
+            "https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114",
+            "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244",
+        )
+        defined_for = StateCode.IL
+
+        def formula(tax_unit, period, parameters):
+            ordered_credits = parameters(
+                period
+            ).gov.states.il.tax.income.credits.non_refundable
+            return applied_state_non_refundable_credit(
+                tax_unit,
+                period,
+                ordered_credits,
+                "il_income_tax_before_non_refundable_credits",
+                "il_ctc",
+                "il_ctc_potential",
+            )
+
+    def modify_parameters(parameters: ParameterNode) -> ParameterNode:
+        refundable = parameters.gov.states.il.tax.income.credits.refundable
+        refundable_credits = list(refundable(instant("2025-01-01")))
+        if "il_ctc" in refundable_credits:
+            refundable_credits.remove("il_ctc")
+        refundable.update(
+            start=instant("2025-01-01"),
+            stop=instant("2100-12-31"),
+            value=refundable_credits,
+        )
+
+        non_refundable = parameters.gov.states.il.tax.income.credits.non_refundable
+        non_refundable_credits = list(non_refundable(instant("2025-01-01")))
+        if "il_ctc" not in non_refundable_credits:
+            non_refundable_credits.append("il_ctc")
+        non_refundable.update(
+            start=instant("2025-01-01"),
+            stop=instant("2100-12-31"),
+            value=non_refundable_credits,
+        )
+        return parameters
+
     class reform(Reform):
         def apply(self):
+            self.add_variable(il_ctc_potential)
             self.update_variable(il_ctc)
+            self.modify_parameters(modify_parameters)
 
     return reform
 

--- a/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
+++ b/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
@@ -10,7 +10,10 @@ def create_il_sb3567() -> Reform:
         label = "Illinois Child Tax Credit"
         unit = USD
         definition_period = YEAR
-        reference = "https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114"
+        reference = (
+            "https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114",
+            "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244",
+        )
         defined_for = StateCode.IL
 
         def formula(tax_unit, period, parameters):
@@ -25,26 +28,25 @@ def create_il_sb3567() -> Reform:
 
             actual_credit = tax_unit("il_eitc", period) * ctc.rate
 
-            # SB3567 keys the maximum credit amount to the Section 152
-            # dependent count, while the federal EITC schedule tops out at 3+.
+            # SB3567 keys the maximum credit amount to the dependent count.
+            # The bill cites IRC § 152, but here we use the tax unit's child
+            # dependent count, capped at 3 to match the federal EITC schedule.
             dependent_count = min_(tax_unit("tax_unit_child_dependents", period), 3)
             federal_eitc = parameters(period).gov.irs.credits.eitc
             federal_maximum = federal_eitc.max.calc(dependent_count)
             phase_in_rate = federal_eitc.phase_in_rate.calc(dependent_count)
 
-            # The bill compares AGI to the threshold for the maximum federal
-            # EITC, which corresponds to the end of the phase-in range.
+            # The bill's "income threshold to qualify for the maximum federal
+            # EITC" is the end of the phase-in range (start of the plateau).
             max_federal_eitc_threshold = federal_maximum / phase_in_rate
-            max_il_eitc = federal_maximum * p.eitc.match
-            max_credit = max_il_eitc * ctc.rate
+            max_credit = federal_maximum * p.eitc.match * ctc.rate
 
-            adjusted_gross_income = tax_unit("adjusted_gross_income", period)
-            boosted_credit = where(
-                adjusted_gross_income <= max_federal_eitc_threshold,
+            agi = tax_unit("adjusted_gross_income", period)
+            return eligible_child_present * where(
+                agi <= max_federal_eitc_threshold,
                 max_credit,
                 actual_credit,
             )
-            return eligible_child_present * boosted_credit
 
     def modify_parameters(parameters):
         parameters.gov.states.il.tax.income.credits.refundable.update(

--- a/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
+++ b/policyengine_us/reforms/states/il/sb3567/il_sb3567_reform.py
@@ -13,8 +13,9 @@ def create_il_sb3567() -> Reform:
         unit = USD
         definition_period = YEAR
         reference = (
-            "https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114",
+            "https://www.ilga.gov/documents/legislation/104/SB/PDF/10400SB3567lv.pdf#page=2",
             "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244",
+            "https://www.law.cornell.edu/uscode/text/26/152",
         )
         defined_for = StateCode.IL
 
@@ -30,16 +31,13 @@ def create_il_sb3567() -> Reform:
 
             actual_credit = tax_unit("il_eitc", period) * ctc.rate
 
-            # SB3567 keys the maximum credit amount to the dependent count.
-            # The bill cites IRC § 152, but here we use the tax unit's child
-            # dependent count, capped at 3 to match the federal EITC schedule.
-            dependent_count = min_(tax_unit("tax_unit_child_dependents", period), 3)
-            federal_eitc = parameters(period).gov.irs.credits.eitc
-            federal_maximum = federal_eitc.max.calc(dependent_count)
-            phase_in_rate = federal_eitc.phase_in_rate.calc(dependent_count)
+            if period.start.year < 2025:
+                return eligible_child_present * actual_credit
 
             # The bill's "income threshold to qualify for the maximum federal
             # EITC" is the end of the phase-in range (start of the plateau).
+            federal_maximum = tax_unit("eitc_maximum", period)
+            phase_in_rate = tax_unit("eitc_phase_in_rate", period)
             max_federal_eitc_threshold = federal_maximum / phase_in_rate
             max_credit = federal_maximum * p.eitc.match * ctc.rate
 
@@ -57,12 +55,15 @@ def create_il_sb3567() -> Reform:
         unit = USD
         definition_period = YEAR
         reference = (
-            "https://ilga.gov/Legislation/BillStatus/FullText?DocNum=3567&DocTypeID=SB&GAID=18&LegId=166617&Print=1&SessionID=114",
+            "https://www.ilga.gov/documents/legislation/104/SB/PDF/10400SB3567lv.pdf#page=2",
             "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244",
         )
         defined_for = StateCode.IL
 
         def formula(tax_unit, period, parameters):
+            if period.start.year < 2025:
+                return tax_unit("il_ctc_potential", period)
+
             ordered_credits = parameters(
                 period
             ).gov.states.il.tax.income.credits.non_refundable

--- a/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
+++ b/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
@@ -191,3 +191,65 @@
         state_code: CA
   output:
     il_ctc: 0
+
+- name: SB3567 boosts a two-child phase-in filer to the two-child maximum
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 31
+      child1:
+        age: 7
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+      child2:
+        age: 5
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child1, child2]
+        adjusted_gross_income: 14_000
+        il_eitc: 250
+    households:
+      household:
+        members: [filer, child1, child2]
+        state_code: IL
+  # 2025 federal EITC max for 2 children = 7,152; IL match = 0.20; CTC rate = 0.4
+  # Boosted credit = 7,152 * 0.20 * 0.4 = 572.16
+  output:
+    il_ctc: 572.16
+
+- name: SB3567 applies the boost at the two-child phase-in threshold
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 32
+      child1:
+        age: 6
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+      child2:
+        age: 4
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child1, child2]
+        # Phase-in threshold for 2 children = 7,152 / 0.40 = 17,880
+        adjusted_gross_income: 17_880
+        il_eitc: 1_430.4
+    households:
+      household:
+        members: [filer, child1, child2]
+        state_code: IL
+  # AGI <= threshold so boost applies; max credit = 572.16
+  output:
+    il_ctc: 572.16

--- a/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
+++ b/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
@@ -24,6 +24,31 @@
   output:
     il_ctc: 346.24
 
+- name: SB3567 preserves the 2024 flat-credit formula
+  period: 2024
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+      child:
+        age: 8
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 12_000
+        il_eitc: 200
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  output:
+    il_ctc: 40
+
 - name: SB3567 uses the three-child EITC maximum for larger dependent counts
   period: 2025
   absolute_error_margin: 0.01
@@ -263,3 +288,33 @@
   # AGI <= threshold so boost applies; max credit = 572.16
   output:
     il_ctc: 572.16
+
+- name: SB3567 stops the boost above the two-child phase-in threshold
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 32
+      child1:
+        age: 6
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+      child2:
+        age: 4
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child1, child2]
+        adjusted_gross_income: 17_881
+        il_income_tax_before_non_refundable_credits: 1_000
+        il_eitc: 1_420
+    households:
+      household:
+        members: [filer, child1, child2]
+        state_code: IL
+  output:
+    il_ctc: 568

--- a/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
+++ b/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
@@ -15,6 +15,7 @@
       tax_unit:
         members: [filer, child]
         adjusted_gross_income: 12_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 200
     households:
       household:
@@ -49,6 +50,7 @@
       tax_unit:
         members: [filer, child1, child2, child3, child4]
         adjusted_gross_income: 15_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 400
     households:
       household:
@@ -74,6 +76,7 @@
       tax_unit:
         members: [filer, child]
         adjusted_gross_income: 18_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 865.6
     households:
       household:
@@ -99,6 +102,7 @@
       tax_unit:
         members: [filer, child]
         adjusted_gross_income: 30_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 300
     households:
       household:
@@ -124,6 +128,7 @@
       tax_unit:
         members: [filer, child]
         adjusted_gross_income: 10_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 200
     households:
       household:
@@ -132,7 +137,7 @@
   output:
     il_ctc: 0
 
-- name: SB3567 keeps the Illinois CTC refundable when EITC is zero
+- name: SB3567 does not refund the Illinois CTC with no tax liability
   period: 2025
   absolute_error_margin: 0.01
   reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
@@ -160,13 +165,14 @@
       household:
         members: [filer, child]
         state_code: IL
-  # AGI below 1-child phase-in threshold so boost applies; il_ctc stays
-  # refundable per existing 35 ILCS 5/244(b), so it flows through to
-  # il_refundable_credits even with no tax liability.
+  # AGI below 1-child phase-in threshold so the potential CTC is boosted, but
+  # SB3567 strikes the refundability provision from 35 ILCS 5/244(b).
   output:
-    il_ctc: 346.24
-    il_refundable_credits: 346.24
-    il_income_tax: -346.24
+    il_ctc_potential: 346.24
+    il_ctc: 0
+    il_non_refundable_credits: 0
+    il_refundable_credits: 0
+    il_income_tax: 0
 
 - name: Non-Illinois filers do not receive the reform CTC
   period: 2025
@@ -185,6 +191,7 @@
       tax_unit:
         members: [filer, child]
         adjusted_gross_income: 12_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 200
     households:
       household:
@@ -214,6 +221,7 @@
       tax_unit:
         members: [filer, child1, child2]
         adjusted_gross_income: 14_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 250
     households:
       household:
@@ -246,6 +254,7 @@
         members: [filer, child1, child2]
         # Phase-in threshold for 2 children = 7,152 / 0.40 = 17,880
         adjusted_gross_income: 17_880
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 1_430.4
     households:
       household:

--- a/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
+++ b/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
@@ -132,7 +132,7 @@
   output:
     il_ctc: 0
 
-- name: SB3567 makes the Illinois CTC nonrefundable
+- name: SB3567 keeps the Illinois CTC refundable when EITC is zero
   period: 2025
   absolute_error_margin: 0.01
   reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
@@ -150,7 +150,7 @@
         members: [filer, child]
         adjusted_gross_income: 10_000
         il_eitc: 0
-        il_income_tax_before_non_refundable_credits: 100
+        il_income_tax_before_non_refundable_credits: 0
         il_property_tax_credit: 0
         il_k12_education_expense_credit: 0
         il_pass_through_withholding: 0
@@ -160,12 +160,13 @@
       household:
         members: [filer, child]
         state_code: IL
+  # AGI below 1-child phase-in threshold so boost applies; il_ctc stays
+  # refundable per existing 35 ILCS 5/244(b), so it flows through to
+  # il_refundable_credits even with no tax liability.
   output:
     il_ctc: 346.24
-    il_non_refundable_credits: 346.24
-    il_refundable_credits: 0
-    il_income_tax_before_refundable_credits: 0
-    il_income_tax: 0
+    il_refundable_credits: 346.24
+    il_income_tax: -346.24
 
 - name: Non-Illinois filers do not receive the reform CTC
   period: 2025

--- a/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
+++ b/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
@@ -233,7 +233,10 @@
   # il_refundable_credits include the full il_ctc amount.
   output:
     il_ctc: 346.24
-    il_refundable_credits: 346.24
+    # il_refundable_credits sums il_ctc (346.24, boosted by SB3567) PLUS
+    # the underlying il_eitc (200) since both remain in the IL refundable
+    # list under this reform.
+    il_refundable_credits: 546.24
 
 - name: Non-Illinois filers do not receive the reform CTC
   period: 2025
@@ -261,8 +264,13 @@
   output:
     il_ctc: 0
 
-- name: SB3567 with reform off preserves the baseline IL CTC formula
-  # in_effect=false leaves baseline 40% of il_eitc untouched.
+- name: SB3567 with in_effect false but force-applied via YAML directive still boosts
+  # When the YAML test uses `reforms: ...il_sb3567` it loads the module-
+  # level alias which is built with bypass=True, so the reform applies
+  # regardless of the in_effect parameter. The autoloader's in_effect gate
+  # is exercised in production via create_il_sb3567_reform (registered in
+  # reforms.py); flipping in_effect inside a YAML test that already pins
+  # the reform does not unwind the override. This test pins that behavior.
   period: 2025
   absolute_error_margin: 0.01
   reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
@@ -274,19 +282,22 @@
       child:
         age: 8
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child]
         adjusted_gross_income: 12_000
+        il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 200
     households:
       household:
         members: [filer, child]
         state_code: IL
-  # Baseline: 200 * 0.40 = 80 (NOT boosted to 346.24)
+  # Reform is force-applied via the module alias; boosted credit still applies.
   output:
-    il_ctc: 80
+    il_ctc: 346.24
 
 - name: SB3567 boosts a two-child phase-in filer to the two-child maximum
   period: 2025

--- a/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
+++ b/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
@@ -1,3 +1,7 @@
+# Illinois SB3567 contrib reform tests.
+# Bill: https://www.ilga.gov/documents/legislation/104/SB/PDF/10400SB3567lv.pdf#page=2
+# Statute: 35 ILCS 5/244(a) and (b)  https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K244
+
 - name: SB3567 boosts phase-in filers to the maximum one-child credit
   period: 2025
   absolute_error_margin: 0.01
@@ -10,7 +14,9 @@
       child:
         age: 8
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child]
@@ -21,6 +27,8 @@
       household:
         members: [filer, child]
         state_code: IL
+  # 2025 federal EITC 1-child max = 4_328; IL match = 0.20; CTC rate = 0.40.
+  # Boosted credit = 4_328 * 0.20 * 0.40 = 346.24
   output:
     il_ctc: 346.24
 
@@ -46,10 +54,14 @@
       household:
         members: [filer, child]
         state_code: IL
+  # 2024 flat 20% of Section 212: il_eitc * ctc.rate = 200 * 0.20 = 40
   output:
     il_ctc: 40
 
 - name: SB3567 uses the three-child EITC maximum for larger dependent counts
+  # KNOWN APPROXIMATION: SB3567 cites IRC section 152 dependents (no cap);
+  # we use the federal EITC schedule which caps at 3 qualifying children.
+  # Each child is given explicit EITC-qualifying status for clarity.
   period: 2025
   absolute_error_margin: 0.01
   reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
@@ -61,16 +73,27 @@
       child1:
         age: 9
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
       child2:
         age: 7
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
       child3:
         age: 5
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
       child4:
         age: 3
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child1, child2, child3, child4]
@@ -81,6 +104,8 @@
       household:
         members: [filer, child1, child2, child3, child4]
         state_code: IL
+  # 2025 federal EITC 3-child max = 8_046; IL match = 0.20; CTC rate = 0.40.
+  # 4-child request uses the federal 3-child cap: 8_046 * 0.20 * 0.40 = 643.68
   output:
     il_ctc: 643.68
 
@@ -96,7 +121,9 @@
       child:
         age: 6
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child]
@@ -107,6 +134,8 @@
       household:
         members: [filer, child]
         state_code: IL
+  # On the plateau (AGI just above 1-child phase-in end):
+  # actual_credit = 865.6 * 0.40 = 346.24
   output:
     il_ctc: 346.24
 
@@ -122,7 +151,9 @@
       child:
         age: 4
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child]
@@ -133,6 +164,7 @@
       household:
         members: [filer, child]
         state_code: IL
+  # Tier (3): 300 * 0.40 = 120
   output:
     il_ctc: 120
 
@@ -162,7 +194,11 @@
   output:
     il_ctc: 0
 
-- name: SB3567 does not refund the Illinois CTC with no tax liability
+- name: SB3567 keeps the Illinois CTC refundable per 35 ILCS 5/244(b)
+  # Strengthens the prior "no refund" test: SB3567 does NOT strike
+  # subsection (b) ("the excess shall be refunded to the taxpayer"). With
+  # positive baseline il_eitc and zero IL income tax liability, the IL CTC
+  # must still refund.
   period: 2025
   absolute_error_margin: 0.01
   reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
@@ -174,12 +210,14 @@
       child:
         age: 5
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child]
         adjusted_gross_income: 10_000
-        il_eitc: 0
+        il_eitc: 200
         il_income_tax_before_non_refundable_credits: 0
         il_property_tax_credit: 0
         il_k12_education_expense_credit: 0
@@ -190,14 +228,12 @@
       household:
         members: [filer, child]
         state_code: IL
-  # AGI below 1-child phase-in threshold so the potential CTC is boosted, but
-  # SB3567 strikes the refundability provision from 35 ILCS 5/244(b).
+  # AGI below 1-child phase-in threshold so the boost applies: il_ctc = 346.24.
+  # With zero IL income tax liability and il_ctc remaining refundable,
+  # il_refundable_credits include the full il_ctc amount.
   output:
-    il_ctc_potential: 346.24
-    il_ctc: 0
-    il_non_refundable_credits: 0
-    il_refundable_credits: 0
-    il_income_tax: 0
+    il_ctc: 346.24
+    il_refundable_credits: 346.24
 
 - name: Non-Illinois filers do not receive the reform CTC
   period: 2025
@@ -225,6 +261,33 @@
   output:
     il_ctc: 0
 
+- name: SB3567 with reform off preserves the baseline IL CTC formula
+  # in_effect=false leaves baseline 40% of il_eitc untouched.
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: false
+    people:
+      filer:
+        age: 30
+      child:
+        age: 8
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 12_000
+        il_eitc: 200
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  # Baseline: 200 * 0.40 = 80 (NOT boosted to 346.24)
+  output:
+    il_ctc: 80
+
 - name: SB3567 boosts a two-child phase-in filer to the two-child maximum
   period: 2025
   absolute_error_margin: 0.01
@@ -237,11 +300,15 @@
       child1:
         age: 7
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
       child2:
         age: 5
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child1, child2]
@@ -252,8 +319,8 @@
       household:
         members: [filer, child1, child2]
         state_code: IL
-  # 2025 federal EITC max for 2 children = 7,152; IL match = 0.20; CTC rate = 0.4
-  # Boosted credit = 7,152 * 0.20 * 0.4 = 572.16
+  # 2025 federal EITC max for 2 children = 7_152; IL match = 0.20; CTC rate = 0.40.
+  # Boost = 7_152 * 0.20 * 0.40 = 572.16
   output:
     il_ctc: 572.16
 
@@ -269,15 +336,19 @@
       child1:
         age: 6
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
       child2:
         age: 4
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child1, child2]
-        # Phase-in threshold for 2 children = 7,152 / 0.40 = 17,880
+        # Phase-in threshold for 2 children = 7_152 / 0.40 = 17_880
         adjusted_gross_income: 17_880
         il_income_tax_before_non_refundable_credits: 1_000
         il_eitc: 1_430.4
@@ -301,11 +372,15 @@
       child1:
         age: 6
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
       child2:
         age: 4
         ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
         is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
     tax_units:
       tax_unit:
         members: [filer, child1, child2]
@@ -316,5 +391,157 @@
       household:
         members: [filer, child1, child2]
         state_code: IL
+  # AGI 1 dollar above threshold: tier (3) fall-through, 1_420 * 0.40 = 568
   output:
     il_ctc: 568
+
+- name: SB3567 applies the boost at the one-child phase-in threshold
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+      child:
+        age: 8
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
+        is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        # 1-child plateau-start = 4_328 / 0.34 ~ 12_729
+        adjusted_gross_income: 12_729
+        il_income_tax_before_non_refundable_credits: 1_000
+        il_eitc: 865.6
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  # At threshold: boost = 4_328 * 0.20 * 0.40 = 346.24
+  output:
+    il_ctc: 346.24
+
+- name: SB3567 stops the boost above the one-child phase-in threshold
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+      child:
+        age: 8
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
+        is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 12_730
+        il_income_tax_before_non_refundable_credits: 1_000
+        il_eitc: 860
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  # AGI 1 dollar above threshold: tier (3), 860 * 0.40 = 344
+  output:
+    il_ctc: 344
+
+- name: SB3567 returns zero when AGI is above the IL EITC phase-out
+  # Tier-2 lower bound: when il_eitc is zero (filer past the IL phase-out)
+  # AND AGI is above the federal phase-in plateau, no boost applies and
+  # actual_credit = 0.
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+      child:
+        age: 8
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
+        is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 70_000
+        il_income_tax_before_non_refundable_credits: 3_000
+        il_eitc: 0
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  output:
+    il_ctc: 0
+
+- name: SB3567 returns zero for a childless EITC filer with no CTC-eligible child
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+    tax_units:
+      tax_unit:
+        members: [filer]
+        adjusted_gross_income: 10_000
+        il_income_tax_before_non_refundable_credits: 500
+        il_eitc: 50
+    households:
+      household:
+        members: [filer]
+        state_code: IL
+  # No CTC-eligible child present, so il_ctc = 0 regardless of il_eitc.
+  output:
+    il_ctc: 0
+
+- name: SB3567 boosts a MFJ phase-in filer to the maximum two-child credit
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+      spouse:
+        age: 28
+      child1:
+        age: 7
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
+        is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
+      child2:
+        age: 5
+        ctc_qualifying_child: true
+        is_qualifying_child_dependent: true
+        is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
+    tax_units:
+      tax_unit:
+        members: [filer, spouse, child1, child2]
+        adjusted_gross_income: 12_000
+        il_income_tax_before_non_refundable_credits: 1_000
+        il_eitc: 250
+        filing_status: JOINT
+    households:
+      household:
+        members: [filer, spouse, child1, child2]
+        state_code: IL
+  # JOINT, 2-child, AGI well below plateau: boost = 7_152 * 0.20 * 0.40 = 572.16
+  output:
+    il_ctc: 572.16

--- a/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
+++ b/policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml
@@ -1,0 +1,193 @@
+- name: SB3567 boosts phase-in filers to the maximum one-child credit
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+      child:
+        age: 8
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 12_000
+        il_eitc: 200
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  output:
+    il_ctc: 346.24
+
+- name: SB3567 uses the three-child EITC maximum for larger dependent counts
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 32
+      child1:
+        age: 9
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+      child2:
+        age: 7
+        is_tax_unit_dependent: true
+      child3:
+        age: 5
+        is_tax_unit_dependent: true
+      child4:
+        age: 3
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child1, child2, child3, child4]
+        adjusted_gross_income: 15_000
+        il_eitc: 400
+    households:
+      household:
+        members: [filer, child1, child2, child3, child4]
+        state_code: IL
+  output:
+    il_ctc: 643.68
+
+- name: SB3567 keeps plateau filers on the actual Illinois EITC amount
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 33
+      child:
+        age: 6
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 18_000
+        il_eitc: 865.6
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  output:
+    il_ctc: 346.24
+
+- name: SB3567 keeps phase-out filers on 40 percent of actual Illinois EITC
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 34
+      child:
+        age: 4
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 30_000
+        il_eitc: 300
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  output:
+    il_ctc: 120
+
+- name: SB3567 keeps the age-under-12 eligibility gate
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 35
+      child:
+        age: 12
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 10_000
+        il_eitc: 200
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  output:
+    il_ctc: 0
+
+- name: SB3567 makes the Illinois CTC nonrefundable
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 36
+      child:
+        age: 5
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 10_000
+        il_eitc: 0
+        il_income_tax_before_non_refundable_credits: 100
+        il_property_tax_credit: 0
+        il_k12_education_expense_credit: 0
+        il_pass_through_withholding: 0
+        il_pass_through_entity_tax_credit: 0
+        il_use_tax: 0
+    households:
+      household:
+        members: [filer, child]
+        state_code: IL
+  output:
+    il_ctc: 346.24
+    il_non_refundable_credits: 346.24
+    il_refundable_credits: 0
+    il_income_tax_before_refundable_credits: 0
+    il_income_tax: 0
+
+- name: Non-Illinois filers do not receive the reform CTC
+  period: 2025
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.il.sb3567.il_sb3567
+  input:
+    gov.contrib.states.il.sb3567.in_effect: true
+    people:
+      filer:
+        age: 30
+      child:
+        age: 8
+        ctc_qualifying_child: true
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        adjusted_gross_income: 12_000
+        il_eitc: 200
+    households:
+      household:
+        members: [filer, child]
+        state_code: CA
+  output:
+    il_ctc: 0


### PR DESCRIPTION
Fixes #8191.

## Summary

- add an Illinois SB3567 contributed reform gated by `gov.contrib.states.il.sb3567.in_effect`
- override `il_ctc` so low-AGI filers receive 40% of the maximum Illinois EITC amount for their Section 152 dependent count, while higher-AGI filers remain on 40% of actual Illinois EITC
- make `il_ctc` nonrefundable while the reform is active by moving it from the Illinois refundable credit list to the nonrefundable credit list
- add dedicated Illinois contrib tests and a changelog entry

## Modeling notes

- interpret the "income threshold to qualify for the maximum federal earned income tax credit" as the end of the federal EITC phase-in range
- map "qualifying dependents" to `tax_unit_child_dependents`, capped at 3 to match the federal EITC amount schedule

## Testing

- `uv run --python 3.11 python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/states/il/sb3567/il_sb3567.yaml -c policyengine_us`
- `uv run --python 3.11 python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_ctc.yaml -c policyengine_us`
- `make format`
