### PR TITLE
Support legacy per-fuel LIHEAP expense inputs as fallbacks

### DIFF
--- a/changelog.d/liheap-legacy-expense-fallback.changed.md
+++ b/changelog.d/liheap-legacy-expense-fallback.changed.md
@@ -1,0 +1,1 @@
+Support legacy per-fuel expense inputs as fallbacks in DC, MA, and IL LIHEAP formulas.

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/doee/liheap/dc_liheap_payment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/doee/liheap/dc_liheap_payment.yaml
@@ -32,3 +32,32 @@
     state_code: DC
   output:
     dc_liheap_payment: 1_386
+
+# Legacy fallback tests — verify pre-PR-#7986 per-fuel inputs still cap the benefit.
+- name: Legacy fallback, electricity heating uses pre_subsidy_electricity_expense.
+  period: 2024
+  input:
+    irs_gross_income: 0
+    dc_liheap_heating_type: ELECTRICITY
+    pre_subsidy_electricity_expense: 999
+    dc_liheap_housing_type: SINGLE_FAMILY
+    spm_unit_size: 1
+    state_code: DC
+  output:
+    # heating_expense_person unset → falls back to pre_subsidy_electricity_expense (999)
+    # min(matrix_amount, 999) = 948
+    dc_liheap_payment: 948
+
+- name: Legacy fallback, gas heating uses gas_expense.
+  period: 2024
+  input:
+    irs_gross_income: 4_001
+    dc_liheap_heating_type: GAS
+    gas_expense: 1_400
+    dc_liheap_housing_type: SINGLE_FAMILY
+    spm_unit_size: 3
+    state_code: DC
+  output:
+    # heating_expense_person unset → falls back to gas_expense (1_400)
+    # min(matrix_amount, 1_400) = 1_386
+    dc_liheap_payment: 1_386

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dceo/liheap/payment/il_liheap_base_payment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dceo/liheap/payment/il_liheap_base_payment.yaml
@@ -148,3 +148,50 @@
     # Bracket 1, size 6, nat gas -> $1,760
     # min(1,760, 2,000) = 1,760
     il_liheap_base_payment: 1_760
+
+# Legacy fallback tests — verify heating_cooling_expense still caps the benefit.
+- name: Case 7, legacy fallback to heating_cooling_expense, not capped.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        irs_gross_income: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        il_liheap_heating_type: NAT_GAS_OTHER
+        heating_cooling_expense: 2_000
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+  output:
+    # heating_expense_person unset → falls back to heating_cooling_expense (2_000)
+    # Bracket 1, size 1, nat gas -> $1,260
+    # min(1_260, 2_000) = 1_260
+    il_liheap_base_payment: 1_260
+
+- name: Case 8, legacy fallback to heating_cooling_expense, capped at expense.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        irs_gross_income: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        il_liheap_heating_type: ALL_ELECTRIC
+        heating_cooling_expense: 150
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+  output:
+    # heating_expense_person unset → falls back to heating_cooling_expense (150)
+    # Bracket 1, size 1, all electric -> $840
+    # min(840, 150) = 150 (capped)
+    il_liheap_base_payment: 150

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/doer/liheap/ma_liheap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/doer/liheap/ma_liheap.yaml
@@ -133,3 +133,55 @@
     ma_liheap_standard_payment: 1_239
     ma_liheap_hecs_payment: 160
     ma_liheap: 500
+
+# Legacy fallback tests — verify pre-PR-#7986 per-fuel inputs still cap the benefit.
+- name: Legacy fallback, electricity heating uses electricity_expense.
+  period: 2023
+  input:
+    spm_unit_size: 4
+    irs_gross_income: 40_000
+    rent: 0
+    ma_liheap_heating_type: ELECTRICITY
+    electricity_expense: 500
+    heat_expense_included_in_rent: false
+    receives_housing_assistance: false
+    heating_expense_last_year: 1_800
+    state_code: MA
+  output:
+    # heating_expense_person unset → falls back to electricity_expense (500)
+    # min(852 + 160, 500) = 500
+    ma_liheap: 500
+
+- name: Legacy fallback, oil heating uses fuel_oil_expense.
+  period: 2023
+  input:
+    spm_unit_size: 4
+    irs_gross_income: 40_000
+    rent: 0
+    ma_liheap_heating_type: HEATING_OIL_AND_PROPANE
+    fuel_oil_expense: 500
+    heat_expense_included_in_rent: false
+    receives_housing_assistance: false
+    heating_expense_last_year: 2_000
+    state_code: MA
+  output:
+    # heating_expense_person unset → falls back to fuel_oil_expense (500)
+    # min(1_239 + 160, 500) = 500
+    ma_liheap: 500
+
+- name: Legacy fallback, other heating uses heating_cooling_expense.
+  period: 2023
+  input:
+    spm_unit_size: 4
+    irs_gross_income: 60_000
+    rent: 18_001
+    ma_liheap_heating_type: OTHER
+    heating_cooling_expense: 800
+    heat_expense_included_in_rent: false
+    receives_housing_assistance: true
+    heating_expense_last_year: 1_800
+    state_code: MA
+  output:
+    # heating_expense_person unset → falls back to heating_cooling_expense (800)
+    # min(672 + 120, 800) = 792
+    ma_liheap: 792

--- a/policyengine_us/variables/gov/states/dc/doee/liheap/dc_liheap_payment.py
+++ b/policyengine_us/variables/gov/states/dc/doee/liheap/dc_liheap_payment.py
@@ -16,8 +16,24 @@ class dc_liheap_payment(Variable):
         heating_type = spm_unit("dc_liheap_heating_type", period)
         income_level = spm_unit("dc_liheap_income_level", period)
         capped_size = clip(spm_unit("spm_unit_size", period), 1, 4)
-        heating_expenses = add(spm_unit, period, ["heating_expense_person"])
+        heating_person = add(spm_unit, period, ["heating_expense_person"])
         types = heating_type.possible_values
+
+        # Legacy fallback: partners may still send the pre-PR-#7986 per-fuel inputs.
+        legacy_expense = select(
+            [
+                heating_type == types.ELECTRICITY,
+                heating_type == types.GAS,
+                heating_type == types.OIL,
+            ],
+            [
+                spm_unit("pre_subsidy_electricity_expense", period),
+                spm_unit("gas_expense", period),
+                spm_unit("fuel_oil_expense", period),
+            ],
+            default=0,
+        )
+        heating_expenses = where(heating_person > 0, heating_person, legacy_expense)
 
         # Heat-in-rent is a direct subsidy — no expense cap.
         matrix_amount = select(

--- a/policyengine_us/variables/gov/states/il/dceo/liheap/payment/il_liheap_base_payment.py
+++ b/policyengine_us/variables/gov/states/il/dceo/liheap/payment/il_liheap_base_payment.py
@@ -34,7 +34,9 @@ class il_liheap_base_payment(Variable):
         )
         # Cap non-cash benefits at actual heating expenses.
         # Cash (heat in rent) is a direct payment — no expense cap.
-        heating_expenses = add(spm_unit, period, ["heating_expense_person"])
+        heating_person = add(spm_unit, period, ["heating_expense_person"])
+        heating_cooling = spm_unit("heating_cooling_expense", period)
+        heating_expenses = where(heating_person > 0, heating_person, heating_cooling)
         return where(
             is_cash,
             matrix_amount,

--- a/policyengine_us/variables/gov/states/ma/doer/liheap/payment/ma_liheap.py
+++ b/policyengine_us/variables/gov/states/ma/doer/liheap/payment/ma_liheap.py
@@ -17,7 +17,28 @@ class ma_liheap(Variable):
         )
         # Heat-in-rent is a direct subsidy — no expense cap.
         heat_in_rent = spm_unit("heat_expense_included_in_rent", period)
-        actual_expense_amount = add(spm_unit, period, ["heating_expense_person"])
+        heating_person = add(spm_unit, period, ["heating_expense_person"])
+        # Legacy fallback: partners may still send the pre-PR-#7986 per-fuel inputs.
+        heating_type = spm_unit("ma_liheap_heating_type", period)
+        types = heating_type.possible_values
+        legacy_expense = select(
+            [
+                heating_type == types.ELECTRICITY,
+                heating_type == types.NATURAL_GAS,
+                heating_type == types.HEATING_OIL_AND_PROPANE,
+                heating_type == types.KEROSENE,
+            ],
+            [
+                spm_unit("electricity_expense", period),
+                spm_unit("gas_expense", period),
+                spm_unit("fuel_oil_expense", period),
+                spm_unit("fuel_oil_expense", period),
+            ],
+            default=spm_unit("heating_cooling_expense", period),
+        )
+        actual_expense_amount = where(
+            heating_person > 0, heating_person, legacy_expense
+        )
         return where(
             heat_in_rent,
             payment_amount,


### PR DESCRIPTION
## Summary
- DC, MA, and IL LIHEAP formulas now fall back to the pre-PR-#7986 per-fuel expense variables (`pre_subsidy_electricity_expense`, `gas_expense`, `fuel_oil_expense`, `electricity_expense`, `heating_cooling_expense`) when `heating_expense_person` is zero.
- Allows API partners to migrate to the new `heating_expense_person` contract at their own pace without breaking existing integrations.
- Behavior is unchanged for any client that already sets `heating_expense_person`.

## Relationship to #8259
Alternative to #8259, which adds a fallback formula directly to `heating_expense_person` that sums all SPM-unit utility expenses. This PR instead routes each heating type to the matching legacy variable — avoiding cap inflation for households with multiple utility expenses or AC bills (since `heating_cooling_expense` includes cooling).

## Changes
### MA LIHEAP (`ma_liheap.py`)
Falls back per heating type when `heating_expense_person` is unset:
- `ELECTRICITY` → `electricity_expense`
- `NATURAL_GAS` → `gas_expense`
- `HEATING_OIL_AND_PROPANE` / `KEROSENE` → `fuel_oil_expense`
- `OTHER` / `NONE` → `heating_cooling_expense`

### DC LIHEAP (`dc_liheap_payment.py`)
Falls back per heating type when `heating_expense_person` is unset:
- `ELECTRICITY` → `pre_subsidy_electricity_expense`
- `GAS` → `gas_expense`
- `OIL` → `fuel_oil_expense`
- `HEAT_IN_RENT` is unaffected (no expense cap, direct subsidy)

### IL LIHEAP (`il_liheap_base_payment.py`)
Falls back to `heating_cooling_expense` (IL never released the per-fuel API contract).

## Test plan
- [x] MA LIHEAP: 44 tests pass
- [x] DC LIHEAP: 8 tests pass
- [x] IL LIHEAP: 23 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)