### PR TITLE
Fix ACA family tier premiums for older dependents

### DIFF
--- a/changelog.d/aca-ny-vt-dependent-tiers.fixed.md
+++ b/changelog.d/aca-ny-vt-dependent-tiers.fixed.md
@@ -1,0 +1,1 @@
+Fix ACA family-tier premium calculations for older dependents in New York and Vermont.

--- a/policyengine_us/parameters/gov/aca/family_tier_dependent_child_age_threshold.yaml
+++ b/policyengine_us/parameters/gov/aca/family_tier_dependent_child_age_threshold.yaml
@@ -1,0 +1,12 @@
+description: ACA family tier rating states count dependent children under this age in family tiers.
+values:
+  2014-01-01: 26
+metadata:
+  unit: year
+  period: year
+  label: ACA family tier dependent child age threshold
+  reference:
+    - title: 2025 New York State of Health SLCSP rates by county
+      href: https://info.nystateofhealth.ny.gov/sites/default/files/2025%20SLCSP%20Rates%20by%20County.FINAL.pdf
+    - title: HealthCare.gov - children under 26
+      href: https://www.healthcare.gov/young-adults/children-under-26/

--- a/policyengine_us/parameters/gov/aca/ny_age_29_dependent_child_age_threshold.yaml
+++ b/policyengine_us/parameters/gov/aca/ny_age_29_dependent_child_age_threshold.yaml
@@ -1,0 +1,12 @@
+description: New York extends ACA family tier dependent child premiums through this age threshold.
+values:
+  2014-01-01: 30
+metadata:
+  unit: year
+  period: year
+  label: New York ACA Age 29 dependent child age threshold
+  reference:
+    - title: 2024 New York State of Health FAQs on SLCSP
+      href: https://info.nystateofhealth.ny.gov/sites/default/files/2024%20FAQs%20on%20SLCSP%20English.pdf
+    - title: New York Insurance Law Section 3216
+      href: https://www.nysenate.gov/legislation/laws/ISC/3216

--- a/policyengine_us/parameters/gov/aca/ny_age_29_dependent_child_tier_multiplier.yaml
+++ b/policyengine_us/parameters/gov/aca/ny_age_29_dependent_child_tier_multiplier.yaml
@@ -1,0 +1,14 @@
+description: New York scales family tier premiums by this factor when a tax unit covers a dependent child ages 26 through 29.
+values:
+  2023-01-01: 1.05
+metadata:
+  unit: /1
+  period: year
+  label: New York ACA Age 29 dependent child family tier multiplier
+  reference:
+    - title: 2025 New York State of Health SLCSP rates by county
+      href: https://info.nystateofhealth.ny.gov/sites/default/files/2025%20SLCSP%20Rates%20by%20County.FINAL.pdf
+    - title: 2024 New York State of Health FAQs on SLCSP
+      href: https://info.nystateofhealth.ny.gov/sites/default/files/2024%20FAQs%20on%20SLCSP%20English.pdf
+    - title: New York State Department of Financial Services 2026 rate filing instructions
+      href: https://www.dfs.ny.gov/system/files/documents/2025/04/2026-instruct-filing-premium-rates.pdf

--- a/policyengine_us/tests/policy/baseline/gov/aca/lcbp/lcbp_family_tier_amount.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/lcbp/lcbp_family_tier_amount.yaml
@@ -47,3 +47,74 @@
     lcbp_family_tier_multiplier: 1.7
     lcbp_family_tier_amount: 861.9
     lcbp: 861.9
+
+- name: NY bronze tier uses Age 29 child rate for 26-year-old dependent
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 26
+        monthly_age: 26
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: NY
+        state_fips: 36
+        lcbp_age_0: 507
+  output:
+    is_aca_ny_age_29_dependent_child: [false, false, true]
+    lcbp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+    lcbp_family_tier_multiplier: 2.9925
+    lcbp_family_tier_amount: 1_517.2
+    lcbp: 1_517.2
+
+- name: VT bronze tier includes adult dependent premium
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 60
+        monthly_age: 60
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: VT
+        state_fips: 50
+        lcbp_age_0: 824
+  output:
+    lcbp_family_tier_category: TWO_ADULTS
+    lcbp_family_tier_multiplier: 3
+    lcbp_family_tier_amount: 2_472
+    lcbp: 2_472

--- a/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_category.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_category.yaml
@@ -82,6 +82,130 @@
   output:
     slcsp_family_tier_category: ONE_ADULT_AND_ONE_OR_MORE_CHILDREN
 
+- name: NY single filer with 25-year-old dependent
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 25
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code_str: NY
+        state_fips: 36
+  output:
+    is_aca_family_tier_dependent_child: [false, true]
+    slcsp_family_tier_category: ONE_ADULT_AND_ONE_OR_MORE_CHILDREN
+
+- name: NY single filer with 26-year-old dependent
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 26
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code_str: NY
+        state_fips: 36
+  output:
+    is_aca_ny_age_29_dependent_child: [false, true]
+    is_aca_family_tier_dependent_child: [false, true]
+    slcsp_family_tier_category: ONE_ADULT_AND_ONE_OR_MORE_CHILDREN
+
+- name: NY single filer with 29-year-old dependent
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 29
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code_str: NY
+        state_fips: 36
+  output:
+    is_aca_ny_age_29_dependent_child: [false, true]
+    is_aca_family_tier_dependent_child: [false, true]
+    slcsp_family_tier_category: ONE_ADULT_AND_ONE_OR_MORE_CHILDREN
+
+- name: NY single filer with 30-year-old dependent
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code_str: NY
+        state_fips: 36
+  output:
+    is_aca_ny_age_29_dependent_child: [false, false]
+    is_aca_family_tier_dependent_child: [false, false]
+    slcsp_family_tier_category: TWO_ADULTS
+
+- name: NY 26-year-old dependent without a covered adult is not child-only
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 55
+        is_tax_unit_dependent: false
+        pays_aca_premium: false
+      person2:
+        age: 26
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code_str: NY
+        state_fips: 36
+  output:
+    is_aca_ny_age_29_dependent_child: [false, true]
+    is_aca_family_tier_dependent_child: [false, true]
+    slcsp_family_tier_category: ONE_ADULT
+
 - name: NY two parents with child
   period: 2023
   input:
@@ -165,6 +289,62 @@
         state_fips: 50
   output:
     slcsp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+
+- name: VT married couple with 25-year-old dependent
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 25
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: VT
+        state_fips: 50
+  output:
+    is_aca_family_tier_dependent_child: [false, false, true]
+    slcsp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+
+- name: VT married couple with 60-year-old dependent
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 60
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: VT
+        state_fips: 50
+  output:
+    is_aca_family_tier_dependent_child: [false, false, false]
+    slcsp_family_tier_category: TWO_ADULTS
 
 - name: NY high-income adult uses family tier category even when PTC-ineligible
   period: 2026

--- a/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_integration.yaml
@@ -52,6 +52,149 @@
     slcsp_family_tier_multiplier: 2.85
     slcsp: 2166  # 760 * 2.85
 
+- name: NY married couple with 25-year-old dependent uses family tier child rate
+  period: 2023-01
+  input:
+    people:
+      person1:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 25
+        monthly_age: 25
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: NY
+        state_fips: 36
+        slcsp_rating_area: 3
+        slcsp_age_0: 760
+  output:
+    slcsp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+    slcsp_family_tier_multiplier: 2.85
+    slcsp: 2166
+
+- name: NY married couple with 26-year-old dependent uses Age 29 child tier rate
+  period: 2023-01
+  input:
+    people:
+      person1:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 26
+        monthly_age: 26
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: NY
+        state_fips: 36
+        slcsp_rating_area: 3
+        slcsp_age_0: 760
+  output:
+    is_aca_ny_age_29_dependent_child: [false, false, true]
+    slcsp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+    slcsp_family_tier_multiplier: 2.9925
+    slcsp: 2274.3
+
+- name: NY married couple with 60-year-old dependent includes an extra adult premium
+  period: 2023-01
+  input:
+    people:
+      person1:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 60
+        monthly_age: 60
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: NY
+        state_fips: 36
+        slcsp_rating_area: 3
+        slcsp_age_0: 760
+  output:
+    slcsp_family_tier_category: TWO_ADULTS
+    slcsp_family_tier_multiplier: 3
+    slcsp: 2280
+
+- name: NY Age 29 child tier does not scale extra adult dependent premium
+  period: 2023-01
+  input:
+    people:
+      person1:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 26
+        monthly_age: 26
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+      person4:
+        age: 60
+        monthly_age: 60
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code_str: NY
+        state_fips: 36
+        slcsp_rating_area: 3
+        slcsp_age_0: 760
+  output:
+    is_aca_ny_age_29_dependent_child: [false, false, true, false]
+    slcsp_family_tier_category: TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN
+    slcsp_family_tier_multiplier: 3.9925
+    slcsp: 3034.3
+
 - name: VT single adult premium calculation
   period: 2023-01
   input:
@@ -74,6 +217,40 @@
     slcsp_family_tier_category: ONE_ADULT
     slcsp_family_tier_multiplier: 1.0
     slcsp: 1277
+
+- name: VT married couple with 60-year-old dependent includes an extra adult premium
+  period: 2023-01
+  input:
+    people:
+      person1:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person2:
+        age: 30
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        pays_aca_premium: true
+      person3:
+        age: 60
+        monthly_age: 60
+        is_tax_unit_dependent: true
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code_str: VT
+        state_fips: 50
+        slcsp_rating_area: 1
+        slcsp_age_0: 1277
+  output:
+    slcsp_family_tier_category: TWO_ADULTS
+    slcsp_family_tier_multiplier: 3
+    slcsp: 3831
 
 - name: VT family with one adult and two children
   period: 2023-01

--- a/policyengine_us/variables/gov/aca/lcbp/lcbp_family_tier_category.py
+++ b/policyengine_us/variables/gov/aca/lcbp/lcbp_family_tier_category.py
@@ -15,16 +15,31 @@ class lcbp_family_tier_category(Variable):
 
     def formula(tax_unit, period, parameters):
         state_code = tax_unit.household("state_code_str", period)
-        max_child_age = parameters(period).gov.aca.slcsp.max_child_age
 
         person = tax_unit.members
-        member_ages = person("monthly_age", period)
         pays_premium = person("pays_aca_premium", period)
+        dependent_child = person("is_aca_family_tier_dependent_child", period)
+        non_dependent_adult_count = tax_unit.sum(pays_premium & ~dependent_child)
+        anchored_child_count = tax_unit.sum(dependent_child)
 
-        is_adult = member_ages > max_child_age
-        eligible_adult_count = tax_unit.sum(is_adult & pays_premium)
-        eligible_people = tax_unit.sum(pays_premium)
-        eligible_child_count = eligible_people - eligible_adult_count
+        under_child_only_age = (
+            person("monthly_age", period)
+            <= parameters(period).gov.aca.slcsp.max_child_age
+        )
+        child_only_child = pays_premium & under_child_only_age
+        unanchored_adult_count = tax_unit.sum(pays_premium & ~child_only_child)
+        unanchored_child_count = tax_unit.sum(child_only_child)
+        has_adult_anchor = non_dependent_adult_count > 0
+        eligible_adult_count = where(
+            has_adult_anchor,
+            non_dependent_adult_count,
+            unanchored_adult_count,
+        )
+        eligible_child_count = where(
+            has_adult_anchor,
+            anchored_child_count,
+            unanchored_child_count,
+        )
 
         one_adult_no_children = (eligible_adult_count == 1) & (
             eligible_child_count == 0

--- a/policyengine_us/variables/gov/aca/lcbp/lcbp_family_tier_multiplier.py
+++ b/policyengine_us/variables/gov/aca/lcbp/lcbp_family_tier_multiplier.py
@@ -18,7 +18,7 @@ class lcbp_family_tier_multiplier(Variable):
         state_code = tax_unit.household("state_code", period)
         in_ny = state_code == state_code.possible_values.NY
 
-        return select(
+        base_multiplier = select(
             [
                 family_category == FamilyTierCategory.ONE_ADULT,
                 family_category == FamilyTierCategory.TWO_ADULTS,
@@ -53,3 +53,17 @@ class lcbp_family_tier_multiplier(Variable):
             ],
             default=0,
         )
+
+        person = tax_unit.members
+        pays_premium = person("pays_aca_premium", period)
+        dependent_child = person("is_aca_family_tier_dependent_child", period)
+        adult_count = tax_unit.sum(pays_premium & ~dependent_child)
+        extra_adults = max_(adult_count - 2, 0)
+        one_adult = where(in_ny, p.ny.ONE_ADULT, p.vt.ONE_ADULT)
+        age_29_child = person("is_aca_ny_age_29_dependent_child", period)
+        age_29_multiplier = where(
+            tax_unit.any(age_29_child),
+            parameters(period).gov.aca.ny_age_29_dependent_child_tier_multiplier,
+            1,
+        )
+        return base_multiplier * age_29_multiplier + extra_adults * one_adult

--- a/policyengine_us/variables/gov/aca/slspc/is_aca_family_tier_dependent_child.py
+++ b/policyengine_us/variables/gov/aca/slspc/is_aca_family_tier_dependent_child.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class is_aca_family_tier_dependent_child(Variable):
+    value_type = bool
+    entity = Person
+    label = "Person is a dependent child for ACA family tier premiums"
+    definition_period = MONTH
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.aca
+        age = person("monthly_age", period)
+        is_tax_dependent = person("is_tax_unit_dependent", period)
+        under_child_only_age = age <= p.slcsp.max_child_age
+        under_age_threshold = age < p.family_tier_dependent_child_age_threshold
+        ny_age_29_child = person("is_aca_ny_age_29_dependent_child", period)
+        return person("pays_aca_premium", period) & (
+            under_child_only_age
+            | (is_tax_dependent & under_age_threshold)
+            | ny_age_29_child
+        )

--- a/policyengine_us/variables/gov/aca/slspc/is_aca_ny_age_29_dependent_child.py
+++ b/policyengine_us/variables/gov/aca/slspc/is_aca_ny_age_29_dependent_child.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class is_aca_ny_age_29_dependent_child(Variable):
+    value_type = bool
+    entity = Person
+    label = "Person is a New York Age 29 dependent child for ACA family tier premiums"
+    definition_period = MONTH
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.aca
+        state_code = person.household("state_code", period)
+        in_ny = state_code == state_code.possible_values.NY
+        age = person("monthly_age", period)
+        lower_age = p.family_tier_dependent_child_age_threshold
+        upper_age = p.ny_age_29_dependent_child_age_threshold
+        in_age_range = (age >= lower_age) & (age < upper_age)
+        is_tax_dependent = person("is_tax_unit_dependent", period)
+        return (
+            person("pays_aca_premium", period) & in_ny & in_age_range & is_tax_dependent
+        )

--- a/policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_category.py
+++ b/policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_category.py
@@ -34,21 +34,30 @@ class slcsp_family_tier_category(Variable):
         # Get inputs
         state_code = tax_unit.household("state_code_str", period)
 
-        # Get the maximum child age from parameters
-        max_child_age = parameters(period).gov.aca.slcsp.max_child_age
-
-        # For tests, since the age variable is defined yearly but we're running monthly
-        # tests, we need to use the direct age values from the input file
         person = tax_unit.members
-        member_ages = person("monthly_age", period)
-
-        # Define adult status using the parameter instead of hardcoded value
         pays_premium = person("pays_aca_premium", period)
-        is_premium_paying_adult = (member_ages > max_child_age) & pays_premium
-        eligible_adult_count = tax_unit.sum(is_premium_paying_adult)
-        # More efficient than recounting: total - adults = children
-        eligible_people = tax_unit.sum(pays_premium)
-        eligible_child_count = eligible_people - eligible_adult_count
+        dependent_child = person("is_aca_family_tier_dependent_child", period)
+        non_dependent_adult_count = tax_unit.sum(pays_premium & ~dependent_child)
+        anchored_child_count = tax_unit.sum(dependent_child)
+
+        under_child_only_age = (
+            person("monthly_age", period)
+            <= parameters(period).gov.aca.slcsp.max_child_age
+        )
+        child_only_child = pays_premium & under_child_only_age
+        unanchored_adult_count = tax_unit.sum(pays_premium & ~child_only_child)
+        unanchored_child_count = tax_unit.sum(child_only_child)
+        has_adult_anchor = non_dependent_adult_count > 0
+        eligible_adult_count = where(
+            has_adult_anchor,
+            non_dependent_adult_count,
+            unanchored_adult_count,
+        )
+        eligible_child_count = where(
+            has_adult_anchor,
+            anchored_child_count,
+            unanchored_child_count,
+        )
 
         # Common conditions for both states
         one_adult_no_children = (eligible_adult_count == 1) & (

--- a/policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_multiplier.py
+++ b/policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_multiplier.py
@@ -1,4 +1,7 @@
 from policyengine_us.model_api import *
+from policyengine_us.variables.gov.aca.slspc.slcsp_family_tier_category import (
+    FamilyTierCategory,
+)
 
 
 class slcsp_family_tier_multiplier(Variable):
@@ -14,4 +17,50 @@ class slcsp_family_tier_multiplier(Variable):
         p = parameters(period).gov.aca.family_tier_ratings
         state_code = tax_unit.household("state_code", period)
         in_ny = state_code == state_code.possible_values.NY
-        return where(in_ny, p.ny[family_category], p.vt[family_category])
+
+        one_adult = where(in_ny, p.ny.ONE_ADULT, p.vt.ONE_ADULT)
+        two_adults = where(in_ny, p.ny.TWO_ADULTS, p.vt.TWO_ADULTS)
+        one_adult_with_children = where(
+            in_ny,
+            p.ny.ONE_ADULT_AND_ONE_OR_MORE_CHILDREN,
+            p.vt.ONE_ADULT_AND_ONE_OR_MORE_CHILDREN,
+        )
+        two_adults_with_children = where(
+            in_ny,
+            p.ny.TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN,
+            p.vt.TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN,
+        )
+        child_only = where(in_ny, p.ny.CHILD_ONLY, 0)
+
+        base_multiplier = select(
+            [
+                family_category == FamilyTierCategory.ONE_ADULT,
+                family_category == FamilyTierCategory.TWO_ADULTS,
+                family_category
+                == FamilyTierCategory.ONE_ADULT_AND_ONE_OR_MORE_CHILDREN,
+                family_category
+                == FamilyTierCategory.TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN,
+                family_category == FamilyTierCategory.CHILD_ONLY,
+            ],
+            [
+                one_adult,
+                two_adults,
+                one_adult_with_children,
+                two_adults_with_children,
+                child_only,
+            ],
+            default=0,
+        )
+
+        person = tax_unit.members
+        pays_premium = person("pays_aca_premium", period)
+        dependent_child = person("is_aca_family_tier_dependent_child", period)
+        adult_count = tax_unit.sum(pays_premium & ~dependent_child)
+        extra_adults = max_(adult_count - 2, 0)
+        age_29_child = person("is_aca_ny_age_29_dependent_child", period)
+        age_29_multiplier = where(
+            tax_unit.any(age_29_child),
+            parameters(period).gov.aca.ny_age_29_dependent_child_tier_multiplier,
+            1,
+        )
+        return base_multiplier * age_29_multiplier + extra_adults * one_adult


### PR DESCRIPTION
## Summary
- Count premium-paying ACA tax dependents under age 26 as dependent children for family-tier states when there is a covered adult family-tier anchor.
- Treat New York tax-dependent children ages 26 through 29 as dependent children using the NY Age 29 child tier rate, while avoiding NY `Child Only` pricing for covered age-26-through-29 dependents without a covered adult.
- Add extra adult benchmark premiums when NY/VT tax units have more than two premium-paying adults, including older adult dependents.
- Apply the same family-tier logic to SLCSP and lowest-cost bronze plan premiums.

## Policy Sources
- Federal PTC uses the taxpayer, spouse, and tax dependents as the relevant tax family/coverage family: https://uscode.house.gov/quicksearch/get.plx?section=36B&title=26
- NY State of Health SLCSP guidance maps an adult child claimed as a tax dependent to `Couple + Child(ren)` and the NY SLCSP rate tables separately publish `Dependent Children Under Age 26` and `Dependent Children Ages 26-29` columns: https://info.nystateofhealth.ny.gov/sites/default/files/2024%20FAQs%20on%20SLCSP%20English.pdf and https://info.nystateofhealth.ny.gov/sites/default/files/2025%20SLCSP%20Rates%20by%20County.FINAL.pdf
- New York's Age 29 dependent coverage authority is in Insurance Law Section 3216: https://www.nysenate.gov/legislation/laws/ISC/3216
- Vermont uses family rating tiers and treats ordinary dependent children as children through age 25; 26+ dependent-child coverage is limited to incapacitated dependents, which the model does not currently represent: https://info.healthconnect.vermont.gov/sites/vhc/files/documents/2025%20Catastrophic_Plans.pdf

## Root Cause
NY and VT use family-tier premiums instead of age curves, but the model reused the under-21 age-rating child cutoff and collapsed all adult counts above two into the two-adult tier. That treated 21-25 tax dependents as adults, missed NY's separate age-26-through-29 child tier, and dropped premium costs for older adult dependents.

## Review Notes
A secondary review found two issues. This revision fixes the `Child Only` edge case for NY age-26-through-29 dependents without a covered adult and avoids applying the NY Age 29 child factor to extra older-adult premiums. The remaining precision limitation is that NYSOH publishes exact SLCSP amounts by county and family type, while the current model stores NY benchmark inputs by rating area/base adult premium; this PR keeps the existing family-tier multiplier approach and adds the Age 29 factor within that framework.

## Tests
- uv run ruff check policyengine_us/variables/gov/aca/slspc/is_aca_family_tier_dependent_child.py policyengine_us/variables/gov/aca/slspc/is_aca_ny_age_29_dependent_child.py policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_category.py policyengine_us/variables/gov/aca/lcbp/lcbp_family_tier_category.py policyengine_us/variables/gov/aca/slspc/slcsp_family_tier_multiplier.py policyengine_us/variables/gov/aca/lcbp/lcbp_family_tier_multiplier.py
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_category.yaml -c policyengine_us
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/slcsp/family_tier_integration.yaml -c policyengine_us
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/lcbp/lcbp_family_tier_amount.yaml -c policyengine_us
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca -c policyengine_us
