### PR TITLE
Fix SPM childcare cap projection

### DIFF
--- a/changelog.d/spm-childcare-cap-projection.fixed.md
+++ b/changelog.d/spm-childcare-cap-projection.fixed.md
@@ -1,0 +1,1 @@
+Fix SPM childcare earnings cap projection for datasets with multiple SPM units.

--- a/policyengine_us/tests/policy/baseline/household/expense/childcare/spm_unit_head_spouse_earned_cap.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/childcare/spm_unit_head_spouse_earned_cap.yaml
@@ -186,3 +186,44 @@
         members: [head, spouse]
   output:
     spm_unit_head_spouse_earned_cap: 4_000
+
+- name: Multiple SPM units project reference spouse and partner flags to members
+  period: 2024
+  absolute_error_margin: 0.001
+  input:
+    people:
+      reference_person:
+        age: 35
+        employment_income: 40_000
+        is_household_head: true
+        is_tax_unit_head: true
+      partner:
+        age: 33
+        employment_income: 3_000
+        is_unmarried_partner_of_household_head: true
+        is_tax_unit_head: true
+      child:
+        age: 8
+      second_reference_person:
+        age: 45
+        employment_income: 50_000
+        is_household_head: true
+        is_tax_unit_head: true
+      second_spouse:
+        age: 44
+        employment_income: 7_000
+        is_tax_unit_spouse: true
+    tax_units:
+      reference_unit:
+        members: [reference_person, child]
+      partner_unit:
+        members: [partner]
+      second_unit:
+        members: [second_reference_person, second_spouse]
+    spm_units:
+      spm_unit:
+        members: [reference_person, partner, child]
+      second_spm_unit:
+        members: [second_reference_person, second_spouse]
+  output:
+    spm_unit_head_spouse_earned_cap: [3_000, 7_000]

--- a/policyengine_us/variables/household/expense/childcare/spm_unit_head_spouse_earned_cap.py
+++ b/policyengine_us/variables/household/expense/childcare/spm_unit_head_spouse_earned_cap.py
@@ -22,11 +22,13 @@ class spm_unit_head_spouse_earned_cap(Variable):
             "is_unmarried_partner_of_household_head", period
         )
         has_spouse = spm_unit.any(is_reference_person_spouse)
+        has_spouse_person = spm_unit.project(has_spouse)
         eligible_reference_person_or_partner = (
             is_reference_person
             | is_reference_person_spouse
-            | (~has_spouse & is_reference_person_partner)
+            | (~has_spouse_person & is_reference_person_partner)
         )
+        has_reference_person = spm_unit.project(has_reference_person)
         eligible_people = where(
             has_reference_person,
             eligible_reference_person_or_partner,

--- a/uv.lock
+++ b/uv.lock
@@ -2974,7 +2974,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.680.0"
+version = "1.690.0"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary

Fixes the SPM childcare earnings cap formula introduced in #8247 so SPM-unit-level `any()` results are projected back to person-level before combining them with person-level partner flags. Without this, projected-year microsimulations over datasets with multiple SPM units can fail with a shape/broadcasting error.

## Testing

- `PYTHONPATH=. uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/expense/childcare/spm_unit_head_spouse_earned_cap.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/household/expense/childcare/spm_unit_head_spouse_earned_cap.py`
- `uv run ruff format --check policyengine_us/variables/household/expense/childcare/spm_unit_head_spouse_earned_cap.py`
- `git diff --check`