### PR TITLE
Model Medicare enrollment as eligible take-up

### DIFF
--- a/changelog.d/8255.fixed.md
+++ b/changelog.d/8255.fixed.md
@@ -1,0 +1,1 @@
+Fix Medicare enrollment defaults by modeling enrollment as eligibility-gated take-up.

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/coverage_report_model_conflict.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/coverage_report_model_conflict.yaml
@@ -12,7 +12,6 @@
     age: 40
     medicaid_enrolled: false
     is_chip_eligible: false
-    medicare_enrolled: false
     has_esi: false
     has_marketplace_health_coverage_at_interview: true
   output:

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/has_qualifying_non_marketplace_health_coverage_at_interview.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/has_qualifying_non_marketplace_health_coverage_at_interview.yaml
@@ -11,7 +11,6 @@
     age: 40
     medicaid_enrolled: false
     is_chip_eligible: false
-    medicare_enrolled: false
     has_esi: false
     has_indian_health_service_coverage_at_interview: true
   output:
@@ -23,3 +22,34 @@
     has_non_marketplace_direct_purchase_health_coverage_at_interview: true
   output:
     has_qualifying_non_marketplace_health_coverage_at_interview: true
+
+- name: Case 4, Medicare enrollment counts as qualifying non-Marketplace coverage.
+  period: 2025
+  input:
+    age: 65
+    medicaid_enrolled: false
+    is_chip_eligible: false
+    has_esi: false
+    has_non_marketplace_direct_purchase_health_coverage_at_interview: false
+    has_other_means_tested_health_coverage_at_interview: false
+    has_tricare_health_coverage_at_interview: false
+    has_champva_health_coverage_at_interview: false
+    has_va_health_coverage_at_interview: false
+  output:
+    has_qualifying_non_marketplace_health_coverage_at_interview: true
+
+- name: Case 5, Medicare eligibility without take-up does not count as qualifying non-Marketplace coverage.
+  period: 2025
+  input:
+    age: 65
+    takes_up_medicare_if_eligible: false
+    medicaid_enrolled: false
+    is_chip_eligible: false
+    has_esi: false
+    has_non_marketplace_direct_purchase_health_coverage_at_interview: false
+    has_other_means_tested_health_coverage_at_interview: false
+    has_tricare_health_coverage_at_interview: false
+    has_champva_health_coverage_at_interview: false
+    has_va_health_coverage_at_interview: false
+  output:
+    has_qualifying_non_marketplace_health_coverage_at_interview: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicare/costs/medicare_cost.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicare/costs/medicare_cost.yaml
@@ -3,7 +3,6 @@
   input:
     age: 65
     is_medicare_eligible: true
-    medicare_enrolled: true
     medicare_quarters_of_coverage: 40
     adjusted_gross_income:
       2023: 50_000  # IRMAA uses income from 2 years prior
@@ -17,7 +16,6 @@
   input:
     age: 65
     is_medicare_eligible: true
-    medicare_enrolled: true
     medicare_quarters_of_coverage: 20
     adjusted_gross_income:
       2023: 50_000  # IRMAA uses income from 2 years prior
@@ -31,7 +29,6 @@
   input:
     age: 65
     is_medicare_eligible: true
-    medicare_enrolled: true
     medicare_quarters_of_coverage: 40
     adjusted_gross_income:
       2023: 500_000  # IRMAA uses income from 2 years prior
@@ -46,7 +43,7 @@
   input:
     age: 65
     is_medicare_eligible: true
-    medicare_enrolled: false
+    takes_up_medicare_if_eligible: false
   output:
     medicare_cost: 0
 
@@ -55,7 +52,6 @@
   input:
     age: 70
     is_medicare_eligible: true
-    medicare_enrolled: true
     medicare_quarters_of_coverage: 40
     adjusted_gross_income:
       2019: 50_000  # IRMAA uses income from 2 years prior
@@ -69,7 +65,6 @@
   input:
     age: 65
     is_medicare_eligible: true
-    medicare_enrolled: true
     medicare_quarters_of_coverage: 40
     gross_medicare_part_b_premium: 3_000
   output:

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicare/costs/medicare_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicare/costs/medicare_enrolled.yaml
@@ -1,0 +1,21 @@
+- name: Non-eligible person is not enrolled when enrollment is omitted.
+  period: 2025
+  input:
+    age: 64
+  output:
+    medicare_enrolled: false
+
+- name: Eligible person defaults to enrolled.
+  period: 2025
+  input:
+    age: 65
+  output:
+    medicare_enrolled: true
+
+- name: Eligible person declining take-up is not enrolled.
+  period: 2025
+  input:
+    age: 65
+    takes_up_medicare_if_eligible: false
+  output:
+    medicare_enrolled: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicare/eligibility/income_adjusted_part_d_premium_surcharge.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicare/eligibility/income_adjusted_part_d_premium_surcharge.yaml
@@ -7,7 +7,6 @@
       2023: 80_000
     tax_exempt_interest_income:
       2023: 0
-    medicare_enrolled: true
   output:
     income_adjusted_part_d_premium_surcharge: 0
 
@@ -20,7 +19,6 @@
       2023: 266_001
     tax_exempt_interest_income:
       2023: 0
-    medicare_enrolled: true
   output:
     income_adjusted_part_d_premium_surcharge: 423.6
 
@@ -33,6 +31,18 @@
       2022: 397_000
     tax_exempt_interest_income:
       2022: 0
-    medicare_enrolled: true
   output:
     income_adjusted_part_d_premium_surcharge: 972
+
+- name: unit test 4 - eligible but not enrolled
+  period: 2025
+  input:
+    age: 65
+    filing_status: SINGLE
+    adjusted_gross_income:
+      2023: 500_000
+    tax_exempt_interest_income:
+      2023: 0
+    takes_up_medicare_if_eligible: false
+  output:
+    income_adjusted_part_d_premium_surcharge: 0

--- a/policyengine_us/variables/gov/hhs/medicare/costs/medicare_enrolled.py
+++ b/policyengine_us/variables/gov/hhs/medicare/costs/medicare_enrolled.py
@@ -9,4 +9,4 @@ class medicare_enrolled(Variable):
     definition_period = YEAR
     reference = "https://www.cms.gov/medicare"
     defined_for = "is_medicare_eligible"
-    default_value = True  # Most Medicare-eligible people are enrolled
+    adds = ["takes_up_medicare_if_eligible"]

--- a/policyengine_us/variables/gov/hhs/medicare/takes_up_medicare_if_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicare/takes_up_medicare_if_eligible.py
@@ -1,0 +1,9 @@
+from policyengine_us.model_api import *
+
+
+class takes_up_medicare_if_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Whether an eligible person takes up Medicare"
+    definition_period = YEAR
+    default_value = True


### PR DESCRIPTION
## Summary
- Model `medicare_enrolled` as an eligibility-gated take-up variable, matching the Medicaid enrollment pattern.
- Add `takes_up_medicare_if_eligible`, defaulting to true for eligible people.
- Update Medicare cost, Part D surcharge, and ACA coverage-conflict fixtures to use take-up rather than directly forcing `medicare_enrolled`.

## Root Cause
Previously, `medicare_enrolled` had `defined_for = "is_medicare_eligible"` and `default_value = True`. When a dataset omitted `medicare_enrolled`, PolicyEngine could treat enrollment as a direct default input instead of a calculated eligibility-and-take-up result, which made downstream datasets vulnerable to overcounting enrollment.

## Validation
- `git diff --check`
- `uv run python -m py_compile policyengine_us/variables/gov/hhs/medicare/takes_up_medicare_if_eligible.py`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicare policyengine_us/tests/policy/baseline/gov/aca/eligibility -c policyengine_us` (`171 passed, 1 warning`)
