### PR TITLE
Fix SNAP BBCE gross income limits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Conventions:
 - Use `where(...)`, `max_(...)`, `min_(...)` inside formulas — never Python `if` / `max` / `min`. Vectorisation requires numpy.
 - Match the variable file name to the class name (e.g. `my_tax_credit.py` defines `class my_tax_credit(Variable)`).
 - Filing-status breakdowns must cover all five statuses: `SINGLE`, `SEPARATE`, `SURVIVING_SPOUSE`, `HEAD_OF_HOUSEHOLD`, `JOINT`. If a source only lists four, treat `SURVIVING_SPOUSE` the same as `JOINT`.
+- Enum breakdown parameters must be real tables, not single-member tables. If a parameter only applies to one enum member, make it a scalar under a member-specific path instead of using `metadata.breakdown`; for example use `.../income_limit/ny/earned_income.yaml` with `values:` rather than a `state_code` table containing only `NY`.
 - For scale parameters returning integers, use `/1` in `rate_unit`, not `int`.
 - Cite the specific CFR / USC / state-code section in the variable's `reference` field.
 - State programs should be self-contained with state-specific variable names (e.g. `il_tanf_countable_income`, not `tanf_countable_income`).

--- a/changelog.d/ny-snap-bbce.fixed.md
+++ b/changelog.d/ny-snap-bbce.fixed.md
@@ -1,0 +1,1 @@
+Fix New York and elderly/disabled SNAP BBCE gross income limits.

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/gross.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/gross.yaml
@@ -87,9 +87,9 @@ NM:
   2024-10-01: 2
   # https://www.hca.nm.gov/2024/09/23/governor-expands-snap-access-increases-benefits-for-new-mexicans/
 NY:
-  # 150% for those with earned income.
-  # 200% for those with dependent care expenses, not currently entered.
-  2015-10-01: 1.5
+  # Households without earned income, dependent care expenses, or elderly/disabled members.
+  # Earned income, dependent care, and elderly/disabled limits are modeled separately.
+  2015-10-01: 1.3
 NC:
   2015-10-01: 2
 ND:

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/gross_hheod.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/gross_hheod.yaml
@@ -1,0 +1,134 @@
+description: Gross income limit as a percent of the poverty line for elderly or disabled households seeking TANF non-cash benefit used for SNAP BBCE, by state.
+
+AL:
+  2015-10-01: 2
+AK:
+  # Alaska had not elected BBCE in the ERS data through 2020.
+  2015-10-01: -.inf
+  2025-07-01: 2
+AZ:
+  2015-10-01: 1.85
+AR:
+  2015-10-01: -.inf
+CA:
+  2015-10-01: 2
+CO:
+  2015-10-01: 2
+CT:
+  2015-10-01: 1.85
+  2022-10-01: 2
+DE:
+  2015-10-01: 2
+DC:
+  2015-10-01: 2
+FL:
+  2015-10-01: 2
+GA:
+  2015-10-01: 2
+GU:
+  2015-10-01: 1.65
+HI:
+  2015-10-01: 2
+ID:
+  2015-10-01: .inf
+IL:
+  2015-10-01: 2
+IN:
+  2015-10-01: -.inf
+  2018-01-01: .inf
+IA:
+  2015-10-01: 1.6
+KS:
+  2015-10-01: -.inf
+KY:
+  2015-10-01: 2
+LA:
+  2015-10-01: -.inf
+  2020-04-01: 1.3
+  2022-07-01: 2
+ME:
+  2015-10-01: 1.85
+  2024-07-01: 2
+MD:
+  2015-10-01: 2
+MA:
+  2015-10-01: 2
+MI:
+  2015-10-01: 2
+MN:
+  2015-10-01: 1.65
+  2022-09-01: 2
+  2024-07-01: .inf
+MO:
+  2015-10-01: -.inf
+MS:
+  2015-10-01: .inf
+  2019-07-01: -.inf
+MT:
+  2015-10-01: 2
+NE:
+  2015-10-01: .inf
+NV:
+  2015-10-01: 2
+NH:
+  2015-10-01: 1.85
+  2023-01-01: 2
+NJ:
+  2015-10-01: 1.85
+NM:
+  2015-10-01: 1.65
+  2024-10-01: 2
+NY:
+  2015-10-01: 2
+NC:
+  2015-10-01: 2
+ND:
+  2015-10-01: 2
+OH:
+  2015-10-01: 2
+OK:
+  2015-10-01: .inf
+OR:
+  2015-10-01: 1.85
+  2022-01-01: 2
+PA:
+  2015-10-01: 2
+RI:
+  2015-10-01: 2
+SC:
+  2015-10-01: 2
+SD:
+  2015-10-01: -.inf
+TX:
+  2015-10-01: 1.65
+TN:
+  2015-10-01: -.inf
+UT:
+  2015-10-01: -.inf
+VT:
+  2015-10-01: 1.85
+VI:
+  2015-10-01: 2
+VA:
+  2015-10-01: -.inf
+  2021-07-01: 2
+WA:
+  2015-10-01: 2
+WV:
+  2015-10-01: 2
+WI:
+  2015-10-01: 2
+WY:
+  2015-10-01: -.inf
+
+metadata:
+  unit: /1
+  period: year
+  label: SNAP BBCE elderly or disabled household gross income limit
+  reference:
+    - title: SNAP Screener SNAP Eligibility Parameters
+      href: https://www.snapscreener.com/?p=table
+    - title: USDA ERS SNAP Policy Database (bbce_elddisinclmt column, Jan 1996 - Dec 2020)
+      href: https://www.ers.usda.gov/data-products/snap-policy-data-sets
+  breakdown:
+  - state_code

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/ny/dependent_care.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/ny/dependent_care.yaml
@@ -1,0 +1,12 @@
+description: Gross income limit as a percent of the poverty line for New York households with dependent care expenses seeking TANF non-cash benefit used for SNAP BBCE.
+
+values:
+  2015-10-01: 2
+
+metadata:
+  unit: /1
+  period: year
+  label: New York SNAP BBCE dependent care gross income limit
+  reference:
+    - title: SNAP Screener SNAP Eligibility Parameters
+      href: https://www.snapscreener.com/?p=table

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/ny/earned_income.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/ny/earned_income.yaml
@@ -1,0 +1,12 @@
+description: Gross income limit as a percent of the poverty line for New York households with earned income seeking TANF non-cash benefit used for SNAP BBCE.
+
+values:
+  2015-10-01: 1.5
+
+metadata:
+  unit: /1
+  period: year
+  label: New York SNAP BBCE earned income gross income limit
+  reference:
+    - title: SNAP Screener SNAP Eligibility Parameters
+      href: https://www.snapscreener.com/?p=table

--- a/policyengine_us/parameters/gov/states/mi/tax/income/deductions/retirement_benefits/tier_three/ss_exempt/not_retired/amount.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/deductions/retirement_benefits/tier_three/ss_exempt/not_retired/amount.yaml
@@ -6,8 +6,6 @@ metadata:
   label: Michigan non-retired tier three retirement and pension benefits deduction amount  
   period: year
   unit: currency-USD
-  breakdown:
-    - filing_status
   reference:
     - title: Michigan Legal Code Section 206.30 - (9)(d)
       href: http://legislature.mi.gov/doc.aspx?mcl-206-30

--- a/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.yaml
@@ -53,3 +53,114 @@
     state_code: IN
   output:
     meets_tanf_non_cash_gross_income_test: true
+
+- name: NY without earned income, dependent care, or elderly/disabled status is capped at 130% FPL
+  period: 2026-01
+  input:
+    snap_gross_income_fpg_ratio: 1.45
+    snap_earned_income: 0
+    snap_dependent_care_deduction: 0
+    has_usda_elderly_disabled: false
+    state_code: NY
+  output:
+    meets_tanf_non_cash_gross_income_test: false
+
+- name: NY with earned income is eligible through 150% FPL
+  period: 2026-01
+  input:
+    snap_gross_income_fpg_ratio: 1.45
+    snap_earned_income: 1
+    snap_dependent_care_deduction: 0
+    has_usda_elderly_disabled: false
+    state_code: NY
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: NY with earned income is ineligible above 150% FPL
+  period: 2026-01
+  input:
+    snap_gross_income_fpg_ratio: 1.55
+    snap_earned_income: 1
+    snap_dependent_care_deduction: 0
+    has_usda_elderly_disabled: false
+    state_code: NY
+  output:
+    meets_tanf_non_cash_gross_income_test: false
+
+- name: NY with dependent care expenses is eligible through 200% FPL
+  period: 2026-01
+  input:
+    snap_gross_income_fpg_ratio: 1.9
+    snap_earned_income: 0
+    snap_dependent_care_deduction: 1
+    has_usda_elderly_disabled: false
+    state_code: NY
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: NY elderly or disabled household is eligible through 200% FPL
+  period: 2026-01
+  input:
+    snap_gross_income_fpg_ratio: 1.9
+    snap_earned_income: 0
+    snap_dependent_care_deduction: 0
+    has_usda_elderly_disabled: true
+    state_code: NY
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: AL all elderly or disabled household is eligible through 200% FPL
+  period: 2026-01
+  input:
+    snap_gross_income_fpg_ratio: 1.9
+    has_usda_elderly_disabled: true
+    has_all_usda_elderly_disabled: true
+    state_code: AL
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: AK elderly or disabled household had no BBCE through ERS coverage
+  period: 2020
+  input:
+    snap_gross_income_fpg_ratio: 1
+    has_usda_elderly_disabled: true
+    state_code: AK
+  output:
+    meets_tanf_non_cash_gross_income_test: false
+
+- name: CO elderly or disabled household had 200% FPL BBCE before the general limit changed
+  period: 2016-01
+  input:
+    snap_gross_income_fpg_ratio: 1.9
+    has_usda_elderly_disabled: true
+    state_code: CO
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: ID elderly or disabled household has no BBCE gross income test
+  period: 2026-01
+  input:
+    snap_gross_income_fpg_ratio: 2.5
+    has_usda_elderly_disabled: true
+    state_code: ID
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: MS elderly or disabled household had no BBCE gross income test before BBCE ended
+  period: 2016-01
+  input:
+    snap_gross_income_fpg_ratio: 2.5
+    has_usda_elderly_disabled: true
+    state_code: MS
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: WV all elderly or disabled household had 200% FPL BBCE before the general limit changed
+  period: 2016-01
+  input:
+    snap_gross_income_fpg_ratio: 1.9
+    has_usda_elderly_disabled: true
+    has_all_usda_elderly_disabled: true
+    state_code: WV
+  output:
+    meets_tanf_non_cash_gross_income_test: true

--- a/policyengine_us/tests/test_parameter_files.py
+++ b/policyengine_us/tests/test_parameter_files.py
@@ -5,6 +5,59 @@ import yaml
 
 
 PARAMETERS_DIR = Path(__file__).resolve().parents[1] / "parameters"
+PARAMETER_SCHEMA_KEYS = {
+    "brackets",
+    "description",
+    "documentation",
+    "label",
+    "metadata",
+    "reference",
+    "unit",
+    "values",
+}
+
+
+class NoDatesSafeLoader(yaml.SafeLoader):
+    pass
+
+
+NoDatesSafeLoader.yaml_implicit_resolvers = {
+    key: [
+        (tag, regexp)
+        for tag, regexp in resolvers
+        if tag != "tag:yaml.org,2002:timestamp"
+    ]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+def _enum_breakdown_parameter_errors(path, data):
+    if not isinstance(data, dict):
+        return []
+
+    metadata = data.get("metadata") or {}
+    if "breakdown" not in metadata:
+        return []
+
+    breakdown = metadata["breakdown"]
+    parameter_keys = [key for key in data if key not in PARAMETER_SCHEMA_KEYS]
+    relative_path = path.relative_to(PARAMETERS_DIR.parent)
+
+    if len(parameter_keys) == 0 and ("values" in data or "brackets" in data):
+        return [
+            f"{relative_path} has metadata.breakdown={breakdown!r} "
+            "but no top-level enum members. Remove metadata.breakdown "
+            "from scalar parameters."
+        ]
+
+    if len(parameter_keys) == 1:
+        return [
+            f"{relative_path} has metadata.breakdown={breakdown!r} "
+            f"but only one top-level member {parameter_keys[0]!r}. "
+            "Use a scalar parameter under a member-specific path instead."
+        ]
+
+    return []
 
 
 def test_parameter_yaml_files_are_syntax_parseable():
@@ -34,3 +87,42 @@ def test_calworks_yaml_fixes_preserve_effective_dates():
 
     assert list(max_au_size["values"].keys()) == [date(2023, 10, 1)]
     assert list(region1_counties["values"].keys()) == [date(2023, 7, 1)]
+
+
+def test_enum_breakdown_guard_rejects_scalar_parameters_with_breakdown():
+    errors = _enum_breakdown_parameter_errors(
+        PARAMETERS_DIR / "gov/hhs/tanf/non_cash/income_limit/ny/earned_income.yaml",
+        {
+            "description": "New York SNAP BBCE gross income limit.",
+            "values": {"2026-01-01": 1.5},
+            "metadata": {"breakdown": ["state_code"]},
+        },
+    )
+
+    assert len(errors) == 1
+    assert "metadata.breakdown" in errors[0]
+
+
+def test_enum_breakdown_guard_ignores_reference_when_counting_members():
+    errors = _enum_breakdown_parameter_errors(
+        PARAMETERS_DIR / "gov/hhs/tanf/non_cash/income_limit/earned.yaml",
+        {
+            "description": "SNAP BBCE gross income limit.",
+            "NY": {"2026-01-01": 1.5},
+            "reference": [{"title": "Example source"}],
+            "metadata": {"breakdown": ["state_code"]},
+        },
+    )
+
+    assert len(errors) == 1
+    assert "only one top-level member 'NY'" in errors[0]
+
+
+def test_enum_breakdown_parameters_do_not_have_single_member_tables():
+    errors = []
+
+    for path in sorted(PARAMETERS_DIR.rglob("*.yaml")):
+        data = yaml.load(path.read_text(), Loader=NoDatesSafeLoader)
+        errors.extend(_enum_breakdown_parameter_errors(path, data))
+
+    assert errors == []

--- a/policyengine_us/variables/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.py
+++ b/policyengine_us/variables/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.py
@@ -13,5 +13,22 @@ class meets_tanf_non_cash_gross_income_test(Variable):
         # All limits and incomes here expressed as % of FPG.
         limits = parameters(period).gov.hhs.tanf.non_cash.income_limit
         gross_limit = limits.gross[state]
+        hheod = spm_unit("is_tanf_non_cash_hheod", period)
+        gross_limit = where(hheod, limits.gross_hheod[state], gross_limit)
+
+        ny = state == "NY"
+        has_dependent_care = spm_unit("snap_dependent_care_deduction", period) > 0
+        has_earned_income = spm_unit("snap_earned_income", period) > 0
+        ny_gross_limit = where(
+            has_dependent_care | hheod,
+            limits.ny.dependent_care,
+            where(
+                has_earned_income,
+                limits.ny.earned_income,
+                limits.gross.NY,
+            ),
+        )
+        gross_limit = where(ny, ny_gross_limit, gross_limit)
+
         gross_income = spm_unit("snap_gross_income_fpg_ratio", period)
         return gross_income <= gross_limit


### PR DESCRIPTION
## Summary
- model NY SNAP BBCE gross-income tiers separately for default, earned-income, dependent-care, and elderly/disabled households
- add HHEOD-specific TANF non-cash gross-income limits for SNAP BBCE states
- add regression coverage for NY tiers and representative non-NY HHEOD cases

## Why
NY households without earned income, dependent-care expenses, or elderly/disabled members should use the 130% FPL BBCE gross limit, while earned-income households use 150% and dependent-care or elderly/disabled households use 200%. The prior scalar NY parameter used 150% for all households, which made some households categorically eligible when they should not be and missed others that should qualify.

Several other states also have elderly/disabled-specific BBCE gross limits, so this adds a separate HHEOD parameter instead of making a NY-only formula patch.

## Validation
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash -c policyengine_us`
- `uv run pytest policyengine_us/tests/test_parameter_files.py`
- `uv run ruff check policyengine_us/variables/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.py`
- Axiom NY ECPS comparison with this branch: PE/Axiom matches improved from 97.7% to 99.5%; remaining dollar differences appear driven by categorical-program facts not projected into the Axiom/SnapScreener diagnostic comparison.
