### PR TITLE
Fix Nebraska refundable CTC child-care eligibility proxy

### DIFF
--- a/changelog.d/ne-ctc-childcare-proxy.fixed.md
+++ b/changelog.d/ne-ctc-childcare-proxy.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Nebraska refundable Child Tax Credit child-care eligibility proxy to read `tax_unit_childcare_expenses` (populated by typical tax filers) instead of `pre_subsidy_childcare_expenses` (only populated by benefits-program calculations).

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ctc/refundable/ne_refundable_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ctc/refundable/ne_refundable_ctc.yaml
@@ -102,3 +102,38 @@
         state_code: NE
   output:
     ne_refundable_ctc: 0
+
+# Reproduces taxsim #863: filer above 100% FPG with childcare expenses
+# should qualify for an eligible age-0-to-5 dependent via § 77-7203(1)(a)
+# even when § 77-7203(1)(c) (income) fails.
+- name: NE refundable CTC for filer above FPG with childcare expenses (taxsim #863)
+  absolute_error_margin: 1
+  period: 2025
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 54_000
+        is_tax_unit_head: true
+      toddler:
+        age: 2
+        is_tax_unit_dependent: true
+      older_child:
+        age: 11
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, toddler, older_child]
+        filing_status: HEAD_OF_HOUSEHOLD
+        tax_unit_childcare_expenses: 3_000
+    spm_units:
+      spm_unit:
+        members: [head, toddler, older_child]
+    households:
+      household:
+        members: [head, toddler, older_child]
+        state_code: NE
+  output:
+    # Age-2 child qualifies via § 77-7203(1)(a) child care pathway;
+    # age-11 fails the § 77-7202 age ceiling regardless.
+    ne_refundable_ctc: 2_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ctc/refundable/ne_refundable_ctc_eligible_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/credits/ctc/refundable/ne_refundable_ctc_eligible_child.yaml
@@ -3,7 +3,7 @@
   input:
     age: 5
     is_tax_unit_dependent: true
-    pre_subsidy_childcare_expenses: 100
+    tax_unit_childcare_expenses: 100
     ne_refundable_ctc_income_eligible: true
     state_code: NE
   output:
@@ -14,7 +14,7 @@
   input:
     age: 5
     is_tax_unit_dependent: true
-    pre_subsidy_childcare_expenses: 0
+    tax_unit_childcare_expenses: 0
     ne_refundable_ctc_income_eligible: true
     state_code: NE
   output:
@@ -25,7 +25,7 @@
   input:
     age: 5
     is_tax_unit_dependent: true
-    pre_subsidy_childcare_expenses: 100
+    tax_unit_childcare_expenses: 100
     ne_refundable_ctc_income_eligible: false
     state_code: NE
   output:
@@ -36,7 +36,7 @@
   input:
     age: 7
     is_tax_unit_dependent: true
-    pre_subsidy_childcare_expenses: 0
+    tax_unit_childcare_expenses: 0
     ne_refundable_ctc_income_eligible: true
     state_code: NE
   output:
@@ -47,7 +47,7 @@
   input:
     age: 3
     is_tax_unit_dependent: false
-    pre_subsidy_childcare_expenses: 100
+    tax_unit_childcare_expenses: 100
     ne_refundable_ctc_income_eligible: true
     state_code: NE
   output:
@@ -58,7 +58,7 @@
   input:
     age: 3
     is_tax_unit_dependent: true
-    pre_subsidy_childcare_expenses: 0
+    tax_unit_childcare_expenses: 0
     ne_refundable_ctc_income_eligible: false
     state_code: NE
   output:

--- a/policyengine_us/variables/gov/states/ne/tax/income/credits/ctc/refundable/ne_refundable_ctc_eligible_child.py
+++ b/policyengine_us/variables/gov/states/ne/tax/income/credits/ctc/refundable/ne_refundable_ctc_eligible_child.py
@@ -23,11 +23,12 @@ class ne_refundable_ctc_eligible_child(Variable):
         # 2) receiving care from an approved license-exempt provider enrolled in
         #    the child care subsidy program pursuant to Neb. Rev. Stat. §§ 68-1202
         #    and 68-1206
-        # As we do not yet model either the Child Care Licensing Act or the
-        # Nebraska child care subsidy program, we approximate it as having incurred
-        # pre-subsidy childcare expenses.
+        # As we do not yet model licensure status or subsidy-program enrollment,
+        # we approximate this gate as the tax unit having reported childcare
+        # expenses — the same input used by the federal CDCC and every other
+        # state dependent-care credit.
         received_qualifying_child_care = (
-            person("pre_subsidy_childcare_expenses", period) > 0
+            person.tax_unit("tax_unit_childcare_expenses", period) > 0
         )
         income_eligible = person.tax_unit("ne_refundable_ctc_income_eligible", period)
         return age_eligible_dependent & (


### PR DESCRIPTION
## Summary

`ne_refundable_ctc_eligible_child` modeled § 77-7203(1)(a)/(b) — child enrolled in licensed care or care from a subsidy-program license-exempt provider — via:

```python
person("pre_subsidy_childcare_expenses", period) > 0
```

`pre_subsidy_childcare_expenses` is populated by benefits-program calculations (VA CCSP, SC CCAP, MA DTA, etc.) and almost never by typical tax filers or the TAXSIM emulator. As a result, the child-care pathway silently never fired, and any filer above 100% FPG was denied the credit regardless of childcare expenses.

This PR swaps the proxy to `tax_unit_childcare_expenses` — the same input used by the federal CDCC and every other state dependent-care credit (MN, CA, MA, NYC, VA, MT, CO, ID, NM, DC, HI, OR, WI). Still a proxy for "licensed / subsidy-program care" since PE doesn't model licensure status, but one that fires for realistic inputs.

Fixes #8290. TAXSIM ticket: [policyengine-taxsim#863](https://github.com/PolicyEngine/policyengine-taxsim/issues/863).

## Verification

Reproducer from the issue (HoH, $54k wages, two dependents ages 2 and 11, $3,000 childcare; AGI $54k > FPG $26,650):

- **Pre-fix**: `ne_refundable_ctc = $0` (path (a) reads empty `pre_subsidy_childcare_expenses`; path (c) fails on income)
- **Post-fix**: `ne_refundable_ctc = $2,000` (age-2 child qualifies via path (a); age-11 fails the § 77-7202 age ceiling regardless)

## Test plan

- [x] All 157 Nebraska baseline tests pass (including the existing 6 `ne_refundable_ctc_eligible_child` unit tests, updated to use the new input variable)
- [x] New integration test reproducing taxsim #863 (single HoH above FPG with childcare)
- [x] `make format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)