### PR TITLE
Fix NJ property tax deduction at filing threshold (strict > should be >=)

### DIFF
--- a/changelog.d/fix-nj-property-tax-deduction-threshold.fixed.md
+++ b/changelog.d/fix-nj-property-tax-deduction-threshold.fixed.md
@@ -1,0 +1,1 @@
+Fix New Jersey property tax deduction eligibility off-by-one at the filing threshold: change strict `>` to `>=` so households with NJ AGI exactly equal to the filing threshold qualify.

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/deductions/property_tax/nj_property_tax_deduction_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/deductions/property_tax/nj_property_tax_deduction_eligible.yaml
@@ -45,3 +45,27 @@
     state_code: NJ
   output:
     nj_property_tax_deduction_eligible: true
+
+- name: 5 Income at exactly the joint filing threshold is eligible (boundary).
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    filing_status: JOINT
+    nj_agi: 20_000
+    real_estate_taxes: 30_000
+    rents: false
+    state_code: NJ
+  output:
+    nj_property_tax_deduction_eligible: true
+
+- name: 6 Income at exactly the single filing threshold is eligible (boundary).
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    filing_status: SINGLE
+    nj_agi: 10_000
+    real_estate_taxes: 30_000
+    rents: false
+    state_code: NJ
+  output:
+    nj_property_tax_deduction_eligible: true

--- a/policyengine_us/variables/gov/states/nj/tax/income/property_tax/nj_property_tax_deduction_eligible.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/property_tax/nj_property_tax_deduction_eligible.py
@@ -13,7 +13,7 @@ class nj_property_tax_deduction_eligible(Variable):
 
         filing_status = tax_unit("filing_status", period)
         nj_agi = tax_unit("nj_agi", period)
-        income_eligible = nj_agi > p.filing_threshold[filing_status]
+        income_eligible = nj_agi >= p.filing_threshold[filing_status]
 
         pays_ptax = add(tax_unit, period, ["real_estate_taxes"]) > 0
         pays_rent = tax_unit("rents", period)


### PR DESCRIPTION
## Summary

Strict `>` in `nj_property_tax_deduction_eligible` excluded households with NJ AGI exactly equal to the joint filing threshold (\$20,000) from the property tax deduction. The deduction is available to any taxpayer who files NJ-1040 (per the 2024 NJ-1040 instructions, page 25); the filing threshold is "must file if income exceeds threshold", and at exactly the threshold a household may still file voluntarily and qualify for the deduction.

Closes #8278. Reported in PolicyEngine/policyengine-taxsim#865.

## Changes

- `policyengine_us/variables/gov/states/nj/tax/income/property_tax/nj_property_tax_deduction_eligible.py` — change `>` to `>=` on the income eligibility check
- `policyengine_us/tests/.../nj_property_tax_deduction_eligible.yaml` — add 2 new boundary tests at exactly \$20,000 (joint) and \$10,000 (single)
- `changelog.d/fix-nj-property-tax-deduction-threshold.fixed.md` — changelog fragment

## Test plan
- [x] All 14 NJ property-tax-deduction tests pass (4 existing + 6 in deduction folder + 2 new boundary)
- [x] End-to-end verification: TAXSIM input `96640,2025,31,2,40,40,2,0,20000,...` now produces correct NJ property tax deduction = \$15,000 (capped) instead of \$0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)