### PR TITLE
Restore medical_out_of_pocket_expenses as deprecated alias

### DIFF
--- a/changelog.d/restore-medical-oop-expenses-alias.added.md
+++ b/changelog.d/restore-medical-oop-expenses-alias.added.md
@@ -1,0 +1,1 @@
+Restore `medical_out_of_pocket_expenses` as a deprecation alias that forwards into `other_medical_expenses`, easing migration from the variable removed in 1.673.0. The alias is documented as deprecated and will be removed in a future release.

--- a/policyengine_us/tests/policy/baseline/household/expense/health/medical_out_of_pocket_expenses.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/health/medical_out_of_pocket_expenses.yaml
@@ -1,0 +1,22 @@
+- name: Legacy medical_out_of_pocket_expenses input flows into other_medical_expenses.
+  period: 2025
+  input:
+    medical_out_of_pocket_expenses: 1_000
+  output:
+    other_medical_expenses: 1_000
+
+- name: Direct other_medical_expenses input overrides the legacy alias.
+  period: 2025
+  input:
+    medical_out_of_pocket_expenses: 1_000
+    other_medical_expenses: 250
+  output:
+    other_medical_expenses: 250
+
+- name: Legacy alias defaults to zero when not supplied.
+  period: 2025
+  input:
+    age: 30
+  output:
+    medical_out_of_pocket_expenses: 0
+    other_medical_expenses: 0

--- a/policyengine_us/variables/household/expense/health/medical_out_of_pocket_expenses.py
+++ b/policyengine_us/variables/household/expense/health/medical_out_of_pocket_expenses.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class medical_out_of_pocket_expenses(Variable):
+    value_type = float
+    entity = Person
+    label = "Medical out-of-pocket expenses (deprecated)"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "DEPRECATED. Removed in 1.673.0 and restored as a temporary "
+        "alias to ease migration. Values supplied here are forwarded "
+        "into `other_medical_expenses`. Migrate to `other_medical_expenses` "
+        "for non-premium medical spending and to `health_insurance_premiums` "
+        "if your value previously included health insurance premiums. "
+        "This alias will be removed in a future release."
+    )

--- a/policyengine_us/variables/household/expense/health/other_medical_expenses.py
+++ b/policyengine_us/variables/household/expense/health/other_medical_expenses.py
@@ -8,3 +8,4 @@ class other_medical_expenses(Variable):
     unit = USD
     definition_period = YEAR
     uprating = "calibration.gov.hhs.cms.moop_per_capita"
+    adds = ["medical_out_of_pocket_expenses"]


### PR DESCRIPTION
## Summary

PR #8178 (shipped in `policyengine-us` 1.673.0) removed the umbrella `medical_out_of_pocket_expenses` Person variable in favor of program-specific aggregates (`itemized_medical_expenses`, `snap_allowable_medical_expenses`, `hud_medical_expenses`, `medicaid_medically_needy_medical_expenses`, `pa_ccw_medical_expenses`) plus decomposed inputs (`health_insurance_premiums`, `other_medical_expenses`, `over_the_counter_health_expenses`, `medicare_part_b_premium`, ...).

Household-API partners that still pass `medical_out_of_pocket_expenses` as input now hit `VariableNotFoundError` (HTTP 500) without prior notice — see PolicyEngine/policyengine-household-api#1493 for the MyFriendBen fixture migration that surfaced this.

This PR re-adds `medical_out_of_pocket_expenses` as a deprecation alias that forwards into `other_medical_expenses`, giving partners a window to migrate.

## Approach

- New Person-level input variable `medical_out_of_pocket_expenses` (default 0). Label and documentation mark it deprecated.
- `other_medical_expenses` now declares `adds = [\"medical_out_of_pocket_expenses\"]`. PolicyEngine input-override semantics mean partners who already pass `other_medical_expenses` (or the new premium inputs) directly are unaffected — direct input always wins over `adds`. Pattern matches existing variables that combine `uprating` and `adds` (e.g. `employment_income`, `self_employment_income`).

## Tradeoff

This is an alias to **`other_medical_expenses` only** — the non-premium catch-all. For partners whose legacy `medical_out_of_pocket_expenses` value previously included **health insurance premiums**, the shim silently routes those dollars into the non-premium path; they will need to migrate that portion to `health_insurance_premiums` to retain correct downstream calculations. Of the three customer-input fixtures in policyengine-household-api (`my_friend_ben`, `amplifi`, `impactica`), only MyFriendBen passed the legacy variable, and they don't pass any premium inputs — so the simple alias is correct for them.

## Removal plan

The shim is a temporary migration aid. We should track its removal as a follow-up issue and pull it after partners have had at least one minor-version cycle to migrate.

## Files

- `policyengine_us/variables/household/expense/health/medical_out_of_pocket_expenses.py` (new)
- `policyengine_us/variables/household/expense/health/other_medical_expenses.py` (modified)
- `policyengine_us/tests/policy/baseline/household/expense/health/medical_out_of_pocket_expenses.yaml` (new)
- `changelog.d/restore-medical-oop-expenses-alias.added.md` (new)

## Test plan

- [x] YAML test verifies legacy input flows into `other_medical_expenses`
- [x] YAML test verifies direct `other_medical_expenses` input overrides the alias
- [x] YAML test verifies default-zero behavior when neither input is supplied
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)