### PR TITLE
Add Trustees core threshold reform

### DIFF
--- a/changelog.d/crfb-trustees-thresholds.added.md
+++ b/changelog.d/crfb-trustees-thresholds.added.md
@@ -1,0 +1,1 @@
+Added an explicit Trustees core threshold reform for long-run TOB analysis scenarios.

--- a/policyengine_us/reforms/ssa/__init__.py
+++ b/policyengine_us/reforms/ssa/__init__.py
@@ -1,0 +1,11 @@
+from .trustees_2025 import (
+    TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT,
+    TRUSTEES_2025_NAWI_ASSUMPTION,
+    apply_trustees_2025_economic_assumptions,
+    apply_trustees_2025_nawi_projection,
+)
+from .trustees_core_thresholds import (
+    TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
+    create_trustees_core_thresholds_reform,
+    trustees_core_thresholds_reform,
+)

--- a/policyengine_us/reforms/ssa/trustees_2025.py
+++ b/policyengine_us/reforms/ssa/trustees_2025.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Any
+
+from policyengine_core.periods import instant
+
+from policyengine_us.parameters.uprating_extensions import (
+    extend_social_security_payroll_cap,
+)
+
+
+TRUSTEES_2025_NAWI_ASSUMPTION: dict[str, Any] = {
+    "name": "trustees-2025-nawi-v1",
+    "description": (
+        "SSA 2025 Trustees intermediate projection for the National Average "
+        "Wage Index, used by explicit long-run Trustees scenarios."
+    ),
+    "source": "SSA 2025 Trustees Report table V.B1",
+    "start_year": 2034,
+    "end_year": 2100,
+    "not_default_current_law": True,
+}
+
+# SSA 2025 Trustees Report, table V.B1, intermediate assumptions. Values are
+# annual percentage changes in the nominal average annual wage in covered
+# employment for the listed calendar year.
+TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT: dict[int, float] = {
+    2034: 3.85,
+    2035: 3.72,
+    2036: 3.65,
+    2037: 3.66,
+    2038: 3.66,
+    2039: 3.68,
+    2040: 3.65,
+    2041: 3.63,
+    2042: 3.62,
+    2043: 3.60,
+    2044: 3.57,
+    2045: 3.55,
+    2046: 3.53,
+    2047: 3.53,
+    2048: 3.53,
+    2049: 3.52,
+    2050: 3.51,
+    2051: 3.51,
+    2052: 3.51,
+    2053: 3.50,
+    2054: 3.50,
+    2055: 3.49,
+    2056: 3.50,
+    2057: 3.51,
+    2058: 3.52,
+    2059: 3.52,
+    2060: 3.53,
+    2061: 3.53,
+    2062: 3.54,
+    2063: 3.55,
+    2064: 3.55,
+    2065: 3.55,
+    2066: 3.55,
+    2067: 3.56,
+    2068: 3.55,
+    2069: 3.55,
+    2070: 3.56,
+    2071: 3.55,
+    2072: 3.55,
+    2073: 3.55,
+    2074: 3.55,
+    2075: 3.56,
+    2076: 3.56,
+    2077: 3.56,
+    2078: 3.56,
+    2079: 3.56,
+    2080: 3.55,
+    2081: 3.56,
+    2082: 3.56,
+    2083: 3.56,
+    2084: 3.56,
+    2085: 3.56,
+    2086: 3.57,
+    2087: 3.56,
+    2088: 3.56,
+    2089: 3.56,
+    2090: 3.56,
+    2091: 3.56,
+    2092: 3.56,
+    2093: 3.55,
+    2094: 3.55,
+    2095: 3.55,
+    2096: 3.55,
+    2097: 3.55,
+    2098: 3.55,
+    2099: 3.55,
+    2100: 3.55,
+}
+
+
+def apply_trustees_2025_nawi_projection(
+    parameters,
+    *,
+    start_year: int = 2034,
+    end_year: int = 2100,
+) -> None:
+    nawi = parameters.gov.ssa.nawi
+    previous_value = float(nawi(f"{start_year - 1}-01-01"))
+    values_by_year = {}
+
+    for year in range(start_year, end_year + 1):
+        try:
+            growth = 1 + TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT[year] / 100
+        except KeyError as error:
+            raise ValueError(
+                f"No SSA Trustees 2025 NAWI growth rate for {year}."
+            ) from error
+        previous_value *= growth
+        values_by_year[year] = previous_value
+
+    for year, value in values_by_year.items():
+        nawi.update(period=f"year:{year}-01-01:1", value=value)
+
+    if values_by_year:
+        nawi.update(
+            start=instant(f"{end_year}-01-01"),
+            value=values_by_year[end_year],
+        )
+
+
+def apply_trustees_2025_economic_assumptions(
+    parameters,
+    *,
+    end_year: int = 2100,
+) -> None:
+    apply_trustees_2025_nawi_projection(parameters, end_year=end_year)
+    extend_social_security_payroll_cap(
+        parameters,
+        last_projected_year=2035,
+        end_year=end_year,
+    )

--- a/policyengine_us/reforms/ssa/trustees_2025.py
+++ b/policyengine_us/reforms/ssa/trustees_2025.py
@@ -21,6 +21,26 @@ TRUSTEES_2025_NAWI_ASSUMPTION: dict[str, Any] = {
     "not_default_current_law": True,
 }
 
+TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS: tuple[str, ...] = (
+    "alimony_income",
+    "employment_income",
+    "farm_income",
+    "farm_rent_income",
+    "long_term_capital_gains",
+    "non_qualified_dividend_income",
+    "partnership_s_corp_income",
+    "qualified_dividend_income",
+    "rental_income",
+    "self_employment_income",
+    "short_term_capital_gains",
+    "social_security",
+    "tax_exempt_interest_income",
+    "tax_exempt_pension_income",
+    "taxable_interest_income",
+    "taxable_pension_income",
+    "unemployment_compensation",
+)
+
 # SSA 2025 Trustees Report, table V.B1, intermediate assumptions. Values are
 # annual percentage changes in the nominal average annual wage in covered
 # employment for the listed calendar year.
@@ -125,12 +145,47 @@ def apply_trustees_2025_nawi_projection(
         )
 
 
+def apply_trustees_2025_soi_income_projection(
+    parameters,
+    *,
+    last_projected_year: int = 2036,
+    end_year: int = 2100,
+) -> None:
+    """Extend SOI income uprating aggregates using the Trustees NAWI path.
+
+    PolicyEngine input variables such as employment income and Social Security
+    benefits use these calibration totals as uprating factors. If they flatten
+    after the CBO projection window, nominal incomes freeze in long-run
+    microsimulations even when NAWI and tax parameters keep growing.
+    """
+
+    nawi = parameters.gov.ssa.nawi
+    soi = parameters.calibration.gov.irs.soi
+
+    for parameter_name in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS:
+        parameter = getattr(soi, parameter_name)
+
+        for year in range(last_projected_year + 1, end_year + 1):
+            previous_value = float(parameter(f"{year - 1}-01-01"))
+            wage_growth = float(nawi(f"{year}-01-01")) / float(
+                nawi(f"{year - 1}-01-01")
+            )
+            parameter.update(
+                period=f"year:{year}-01-01:1",
+                value=previous_value * wage_growth,
+            )
+
+        final_value = float(parameter(f"{end_year}-01-01"))
+        parameter.update(start=instant(f"{end_year}-01-01"), value=final_value)
+
+
 def apply_trustees_2025_economic_assumptions(
     parameters,
     *,
     end_year: int = 2100,
 ) -> None:
     apply_trustees_2025_nawi_projection(parameters, end_year=end_year)
+    apply_trustees_2025_soi_income_projection(parameters, end_year=end_year)
     extend_social_security_payroll_cap(
         parameters,
         last_projected_year=2035,

--- a/policyengine_us/reforms/ssa/trustees_core_thresholds.py
+++ b/policyengine_us/reforms/ssa/trustees_core_thresholds.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from policyengine_us.model_api import Reform
+from policyengine_us.reforms.ssa.trustees_2025 import (
+    TRUSTEES_2025_NAWI_ASSUMPTION,
+    apply_trustees_2025_economic_assumptions,
+)
+
+
+TRUSTEES_CORE_THRESHOLD_ASSUMPTION: dict[str, Any] = {
+    "name": "trustees-2025-core-thresholds-v1",
+    "description": (
+        "Best-public Trustees tax-side approximation: keep Social Security "
+        "benefit-tax thresholds fixed, but wage-index core ordinary federal "
+        "tax thresholds after 2034 using the active NAWI path."
+    ),
+    "source": "SSA 2025 Trustees Report V.C.7",
+    "start_year": 2035,
+    "projection_base_year": 2026,
+    "parameter_groups": [
+        "ordinary_income_brackets",
+        "standard_deduction",
+        "aged_blind_standard_deduction",
+        "capital_gains_thresholds",
+        "amt_thresholds",
+    ],
+    "economic_assumption": TRUSTEES_2025_NAWI_ASSUMPTION["name"],
+    "not_default_current_law": True,
+}
+
+
+def _round_amount(amount: float, rounding: dict | None) -> float:
+    if not rounding:
+        return amount
+
+    interval = float(rounding["interval"])
+    rounding_type = rounding["type"]
+
+    if rounding_type == "downwards":
+        return math.floor(amount / interval) * interval
+    if rounding_type == "nearest":
+        return math.floor(amount / interval + 0.5) * interval
+
+    raise ValueError(f"Unsupported rounding type: {rounding_type}")
+
+
+def _uprating_parameter_name(parameter) -> str | None:
+    metadata = getattr(parameter, "metadata", {})
+    uprating = metadata.get("uprating")
+    if isinstance(uprating, dict):
+        return uprating.get("parameter")
+    return uprating
+
+
+def _get_parameter_by_name(parameters, name: str):
+    current = parameters
+    for part in name.split("."):
+        current = getattr(current, part)
+    return current
+
+
+def _nawi_growth_for_tax_year(parameters, year: int) -> float:
+    nawi = parameters.gov.ssa.nawi
+    return float(nawi(f"{year - 1}-01-01")) / float(nawi(f"{year - 2}-01-01"))
+
+
+def _iter_updatable_parameters(
+    root,
+    *,
+    uprating_parameter: str | None = None,
+) -> list:
+    candidates = [root]
+    if hasattr(root, "get_descendants"):
+        candidates.extend(root.get_descendants())
+
+    result = []
+    for candidate in candidates:
+        if candidate.__class__.__name__ != "Parameter":
+            continue
+        uprating_name = _uprating_parameter_name(candidate)
+        if uprating_name is None:
+            continue
+        if uprating_parameter is not None and uprating_name != uprating_parameter:
+            continue
+        result.append(candidate)
+    return result
+
+
+def _apply_wage_growth_to_parameter(
+    parameter,
+    *,
+    parameters,
+    start_year: int,
+    end_year: int,
+    projection_base_year: int,
+) -> None:
+    metadata = getattr(parameter, "metadata", {})
+    uprating = metadata.get("uprating")
+    rounding = uprating.get("rounding") if isinstance(uprating, dict) else None
+    uprating_name = _uprating_parameter_name(parameter)
+    if uprating_name is None:
+        return
+
+    # Validate that the referenced default uprating parameter exists.
+    _get_parameter_by_name(parameters, uprating_name)
+    values_by_year = {}
+
+    for year in range(projection_base_year + 1, start_year):
+        values_by_year[year] = float(parameter(f"{year}-01-01"))
+
+    for year in range(start_year, end_year + 1):
+        if year - 1 in values_by_year:
+            previous_value = values_by_year[year - 1]
+        else:
+            previous_value = float(parameter(f"{year - 1}-01-01"))
+        updated_value = _round_amount(
+            previous_value * _nawi_growth_for_tax_year(parameters, year),
+            rounding,
+        )
+        values_by_year[year] = updated_value
+
+    for year, value in values_by_year.items():
+        parameter.update(
+            period=f"year:{year}-01-01:1",
+            value=value,
+        )
+
+
+def _core_threshold_roots(parameters) -> list:
+    return [
+        parameters.gov.irs.income.bracket.thresholds,
+        parameters.gov.irs.deductions.standard.amount,
+        parameters.gov.irs.deductions.standard.aged_or_blind.amount,
+        parameters.gov.irs.capital_gains.thresholds,
+        parameters.gov.irs.income.amt.brackets,
+        parameters.gov.irs.income.amt.exemption.amount,
+        parameters.gov.irs.income.amt.exemption.phase_out.start,
+        parameters.gov.irs.income.amt.exemption.separate_limit,
+    ]
+
+
+def _parameters_have_long_run_projection(parameters, end_year: int) -> bool:
+    parameter = parameters.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    return any(
+        value.instant_str == f"{end_year}-01-01" for value in parameter.values_list
+    )
+
+
+def create_trustees_core_thresholds_reform(
+    *,
+    start_year: int = 2035,
+    end_year: int = 2100,
+    projection_base_year: int = 2026,
+) -> Reform:
+    """Return a Trustees-style long-run tax-threshold assumption reform.
+
+    This is an explicit scenario assumption, not default current law. It leaves
+    Social Security benefit-tax thresholds unchanged and wage-indexes the core
+    IRS thresholds used by the CRFB long-run TOB analysis from ``start_year``.
+    """
+
+    def modify_parameters(parameters):
+        if not _parameters_have_long_run_projection(parameters, end_year):
+            return parameters
+
+        apply_trustees_2025_economic_assumptions(
+            parameters,
+            end_year=end_year,
+        )
+
+        seen = set()
+        for root in _core_threshold_roots(parameters):
+            for parameter in _iter_updatable_parameters(root):
+                if parameter.name in seen:
+                    continue
+                seen.add(parameter.name)
+                _apply_wage_growth_to_parameter(
+                    parameter,
+                    parameters=parameters,
+                    start_year=start_year,
+                    end_year=end_year,
+                    projection_base_year=projection_base_year,
+                )
+        return parameters
+
+    class reform(Reform):
+        def apply(self):
+            self.modify_parameters(modify_parameters)
+
+    return reform
+
+
+trustees_core_thresholds_reform = create_trustees_core_thresholds_reform()

--- a/policyengine_us/reforms/ssa/trustees_core_thresholds.py
+++ b/policyengine_us/reforms/ssa/trustees_core_thresholds.py
@@ -28,6 +28,7 @@ TRUSTEES_CORE_THRESHOLD_ASSUMPTION: dict[str, Any] = {
         "amt_thresholds",
     ],
     "economic_assumption": TRUSTEES_2025_NAWI_ASSUMPTION["name"],
+    "income_uprating_assumption": "trustees-2025-soi-income-nawi-v1",
     "not_default_current_law": True,
 }
 

--- a/policyengine_us/tests/core/test_run_selective_tests.py
+++ b/policyengine_us/tests/core/test_run_selective_tests.py
@@ -54,3 +54,39 @@ def test_limit_test_paths_can_defer_to_full_suite_when_no_changed_tests_exist():
     )
 
     assert limited_paths == set()
+
+
+def test_limit_test_paths_defers_slow_ssa_baseline_directory():
+    runner = SelectiveTestRunner()
+
+    changed_files = {
+        "policyengine_us/variables/gov/ssa/ss/social_security_retirement.py",
+    }
+
+    limited_paths = runner.limit_test_paths(
+        runner.map_files_to_tests(changed_files), changed_files
+    )
+
+    assert "policyengine_us/tests/policy/baseline/gov/ssa" not in limited_paths
+    assert limited_paths == set()
+
+
+def test_limit_test_paths_keeps_direct_tests_when_deferring_slow_directory():
+    runner = SelectiveTestRunner()
+
+    changed_files = {
+        "policyengine_us/reforms/ssa/trustees_core_thresholds.py",
+        "policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py",
+        "policyengine_us/variables/gov/ssa/ss/social_security_retirement.py",
+    }
+
+    limited_paths = runner.limit_test_paths(
+        runner.map_files_to_tests(changed_files), changed_files
+    )
+
+    assert "policyengine_us/tests/policy/baseline/gov/ssa" not in limited_paths
+    assert "policyengine_us/tests/policy/reform" not in limited_paths
+    assert limited_paths == {
+        "policyengine_us/tests/policy/contrib/ssa",
+        "policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py",
+    }

--- a/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
+++ b/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
@@ -75,7 +75,11 @@ def test_reform_extends_soi_income_upraters_from_trustees_2025_nawi_path():
     assert "social_security" in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS
 
     nawi = reformed.gov.ssa.nawi
-    for parameter_name in ["employment_income", "self_employment_income", "social_security"]:
+    for parameter_name in [
+        "employment_income",
+        "self_employment_income",
+        "social_security",
+    ]:
         baseline_parameter = getattr(baseline.calibration.gov.irs.soi, parameter_name)
         reformed_parameter = getattr(reformed.calibration.gov.irs.soi, parameter_name)
 

--- a/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
+++ b/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
@@ -9,6 +9,7 @@ from policyengine_us.parameters.uprating_extensions import (
 from policyengine_us.reforms.ssa.trustees_2025 import (
     TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT,
     TRUSTEES_2025_NAWI_ASSUMPTION,
+    TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS,
 )
 from policyengine_us.reforms.ssa.trustees_core_thresholds import (
     TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
@@ -29,6 +30,10 @@ def test_metadata_marks_trustees_core_thresholds_as_explicit_assumption():
     assert (
         TRUSTEES_CORE_THRESHOLD_ASSUMPTION["economic_assumption"]
         == TRUSTEES_2025_NAWI_ASSUMPTION["name"]
+    )
+    assert (
+        TRUSTEES_CORE_THRESHOLD_ASSUMPTION["income_uprating_assumption"]
+        == "trustees-2025-soi-income-nawi-v1"
     )
     assert "amt_thresholds" in TRUSTEES_CORE_THRESHOLD_ASSUMPTION["parameter_groups"]
 
@@ -60,6 +65,53 @@ def test_reform_recomputes_payroll_cap_from_trustees_2025_nawi_path():
             current_cap * nawi(f"{year - 2}-01-01") / nawi(f"{year - 3}-01-01")
         )
         assert payroll_cap(f"{year}-01-01") == expected_cap
+
+
+def test_reform_extends_soi_income_upraters_from_trustees_2025_nawi_path():
+    baseline = _parameters()
+    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+
+    assert "employment_income" in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS
+    assert "social_security" in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS
+
+    nawi = reformed.gov.ssa.nawi
+    for parameter_name in ["employment_income", "self_employment_income", "social_security"]:
+        baseline_parameter = getattr(baseline.calibration.gov.irs.soi, parameter_name)
+        reformed_parameter = getattr(reformed.calibration.gov.irs.soi, parameter_name)
+
+        assert reformed_parameter("2036-01-01") == baseline_parameter("2036-01-01")
+        assert reformed_parameter("2075-01-01") > baseline_parameter("2075-01-01")
+
+        growth = float(reformed_parameter("2075-01-01")) / float(
+            reformed_parameter("2074-01-01")
+        )
+        expected_growth = float(nawi("2075-01-01")) / float(nawi("2074-01-01"))
+        assert growth == pytest.approx(expected_growth)
+
+
+def test_reported_social_security_components_use_aggregate_ss_uprater():
+    from policyengine_us.variables.gov.ssa.social_security.social_security_retirement_reported import (
+        social_security_retirement_reported,
+    )
+    from policyengine_us.variables.gov.ssa.ss.social_security_dependents import (
+        social_security_dependents,
+    )
+    from policyengine_us.variables.gov.ssa.ss.social_security_disability import (
+        social_security_disability,
+    )
+    from policyengine_us.variables.gov.ssa.ss.social_security_retirement import (
+        social_security_retirement,
+    )
+    from policyengine_us.variables.gov.ssa.ss.social_security_survivors import (
+        social_security_survivors,
+    )
+
+    expected_uprater = "calibration.gov.irs.soi.social_security"
+    assert social_security_retirement.uprating == expected_uprater
+    assert social_security_retirement_reported.uprating == expected_uprater
+    assert social_security_disability.uprating == expected_uprater
+    assert social_security_dependents.uprating == expected_uprater
+    assert social_security_survivors.uprating == expected_uprater
 
 
 def test_reform_wage_indexes_core_tax_threshold_from_2035():

--- a/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
+++ b/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
@@ -1,0 +1,116 @@
+import math
+
+import pytest
+
+from policyengine_us import CountryTaxBenefitSystem
+from policyengine_us.parameters.uprating_extensions import (
+    round_social_security_payroll_cap,
+)
+from policyengine_us.reforms.ssa.trustees_2025 import (
+    TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT,
+    TRUSTEES_2025_NAWI_ASSUMPTION,
+)
+from policyengine_us.reforms.ssa.trustees_core_thresholds import (
+    TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
+    create_trustees_core_thresholds_reform,
+)
+
+
+def _parameters(reform=None):
+    return CountryTaxBenefitSystem(reform=reform).parameters
+
+
+def test_metadata_marks_trustees_core_thresholds_as_explicit_assumption():
+    assert (
+        TRUSTEES_CORE_THRESHOLD_ASSUMPTION["name"] == "trustees-2025-core-thresholds-v1"
+    )
+    assert TRUSTEES_CORE_THRESHOLD_ASSUMPTION["not_default_current_law"] is True
+    assert TRUSTEES_CORE_THRESHOLD_ASSUMPTION["start_year"] == 2035
+    assert (
+        TRUSTEES_CORE_THRESHOLD_ASSUMPTION["economic_assumption"]
+        == TRUSTEES_2025_NAWI_ASSUMPTION["name"]
+    )
+    assert "amt_thresholds" in TRUSTEES_CORE_THRESHOLD_ASSUMPTION["parameter_groups"]
+
+
+def test_reform_applies_trustees_2025_nawi_path():
+    baseline = _parameters()
+    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+
+    baseline_nawi = baseline.gov.ssa.nawi
+    reformed_nawi = reformed.gov.ssa.nawi
+
+    assert reformed_nawi("2033-01-01") == baseline_nawi("2033-01-01")
+    for year in [2034, 2035, 2040, 2100]:
+        growth = float(reformed_nawi(f"{year}-01-01")) / float(
+            reformed_nawi(f"{year - 1}-01-01")
+        )
+        expected_growth = 1 + TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT[year] / 100
+        assert growth == pytest.approx(expected_growth)
+
+
+def test_reform_recomputes_payroll_cap_from_trustees_2025_nawi_path():
+    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+    nawi = reformed.gov.ssa.nawi
+    payroll_cap = reformed.gov.irs.payroll.social_security.cap
+
+    for year in [2036, 2040, 2100]:
+        current_cap = payroll_cap(f"{year - 1}-01-01")
+        expected_cap = round_social_security_payroll_cap(
+            current_cap * nawi(f"{year - 2}-01-01") / nawi(f"{year - 3}-01-01")
+        )
+        assert payroll_cap(f"{year}-01-01") == expected_cap
+
+
+def test_reform_wage_indexes_core_tax_threshold_from_2035():
+    baseline = _parameters()
+    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+
+    baseline_threshold = baseline.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    reformed_threshold = reformed.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    nawi = reformed.gov.ssa.nawi
+
+    assert reformed_threshold("2034-01-01") == baseline_threshold("2034-01-01")
+    nawi_growth = float(nawi("2034-01-01")) / float(nawi("2033-01-01"))
+    expected_2035 = (
+        math.floor(float(reformed_threshold("2034-01-01")) * nawi_growth / 25) * 25
+    )
+    assert reformed_threshold("2035-01-01") == expected_2035
+    assert reformed_threshold("2035-01-01") != baseline_threshold("2035-01-01")
+
+
+def test_reform_updates_standard_deduction_and_amt_thresholds():
+    baseline = _parameters()
+    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+
+    standard_deduction = reformed.gov.irs.deductions.standard.amount.SINGLE
+    amt_bracket = reformed.gov.irs.income.amt.brackets[1].threshold
+
+    assert standard_deduction(
+        "2034-01-01"
+    ) == baseline.gov.irs.deductions.standard.amount.SINGLE("2034-01-01")
+    assert amt_bracket("2034-01-01") == baseline.gov.irs.income.amt.brackets[
+        1
+    ].threshold("2034-01-01")
+    assert standard_deduction(
+        "2035-01-01"
+    ) != baseline.gov.irs.deductions.standard.amount.SINGLE("2035-01-01")
+    assert amt_bracket("2035-01-01") != baseline.gov.irs.income.amt.brackets[
+        1
+    ].threshold("2035-01-01")
+
+
+def test_reform_does_not_change_social_security_benefit_tax_thresholds():
+    baseline = _parameters()
+    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+
+    baseline_threshold = (
+        baseline.gov.irs.social_security.taxability.threshold.base.main.SINGLE
+    )
+    reformed_threshold = (
+        reformed.gov.irs.social_security.taxability.threshold.base.main.SINGLE
+    )
+
+    for year in [2034, 2035, 2100]:
+        instant = f"{year}-01-01"
+        assert reformed_threshold(instant) == baseline_threshold(instant)

--- a/policyengine_us/tests/run_selective_tests.py
+++ b/policyengine_us/tests/run_selective_tests.py
@@ -24,6 +24,12 @@ STOP_TEST_DIRS = frozenset(
         Path("policyengine_us/tests"),
     }
 )
+QUICK_FEEDBACK_DEFERRED_DIRS = frozenset(
+    {
+        "policyengine_us/tests/policy/baseline/gov/ssa",
+        "policyengine_us/tests/policy/reform",
+    }
+)
 
 
 class SelectiveTestRunner:
@@ -333,6 +339,15 @@ class SelectiveTestRunner:
     def limit_test_paths(
         self, test_paths: Set[str], changed_files: Set[str]
     ) -> Set[str]:
+        deferred_paths = test_paths & QUICK_FEEDBACK_DEFERRED_DIRS
+        if deferred_paths:
+            deferred_list = ", ".join(sorted(deferred_paths))
+            print(
+                "\nQuick Feedback is deferring slow directory target(s) "
+                f"to the full suite jobs: {deferred_list}."
+            )
+            test_paths = test_paths - deferred_paths
+
         total_test_files = self.count_test_files(test_paths)
         if (
             len(test_paths) <= self.max_test_targets

--- a/policyengine_us/variables/gov/ssa/social_security/social_security_retirement_reported.py
+++ b/policyengine_us/variables/gov/ssa/social_security/social_security_retirement_reported.py
@@ -12,4 +12,4 @@ class social_security_retirement_reported(Variable):
         "the reported_social_security_retirement parameter is true."
     )
     unit = USD
-    uprating = "gov.ssa.uprating"
+    uprating = "calibration.gov.irs.soi.social_security"

--- a/policyengine_us/variables/gov/ssa/ss/social_security_dependents.py
+++ b/policyengine_us/variables/gov/ssa/ss/social_security_dependents.py
@@ -7,4 +7,4 @@ class social_security_dependents(Variable):
     definition_period = YEAR
     label = "Social Security dependents benefits"
     unit = USD
-    # uprating = "gov.ssa.uprating"
+    uprating = "calibration.gov.irs.soi.social_security"

--- a/policyengine_us/variables/gov/ssa/ss/social_security_disability.py
+++ b/policyengine_us/variables/gov/ssa/ss/social_security_disability.py
@@ -7,4 +7,4 @@ class social_security_disability(Variable):
     definition_period = YEAR
     label = "Social Security disability benefits (SSDI)"
     unit = USD
-    uprating = "gov.ssa.uprating"
+    uprating = "calibration.gov.irs.soi.social_security"

--- a/policyengine_us/variables/gov/ssa/ss/social_security_retirement.py
+++ b/policyengine_us/variables/gov/ssa/ss/social_security_retirement.py
@@ -7,7 +7,7 @@ class social_security_retirement(Variable):
     definition_period = YEAR
     label = "Social Security retirement benefits"
     unit = USD
-    uprating = "gov.ssa.uprating"
+    uprating = "calibration.gov.irs.soi.social_security"
 
     def formula(person, period, parameters):
         # `reported_social_security_retirement` is a scalar simulation

--- a/policyengine_us/variables/gov/ssa/ss/social_security_survivors.py
+++ b/policyengine_us/variables/gov/ssa/ss/social_security_survivors.py
@@ -7,4 +7,4 @@ class social_security_survivors(Variable):
     definition_period = YEAR
     label = "Social Security survivors benefits"
     unit = USD
-    # uprating = "gov.ssa.uprating"
+    uprating = "calibration.gov.irs.soi.social_security"

--- a/uv.lock
+++ b/uv.lock
@@ -2974,7 +2974,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.665.0"
+version = "1.680.0"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- add an explicit trustees-2025-nawi-v1 economic-assumption helper for long-run Trustees scenarios
- add trustees-2025-core-thresholds-v1, which applies that NAWI/payroll-cap path and then wage-indexes core ordinary federal tax thresholds after 2034
- extend long-run SOI income uprating aggregates with the Trustees NAWI path so incomes and Social Security benefits do not freeze after the projection window
- uprate reported Social Security benefit components from calibration.gov.irs.soi.social_security instead of gov.ssa.uprating

## Validation
- uv run ruff check policyengine_us/reforms/ssa/trustees_2025.py policyengine_us/reforms/ssa/trustees_core_thresholds.py policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py policyengine_us/variables/gov/ssa/social_security/social_security_retirement_reported.py policyengine_us/variables/gov/ssa/ss/social_security_dependents.py policyengine_us/variables/gov/ssa/ss/social_security_disability.py policyengine_us/variables/gov/ssa/ss/social_security_retirement.py policyengine_us/variables/gov/ssa/ss/social_security_survivors.py
- uv run ruff format --check policyengine_us/reforms/ssa/trustees_2025.py policyengine_us/reforms/ssa/trustees_core_thresholds.py policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py policyengine_us/variables/gov/ssa/social_security/social_security_retirement_reported.py policyengine_us/variables/gov/ssa/ss/social_security_dependents.py policyengine_us/variables/gov/ssa/ss/social_security_disability.py policyengine_us/variables/gov/ssa/ss/social_security_retirement.py policyengine_us/variables/gov/ssa/ss/social_security_survivors.py
- uv run pytest policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py -q

## Notes
- This is an explicit scenario assumption, not default current law.
- Average-wage growth is owned by the NAWI projection helper; the threshold reform consumes gov.ssa.nawi rather than carrying its own wage-growth table.
- PolicyEngine/policyengine-us-data#886 consumes this native reform when available.