### PR TITLE
Fix WIC income guideline timing

### DIFF
--- a/changelog.d/wic-income-guidelines.fixed
+++ b/changelog.d/wic-income-guidelines.fixed
@@ -1,0 +1,1 @@
+Fix WIC income eligibility to use the July-June WIC income guideline year.

--- a/policyengine_us/tests/policy/baseline/gov/usda/wic/meets_wic_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/wic/meets_wic_income_test.yaml
@@ -1,15 +1,45 @@
-- name: Up to 185% of the poverty line (reduced school meal limit) is eligible.
-  period: 2022
+- name: Up to the WIC annual income limit is eligible.
+  period: 2022-01
   input:
-    wic_fpg: 1
+    wic_income_limit: 1.85
     wic_countable_income: 1.85
   output:
     meets_wic_income_test: true
 
-- name: Above 185% of the poverty line (reduced school meal limit) is ineligible.
-  period: 2022
+- name: Above the WIC annual income limit is ineligible.
+  period: 2022-01
   input:
-    wic_fpg: 1
+    wic_income_limit: 1.85
     wic_countable_income: 1.86
+  output:
+    meets_wic_income_test: false
+
+- name: Two-person household at the 2025-2026 WIC annual income limit qualifies.
+  period: 2026-01
+  input:
+    people:
+      parent:
+        age: 30
+      child:
+        age: 2
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+        wic_countable_income: 39_128
+  output:
+    meets_wic_income_test: true
+
+- name: Two-person household above the 2025-2026 WIC annual income limit does not qualify.
+  period: 2026-01
+  input:
+    people:
+      parent:
+        age: 30
+      child:
+        age: 2
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+        wic_countable_income: 40_000
   output:
     meets_wic_income_test: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/wic/wic_income_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/wic/wic_income_limit.yaml
@@ -1,0 +1,44 @@
+- name: Two-person WIC income limit uses 2025 guidelines before July 2026.
+  period: 2026-01
+  input:
+    people:
+      parent:
+        age: 30
+      child:
+        age: 2
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+  output:
+    wic_income_limit: 39_128
+
+- name: Pregnancy increases the WIC income unit by one.
+  period: 2026-01
+  input:
+    people:
+      parent:
+        age: 30
+        is_pregnant: true
+    spm_units:
+      spm_unit:
+        members: [parent]
+  output:
+    wic_income_limit: 39_128
+
+- name: Guam uses the contiguous U.S. WIC income limit.
+  period: 2026-01
+  input:
+    people:
+      parent:
+        age: 30
+      child:
+        age: 2
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: GU
+  output:
+    wic_income_limit: 39_128

--- a/policyengine_us/variables/gov/usda/wic/meets_wic_income_test.py
+++ b/policyengine_us/variables/gov/usda/wic/meets_wic_income_test.py
@@ -10,10 +10,6 @@ class meets_wic_income_test(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/42/1786#d_2_A_i"
 
     def formula(spm_unit, period, parameters):
-        # WIC uses the reduced-price school meal income limit, with a
-        # WIC-specific countable income definition and pregnancy adjustment.
-        income = spm_unit("wic_countable_income", period)
-        adj_fpg = spm_unit("wic_fpg", period)
-        limit = parameters(period).gov.usda.school_meals.income.limit.REDUCED
-        income_fpg_ratio = income / adj_fpg
-        return income_fpg_ratio <= limit
+        income = spm_unit("wic_countable_income", period.this_year)
+        limit = spm_unit("wic_income_limit", period.first_month)
+        return income <= limit

--- a/policyengine_us/variables/gov/usda/wic/wic_income_limit.py
+++ b/policyengine_us/variables/gov/usda/wic/wic_income_limit.py
@@ -1,0 +1,38 @@
+from policyengine_us.model_api import *
+
+
+class wic_income_limit(Variable):
+    value_type = float
+    entity = SPMUnit
+    definition_period = MONTH
+    unit = USD
+    label = "WIC income limit"
+    documentation = "Annual income limit for WIC direct income eligibility"
+    reference = [
+        "https://www.law.cornell.edu/uscode/text/42/1786#d_2_A_i",
+        "https://www.fns.usda.gov/wic/income-eligibility-guidelines-2025-26",
+    ]
+
+    def formula(spm_unit, period, parameters):
+        spm_unit_size = spm_unit("spm_unit_size", period.this_year)
+        pregnant = spm_unit.any(spm_unit.members("is_pregnant", period))
+        wic_unit_size = spm_unit_size + pregnant
+
+        state_group = spm_unit.household("state_group_str", period.this_year)
+        wic_state_group = np.where(
+            np.isin(state_group, ("AK", "HI")),
+            state_group,
+            "CONTIGUOUS_US",
+        )
+
+        year = period.start.year
+        month = period.start.month
+        hhs_guideline_year = year if month >= 7 else year - 1
+        p_fpg = parameters(f"{hhs_guideline_year}-01-01").gov.hhs.fpg
+        first_person = p_fpg.first_person[wic_state_group]
+        additional_person = p_fpg.additional_person[wic_state_group]
+        fpg = first_person + additional_person * (wic_unit_size - 1)
+        reduced_school_meal_limit = parameters(
+            period
+        ).gov.usda.school_meals.income.limit.REDUCED
+        return np.ceil(fpg * reduced_school_meal_limit)


### PR DESCRIPTION
## Summary

- Add a WIC-specific annual income limit variable using the July-through-June WIC guideline year.
- Compare WIC countable annual income to the rounded annual WIC limit instead of comparing against calendar-year HHS FPG through the school-meal ratio.
- Add WIC boundary tests for the 2025-2026 two-person limit, pregnancy size adjustment, and territories using the contiguous U.S. WIC limit.

## Why

WIC income guidelines are issued on a July 1 through June 30 cycle. For January-June 2026, the applicable two-person annual limit is $39,128, so a two-person household at $40,000 should fail the direct WIC income test before categorical eligibility is considered.

Sources:
- USDA FNS 2025-2026 WIC income eligibility guidelines: https://www.fns.usda.gov/wic/income-eligibility-guidelines-2025-26
- 42 U.S.C. 1786(d)(2)(A)(i): https://www.law.cornell.edu/uscode/text/42/1786#d_2_A_i

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/usda/wic -c policyengine_us`
- `uv run python -m compileall -q policyengine_us/variables/gov/usda/wic policyengine_us/tests/policy/baseline/gov/usda/wic`
- `git diff --check`

Downstream Axiom validation with this branch plus point-in-time PE periods: `80/80` ACCESS NYC vs PolicyEngine comparisons match on `nyc-synthetic`.
