### PR TITLE
Fix MA LIHEAP expense cap when called without microdata person-level inputs

### DIFF
--- a/changelog.d/fix-ma-liheap-expense-cap-api.fixed.md
+++ b/changelog.d/fix-ma-liheap-expense-cap-api.fixed.md
@@ -1,0 +1,1 @@
+Fall back to SPM unit-level utility expenses for `heating_expense_person` so the MA, DC, and IL LIHEAP expense caps work for households calculated without microdata-imputed person-level heating costs.

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/doer/liheap/ma_liheap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/doer/liheap/ma_liheap.yaml
@@ -133,3 +133,37 @@
     ma_liheap_standard_payment: 1_239
     ma_liheap_hecs_payment: 160
     ma_liheap: 500
+
+- name: SPM-level heating_cooling_expense input drives expense cap when heating_expense_person not supplied
+  period: 2025
+  input:
+    age: 65
+    employment_income: 3_600
+    receives_housing_assistance: true
+    heat_expense_included_in_rent: false
+    heating_cooling_expense: 10_200
+    gas_expense: 0
+    electricity_expense: 0
+    state_code: MA
+  output:
+    ma_liheap_eligible: true
+    ma_liheap_standard_payment: 718
+    ma_liheap_hecs_payment: 0
+    ma_liheap: 718
+
+- name: SPM-level expense below payment — capped at SPM-level total
+  period: 2025
+  input:
+    age: 65
+    employment_income: 3_600
+    receives_housing_assistance: true
+    heat_expense_included_in_rent: false
+    heating_cooling_expense: 300
+    gas_expense: 100
+    electricity_expense: 50
+    state_code: MA
+  output:
+    ma_liheap_eligible: true
+    ma_liheap_standard_payment: 718
+    ma_liheap_hecs_payment: 0
+    ma_liheap: 450

--- a/policyengine_us/variables/household/expense/housing/heating_expense_person.py
+++ b/policyengine_us/variables/household/expense/housing/heating_expense_person.py
@@ -7,3 +7,21 @@ class heating_expense_person(Variable):
     label = "Heating cost for each person"
     unit = USD
     definition_period = YEAR
+
+    def formula(person, period, parameters):
+        spm_unit = person.spm_unit
+        total = add(
+            spm_unit,
+            period,
+            [
+                "electricity_expense",
+                "gas_expense",
+                "fuel_oil_expense",
+                "heating_cooling_expense",
+            ],
+        )
+        spm_size = spm_unit.nb_persons()
+        per_person = np.zeros_like(total)
+        mask = spm_size > 0
+        per_person[mask] = total[mask] / spm_size[mask]
+        return spm_unit.project(per_person)


### PR DESCRIPTION
## Summary

- `ma_liheap` (and DC/IL equivalents) cap the benefit by `add(spm_unit, period, ["heating_expense_person"])`. `heating_expense_person` has no formula — it is filled in by CPS microdata imputation. When the model is called via the API with only SPM unit-level utility inputs (`heating_cooling_expense`, `electricity_expense`, `gas_expense`, `fuel_oil_expense`), `heating_expense_person` stays at 0 and the cap zeroes out the benefit even for an eligible household.
- This PR adds a fallback formula on `heating_expense_person` that distributes the SPM unit's reported utility expenses evenly across its members. Microdata still wins because it sets the variable directly; the formula only runs when no per-person value is provided.

## Reproducer (reported in #mfb-policy-engine)

Before this change, the household below returns `ma_liheap = 0` despite `ma_liheap_eligible = true` and `ma_liheap_standard_payment = 718`. After this change it returns `ma_liheap = 718`.

```json
{
  "people": {"you": {"age": {"2025": 65}, "employment_income": {"2025": 3600}}},
  "spm_units": {
    "your_spm_unit": {
      "members": ["you"],
      "receives_housing_assistance": {"2025": true},
      "heat_expense_included_in_rent": {"2025": false},
      "heating_cooling_expense": {"2025": 10200},
      "gas_expense": {"2025": 0},
      "electricity_expense": {"2025": 0}
    }
  },
  "households": {"your_household": {"members": ["you"], "state_code": {"2025": "MA"}}}
}
```

## Test plan

- [x] Added two regression cases to ma_liheap.yaml (full reproducer and expense-below-payment cap case)
- [x] policyengine-core test on MA LIHEAP suite → 44/44 pass
- [x] policyengine-core test on DC and IL LIHEAP suites → 31/31 pass