### PR TITLE
Add 2025 values for Maine Sales Tax Fairness Credit

### DIFF
--- a/changelog.d/me-stfc-2025.fixed.md
+++ b/changelog.d/me-stfc-2025.fixed.md
@@ -1,0 +1,1 @@
+Updated the Maine Sales Tax Fairness Credit base amount and phase-out start for 2025.

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/base.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/base.yaml
@@ -4,6 +4,7 @@ SINGLE:
     2021-01-01: 130
     2023-01-01: 140
     2024-01-01: 150
+    2025-01-01: 155
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -15,6 +16,7 @@ JOINT:
     2022-01-01: 185
     2023-01-01: 200
     2024-01-01: 210
+    2025-01-01: 220
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -34,6 +36,7 @@ HEAD_OF_HOUSEHOLD:
     2022-01-01: 185
     2023-01-01: 200
     2024-01-01: 210
+    2025-01-01: 220
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -45,6 +48,7 @@ SURVIVING_SPOUSE:
     2022-01-01: 185
     2023-01-01: 200
     2024-01-01: 210
+    2025-01-01: 220
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -67,6 +71,8 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
     - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+    - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   period: year
   label: Maine sales tax fairness credit base amount
   breakdown:

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/reduction/start.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/reduction/start.yaml
@@ -17,6 +17,8 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
     - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+    - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   breakdown:
     - filing_status
 SINGLE:
@@ -25,6 +27,7 @@ SINGLE:
     2022-01-01: 21_850
     2023-01-01: 23_300
     2024-01-01: 24_750
+    2025-01-01: 25_450
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -44,6 +47,7 @@ HEAD_OF_HOUSEHOLD:
     2022-01-01: 32_800
     2023-01-01: 34_950
     2024-01-01: 37_100
+    2025-01-01: 38_200
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -55,6 +59,7 @@ JOINT:
     2022-01-01: 43_700
     2023-01-01: 46_600
     2024-01-01: 49_500
+    2025-01-01: 50_950
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -66,6 +71,7 @@ SURVIVING_SPOUSE:
     2022-01-01: 43_700
     2023-01-01: 46_600
     2024-01-01: 49_500
+    2025-01-01: 50_950
   uprating:
     parameter: gov.irs.uprating
     rounding:

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/sales_tax_fairness_credit/me_sales_tax_fairness_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/sales_tax_fairness_credit/me_sales_tax_fairness_credit.yaml
@@ -67,3 +67,13 @@
     me_sales_and_property_tax_fairness_credit_income: 50_000
   output:
     me_sales_tax_fairness_credit: 0
+
+- name: 2025 ME STFC matches Schedule PTFC/STFC line 17 table for MFJ with 2 deps at income ~$52.6K
+  period: 2025
+  input:
+    me_sales_tax_fairness_credit_eligible: true
+    ctc_qualifying_children: 2
+    filing_status: JOINT
+    me_sales_and_property_tax_fairness_credit_income: 52_630
+  output:
+    me_sales_tax_fairness_credit: 240


### PR DESCRIPTION
## Summary

- Adds `2025-01-01` entries to `amount/base.yaml` ($155 single, $220 joint/HoH/surviving spouse) and `reduction/start.yaml` ($25,450 single, $38,200 HoH, $50,950 joint/surviving spouse), matching the [2025 Schedule PTFC/STFC line 17 table](https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4).
- Adds an integration test reproducing the MFJ-with-2-deps case from policyengine-taxsim #873 ($52,630 ME total income → $240 credit).
- PR #7384 updated other Maine 2025 parameters but skipped the STFC; this fills that gap.

Fixes #8262

## Test plan

- [x] `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/sales_tax_fairness_credit -c policyengine_us` — 11 passed
- [x] `make format` clean
- [x] Manual formula trace: max_credit ($220 + $60) − ceil(($52,630 − $50,950) / $1,000) × $20 = $280 − $40 = $240
- [x] Values cross-checked against page 4 of the 2025 Schedule PTFC/STFC PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)