### PR TITLE
Update Medicaid work requirement implementation

### DIFF
--- a/changelog.d/8257.changed.md
+++ b/changelog.d/8257.changed.md
@@ -1,0 +1,1 @@
+Update Medicaid work requirement eligibility to reflect CMS community engagement guidance.

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/work_requirements/applies.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/work_requirements/applies.yaml
@@ -1,4 +1,4 @@
-description: The Department of Health and Human Services limits Medicaid to filers who meet work requirements, if this is true. 
+description: The Department of Health and Human Services limits Medicaid adult group eligibility to applicable individuals who meet work requirements, if this is true.
 
 values:
   0000-01-01: false
@@ -11,3 +11,5 @@ metadata:
   reference:
     - title: H.R.1 - One Big Beautiful Bill Act
       href: https://www.congress.gov/bill/119th-congress/house-bill/1/text
+    - title: CMCS Informational Bulletin, Dec. 8, 2025
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/work_requirements/former_foster_care_age_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/work_requirements/former_foster_care_age_limit.yaml
@@ -1,12 +1,12 @@
-description: The Department of Health and Human Services allows applicable individuals to meet Medicaid work requirements by working at least this number of monthly hours.
+description: The Department of Health and Human Services excludes individuals below this age who are in the former foster care Medicaid eligibility group from Medicaid work requirements.
 
 values:
-  2027-01-01: 80
+  2027-01-01: 26
 
 metadata:
-  unit: hours
-  label: Medicaid work requirement monthly hours threshold
-  period: month
+  unit: year
+  label: Medicaid work requirement former foster care age limit
+  period: year
   reference:
     - title: H.R.1 - One Big Beautiful Bill Act
       href: https://www.congress.gov/bill/119th-congress/house-bill/1/text

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
@@ -188,3 +188,28 @@
   output:
     medicaid_category: WORKING_DISABLED_BUY_IN
     is_medicaid_eligible: true
+
+- name: Case 6, adult group enrollee is ineligible when work requirements apply and are unmet.
+  period: 2027
+  input:
+    medicaid_category: ADULT
+    immigration_status: CITIZEN
+  output:
+    is_medicaid_eligible: false
+
+- name: Case 7, parent category remains eligible when adult group work requirements apply.
+  period: 2027
+  input:
+    medicaid_category: PARENT
+    immigration_status: CITIZEN
+  output:
+    is_medicaid_eligible: true
+
+- name: Case 8, adult group enrollee meets work requirements through the income safe harbor.
+  period: 2027
+  input:
+    medicaid_category: ADULT
+    immigration_status: CITIZEN
+    employment_income: 6_960
+  output:
+    is_medicaid_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -127,3 +127,11 @@
     is_incarcerated: true
   output:
     medicaid_work_requirement_eligible: true
+
+- name: Case 15, person with Indian Health Service coverage is excluded from the work requirement.
+  period: 2027
+  input:
+    age: 30
+    has_indian_health_service_coverage_at_interview: true
+  output:
+    medicaid_work_requirement_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -86,3 +86,44 @@
         is_tax_unit_dependent: true
   output:
     medicaid_work_requirement_eligible: [false, true]
+
+- name: Case 10, half-time college student meets the work requirement.
+  period: 2027
+  input:
+    age: 30
+    is_part_time_college_student: true
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 11, monthly income at the federal minimum wage safe harbor meets the work requirement.
+  period: 2027
+  input:
+    age: 30
+    employment_income: 6_960
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 12, former foster care youth is excluded from the work requirement.
+  period: 2027
+  input:
+    age: 25
+    was_in_foster_care: true
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 13, Medicare-eligible adult is excepted from the work requirement.
+  period: 2027
+  input:
+    age: 30
+    social_security_disability: 1_000
+    months_receiving_social_security_disability: 24
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 14, incarcerated adult is excluded from the work requirement.
+  period: 2027
+  input:
+    age: 30
+    is_incarcerated: true
+  output:
+    medicaid_work_requirement_eligible: true

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py
@@ -21,22 +21,15 @@ class is_medicaid_eligible(Variable):
         il_hbi_eligible = person("il_hbi_eligible", period)
 
         p = parameters(period).gov.hhs.medicaid.eligibility
-        federal_medicaid_eligible = (
-            categorically_eligible & immigration_status_eligible
-        )
+        federal_medicaid_eligible = categorically_eligible & immigration_status_eligible
         if p.work_requirements.applies:
             work_requirement_eligible = person(
                 "medicaid_work_requirement_eligible", period
             )
             adult_group = category == category.possible_values.ADULT
             return (
-                federal_medicaid_eligible
-                & (~adult_group | work_requirement_eligible)
+                federal_medicaid_eligible & (~adult_group | work_requirement_eligible)
                 | ca_ffyp_eligible
                 | il_hbi_eligible
             )
-        return (
-            federal_medicaid_eligible
-            | ca_ffyp_eligible
-            | il_hbi_eligible
-        )
+        return federal_medicaid_eligible | ca_ffyp_eligible | il_hbi_eligible

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py
@@ -21,21 +21,22 @@ class is_medicaid_eligible(Variable):
         il_hbi_eligible = person("il_hbi_eligible", period)
 
         p = parameters(period).gov.hhs.medicaid.eligibility
+        federal_medicaid_eligible = (
+            categorically_eligible & immigration_status_eligible
+        )
         if p.work_requirements.applies:
             work_requirement_eligible = person(
                 "medicaid_work_requirement_eligible", period
             )
+            adult_group = category == category.possible_values.ADULT
             return (
-                (
-                    categorically_eligible
-                    & immigration_status_eligible
-                    & work_requirement_eligible
-                )
+                federal_medicaid_eligible
+                & (~adult_group | work_requirement_eligible)
                 | ca_ffyp_eligible
                 | il_hbi_eligible
             )
         return (
-            (categorically_eligible & immigration_status_eligible)
+            federal_medicaid_eligible
             | ca_ffyp_eligible
             | il_hbi_eligible
         )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -6,20 +6,39 @@ class medicaid_work_requirement_eligible(Variable):
     entity = Person
     label = "Eligible person for Medicaid via work requirement"
     definition_period = YEAR
-    reference = "https://www.congress.gov/bill/119th-congress/house-bill/1/text"
+    reference = (
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf",
+    )
 
     def formula(person, period, parameters):
         p = parameters(period).gov.hhs.medicaid.eligibility.work_requirements
         # Works no less than 80 hours p.680 (2)(A)
         monthly_hours_worked = person("monthly_hours_worked", period)
         meets_monthly_work_hours = monthly_hours_worked >= p.monthly_hours_threshold
-        # The individual is enrolled in an educational program at least half-time. p.680 (2)(D)
-        is_full_time_student = person("is_full_time_student", period)
-        # pregnant or postpartum medical assistance p.681 (3)(A)(i)(II)(bb)
-        is_pregnant = person("is_pregnant", period)
+        # Monthly income of at least federal minimum wage times 80 hours.
+        monthly_income_threshold = (
+            parameters(period).gov.dol.minimum_wage * p.monthly_hours_threshold
+        )
+        meets_monthly_income = person("earned_income", period) >= (
+            monthly_income_threshold * MONTHS_IN_YEAR
+        )
+        # The individual is enrolled in an educational program at least half-time.
+        is_enrolled_at_least_half_time = person(
+            "is_full_time_student", period
+        ) | person("is_part_time_college_student", period)
+        # Pregnant or postpartum medical assistance.
+        is_pregnant_or_postpartum = person("is_pregnant_for_medicaid_nfc", period)
         # Has attained age of 19 and is under 65 is require to work p.693 (bb)
         age = person("age", period)
         work_required_age = p.age_range.calc(age)
+        # Former foster care Medicaid eligibility group.
+        was_in_foster_care = person("was_in_foster_care", period)
+        former_foster_care_youth = was_in_foster_care & (
+            age < p.former_foster_care_age_limit
+        )
+        # Entitled to or enrolled in Medicare Part A or B.
+        medicare_eligible = person("is_medicare_eligible", period)
         # parent, guardian, caretaker of a disabled person
         is_dependent = person("is_tax_unit_dependent", period)
         is_disabled = person("is_disabled", period)
@@ -34,18 +53,24 @@ class medicaid_work_requirement_eligible(Variable):
         is_blind = person("is_blind", period)
         is_incapable_of_self_care = person("is_incapable_of_self_care", period)
         eligible_disabled = is_blind | is_disabled | is_incapable_of_self_care
+        is_incarcerated = person("is_incarcerated", period)
         # parent, guardian, caretaker of a dependent child 13 years of age or under  p.694 (III)
         child_age_eligible = age <= p.dependent_age_limit
         has_eligible_dependent_child = person.tax_unit.any(
             is_dependent & child_age_eligible
         )
         exempted_from_work = (
-            is_full_time_student
-            | is_pregnant
+            is_enrolled_at_least_half_time
+            | is_pregnant_or_postpartum
+            | former_foster_care_youth
+            | medicare_eligible
             | has_disabled
             | eligible_veteran
             | eligible_disabled
+            | is_incarcerated
         )
-        meets_base_requirement = meets_monthly_work_hours | exempted_from_work
+        meets_base_requirement = (
+            meets_monthly_work_hours | meets_monthly_income | exempted_from_work
+        )
         meets_conditions = meets_base_requirement | has_eligible_dependent_child
         return where(work_required_age, meets_conditions, True)

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -37,6 +37,10 @@ class medicaid_work_requirement_eligible(Variable):
         former_foster_care_youth = was_in_foster_care & (
             age < p.former_foster_care_age_limit
         )
+        # American Indian or Alaska Native / IHS eligibility exclusion.
+        has_ihs_coverage = person(
+            "has_indian_health_service_coverage_at_interview", period
+        )
         # Entitled to or enrolled in Medicare Part A or B.
         medicare_eligible = person("is_medicare_eligible", period)
         # parent, guardian, caretaker of a disabled person
@@ -63,6 +67,7 @@ class medicaid_work_requirement_eligible(Variable):
             is_enrolled_at_least_half_time
             | is_pregnant_or_postpartum
             | former_foster_care_youth
+            | has_ihs_coverage
             | medicare_eligible
             | has_disabled
             | eligible_veteran


### PR DESCRIPTION
Summary:
- Scope Medicaid work requirement gating to the ACA adult Medicaid category instead of all Medicaid categories.
- Add currently modelable CMS/law exclusions and safe harbors: earned-income threshold, half-time student status, pregnant/postpartum medical assistance, former foster care under 26, Medicare eligibility, incarceration, and Indian Health Service coverage.
- Refresh parameter citations/descriptions and add targeted eligibility tests.

Audit notes:
- H.R. 1 became Public Law 119-21 on July 4, 2025.
- CMS published the Dec. 8, 2025 CMCS Informational Bulletin on Medicaid community engagement requirements.
- I did not find a published Medicaid community engagement interim final rule as of May 12, 2026.

Tests:
- uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/hhs/medicaid --batches 1
- .venv/bin/ruff format --check .
- .venv/bin/ruff check .
- git diff --check upstream/main...HEAD
- GitHub Actions: all PR checks passing