### PR TITLE
Fix SC SALT addback to use pre-OBBBA cap (SC IL #26-4)

### DIFF
--- a/changelog.d/fix-sc-salt-addback-pre-obbba.fixed.md
+++ b/changelog.d/fix-sc-salt-addback-pre-obbba.fixed.md
@@ -1,0 +1,1 @@
+Fix South Carolina State Tax addback to use the pre-OBBBA $10,000 / $5,000 MFS SALT cap per SC Information Letter #26-4 Item 6 (SC did not conform to the 2025 federal SALT cap increase to $40,000).

--- a/policyengine_us/parameters/gov/states/sc/tax/income/additions/state_tax_addback/salt_cap.yaml
+++ b/policyengine_us/parameters/gov/states/sc/tax/income/additions/state_tax_addback/salt_cap.yaml
@@ -1,0 +1,27 @@
+description: South Carolina applies this state and local tax cap when computing the State Tax addback worksheet, holding to the pre-OBBBA federal SALT cap because SC has not conformed to the 2025 federal SALT cap increase.
+metadata:
+  label: South Carolina State Tax addback SALT cap
+  breakdown:
+    - filing_status
+  unit: currency-USD
+  period: year
+  reference:
+    - title: SC Information Letter #26-4 Revised — Item 6 (SALT cap non-conformity)
+      href: https://dor.sc.gov/income-tax-south-carolina-internal-revenue-code-conformity-update
+    - title: SC1040 Instructions — State Tax Addback Worksheet, Line 5 ("the federal limit of $10,000 ($5,000 if MFS)")
+      href: https://dor.sc.gov/forms-site/Forms/SC1040inst_2022.pdf#page=3
+HEAD_OF_HOUSEHOLD:
+  values:
+    2018-01-01: 10_000
+JOINT:
+  values:
+    2018-01-01: 10_000
+SEPARATE:
+  values:
+    2018-01-01: 5_000
+SINGLE:
+  values:
+    2018-01-01: 10_000
+SURVIVING_SPOUSE:
+  values:
+    2018-01-01: 10_000

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/sc_state_tax_addback.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/sc_state_tax_addback.yaml
@@ -90,3 +90,77 @@
     state_code: SC
   output:
     sc_state_tax_addback: 0
+
+# 2025+ tests: SC IL #26-4 Item 6 — SC has not conformed to OBBBA's federal SALT
+# cap increase from $10K to $40K. SC's State Tax Addback worksheet must continue
+# to use the pre-OBBBA $10K / $5K MFS cap. The federal SALT cap parameter
+# steps up to $40K at 2025-01-01, so a SC-frozen cap parameter is required.
+- name: 2025 SC JOINT itemizer with SALT just above $10K — non-conformity holds
+  period: 2025
+  input:
+    filing_status: JOINT
+    tax_unit_itemizes: true
+    itemized_taxable_income_deductions: 50_000
+    standard_deduction: 30_000
+    real_estate_taxes: 5_000
+    state_and_local_sales_or_income_tax: 8_000
+    state_code: SC
+  output:
+    # line 3 = 50000 - 30000 = 20000
+    # line 4 = 8000
+    # line 5 (SC-frozen $10K cap) = 10000 - 5000 = 5000
+    # addback = min(min(8000, 5000), 20000) = 5000
+    sc_state_tax_addback: 5_000
+
+- name: 2025 SC JOINT high-SALT itemizer — addback capped by SC-frozen $10K, not federal $40K
+  period: 2025
+  input:
+    filing_status: JOINT
+    tax_unit_itemizes: true
+    itemized_taxable_income_deductions: 60_000
+    standard_deduction: 30_000
+    real_estate_taxes: 10_000
+    state_and_local_sales_or_income_tax: 30_000
+    state_code: SC
+  output:
+    # line 3 = 60000 - 30000 = 30000
+    # line 4 = 30000
+    # line 5 (SC-frozen $10K cap) = max(0, 10000 - 10000) = 0
+    # addback = min(min(30000, 0), 30000) = 0
+    # If using federal $40K cap: line 5 = 30000, addback = 30000 — wrong per IL #26-4
+    sc_state_tax_addback: 0
+
+- name: 2025 SC SINGLE itemizer with SALT > $10K — non-conformity
+  period: 2025
+  input:
+    filing_status: SINGLE
+    tax_unit_itemizes: true
+    itemized_taxable_income_deductions: 30_000
+    standard_deduction: 15_000
+    real_estate_taxes: 2_000
+    state_and_local_sales_or_income_tax: 12_000
+    state_code: SC
+  output:
+    # line 3 = 30000 - 15000 = 15000
+    # line 4 = 12000
+    # line 5 (SC-frozen $10K cap) = 10000 - 2000 = 8000
+    # addback = min(min(12000, 8000), 15000) = 8000
+    sc_state_tax_addback: 8_000
+
+- name: 2025 SC MFS itemizer — SC-frozen $5K cap (not federal $20K)
+  period: 2025
+  input:
+    filing_status: SEPARATE
+    tax_unit_itemizes: true
+    itemized_taxable_income_deductions: 20_000
+    standard_deduction: 15_000
+    real_estate_taxes: 3_000
+    state_and_local_sales_or_income_tax: 6_000
+    state_code: SC
+  output:
+    # line 2 = 0 (MFS not eligible for the line-2 reduction in this worksheet)
+    # line 3 = 20000 - 0 = 20000
+    # line 4 = 6000
+    # line 5 (SC-frozen $5K MFS cap) = max(0, 5000 - 3000) = 2000
+    # addback = min(min(6000, 2000), 20000) = 2000
+    sc_state_tax_addback: 2_000

--- a/policyengine_us/variables/gov/states/sc/tax/income/additions/sc_state_tax_addback.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/additions/sc_state_tax_addback.py
@@ -11,12 +11,11 @@ class sc_state_tax_addback(Variable):
         "https://dor.sc.gov/forms-site/Forms/SC1040_2022.pdf#page=2",
         "https://dor.sc.gov/forms-site/Forms/SC1040inst_2022.pdf#page=2",
         "https://www.scstatehouse.gov/code/t12c006.php",  # SECTION 12-6-1130 (2)
+        "https://dor.sc.gov/income-tax-south-carolina-internal-revenue-code-conformity-update",  # IL #26-4 Item 6 — SALT cap non-conformity
     )
     defined_for = StateCode.SC
 
     def formula(tax_unit, period, parameters):
-        p_us = parameters(period).gov.irs.deductions
-
         us_itemizing = tax_unit("tax_unit_itemizes", period)
         standard_deduction = tax_unit("standard_deduction", period)
         filing_status = tax_unit("filing_status", period)
@@ -33,11 +32,14 @@ class sc_state_tax_addback(Variable):
         )
         # line 4
         salt = tax_unit("state_and_local_sales_or_income_tax", period)
-        # line 5
+        # line 5: SC has not conformed to OBBBA's 2025 SALT cap increase from
+        # $10,000 to $40,000 (SC IL #26-4 Item 6). Use the SC-frozen cap so
+        # the addback continues to reflect the pre-OBBBA $10K / $5K MFS limit.
+        p_sc = parameters(period).gov.states.sc.tax.income.additions
         real_estate_and_property_taxes = add(tax_unit, period, ["real_estate_taxes"])
         less_income_amount = max_(
             0,
-            p_us.itemized.salt_and_real_estate.cap[filing_status]
+            p_sc.state_tax_addback.salt_cap[filing_status]
             - real_estate_and_property_taxes,
         )
         # compare line 3,4,5. get the minimum


### PR DESCRIPTION
## Summary

South Carolina has not conformed to OBBBA's 2025 federal SALT cap increase from \$10,000 to \$40,000 (\$20,000 MFS) per [SC Information Letter #26-4 Revised, Item 6](https://dor.sc.gov/income-tax-south-carolina-internal-revenue-code-conformity-update). The SC1040 line 1d State Tax Addback worksheet must continue to use the pre-OBBBA \$10K / \$5K MFS cap.

This is a follow-up to the comment on PR #7870.

## Bug

`sc_state_tax_addback.py` reads the federal SALT cap directly:
```python
cap = parameters(period).gov.irs.deductions.itemized.salt_and_real_estate.cap[filing_status]
```

The federal parameter steps up to \$40K at 2025-01-01, so SC inherits the post-OBBBA cap. For 2025+ itemizers, this **overstates** the SC State Tax addback (worksheet line 5 = `cap − real_estate_taxes`; a higher cap leaves more room for state-income-tax addback) and therefore **overstates** SC tax liability.

> Direction-of-bias note: the original review on PR #7870 said the bug "understates" SC tax. After tracing the worksheet math, the bug actually **overstates** SC tax — a higher federal cap means a larger amount of state income tax was deducted federally, which means a larger required SC addback. Either way, the fix is the same: use the SC-frozen \$10K / \$5K MFS cap.

## Fix

1. Add `policyengine_us/parameters/gov/states/sc/tax/income/additions/state_tax_addback/salt_cap.yaml` holding \$10,000 / \$5,000 MFS effective 2018-01-01 (the federal TCJA SALT-cap effective date), referenced to SC IL #26-4 and the SC1040 worksheet instructions.
2. Update `sc_state_tax_addback.py` to read this SC parameter instead of `gov.irs.deductions.itemized.salt_and_real_estate.cap`.

## Tests

- Existing 6 pre-OBBBA cases (period 2021): pass unchanged — the SC-frozen \$10K matches the then-applicable federal \$10K.
- 4 new 2025 cases:
  - MFJ itemizer with SALT just above \$10K — addback locked by SC \$10K cap
  - MFJ high-SALT itemizer (\$30K state income, \$10K real estate) — addback drops to \$0 (full \$10K cap consumed by real estate); under federal \$40K cap this would have been \$30K
  - SINGLE itemizer with SALT > \$10K
  - MFS itemizer — SC \$5K cap, not federal \$20K

## Verification
- [x] 10 / 10 `sc_state_tax_addback.yaml` tests pass
- [x] 309 / 309 SC tax tests pass
- [x] \`make format\` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)