### PR TITLE
Fix ACA below-FPL immigrant PTC eligibility

### DIFF
--- a/changelog.d/aca-below-fpl-immigration-ptc.fixed.md
+++ b/changelog.d/aca-below-fpl-immigration-ptc.fixed.md
@@ -1,0 +1,1 @@
+Fix ACA Premium Tax Credit and Basic Health Program eligibility for lawfully present immigrants who are ineligible for Medicaid due to immigration status, including Medicaid five-year-bar cases.

--- a/policyengine_us/parameters/gov/aca/below_fpl_immigration_exception_in_effect.yaml
+++ b/policyengine_us/parameters/gov/aca/below_fpl_immigration_exception_in_effect.yaml
@@ -1,0 +1,13 @@
+description: ACA Premium Tax Credit below-FPL immigration exception is in effect.
+values:
+  2014-01-01: true
+  2026-01-01: false
+metadata:
+  unit: bool
+  period: year
+  label: ACA PTC below-FPL immigration exception in effect
+  reference:
+    - title: 26 U.S. Code § 36B(c)(1)(B) - Special rule for certain individuals lawfully present in the United States
+      href: https://www.law.cornell.edu/uscode/text/26/36B#c_1_B
+    - title: Pub. L. 119-21, Section 71302(b), effective date for repeal of 26 U.S.C. § 36B(c)(1)(B)
+      href: https://www.law.cornell.edu/uscode/text/26/36B#notes

--- a/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/ineligible_immigration_statuses.yaml
+++ b/policyengine_us/parameters/gov/hhs/basic_health_program/eligibility/ineligible_immigration_statuses.yaml
@@ -1,0 +1,28 @@
+description: Basic Health Program excludes these immigration statuses from lawfully present eligibility.
+values:
+  2015-01-01:
+    - DACA
+    - UNDOCUMENTED
+
+  # The 2024 DACA eligibility rule amended lawfully present definitions for
+  # Marketplace and Basic Health Program eligibility before the 2025 repeal.
+  2024-11-01:
+    - UNDOCUMENTED
+
+  2025-08-25:
+    - DACA
+    - UNDOCUMENTED
+
+metadata:
+  label: Basic Health Program ineligible immigration statuses
+  period: year
+  unit: list
+  reference:
+    - title: 42 CFR § 600.305 - Eligible individuals
+      href: https://www.law.cornell.edu/cfr/text/42/600.305
+    - title: 45 CFR § 155.20 - Lawfully present definition
+      href: https://www.law.cornell.edu/cfr/text/45/155.20
+    - title: 89 FR 39392 - DACA Recipients Eligibility Final Rule (2024-11-01)
+      href: https://www.federalregister.gov/documents/2024/05/08/2024-09661/clarifying-the-eligibility-of-deferred-action-for-childhood-arrivals-daca-recipients-and-certain
+    - title: 90 FR 27220 - Marketplace Integrity and Affordability Final Rule (2025-08-25)
+      href: https://www.federalregister.gov/documents/2025/06/25/2025-11606/patient-protection-and-affordable-care-act-marketplace-integrity-and-affordability

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/bar_exempt_immigration_statuses.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/bar_exempt_immigration_statuses.yaml
@@ -1,0 +1,20 @@
+description: The United States exempts these Medicaid-qualified immigration statuses from the federal five-year bar.
+
+# PolicyEngine does not currently distinguish humanitarian parolee subgroups
+# from the general PAROLED_ONE_YEAR qualified-alien category, so parolees are
+# modeled as subject to the five-year bar unless years_since_us_entry is at
+# least five.
+values:
+  1996-08-22:
+    - REFUGEE
+    - ASYLEE
+    - CUBAN_HAITIAN_ENTRANT
+    - DEPORTATION_WITHHELD
+
+metadata:
+  unit: list
+  period: year
+  label: Medicaid five-year bar exempt immigration statuses
+  reference:
+    - title: 8 USC 1613(b)(1) - Exceptions to five-year limited eligibility
+      href: https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title8-section1613&num=0&edition=prelim

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/five_year_bar_years.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/five_year_bar_years.yaml
@@ -1,0 +1,12 @@
+description: The United States bars qualified aliens from federal Medicaid eligibility for this many years after obtaining qualified status, unless an exception applies.
+
+values:
+  1996-08-22: 5
+
+metadata:
+  unit: year
+  period: year
+  label: Medicaid five-year bar duration
+  reference:
+    - title: 8 USC 1613(a) - Five-year limited eligibility
+      href: https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title8-section1613&num=0&edition=prelim

--- a/policyengine_us/parameters/gov/states/or/oha/healthier_oregon/eligibility/qualified_immigration_statuses.yaml
+++ b/policyengine_us/parameters/gov/states/or/oha/healthier_oregon/eligibility/qualified_immigration_statuses.yaml
@@ -1,4 +1,4 @@
-description: Oregon provides Healthier Oregon coverage to immigrants with these statuses who are not eligible for federal Medicaid.
+description: Oregon explicitly covers immigrants with these statuses through Healthier Oregon when they are not eligible for federal Medicaid.
 values:
   2023-07-01:
     - UNDOCUMENTED

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
@@ -41,6 +41,262 @@
   output:
     is_aca_ptc_eligible: false
 
+- name: Lawfully present Medicaid-ineligible immigrant below FPL qualifies
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: TPS
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+        state_fips: 48
+  output:
+    is_aca_ptc_immigration_status_eligible: [true]
+    is_medicaid_immigration_status_eligible: [false]
+    aca_ptc_below_fpl_immigration_exception: true
+    is_aca_ptc_eligible: [true]
+
+- name: Medicaid immigration-eligible immigrant below FPL does not qualify through exception
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: LEGAL_PERMANENT_RESIDENT
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+        state_fips: 48
+  output:
+    is_aca_ptc_immigration_status_eligible: [true]
+    is_medicaid_immigration_status_eligible: [true]
+    aca_ptc_below_fpl_immigration_exception: false
+    is_aca_ptc_eligible: [false]
+
+- name: Recent legal permanent resident below FPL qualifies through exception
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: LEGAL_PERMANENT_RESIDENT
+        years_since_us_entry: 2
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+        state_fips: 48
+  output:
+    is_aca_ptc_immigration_status_eligible: [true]
+    is_medicaid_immigration_status_eligible: [false]
+    aca_ptc_below_fpl_immigration_exception: true
+    is_aca_ptc_eligible: [true]
+
+- name: Recent one-year parolee below FPL qualifies through exception
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: PAROLED_ONE_YEAR
+        years_since_us_entry: 0
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+        state_fips: 48
+  output:
+    is_aca_ptc_immigration_status_eligible: [true]
+    is_medicaid_immigration_status_eligible: [false]
+    aca_ptc_below_fpl_immigration_exception: true
+    is_aca_ptc_eligible: [true]
+
+- name: Below-FPL immigrant exception expires in 2026
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: TPS
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+        state_fips: 48
+  output:
+    is_aca_ptc_immigration_status_eligible: [true]
+    is_medicaid_immigration_status_eligible: [false]
+    aca_ptc_below_fpl_immigration_exception: false
+    is_aca_ptc_eligible: [false]
+
+- name: Below-FPL lawfully present immigrant in New York BHP is not PTC eligible
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    is_aca_ptc_immigration_status_eligible: [true]
+    is_medicaid_immigration_status_eligible: [false]
+    aca_ptc_below_fpl_immigration_exception: true
+    is_basic_health_program_eligible: [true]
+    pays_aca_premium: [false]
+    is_aca_ptc_eligible: [false]
+
+- name: Lawfully present immigrant in DC BHP is not PTC eligible after 2026 repeal
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: TPS
+        medicaid_income_level: 1.2
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.2
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: DC
+  output:
+    aca_ptc_below_fpl_immigration_exception: false
+    is_basic_health_program_eligible: [true]
+    pays_aca_premium: [false]
+    is_aca_ptc_eligible: [false]
+
+- name: Oregon Healthier Oregon coverage blocks PTC below FPL
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: OR
+  output:
+    aca_ptc_below_fpl_immigration_exception: true
+    or_healthier_oregon_eligible: [true]
+    is_basic_health_program_eligible: [false]
+    pays_aca_premium: [false]
+    is_aca_ptc_eligible: [false]
+
+- name: Oregon Healthier Oregon covers recent LPR below FPL instead of PTC
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: LEGAL_PERMANENT_RESIDENT
+        years_since_us_entry: 2
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0.75
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: OR
+  output:
+    is_medicaid_immigration_status_eligible: [false]
+    aca_ptc_below_fpl_immigration_exception: true
+    or_healthier_oregon_eligible: [true]
+    is_basic_health_program_eligible: [false]
+    pays_aca_premium: [false]
+    is_aca_ptc_eligible: [false]
+
 - name: is_aca_ptc_eligible unit test 5 --- income B
   period: 2022
   input:

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
@@ -21,6 +21,69 @@
   output:
     aca_ptc: 200  # 1200 - 0.04 * 25000 = 200
 
+- name: Below-FPL lawfully present immigrant receives PTC in 2025
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: TPS
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 10_000
+        aca_magi_fraction: 0.75
+        slcsp: 1_200
+        tax_unit_is_filer: true
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+        state_fips: 48
+  output:
+    aca_ptc_below_fpl_immigration_exception: true
+    is_aca_ptc_eligible: [true]
+    aca_required_contribution_percentage: 0
+    aca_ptc: 1_200
+
+- name: Below-FPL lawfully present immigrant in New York BHP receives no PTC
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 10_000
+        aca_magi_fraction: 0.75
+        slcsp: 1_200
+        tax_unit_is_filer: true
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    aca_ptc_below_fpl_immigration_exception: true
+    is_basic_health_program_eligible: [true]
+    is_aca_ptc_eligible: [false]
+    aca_ptc: 0
+
 - name: ACA PTC floors at zero when contribution exceeds plan cost
   absolute_error_margin: 0.01
   period: 2025

--- a/policyengine_us/tests/policy/baseline/gov/hhs/basic_health_program/is_basic_health_program_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/basic_health_program/is_basic_health_program_eligible.yaml
@@ -137,6 +137,139 @@
   output:
     is_basic_health_program_eligible: [false]
 
+- name: Lawfully present Medicaid-barred immigrant below 133 percent FPL qualifies for BHP
+  period: 2025
+  input:
+    people:
+      person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: NY
+  output:
+    is_medicaid_immigration_status_eligible: [false]
+    is_basic_health_program_eligible: [true]
+
+- name: BHP alien-status lane excludes Oregon Healthier Oregon coverage
+  period: 2026
+  input:
+    people:
+      mn_person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+      ny_person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+      or_person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+      dc_person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      mn_household:
+        members: [mn_person]
+        state_code: MN
+      ny_household:
+        members: [ny_person]
+        state_code: NY
+      or_household:
+        members: [or_person]
+        state_code: OR
+      dc_household:
+        members: [dc_person]
+        state_code: DC
+  output:
+    or_healthier_oregon_eligible: [false, false, true, false]
+    is_basic_health_program_eligible: [true, true, false, true]
+
+- name: Oregon Healthier Oregon coverage blocks BHP below 138 percent FPL
+  period: 2025
+  input:
+    people:
+      person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 0.75
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: OR
+  output:
+    or_healthier_oregon_eligible: [true]
+    is_basic_health_program_eligible: [false]
+
+- name: Lawfully present Medicaid-barred immigrant at 133 percent FPL qualifies for BHP
+  period: 2025
+  input:
+    people:
+      person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 1.33
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: NY
+  output:
+    is_basic_health_program_eligible: [true]
+
+- name: BHP eligibility survives 2027 PTC alien restriction
+  period: 2027
+  input:
+    people:
+      person:
+        age: 30
+        immigration_status: TPS
+        medicaid_income_level: 1.2
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    households:
+      household:
+        members: [person]
+        state_code: NY
+  output:
+    is_aca_ptc_immigration_status_eligible: [false]
+    is_basic_health_program_immigration_status_eligible: [true]
+    is_basic_health_program_eligible: [true]
+
 # Regression: NY Essential Plan at 150% FPL in 2016 (first full BHP year).
 - name: New York Basic Health Program is active from 2016 onward in annual simulations
   period: 2016

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_immigration_status_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_immigration_status_eligible.yaml
@@ -12,10 +12,50 @@
   output:
     is_medicaid_immigration_status_eligible: true
 
+- name: Recent legal permanent resident is ineligible during five-year bar
+  period: 2025
+  input:
+    immigration_status: LEGAL_PERMANENT_RESIDENT
+    years_since_us_entry: 4
+  output:
+    is_medicaid_immigration_status_eligible: false
+
+- name: Legal permanent resident past five-year bar remains eligible
+  period: 2025
+  input:
+    immigration_status: LEGAL_PERMANENT_RESIDENT
+    years_since_us_entry: 5
+  output:
+    is_medicaid_immigration_status_eligible: true
+
+- name: Recent one-year parolee is ineligible during five-year bar
+  period: 2025
+  input:
+    immigration_status: PAROLED_ONE_YEAR
+    years_since_us_entry: 0
+  output:
+    is_medicaid_immigration_status_eligible: false
+
+- name: One-year parolee past five-year bar is eligible
+  period: 2025
+  input:
+    immigration_status: PAROLED_ONE_YEAR
+    years_since_us_entry: 5
+  output:
+    is_medicaid_immigration_status_eligible: true
+
 - name: Eligible immigration status - Refugee
   period: 2024
   input:
     immigration_status: REFUGEE
+  output:
+    is_medicaid_immigration_status_eligible: true
+
+- name: Refugee is exempt from five-year bar
+  period: 2025
+  input:
+    immigration_status: REFUGEE
+    years_since_us_entry: 0
   output:
     is_medicaid_immigration_status_eligible: true
 

--- a/policyengine_us/tests/policy/baseline/gov/states/or/oha/healthier_oregon/eligibility/or_healthier_oregon_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/oha/healthier_oregon/eligibility/or_healthier_oregon_eligible.yaml
@@ -70,6 +70,30 @@
   output:
     or_healthier_oregon_eligible: true
 
+- name: Recent legal permanent resident with low income eligible
+  period: 2025
+  input:
+    age: 30
+    immigration_status: LEGAL_PERMANENT_RESIDENT
+    years_since_us_entry: 2
+    medicaid_income_level: 1.0
+    state_code: OR
+  output:
+    is_medicaid_immigration_status_eligible: false
+    or_healthier_oregon_eligible: true
+
+- name: Legal permanent resident past five-year bar uses federal Medicaid instead
+  period: 2025
+  input:
+    age: 30
+    immigration_status: LEGAL_PERMANENT_RESIDENT
+    years_since_us_entry: 5
+    medicaid_income_level: 1.0
+    state_code: OR
+  output:
+    is_medicaid_immigration_status_eligible: true
+    or_healthier_oregon_eligible: false
+
 - name: Adult at exactly 138% FPL eligible
   period: 2024
   input:

--- a/policyengine_us/variables/gov/aca/eligibility/aca_ptc_below_fpl_immigration_exception.py
+++ b/policyengine_us/variables/gov/aca/eligibility/aca_ptc_below_fpl_immigration_exception.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class aca_ptc_below_fpl_immigration_exception(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "ACA PTC below-FPL immigration exception"
+    definition_period = YEAR
+    reference = [
+        "https://www.law.cornell.edu/uscode/text/26/36B#c_1_B",
+        "https://www.law.cornell.edu/cfr/text/26/1.36B-2#b_5",
+    ]
+
+    def formula(tax_unit, period, parameters):
+        in_effect = parameters(period).gov.aca.below_fpl_immigration_exception_in_effect
+        below_fpl = tax_unit("aca_magi_fraction", period) < 1
+
+        person = tax_unit.members
+        immigration_status = person("immigration_status", period)
+        non_citizen = immigration_status != immigration_status.possible_values.CITIZEN
+        aca_lawfully_present = person("is_aca_ptc_immigration_status_eligible", period)
+        medicaid_ineligible_due_to_status = ~person(
+            "is_medicaid_immigration_status_eligible", period
+        )
+
+        qualifying_family_member = tax_unit.any(
+            non_citizen & aca_lawfully_present & medicaid_ineligible_due_to_status
+        )
+        return in_effect & below_fpl & qualifying_family_member

--- a/policyengine_us/variables/gov/aca/eligibility/is_aca_ptc_eligible.py
+++ b/policyengine_us/variables/gov/aca/eligibility/is_aca_ptc_eligible.py
@@ -14,6 +14,10 @@ class is_aca_ptc_eligible(Variable):
         # determine income eligibility for ACA PTC
         p = parameters(period).gov.aca
         magi_frac = person.tax_unit("aca_magi_fraction", period)
-        is_income_eligible = p.ptc_income_eligibility.calc(magi_frac)
+        standard_income_eligible = p.ptc_income_eligibility.calc(magi_frac)
+        below_fpl_exception = person.tax_unit(
+            "aca_ptc_below_fpl_immigration_exception", period
+        )
+        is_income_eligible = standard_income_eligible | below_fpl_exception
 
         return person("pays_aca_premium", period) & ~separate & is_income_eligible

--- a/policyengine_us/variables/gov/aca/eligibility/pays_aca_premium.py
+++ b/policyengine_us/variables/gov/aca/eligibility/pays_aca_premium.py
@@ -18,6 +18,7 @@ class pays_aca_premium(Variable):
             "is_basic_health_program_eligible",
             "is_aca_eshi_eligible",
             "is_medicare_eligible",
+            "or_healthier_oregon_eligible",
         ]
         is_coverage_eligible = add(person, period, INELIGIBLE_COVERAGE) == 0
 

--- a/policyengine_us/variables/gov/hhs/basic_health_program/is_basic_health_program_eligible.py
+++ b/policyengine_us/variables/gov/hhs/basic_health_program/is_basic_health_program_eligible.py
@@ -7,6 +7,7 @@ class is_basic_health_program_eligible(Variable):
     label = "Eligible for Basic Health Program coverage"
     definition_period = YEAR
     reference = (
+        "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section18051&num=0&edition=prelim",
         "https://www.medicaid.gov/basic-health-program",
         "https://mn.gov/dhs/people-we-serve/adults/health-care/health-care-programs/programs-and-services/minnesotacare.jsp",
         "https://info.nystateofhealth.ny.gov/EssentialPlan",
@@ -37,7 +38,13 @@ class is_basic_health_program_eligible(Variable):
         chip_eligible = person("is_chip_eligible", period)
         esi_eligible = person("is_aca_eshi_eligible", period)
         medicare_eligible = person("is_medicare_eligible", period)
-        immigration_eligible = person("is_aca_ptc_immigration_status_eligible", period)
+        healthier_oregon_eligible = person("or_healthier_oregon_eligible", period)
+        immigration_eligible = person(
+            "is_basic_health_program_immigration_status_eligible", period
+        )
+        medicaid_immigration_status_eligible = person(
+            "is_medicaid_immigration_status_eligible", period
+        )
 
         income_level = person("medicaid_income_level", period)
         expanded_limit_state = np.isin(state, p.expanded_income_limit_states)
@@ -46,14 +53,16 @@ class is_basic_health_program_eligible(Variable):
             p.expanded_income_limit,
             p.income_limit,
         )
-        # 42 USC 18051(b)(2)(B): BHP covers income above 133% FPL. The
-        # ~medicaid_eligible guard alone is insufficient for non-expansion
-        # states (where Medicaid may cut off below 133% FPL), so enforce
-        # the statutory floor explicitly. Citizens below 133% are in
-        # Medicaid in expansion states or the coverage gap otherwise.
-        in_income_range = (income_level >= p.income_floor) & (
+        # 42 USC 18051(e)(1)(B): standard BHP covers income above 133% FPL.
+        # Lawfully present immigrants below that floor also qualify when
+        # Medicaid-ineligible by alien status.
+        standard_income_range = (income_level >= p.income_floor) & (
             income_level <= income_limit
         )
+        alien_status_income_range = (income_level < p.income_floor) & (
+            ~medicaid_immigration_status_eligible
+        )
+        in_income_range = standard_income_range | alien_status_income_range
 
         return (
             in_effect
@@ -63,5 +72,6 @@ class is_basic_health_program_eligible(Variable):
             & ~chip_eligible
             & ~esi_eligible
             & ~medicare_eligible
+            & ~healthier_oregon_eligible
             & in_income_range
         )

--- a/policyengine_us/variables/gov/hhs/basic_health_program/is_basic_health_program_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/hhs/basic_health_program/is_basic_health_program_immigration_status_eligible.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class is_basic_health_program_immigration_status_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible immigration status for Basic Health Program coverage"
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/cfr/text/42/600.305",
+        "https://www.law.cornell.edu/cfr/text/45/155.20",
+        "https://www.federalregister.gov/documents/2024/05/08/2024-09661/clarifying-the-eligibility-of-deferred-action-for-childhood-arrivals-daca-recipients-and-certain",
+        "https://www.federalregister.gov/documents/2025/06/25/2025-11606/patient-protection-and-affordable-care-act-marketplace-integrity-and-affordability",
+    )
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.hhs.basic_health_program.eligibility
+        immigration_status = person("immigration_status", period)
+        immigration_status_str = immigration_status.decode_to_str()
+        ineligible_immigration_status = np.isin(
+            immigration_status_str, p.ineligible_immigration_statuses
+        )
+        return ~ineligible_immigration_status

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_immigration_status_eligible.py
@@ -9,6 +9,7 @@ class is_medicaid_immigration_status_eligible(Variable):
     reference = [
         "https://www.law.cornell.edu/uscode/text/42/1396b#v",
         "https://www.law.cornell.edu/uscode/text/8/1641",
+        "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title8-section1613&num=0&edition=prelim",
         "https://www.kff.org/racial-equity-and-health-policy/fact-sheet/key-facts-on-health-coverage-of-immigrants/",
     ]
 
@@ -17,9 +18,17 @@ class is_medicaid_immigration_status_eligible(Variable):
         immigration_status = person("immigration_status", period)
         immigration_status_str = immigration_status.decode_to_str()
 
-        # Check if immigration status is in the eligible list
         eligible_immigration_status = np.isin(
             immigration_status_str, p.eligible_immigration_statuses
+        )
+        citizen = immigration_status == immigration_status.possible_values.CITIZEN
+        bar_exempt_status = np.isin(
+            immigration_status_str, p.bar_exempt_immigration_statuses
+        )
+        years_since_entry = person("years_since_us_entry", period.this_year)
+        past_five_year_bar = years_since_entry >= p.five_year_bar_years
+        federally_eligible_status = citizen | (
+            eligible_immigration_status & (bar_exempt_status | past_five_year_bar)
         )
 
         # Special handling for undocumented immigrants in states that cover them
@@ -35,7 +44,7 @@ class is_medicaid_immigration_status_eligible(Variable):
         )
 
         return (
-            eligible_immigration_status
+            federally_eligible_status
             | undocumented_eligible
             | ca_eligible_regardless_of_immigration_status
         )

--- a/policyengine_us/variables/gov/states/or/oha/healthier_oregon/eligibility/or_healthier_oregon_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/states/or/oha/healthier_oregon/eligibility/or_healthier_oregon_immigration_status_eligible.py
@@ -17,7 +17,13 @@ class or_healthier_oregon_immigration_status_eligible(Variable):
         p = parameters(period).gov.states["or"].oha.healthier_oregon.eligibility
         immigration_status = person("immigration_status", period)
         immigration_status_str = immigration_status.decode_to_str()
-        return np.isin(
+        explicitly_covered_status = np.isin(
             immigration_status_str,
             p.qualified_immigration_statuses,
         )
+        non_citizen = immigration_status != immigration_status.possible_values.CITIZEN
+        federally_medicaid_status_eligible = person(
+            "is_medicaid_immigration_status_eligible", period
+        )
+        federally_barred_non_citizen = non_citizen & ~federally_medicaid_status_eligible
+        return explicitly_covered_status | federally_barred_non_citizen


### PR DESCRIPTION
## Summary
- Add the ACA PTC below-FPL immigration exception for tax years through 2025.
- Treat a tax unit below 100% FPL as income-eligible when at least one non-citizen family member is ACA-lawfully-present and Medicaid-ineligible due to immigration status.
- Gate the exception off starting in 2026 to reflect Pub. L. 119-21 repeal of IRC 36B(c)(1)(B).

## Policy Sources
- IRC 36B(c)(1)(B) created a special below-FPL rule for certain lawfully present individuals: https://www.law.cornell.edu/uscode/text/26/36B#c_1_B
- Treasury regulations describe the same below-FPL rule for lawfully present aliens ineligible for Medicaid: https://www.law.cornell.edu/cfr/text/26/1.36B-2#b_5
- Pub. L. 119-21 repealed IRC 36B(c)(1)(B), effective for taxable years beginning after December 31, 2025: https://www.law.cornell.edu/uscode/text/26/36B#notes

## Tests
- TDD failure first: `is_aca_ptc_eligible.yaml` failed before adding `aca_ptc_below_fpl_immigration_exception`; the 2026 expiry regression failed before adding the in-effect parameter.
- `uv run ruff check policyengine_us/variables/gov/aca/eligibility/aca_ptc_below_fpl_immigration_exception.py policyengine_us/variables/gov/aca/eligibility/is_aca_ptc_eligible.py`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca -c policyengine_us`
