### PR TITLE
Reconcile FLSA overtime regular rate with employment income

### DIFF
--- a/changelog.d/8190.fixed.md
+++ b/changelog.d/8190.fixed.md
@@ -1,0 +1,1 @@
+Reconciled FLSA overtime regular-rate calculations with annual employment income.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/exemptions/fsla_overtime_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/exemptions/fsla_overtime_premium.yaml
@@ -40,7 +40,22 @@
   output:
     fsla_overtime_premium: 5105.4545
 
-- name: Overtime income premium calculation uses hourly wage for hourly workers
+- name: Overtime income premium calculation uses hourly wage for hourly workers when compatible with annual income
+  period: 2024
+  input:
+    hours_worked_last_week: 50
+    employment_income: 57200
+    hourly_wage: 20
+    is_paid_hourly: true
+    has_never_worked: false
+    is_military: false
+    is_executive_administrative_professional: true
+    is_farmer_fisher: false
+    is_computer_scientist: false
+  output:
+    fsla_overtime_premium: 5200
+
+- name: Overtime income premium calculation uses annual income implied rate when hourly wage understates annual income
   period: 2024
   input:
     hours_worked_last_week: 50
@@ -53,7 +68,22 @@
     is_farmer_fisher: false
     is_computer_scientist: false
   output:
-    fsla_overtime_premium: 5200
+    fsla_overtime_premium: 9090.9091
+
+- name: Overtime income premium calculation caps hourly wage at annual income implied rate
+  period: 2024
+  input:
+    hours_worked_last_week: 50
+    employment_income: 65000
+    hourly_wage: 25
+    is_paid_hourly: true
+    has_never_worked: false
+    is_military: false
+    is_executive_administrative_professional: true
+    is_farmer_fisher: false
+    is_computer_scientist: false
+  output:
+    fsla_overtime_premium: 5909.0909
 
 - name: Overtime income premium falls back when hourly wage is unavailable
   period: 2024

--- a/policyengine_us/tests/policy/baseline/household/income/person/fsla_regular_rate.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/fsla_regular_rate.yaml
@@ -1,0 +1,39 @@
+- name: FLSA regular rate uses annual employment income when wages and hours are available
+  period: 2024
+  input:
+    hours_worked_last_week: 50
+    employment_income: 100000
+    hourly_wage: 20
+    is_paid_hourly: true
+  output:
+    fsla_regular_rate: 34.9650
+
+- name: FLSA regular rate matches hourly wage when annual income reconciles
+  period: 2024
+  input:
+    hours_worked_last_week: 50
+    employment_income: 57200
+    hourly_wage: 20
+    is_paid_hourly: true
+  output:
+    fsla_regular_rate: 20
+
+- name: FLSA regular rate falls back to hourly wage when annual employment income is unavailable
+  period: 2024
+  input:
+    hours_worked_last_week: 50
+    employment_income: 0
+    hourly_wage: 25
+    is_paid_hourly: true
+  output:
+    fsla_regular_rate: 25
+
+- name: FLSA regular rate is zero without annual employment income or hourly wage
+  period: 2024
+  input:
+    hours_worked_last_week: 50
+    employment_income: 0
+    hourly_wage: 0
+    is_paid_hourly: true
+  output:
+    fsla_regular_rate: 0

--- a/policyengine_us/variables/household/income/person/fsla_overtime_premium.py
+++ b/policyengine_us/variables/household/income/person/fsla_overtime_premium.py
@@ -12,22 +12,13 @@ class fsla_overtime_premium(Variable):
     def formula_2014(person, period, parameters):
         p = parameters(period).gov.irs.income.exemption.overtime
         worked_hours = person("hours_worked_last_week", period)
-        is_paid_hourly = person("is_paid_hourly", period)
-        hourly_wage = person("hourly_wage", period)
+        regular_rate = person("fsla_regular_rate", period)
 
         weekly_overtime_hours = max_(worked_hours - p.hours_threshold, 0)
-        # Straight-time–equivalent hours in the year
-        hour_equivalents = WEEKS_IN_YEAR * (
-            p.hours_threshold + weekly_overtime_hours * p.rate_multiplier
-        )
-        implied_base_rate = person("employment_income", period) / hour_equivalents
-        # Hourly workers can use the ORG-backed straight-time rate directly.
-        base_rate = where(
-            is_paid_hourly & (hourly_wage > 0),
-            hourly_wage,
-            implied_base_rate,
-        )
         # Return only the overtime premium (e.g. the 50 % in time-and-a-half)
         return (
-            base_rate * (p.rate_multiplier - 1) * weekly_overtime_hours * WEEKS_IN_YEAR
+            regular_rate
+            * (p.rate_multiplier - 1)
+            * weekly_overtime_hours
+            * WEEKS_IN_YEAR
         )

--- a/policyengine_us/variables/household/income/person/fsla_regular_rate.py
+++ b/policyengine_us/variables/household/income/person/fsla_regular_rate.py
@@ -1,0 +1,40 @@
+from policyengine_us.model_api import *
+
+
+class fsla_regular_rate(Variable):
+    value_type = float
+    entity = Person
+    label = "regular hourly rate for FLSA overtime"
+    documentation = (
+        "Reconciles weekly hours with annual employment income for FLSA overtime "
+        "calculations. ORG-backed hourly wage is a fallback when annual earnings "
+        "and hours cannot identify a regular rate."
+    )
+    unit = USD
+    definition_period = YEAR
+
+    def formula_2014(person, period, parameters):
+        p = parameters(period).gov.irs.income.exemption.overtime
+        worked_hours = person("hours_worked_last_week", period)
+        employment_income = person("employment_income", period)
+        is_paid_hourly = person("is_paid_hourly", period)
+        hourly_wage = person("hourly_wage", period)
+
+        weekly_overtime_hours = max_(worked_hours - p.hours_threshold, 0)
+        weekly_straight_time_hours = min_(max_(worked_hours, 0), p.hours_threshold)
+        straight_time_equivalent_hours = WEEKS_IN_YEAR * (
+            weekly_straight_time_hours + weekly_overtime_hours * p.rate_multiplier
+        )
+        employment_income_rate = employment_income / max_(
+            straight_time_equivalent_hours, 1
+        )
+        employment_income_rate_available = (employment_income > 0) & (
+            straight_time_equivalent_hours > 0
+        )
+        hourly_wage_available = is_paid_hourly & (hourly_wage > 0)
+
+        return where(
+            employment_income_rate_available,
+            employment_income_rate,
+            where(hourly_wage_available, hourly_wage, 0),
+        )


### PR DESCRIPTION
## Summary

Fixes #8190.

- Add `fsla_regular_rate` as the explicit reconciliation point for FLSA overtime calculations.
- Use annual `employment_income` and weekly hours to infer the regular rate when they are available.
- Fall back to ORG-backed `hourly_wage` only when annual employment income and hours cannot identify a rate.
- Update `fsla_overtime_premium` to consume `fsla_regular_rate`.
- Add regression coverage for both mismatch directions and the issue example.

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/income/exemptions/fsla_overtime_premium.yaml policyengine_us/tests/policy/baseline/household/income/person/fsla_regular_rate.yaml -c policyengine_us`
- `uv run ruff format policyengine_us/variables/household/income/person/fsla_regular_rate.py policyengine_us/variables/household/income/person/fsla_overtime_premium.py`
- `uv run ruff check policyengine_us/variables/household/income/person/fsla_regular_rate.py policyengine_us/variables/household/income/person/fsla_overtime_premium.py`
- `git diff --check`
- GitNexus impact/detect-changes: low risk, 0 affected processes