### PR TITLE
Fix SNAP SSI categorical eligibility

### DIFF
--- a/changelog.d/codex-fix-snap-ssi-categorical.fixed.md
+++ b/changelog.d/codex-fix-snap-ssi-categorical.fixed.md
@@ -1,0 +1,1 @@
+Fixed SNAP categorical eligibility so SSI only qualifies a multi-person SPM unit when all members receive SSI.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.yaml
@@ -18,6 +18,36 @@
   output:
     meets_snap_categorical_eligibility: true
 
+- name: Single SSI recipient in multi-person SPM unit does not create eligibility.
+  period: 2022
+  input:
+    people:
+      person1:
+        ssi: 1
+      person2:
+        ssi: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        is_tanf_non_cash_eligible: false
+  output:
+    meets_snap_categorical_eligibility: false
+
+- name: All SSI recipients in multi-person SPM unit create eligibility.
+  period: 2022
+  input:
+    people:
+      person1:
+        ssi: 1
+      person2:
+        ssi: 1
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        is_tanf_non_cash_eligible: false
+  output:
+    meets_snap_categorical_eligibility: true
+
 - name: SSDI does not create eligibility.
   period: 2022
   input:

--- a/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
@@ -11,4 +11,7 @@ class meets_snap_categorical_eligibility(Variable):
 
     def formula(spm_unit, period, parameters):
         programs = parameters(period).gov.usda.snap.categorical_eligibility
-        return add(spm_unit, period, programs) > 0
+        spm_level_programs = [program for program in programs if program != "ssi"]
+        person = spm_unit.members
+        all_members_receive_ssi = spm_unit.all(person("ssi", period) > 0)
+        return all_members_receive_ssi | (add(spm_unit, period, spm_level_programs) > 0)


### PR DESCRIPTION
## Summary
- require all SPM-unit members to receive SSI before SSI confers SNAP categorical eligibility
- keep SPM-level categorical programs, such as TANF non-cash eligibility, on the existing parameter-driven path
- add YAML coverage for mixed-SSI and all-SSI multi-person SPM units

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.yaml
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.yaml policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/is_snap_eligible.yaml policyengine_us/tests/policy/baseline/gov/usda/snap/snap_normal_allotment.yaml
- uv run ruff format --check policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
- uv run ruff check policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
- Axiom NY SNAP ECPS comparison with this local PE build: 558/558 matches
- Axiom CO SNAP ECPS comparison with this local PE build: 159/159 matches