### PR TITLE
Add Trustees long-run federal tax indexing assumption

### DIFF
--- a/changelog.d/crfb-trustees-thresholds.added.md
+++ b/changelog.d/crfb-trustees-thresholds.added.md
@@ -1,0 +1,1 @@
+Added an explicit Trustees federal income tax parameter reform for long-run TOB analysis scenarios.

--- a/policyengine_us/reforms/ssa/trustees_core_thresholds.py
+++ b/policyengine_us/reforms/ssa/trustees_core_thresholds.py
@@ -14,19 +14,17 @@ TRUSTEES_CORE_THRESHOLD_ASSUMPTION: dict[str, Any] = {
     "name": "trustees-2025-core-thresholds-v1",
     "description": (
         "Best-public Trustees tax-side approximation: keep Social Security "
-        "benefit-tax thresholds fixed, but wage-index core ordinary federal "
-        "tax thresholds after 2034 using the active NAWI path."
+        "benefit-tax thresholds fixed, but wage-index all federal income tax "
+        "parameters that otherwise use IRS CPI uprating after 2034 using the "
+        "active NAWI path."
     ),
-    "source": "SSA 2025 Trustees Report V.C.7",
+    "source": "SSA 2025 Trustees Report V.C.7 and OACT email clarification, May 6, 2026",
     "start_year": 2035,
     "projection_base_year": 2026,
     "parameter_groups": [
-        "ordinary_income_brackets",
-        "standard_deduction",
-        "aged_blind_standard_deduction",
-        "capital_gains_thresholds",
-        "amt_thresholds",
+        "all_gov_irs_uprating_parameters",
     ],
+    "uprating_parameter": "gov.irs.uprating",
     "economic_assumption": TRUSTEES_2025_NAWI_ASSUMPTION["name"],
     "income_uprating_assumption": "trustees-2025-soi-income-nawi-v1",
     "not_default_current_law": True,
@@ -61,11 +59,6 @@ def _get_parameter_by_name(parameters, name: str):
     for part in name.split("."):
         current = getattr(current, part)
     return current
-
-
-def _nawi_growth_for_tax_year(parameters, year: int) -> float:
-    nawi = parameters.gov.ssa.nawi
-    return float(nawi(f"{year - 1}-01-01")) / float(nawi(f"{year - 2}-01-01"))
 
 
 def _iter_updatable_parameters(
@@ -112,13 +105,12 @@ def _apply_wage_growth_to_parameter(
     for year in range(projection_base_year + 1, start_year):
         values_by_year[year] = float(parameter(f"{year}-01-01"))
 
+    base_value = float(parameter(f"{start_year - 1}-01-01"))
+    base_nawi = float(parameters.gov.ssa.nawi(f"{start_year - 2}-01-01"))
     for year in range(start_year, end_year + 1):
-        if year - 1 in values_by_year:
-            previous_value = values_by_year[year - 1]
-        else:
-            previous_value = float(parameter(f"{year - 1}-01-01"))
+        nawi_ratio = float(parameters.gov.ssa.nawi(f"{year - 1}-01-01")) / base_nawi
         updated_value = _round_amount(
-            previous_value * _nawi_growth_for_tax_year(parameters, year),
+            base_value * nawi_ratio,
             rounding,
         )
         values_by_year[year] = updated_value
@@ -130,16 +122,9 @@ def _apply_wage_growth_to_parameter(
         )
 
 
-def _core_threshold_roots(parameters) -> list:
+def _federal_income_tax_roots(parameters) -> list:
     return [
-        parameters.gov.irs.income.bracket.thresholds,
-        parameters.gov.irs.deductions.standard.amount,
-        parameters.gov.irs.deductions.standard.aged_or_blind.amount,
-        parameters.gov.irs.capital_gains.thresholds,
-        parameters.gov.irs.income.amt.brackets,
-        parameters.gov.irs.income.amt.exemption.amount,
-        parameters.gov.irs.income.amt.exemption.phase_out.start,
-        parameters.gov.irs.income.amt.exemption.separate_limit,
+        parameters.gov.irs,
     ]
 
 
@@ -156,11 +141,12 @@ def create_trustees_core_thresholds_reform(
     end_year: int = 2100,
     projection_base_year: int = 2026,
 ) -> Reform:
-    """Return a Trustees-style long-run tax-threshold assumption reform.
+    """Return a Trustees-style long-run federal tax assumption reform.
 
     This is an explicit scenario assumption, not default current law. It leaves
-    Social Security benefit-tax thresholds unchanged and wage-indexes the core
-    IRS thresholds used by the CRFB long-run TOB analysis from ``start_year``.
+    Social Security benefit-tax thresholds unchanged and wage-indexes federal
+    IRS parameters that otherwise use CPI-linked IRS uprating from
+    ``start_year``.
     """
 
     def modify_parameters(parameters):
@@ -173,8 +159,13 @@ def create_trustees_core_thresholds_reform(
         )
 
         seen = set()
-        for root in _core_threshold_roots(parameters):
-            for parameter in _iter_updatable_parameters(root):
+        for root in _federal_income_tax_roots(parameters):
+            for parameter in _iter_updatable_parameters(
+                root,
+                uprating_parameter=TRUSTEES_CORE_THRESHOLD_ASSUMPTION[
+                    "uprating_parameter"
+                ],
+            ):
                 if parameter.name in seen:
                     continue
                 seen.add(parameter.name)

--- a/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
+++ b/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
@@ -1,4 +1,5 @@
 import math
+from functools import lru_cache
 
 import pytest
 
@@ -17,8 +18,14 @@ from policyengine_us.reforms.ssa.trustees_core_thresholds import (
 )
 
 
+@lru_cache
 def _parameters(reform=None):
     return CountryTaxBenefitSystem(reform=reform).parameters
+
+
+@lru_cache
+def _trustees_parameters():
+    return _parameters((create_trustees_core_thresholds_reform(),))
 
 
 def test_metadata_marks_trustees_core_thresholds_as_explicit_assumption():
@@ -35,12 +42,19 @@ def test_metadata_marks_trustees_core_thresholds_as_explicit_assumption():
         TRUSTEES_CORE_THRESHOLD_ASSUMPTION["income_uprating_assumption"]
         == "trustees-2025-soi-income-nawi-v1"
     )
-    assert "amt_thresholds" in TRUSTEES_CORE_THRESHOLD_ASSUMPTION["parameter_groups"]
+    assert (
+        "all_gov_irs_uprating_parameters"
+        in TRUSTEES_CORE_THRESHOLD_ASSUMPTION["parameter_groups"]
+    )
+    assert (
+        TRUSTEES_CORE_THRESHOLD_ASSUMPTION["uprating_parameter"] == "gov.irs.uprating"
+    )
+    assert "OACT email clarification" in TRUSTEES_CORE_THRESHOLD_ASSUMPTION["source"]
 
 
 def test_reform_applies_trustees_2025_nawi_path():
     baseline = _parameters()
-    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+    reformed = _trustees_parameters()
 
     baseline_nawi = baseline.gov.ssa.nawi
     reformed_nawi = reformed.gov.ssa.nawi
@@ -55,7 +69,7 @@ def test_reform_applies_trustees_2025_nawi_path():
 
 
 def test_reform_recomputes_payroll_cap_from_trustees_2025_nawi_path():
-    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+    reformed = _trustees_parameters()
     nawi = reformed.gov.ssa.nawi
     payroll_cap = reformed.gov.irs.payroll.social_security.cap
 
@@ -69,7 +83,7 @@ def test_reform_recomputes_payroll_cap_from_trustees_2025_nawi_path():
 
 def test_reform_extends_soi_income_upraters_from_trustees_2025_nawi_path():
     baseline = _parameters()
-    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+    reformed = _trustees_parameters()
 
     assert "employment_income" in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS
     assert "social_security" in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS
@@ -120,7 +134,7 @@ def test_reported_social_security_components_use_aggregate_ss_uprater():
 
 def test_reform_wage_indexes_core_tax_threshold_from_2035():
     baseline = _parameters()
-    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+    reformed = _trustees_parameters()
 
     baseline_threshold = baseline.gov.irs.income.bracket.thresholds.children["1"].SINGLE
     reformed_threshold = reformed.gov.irs.income.bracket.thresholds.children["1"].SINGLE
@@ -137,7 +151,7 @@ def test_reform_wage_indexes_core_tax_threshold_from_2035():
 
 def test_reform_updates_standard_deduction_and_amt_thresholds():
     baseline = _parameters()
-    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+    reformed = _trustees_parameters()
 
     standard_deduction = reformed.gov.irs.deductions.standard.amount.SINGLE
     amt_bracket = reformed.gov.irs.income.amt.brackets[1].threshold
@@ -156,9 +170,49 @@ def test_reform_updates_standard_deduction_and_amt_thresholds():
     ].threshold("2035-01-01")
 
 
+def test_reform_wage_indexes_indexed_credit_parameters():
+    baseline = _parameters()
+    reformed = _trustees_parameters()
+    nawi = reformed.gov.ssa.nawi
+
+    eitc_max = reformed.gov.irs.credits.eitc.max.brackets[3].amount
+    baseline_eitc_max = baseline.gov.irs.credits.eitc.max.brackets[3].amount
+
+    assert eitc_max("2034-01-01") == baseline_eitc_max("2034-01-01")
+    nawi_growth = float(nawi("2034-01-01")) / float(nawi("2033-01-01"))
+    expected_eitc_2035 = math.floor(float(eitc_max("2034-01-01")) * nawi_growth + 0.5)
+    assert eitc_max("2035-01-01") == expected_eitc_2035
+    assert eitc_max("2035-01-01") != baseline_eitc_max("2035-01-01")
+
+    ctc_base = reformed.gov.irs.credits.ctc.amount.base.brackets[0].amount
+    baseline_ctc_base = baseline.gov.irs.credits.ctc.amount.base.brackets[0].amount
+    ctc_ratio_2040 = float(nawi("2039-01-01")) / float(nawi("2033-01-01"))
+    expected_ctc_2040 = (
+        math.floor(float(ctc_base("2034-01-01")) * ctc_ratio_2040 / 100) * 100
+    )
+
+    assert ctc_base("2034-01-01") == baseline_ctc_base("2034-01-01")
+    assert ctc_base("2040-01-01") == expected_ctc_2040
+    assert ctc_base("2040-01-01") != baseline_ctc_base("2040-01-01")
+
+    ctc_refundable_max = reformed.gov.irs.credits.ctc.refundable.individual_max
+    baseline_ctc_refundable_max = baseline.gov.irs.credits.ctc.refundable.individual_max
+    ctc_refundable_ratio_2040 = float(nawi("2039-01-01")) / float(nawi("2033-01-01"))
+    expected_ctc_refundable_2040 = (
+        math.floor(
+            float(ctc_refundable_max("2034-01-01")) * ctc_refundable_ratio_2040 / 100
+        )
+        * 100
+    )
+
+    assert ctc_refundable_max("2034-01-01") == baseline_ctc_refundable_max("2034-01-01")
+    assert ctc_refundable_max("2040-01-01") == expected_ctc_refundable_2040
+    assert ctc_refundable_max("2040-01-01") != baseline_ctc_refundable_max("2040-01-01")
+
+
 def test_reform_does_not_change_social_security_benefit_tax_thresholds():
     baseline = _parameters()
-    reformed = _parameters((create_trustees_core_thresholds_reform(),))
+    reformed = _trustees_parameters()
 
     baseline_threshold = (
         baseline.gov.irs.social_security.taxability.threshold.base.main.SINGLE
@@ -170,3 +224,21 @@ def test_reform_does_not_change_social_security_benefit_tax_thresholds():
     for year in [2034, 2035, 2100]:
         instant = f"{year}-01-01"
         assert reformed_threshold(instant) == baseline_threshold(instant)
+
+
+def test_reform_does_not_change_state_parameters_using_irs_uprating():
+    baseline = _parameters()
+    reformed = _trustees_parameters()
+
+    baseline_state_ctc = baseline.gov.states.dc.tax.income.credits.ctc.amount
+    reformed_state_ctc = reformed.gov.states.dc.tax.income.credits.ctc.amount
+
+    uprating = baseline_state_ctc.metadata["uprating"]
+    uprating_parameter = (
+        uprating["parameter"] if isinstance(uprating, dict) else uprating
+    )
+    assert uprating_parameter == "gov.irs.uprating"
+
+    for year in [2034, 2035, 2040, 2100]:
+        instant = f"{year}-01-01"
+        assert reformed_state_ctc(instant) == baseline_state_ctc(instant)


### PR DESCRIPTION
## Summary

- broadens the Trustees long-run tax-side reform so every `gov.irs` parameter using `gov.irs.uprating` switches from CPI-linked IRS uprating to the Trustees NAWI path after 2034
- keeps Social Security benefit-tax combined-income thresholds fixed in nominal dollars
- changes the explicit wage-indexing calculation to use cumulative NAWI growth from 2034, preserving normal cumulative-uprating behavior for rounded credit parameters
- updates tests to cover EITC and CTC parameters in addition to brackets, standard deduction, AMT, payroll cap, and TOB thresholds

## Context

OACT clarified by email on May 6, 2026 that the Trustees projection is most consistent with applying post-10th-year wage-growth indexing to all income tax parameters, including indexed credit parameters, not just brackets and deduction amounts.

## Tests

- `uv run ruff format --check policyengine_us/reforms/ssa/trustees_core_thresholds.py policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py`
- `uv run ruff check policyengine_us/reforms/ssa/trustees_core_thresholds.py policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py`
- `uv run pytest policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py -q`
- `uv run pytest policyengine_us/tests/core/test_run_selective_tests.py -q`
- `git diff --check`
