### PR TITLE
Fix asset stock period handling

### DIFF
--- a/changelog.d/snap-assets-stock.fixed.md
+++ b/changelog.d/snap-assets-stock.fixed.md
@@ -1,0 +1,1 @@
+Fix asset stock variables being divided across months in SNAP categorical eligibility calculations.

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/asset_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/asset_limit.yaml
@@ -100,7 +100,7 @@ RI: # *
 SC: # *
   2015-10-01: .inf
 TX:
-  2015-10-01: 5_000 # Excludes 1 vehicle up to $15,000 & includes excess vehicle value (not modeled).
+  2015-10-01: 5_000 # Excludes 1 vehicle up to $15,000 & includes excess vehicle value.
 UT:
   2015-10-01: -.inf # Non-BBCE.
 VT:

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/tx_additional_vehicle_exemption.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/tx_additional_vehicle_exemption.yaml
@@ -1,0 +1,15 @@
+description: Texas excludes up to this value for each additional vehicle after the first vehicle from the TANF non-cash asset test used for SNAP broad-based categorical eligibility.
+
+values:
+  2015-10-01: 0
+  2023-09-01: 8_700
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: Texas TANF non-cash additional vehicle exemption for SNAP BBCE
+  reference:
+    - title: 88(R) HB 1287 - Enrolled version
+      href: https://capitol.texas.gov/tlodocs/88R/billtext/html/HB01287F.htm
+    - title: Texas Works Handbook 24-3, A-1210 General Policy
+      href: https://www.hhs.texas.gov/sites/default/files/documents/twh_24-3.pdf

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/tx_vehicle_exemption.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/tx_vehicle_exemption.yaml
@@ -2,12 +2,17 @@ description: Texas excludes up to this value for one vehicle from the TANF non-c
 
 values:
   2015-10-01: 15_000
+  2023-09-01: 22_500
 
 metadata:
   unit: currency-USD
   period: year
   label: Texas TANF non-cash vehicle exemption for SNAP BBCE
   reference:
+    - title: 88(R) HB 1287 - Enrolled version
+      href: https://capitol.texas.gov/tlodocs/88R/billtext/html/HB01287F.htm
+    - title: Texas Works Handbook 24-3, A-1210 General Policy
+      href: https://www.hhs.texas.gov/sites/default/files/documents/twh_24-3.pdf
     - title: USDA Broad-based Categorical Eligibility
       href: https://www.fns.usda.gov/snap/broad-based-categorical-eligibility
     - title: USDA ERS SNAP Policy Database (bbce_asset/bbce_a_amt columns, Jan 1996 - Dec 2020)

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/tx_vehicle_exemption.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/tx_vehicle_exemption.yaml
@@ -1,0 +1,14 @@
+description: Texas excludes up to this value for one vehicle from the TANF non-cash asset test used for SNAP broad-based categorical eligibility.
+
+values:
+  2015-10-01: 15_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: Texas TANF non-cash vehicle exemption for SNAP BBCE
+  reference:
+    - title: USDA Broad-based Categorical Eligibility
+      href: https://www.fns.usda.gov/snap/broad-based-categorical-eligibility
+    - title: USDA ERS SNAP Policy Database (bbce_asset/bbce_a_amt columns, Jan 1996 - Dec 2020)
+      href: https://www.ers.usda.gov/data-products/snap-policy-data-sets

--- a/policyengine_us/tests/core/test_vectorized_reductions.py
+++ b/policyengine_us/tests/core/test_vectorized_reductions.py
@@ -1,0 +1,64 @@
+from policyengine_us import Simulation
+
+
+def _two_person_two_household_situation(
+    person_a: dict,
+    person_b: dict,
+    *,
+    state: str = "CA",
+) -> dict:
+    return {
+        "people": {
+            "a": person_a,
+            "b": person_b,
+        },
+        "tax_units": {
+            "tax_unit_a": {"members": ["a"]},
+            "tax_unit_b": {"members": ["b"]},
+        },
+        "spm_units": {
+            "spm_unit_a": {"members": ["a"]},
+            "spm_unit_b": {"members": ["b"]},
+        },
+        "families": {
+            "family_a": {"members": ["a"]},
+            "family_b": {"members": ["b"]},
+        },
+        "households": {
+            "household_a": {"members": ["a"], "state_code": {"2026": state}},
+            "household_b": {"members": ["b"], "state_code": {"2026": state}},
+        },
+    }
+
+
+def test_is_usda_disabled_reduces_per_person_not_across_simulation():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2026": 30}},
+            person_b={
+                "age": {"2026": 40},
+                "social_security_disability": {"2026": 100},
+            },
+        )
+    )
+
+    assert simulation.calculate("is_usda_disabled", 2026).tolist() == [
+        False,
+        True,
+    ]
+
+
+def test_medicaid_medically_needy_category_reduces_per_person():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2026": 30}},
+            person_b={"age": {"2026": 70}},
+        )
+    )
+
+    assert simulation.calculate(
+        "is_in_medicaid_medically_needy_category", 2026
+    ).tolist() == [
+        False,
+        True,
+    ]

--- a/policyengine_us/tests/core/test_vectorized_reductions.py
+++ b/policyengine_us/tests/core/test_vectorized_reductions.py
@@ -179,6 +179,22 @@ def test_county_mixed_known_and_missing_fips_preserves_known_rows():
     ]
 
 
+def test_county_all_missing_fips_uses_state_fallback():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2025": 30}},
+            person_b={"age": {"2025": 40}},
+        )
+    )
+    simulation.set_input("state_code", 2025, ["NY", "CA"])
+    simulation.set_input("county_fips", 2025, ["", ""])
+
+    assert simulation.calculate("county_str", 2025).tolist() == [
+        "ALBANY_COUNTY_NY",
+        "ALAMEDA_COUNTY_CA",
+    ]
+
+
 def test_il_aabd_utility_allowance_uses_elementwise_caps():
     simulation = Simulation(
         situation=_two_person_two_household_situation(

--- a/policyengine_us/tests/core/test_vectorized_reductions.py
+++ b/policyengine_us/tests/core/test_vectorized_reductions.py
@@ -120,3 +120,22 @@ def test_numpy_any_all_outputs_specify_axis_or_stay_in_control_flow():
                 offenders.append(f"{path.relative_to(variables_dir)}:{node.lineno}")
 
     assert offenders == []
+
+
+def test_tanf_non_cash_asset_test_does_not_mutate_snap_assets():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2026": 30}},
+            person_b={"age": {"2026": 40}},
+            state="TX",
+        )
+    )
+    simulation.set_input("snap_assets", 2026, [4_000, 4_000])
+    simulation.set_input("household_vehicles_value", 2026, [24_000, 0])
+
+    simulation.calculate("meets_tanf_non_cash_asset_test", "2026-01")
+
+    assert simulation.calculate("snap_assets", "2026-01").tolist() == [
+        4_000,
+        4_000,
+    ]

--- a/policyengine_us/tests/core/test_vectorized_reductions.py
+++ b/policyengine_us/tests/core/test_vectorized_reductions.py
@@ -1,6 +1,8 @@
 import ast
 from pathlib import Path
 
+import pytest
+
 from policyengine_us import Simulation
 
 
@@ -138,4 +140,77 @@ def test_tanf_non_cash_asset_test_does_not_mutate_snap_assets():
     assert simulation.calculate("snap_assets", "2026-01").tolist() == [
         4_000,
         4_000,
+    ]
+
+
+def test_tanf_non_cash_asset_test_applies_texas_additional_vehicle_exemption():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2026": 30}},
+            person_b={"age": {"2026": 40}},
+            state="TX",
+        )
+    )
+    simulation.set_input("snap_assets", 2026, [4_000, 4_000])
+    simulation.set_input("household_vehicles_value", 2026, [31_200, 32_300])
+    simulation.set_input("household_vehicles_owned", 2026, [2, 2])
+
+    assert simulation.calculate(
+        "meets_tanf_non_cash_asset_test", "2026-01"
+    ).tolist() == [
+        True,
+        False,
+    ]
+
+
+def test_county_mixed_known_and_missing_fips_preserves_known_rows():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2025": 30}},
+            person_b={"age": {"2025": 40}},
+        )
+    )
+    simulation.set_input("state_code", 2025, ["NY", "CA"])
+    simulation.set_input("county_fips", 2025, ["36059", ""])
+
+    assert simulation.calculate("county_str", 2025).tolist() == [
+        "NASSAU_COUNTY_NY",
+        "ALAMEDA_COUNTY_CA",
+    ]
+
+
+def test_il_aabd_utility_allowance_uses_elementwise_caps():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2022": 30}},
+            person_b={"age": {"2022": 40}},
+            state="IL",
+        )
+    )
+    simulation.set_input("state_code", 2022, ["IL", "IL"])
+    simulation.set_input("county_str", 2022, ["COOK_COUNTY_IL", "BOND_COUNTY_IL"])
+    simulation.set_input("water_expense", 2022, [60, 0])
+    simulation.set_input("coal_expense", 2022, [0, 144])
+
+    assert simulation.calculate(
+        "il_aabd_utility_allowance", "2022-01"
+    ).tolist() == pytest.approx([3.8, 11.1])
+
+
+def test_co_ccap_unknown_county_fallback_is_row_specific():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2023": 30}},
+            person_b={"age": {"2023": 40}},
+            state="CO",
+        )
+    )
+    simulation.set_input("state_code", 2023, ["CO", "CO"])
+    simulation.set_input("county_str", 2023, ["BACA_COUNTY_CO", "UNKNOWN"])
+    simulation.set_input("co_ccap_countable_income", 2023, [30 * 12, 0])
+    simulation.set_input("spm_unit_fpg", 2023, [12 * 12, 12 * 12])
+
+    assert simulation.calculate("co_ccap_fpg_eligible", "2023-01").tolist() == [
+        False,
+        True,
     ]

--- a/policyengine_us/tests/core/test_vectorized_reductions.py
+++ b/policyengine_us/tests/core/test_vectorized_reductions.py
@@ -1,3 +1,6 @@
+import ast
+from pathlib import Path
+
 from policyengine_us import Simulation
 
 
@@ -62,3 +65,58 @@ def test_medicaid_medically_needy_category_reduces_per_person():
         False,
         True,
     ]
+
+
+def test_has_qdiv_or_ltcg_reduces_per_tax_unit_not_across_simulation():
+    simulation = Simulation(
+        situation=_two_person_two_household_situation(
+            person_a={"age": {"2026": 30}},
+            person_b={
+                "age": {"2026": 40},
+                "qualified_dividend_income": {"2026": 100},
+            },
+        )
+    )
+
+    assert simulation.calculate("has_qdiv_or_ltcg", 2026).tolist() == [
+        False,
+        True,
+    ]
+
+
+def test_numpy_any_all_outputs_specify_axis_or_stay_in_control_flow():
+    variables_dir = Path(__file__).parents[2] / "variables"
+    offenders = []
+
+    for path in variables_dir.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        parents = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in {"any", "all"}
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "np"
+            ):
+                continue
+
+            if any(keyword.arg == "axis" for keyword in node.keywords):
+                continue
+
+            parent = parents.get(node)
+            in_control_flow_test = False
+            while parent is not None:
+                if isinstance(parent, (ast.If, ast.While)):
+                    in_control_flow_test = node in ast.walk(parent.test)
+                    break
+                parent = parents.get(parent)
+
+            if not in_control_flow_test:
+                offenders.append(f"{path.relative_to(variables_dir)}:{node.lineno}")
+
+    assert offenders == []

--- a/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.yaml
@@ -51,17 +51,26 @@
   output:
     meets_tanf_non_cash_asset_test: false
 
-- name: Texas BBCE ignores one vehicle up to $15,000
+- name: Texas BBCE ignores one vehicle up to $22,500 from September 2023
   period: 2026
   input:
     state_code_str: TX
     snap_assets: 4_000
-    household_vehicles_value: 15_000
+    household_vehicles_value: 22_500
   output:
     meets_tanf_non_cash_asset_test: true
 
-- name: Texas BBCE counts excess vehicle value above $15,000
+- name: Texas BBCE counts excess vehicle value above $22,500 from September 2023
   period: 2026
+  input:
+    state_code_str: TX
+    snap_assets: 4_000
+    household_vehicles_value: 24_000
+  output:
+    meets_tanf_non_cash_asset_test: false
+
+- name: Texas BBCE counted excess vehicle value above $15,000 before September 2023
+  period: 2022
   input:
     state_code_str: TX
     snap_assets: 4_000

--- a/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.yaml
@@ -3,19 +3,19 @@
   output:
     meets_tanf_non_cash_asset_test: true
 
-- name: Texas asset test is $5,000, monthly assets below limit
+- name: Texas asset test is $5,000, asset stock below limit
   period: 2022
   input:
     state_code_str: TX
-    snap_assets: 16_000 # $1,333.33 monthly
+    snap_assets: 4_000
   output:
     meets_tanf_non_cash_asset_test: true
 
-- name: Texas asset test is $5,000, monthly assets above limit
+- name: Texas asset test is $5,000, asset stock above limit
   period: 2025
   input:
     state_code_str: TX
-    snap_assets: 61_200 # $5,100 monthly
+    snap_assets: 5_100
   output:
     meets_tanf_non_cash_asset_test: false
 
@@ -31,7 +31,7 @@
   period: 2024
   input:
     state_code_str: IN
-    snap_assets: 48_000 # $4,000 monthly
+    snap_assets: 4_000
   output:
     meets_tanf_non_cash_asset_test: true
 
@@ -39,6 +39,41 @@
   period: 2024
   input:
     state_code_str: IN
-    snap_assets: 72_000 # $6,000 monthly
+    snap_assets: 6_000
   output:
     meets_tanf_non_cash_asset_test: false
+
+- name: Texas asset test uses annual asset stock in monthly formula
+  period: 2026
+  input:
+    state_code_str: TX
+    snap_assets: 15_000
+  output:
+    meets_tanf_non_cash_asset_test: false
+
+- name: Texas BBCE ignores one vehicle up to $15,000
+  period: 2026
+  input:
+    state_code_str: TX
+    snap_assets: 4_000
+    household_vehicles_value: 15_000
+  output:
+    meets_tanf_non_cash_asset_test: true
+
+- name: Texas BBCE counts excess vehicle value above $15,000
+  period: 2026
+  input:
+    state_code_str: TX
+    snap_assets: 4_000
+    household_vehicles_value: 18_000
+  output:
+    meets_tanf_non_cash_asset_test: false
+
+- name: Non-Texas BBCE asset tests do not use the Texas vehicle rule
+  period: 2026
+  input:
+    state_code_str: IN
+    snap_assets: 4_000
+    household_vehicles_value: 18_000
+  output:
+    meets_tanf_non_cash_asset_test: true

--- a/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.yaml
@@ -69,6 +69,26 @@
   output:
     meets_tanf_non_cash_asset_test: false
 
+- name: Texas BBCE excludes first and additional vehicles from September 2023
+  period: 2026
+  input:
+    state_code_str: TX
+    snap_assets: 4_000
+    household_vehicles_value: 31_200
+    household_vehicles_owned: 2
+  output:
+    meets_tanf_non_cash_asset_test: true
+
+- name: Texas BBCE counts excess above first and additional vehicle exemptions
+  period: 2026
+  input:
+    state_code_str: TX
+    snap_assets: 4_000
+    household_vehicles_value: 32_300
+    household_vehicles_owned: 2
+  output:
+    meets_tanf_non_cash_asset_test: false
+
 - name: Texas BBCE counted excess vehicle value above $15,000 before September 2023
   period: 2022
   input:

--- a/policyengine_us/tests/policy/baseline/gov/states/co/ccap/entry/co_ccap_fpg_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/ccap/entry/co_ccap_fpg_eligible.yaml
@@ -27,3 +27,13 @@
     spm_unit_fpg: 12
   output:
     co_ccap_fpg_eligible: false
+
+- name: Unknown county fallback does not overwrite valid county rows
+  period: 2023-01
+  input:
+    state_code_str: [CO, CO]
+    co_ccap_countable_income: [2.3, 0]
+    county_str: [BACA_COUNTY_CO, UNKNOWN]
+    spm_unit_fpg: [12, 12]
+  output:
+    co_ccap_fpg_eligible: [false, true]

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/asset/il_aabd_countable_vehicle_value.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/asset/il_aabd_countable_vehicle_value.yaml
@@ -51,4 +51,4 @@
     spm_unit_size: 2
     state_code: IL
   output:
-    il_aabd_countable_vehicle_value: 4_000*12
+    il_aabd_countable_vehicle_value: 4_000

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/payment/il_aabd_utility_allowance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/payment/il_aabd_utility_allowance.yaml
@@ -29,3 +29,14 @@
     state_code: IL
   output:
     il_aabd_utility_allowance: 18.45  # 9.45 + 9
+
+- name: Vectorized utility allowances use elementwise caps
+  period: 2022-01
+  input:
+    spm_unit_size: [1, 6]
+    county_str: [COOK_COUNTY_IL, BOND_COUNTY_IL]
+    water_expense: [60, 0]
+    coal_expense: [0, 144]
+    state_code: [IL, IL]
+  output:
+    il_aabd_utility_allowance: [3.8, 12]

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/snap_assets.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/snap_assets.yaml
@@ -57,3 +57,17 @@
         members: [person1, person2]
   output:
     snap_assets: 2_000
+
+- name: Monthly SNAP asset requests preserve annual asset stocks
+  period: 2024-01
+  input:
+    people:
+      person:
+        bank_account_assets: 1_200
+        stock_assets: 600
+        bond_assets: 300
+    spm_units:
+      spm_unit:
+        members: [person]
+  output:
+    snap_assets: 2_100

--- a/policyengine_us/tests/policy/baseline/household/demographic/geographic/county/county.yaml
+++ b/policyengine_us/tests/policy/baseline/household/demographic/geographic/county/county.yaml
@@ -40,6 +40,14 @@
   output:
     county: [NASSAU_COUNTY_NY, LOS_ANGELES_COUNTY_CA, WAYNE_COUNTY_MI, CLARK_COUNTY_NV]
 
+- name: Mixed known and missing county FIPS preserves known rows
+  period: 2025
+  input:
+    county_fips: ["36059", ""]
+    state_code: [NY, CA]
+  output:
+    county: [NASSAU_COUNTY_NY, ALAMEDA_COUNTY_CA]
+
 - name: Only have the state code CA as input, return the first county of that state.
   period: 2025
   input:

--- a/policyengine_us/variables/gov/ed/pell_grant/head/pell_grant_head_assets.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/head/pell_grant_head_assets.py
@@ -5,6 +5,7 @@ class pell_grant_head_assets(Variable):
     value_type = float
     entity = TaxUnit
     unit = USD
+    quantity_type = STOCK
     label = "Pell Grant head assets"
     definition_period = YEAR
 

--- a/policyengine_us/variables/gov/ed/pell_grant/pell_grant_countable_assets.py
+++ b/policyengine_us/variables/gov/ed/pell_grant/pell_grant_countable_assets.py
@@ -6,4 +6,5 @@ class pell_grant_countable_assets(Variable):
     entity = Person
     label = "Pell Grant countable assets"
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medically_needy/is_in_medicaid_medically_needy_category.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medically_needy/is_in_medicaid_medically_needy_category.py
@@ -35,7 +35,7 @@ class is_in_medicaid_medically_needy_category(Variable):
             is_pregnant,
             is_senior,
         ]
-        return np.any(
+        return np.logical_or.reduce(
             [
                 person_in_category & category_is_covered
                 for person_in_category, category_is_covered in zip(

--- a/policyengine_us/variables/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.py
+++ b/policyengine_us/variables/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.py
@@ -13,7 +13,17 @@ class meets_tanf_non_cash_asset_test(Variable):
         state = spm_unit.household("state_code_str", period)
         limits = parameters(period).gov.hhs.tanf.non_cash
         vehicle_value = spm_unit.household("household_vehicles_value", period)
-        tx_vehicle_value = max_(vehicle_value - limits.tx_vehicle_exemption, 0)
-        assets += where(state == "TX", tx_vehicle_value, 0)
+        vehicles_owned = spm_unit.household("household_vehicles_owned", period)
+        # Preserve the historical one-vehicle assumption when vehicle value is
+        # provided without a vehicle count.
+        vehicle_count = max_(vehicles_owned, vehicle_value > 0)
+        vehicle_exemption = where(
+            vehicle_count > 0,
+            limits.tx_vehicle_exemption
+            + max_(vehicle_count - 1, 0) * limits.tx_additional_vehicle_exemption,
+            0,
+        )
+        tx_vehicle_value = max_(vehicle_value - vehicle_exemption, 0)
+        assets = assets + where(state == "TX", tx_vehicle_value, 0)
         asset_limit = limits.asset_limit[state]
         return assets <= asset_limit

--- a/policyengine_us/variables/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.py
+++ b/policyengine_us/variables/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.py
@@ -12,5 +12,8 @@ class meets_tanf_non_cash_asset_test(Variable):
         assets = spm_unit("snap_assets", period)
         state = spm_unit.household("state_code_str", period)
         limits = parameters(period).gov.hhs.tanf.non_cash
+        vehicle_value = spm_unit.household("household_vehicles_value", period)
+        tx_vehicle_value = max_(vehicle_value - limits.tx_vehicle_exemption, 0)
+        assets += where(state == "TX", tx_vehicle_value, 0)
         asset_limit = limits.asset_limit[state]
         return assets <= asset_limit

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/has_qdiv_or_ltcg.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/has_qdiv_or_ltcg.py
@@ -21,5 +21,6 @@ class has_qdiv_or_ltcg(Variable):
             [
                 add(tax_unit, period, [income_source]) > 0
                 for income_source in INCOME_SOURCES
-            ]
+            ],
+            axis=0,
         )

--- a/policyengine_us/variables/gov/local/tax/assessed_property_value.py
+++ b/policyengine_us/variables/gov/local/tax/assessed_property_value.py
@@ -6,5 +6,6 @@ class assessed_property_value(Variable):
     entity = Person
     label = "Assessed property value"
     unit = USD
+    quantity_type = STOCK
     documentation = "Total assessed value of property owned by this person."
     definition_period = YEAR

--- a/policyengine_us/variables/gov/states/co/ccap/entry/co_ccap_fpg_eligible.py
+++ b/policyengine_us/variables/gov/states/co/ccap/entry/co_ccap_fpg_eligible.py
@@ -26,16 +26,14 @@ class co_ccap_fpg_eligible(Variable):
         county = household("county_str", period.this_year)
         fpg_rate = np.zeros_like(county, dtype=float)
         mask = state_eligible
-
-        # Current fix for counties not in the dataset.
-        try:
-            p.entry.fpg_rate[county[mask]]
-        except:
-            county = np.array(
-                ["DENVER_COUNTY_CO"] * len(county),
-            )
         if mask.any():
-            fpg_rate[mask] = p.entry.fpg_rate[county[mask]]
+            valid_counties = np.array(list(p.entry.fpg_rate._children))
+            lookup_county = np.where(
+                np.isin(county, valid_counties),
+                county,
+                "DENVER_COUNTY_CO",
+            )
+            fpg_rate[mask] = p.entry.fpg_rate[lookup_county[mask]]
         fpg = spm_unit("spm_unit_fpg", period)
         fpg_limit = np.round(fpg * fpg_rate, 2)
         meets_income_limit = monthly_gross_income < fpg_limit

--- a/policyengine_us/variables/gov/states/dc/dhs/ccsp/dc_ccsp_assets.py
+++ b/policyengine_us/variables/gov/states/dc/dhs/ccsp/dc_ccsp_assets.py
@@ -6,6 +6,7 @@ class dc_ccsp_assets(Variable):
     entity = SPMUnit
     label = "DC Child Care Subsidy Program (CCSP) asset"
     definition_period = MONTH
+    quantity_type = STOCK
     reference = "https://osse.dc.gov/sites/default/files/dc/sites/osse/publication/attachments/DC%20Child%20Care%20Subsidy%20Program%20Policy%20Manual.pdf#page=12"
     defined_for = StateCode.DC
 

--- a/policyengine_us/variables/gov/states/il/dhs/aabd/asset/il_aabd_countable_assets.py
+++ b/policyengine_us/variables/gov/states/il/dhs/aabd/asset/il_aabd_countable_assets.py
@@ -5,6 +5,7 @@ class il_aabd_countable_assets(Variable):
     value_type = float
     entity = SPMUnit
     definition_period = MONTH
+    quantity_type = STOCK
     label = "Illinois Aid to the Aged, Blind or Disabled (AABD) countable assets"
     reference = (
         "https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-113.140",

--- a/policyengine_us/variables/gov/states/il/dhs/aabd/asset/il_aabd_countable_vehicle_value.py
+++ b/policyengine_us/variables/gov/states/il/dhs/aabd/asset/il_aabd_countable_vehicle_value.py
@@ -5,6 +5,7 @@ class il_aabd_countable_vehicle_value(Variable):
     value_type = float
     entity = SPMUnit
     definition_period = MONTH
+    quantity_type = STOCK
     label = (
         "Illinois Aid to the Aged, Blind or Disabled (AABD) countable vehicles value"
     )
@@ -16,9 +17,7 @@ class il_aabd_countable_vehicle_value(Variable):
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.il.dhs.aabd.asset.vehicle_exemption
         vehicle_count = spm_unit.household("household_vehicles_owned", period)
-        total_vehicle_value = (
-            spm_unit.household("household_vehicles_value", period) * MONTHS_IN_YEAR
-        )
+        total_vehicle_value = spm_unit.household("household_vehicles_value", period)
         avg_vehicle_value = np.zeros_like(vehicle_count)
         mask = vehicle_count != 0
         avg_vehicle_value[mask] = total_vehicle_value[mask] / vehicle_count[mask]

--- a/policyengine_us/variables/gov/states/il/dhs/aabd/payment/utility/il_utility_allowance.py
+++ b/policyengine_us/variables/gov/states/il/dhs/aabd/payment/utility/il_utility_allowance.py
@@ -22,7 +22,7 @@ class il_aabd_utility_allowance(Variable):
             [
                 where(
                     spm_unit(expense, period) > 0,
-                    min(
+                    min_(
                         spm_unit(expense, period),
                         p.utility[expense.replace("_expense", "")][area][capped_size],
                     ),

--- a/policyengine_us/variables/gov/states/il/hfs/hbwd/asset/il_hbwd_countable_assets.py
+++ b/policyengine_us/variables/gov/states/il/hfs/hbwd/asset/il_hbwd_countable_assets.py
@@ -7,6 +7,7 @@ class il_hbwd_countable_assets(Variable):
     entity = Person
     label = "Illinois Health Benefits for Workers with Disabilities countable assets"
     definition_period = MONTH
+    quantity_type = STOCK
     reference = (
         "https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-120.381",
         "https://www.law.cornell.edu/regulations/illinois/Ill-Admin-Code-tit-89-SS-120.510",

--- a/policyengine_us/variables/gov/states/ma/dta/tcap/eaedc/ma_eaedc_countable_assets.py
+++ b/policyengine_us/variables/gov/states/ma/dta/tcap/eaedc/ma_eaedc_countable_assets.py
@@ -7,6 +7,7 @@ class ma_eaedc_countable_assets(Variable):
     label = "Massachusetts EAEDC countable assets"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     defined_for = StateCode.MA
 
     adds = "gov.states.ma.dta.tcap.eaedc.assets.sources"

--- a/policyengine_us/variables/gov/usda/is_usda_disabled.py
+++ b/policyengine_us/variables/gov/usda/is_usda_disabled.py
@@ -10,4 +10,4 @@ class is_usda_disabled(Variable):
 
     def formula(person, period, parameters):
         programs = parameters(period).gov.usda.disabled_programs
-        return np.any([person(program, period) for program in programs])
+        return np.logical_or.reduce([person(program, period) for program in programs])

--- a/policyengine_us/variables/gov/usda/snap/eligibility/snap_assets.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/snap_assets.py
@@ -16,6 +16,7 @@ class snap_assets(Variable):
     )
     label = "SNAP assets"
     unit = USD
+    quantity_type = STOCK
     reference = (
         "https://www.law.cornell.edu/uscode/text/7/2014#g",
         "https://www.law.cornell.edu/cfr/text/7/273.8",

--- a/policyengine_us/variables/household/assets/bank_account_assets.py
+++ b/policyengine_us/variables/household/assets/bank_account_assets.py
@@ -10,6 +10,7 @@ class bank_account_assets(Variable):
         "Imputed from SIPP TVAL_BANK."
     )
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"
     reference = "https://secure.ssa.gov/poms.nsf/lnx/0501140200"

--- a/policyengine_us/variables/household/assets/bond_assets.py
+++ b/policyengine_us/variables/household/assets/bond_assets.py
@@ -9,6 +9,7 @@ class bond_assets(Variable):
         "Value of bonds and government securities. Imputed from SIPP TVAL_BOND."
     )
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"
     reference = (

--- a/policyengine_us/variables/household/assets/household_business_assets_debt.py
+++ b/policyengine_us/variables/household/assets/household_business_assets_debt.py
@@ -7,5 +7,6 @@ class household_business_assets_debt(Variable):
     label = "Business asset debt"
     documentation = "Debt secured by household business assets."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_business_assets_equity.py
+++ b/policyengine_us/variables/household/assets/household_business_assets_equity.py
@@ -7,5 +7,6 @@ class household_business_assets_equity(Variable):
     label = "Business asset equity"
     documentation = "Net equity in business assets held by the household."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_business_assets_value.py
+++ b/policyengine_us/variables/household/assets/household_business_assets_value.py
@@ -7,5 +7,6 @@ class household_business_assets_value(Variable):
     label = "Business asset value"
     documentation = "Value of business assets held by the household."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_other_real_estate_debt.py
+++ b/policyengine_us/variables/household/assets/household_other_real_estate_debt.py
@@ -7,5 +7,6 @@ class household_other_real_estate_debt(Variable):
     label = "Other real estate debt"
     documentation = "Debt secured by non-homestead real estate held by the household."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_other_real_estate_equity.py
+++ b/policyengine_us/variables/household/assets/household_other_real_estate_equity.py
@@ -7,5 +7,6 @@ class household_other_real_estate_equity(Variable):
     label = "Other real estate equity"
     documentation = "Net equity in non-homestead real estate held by the household."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_other_real_estate_value.py
+++ b/policyengine_us/variables/household/assets/household_other_real_estate_value.py
@@ -7,5 +7,6 @@ class household_other_real_estate_value(Variable):
     label = "Other real estate value"
     documentation = "Value of non-homestead real estate held by the household."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_rental_property_debt.py
+++ b/policyengine_us/variables/household/assets/household_rental_property_debt.py
@@ -7,5 +7,6 @@ class household_rental_property_debt(Variable):
     label = "Rental property debt"
     documentation = "Debt secured by household rental property assets."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_rental_property_equity.py
+++ b/policyengine_us/variables/household/assets/household_rental_property_equity.py
@@ -7,5 +7,6 @@ class household_rental_property_equity(Variable):
     label = "Rental property equity"
     documentation = "Net equity in household rental property assets."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_rental_property_value.py
+++ b/policyengine_us/variables/household/assets/household_rental_property_value.py
@@ -7,5 +7,6 @@ class household_rental_property_value(Variable):
     label = "Rental property value"
     documentation = "Value of rental property assets held by the household."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_vehicles_debt.py
+++ b/policyengine_us/variables/household/assets/household_vehicles_debt.py
@@ -7,5 +7,6 @@ class household_vehicles_debt(Variable):
     label = "Vehicle debt"
     documentation = "Outstanding debt secured by household vehicles."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/household_vehicles_equity.py
+++ b/policyengine_us/variables/household/assets/household_vehicles_equity.py
@@ -7,5 +7,6 @@ class household_vehicles_equity(Variable):
     label = "Vehicle equity"
     documentation = "Net equity in household vehicles after secured vehicle debt."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/net_worth.py
+++ b/policyengine_us/variables/household/assets/net_worth.py
@@ -6,5 +6,6 @@ class net_worth(Variable):
     entity = Household
     label = "net worth"
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"

--- a/policyengine_us/variables/household/assets/spm_unit_assets.py
+++ b/policyengine_us/variables/household/assets/spm_unit_assets.py
@@ -7,3 +7,4 @@ class spm_unit_assets(Variable):
     label = "SPM unit assets"
     definition_period = YEAR
     unit = USD
+    quantity_type = STOCK

--- a/policyengine_us/variables/household/assets/spm_unit_cash_assets.py
+++ b/policyengine_us/variables/household/assets/spm_unit_cash_assets.py
@@ -7,5 +7,6 @@ class spm_unit_cash_assets(Variable):
     label = "SPM unit cash assets"
     definition_period = YEAR
     unit = USD
+    quantity_type = STOCK
 
     adds = ["bank_account_assets", "stock_assets", "bond_assets"]

--- a/policyengine_us/variables/household/assets/stock_assets.py
+++ b/policyengine_us/variables/household/assets/stock_assets.py
@@ -7,6 +7,7 @@ class stock_assets(Variable):
     label = "Stock assets"
     documentation = "Value of stocks and mutual funds. Imputed from SIPP TVAL_STMF."
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     uprating = "gov.bls.cpi.cpi_u"
     reference = "https://secure.ssa.gov/poms.nsf/lnx/0501140220"

--- a/policyengine_us/variables/household/demographic/geographic/county/county.py
+++ b/policyengine_us/variables/household/demographic/geographic/county/county.py
@@ -35,13 +35,26 @@ class county(Variable):
         # First look if county FIPS is provided; if so, map to county name
         county_fips: "pd.Series[str]" | None = household("county_fips", period)
 
-        if not simulation.is_over_dataset and county_fips.all():
+        if not simulation.is_over_dataset:
             COUNTY_FIPS_DATASET: "pd.DataFrame" = load_county_fips_dataset()
 
             # Decode FIPS codes
             county_fips_codes = COUNTY_FIPS_DATASET.set_index("county_fips")
-            county_name = county_fips_codes.loc[county_fips, "county_name"]
-            state_code = county_fips_codes.loc[county_fips, "state"]
-            return map_county_string_to_enum(county_name, state_code)
+            result = household("first_county_in_state", period)
+            county_fips = np.asarray(county_fips).astype(str)
+            known_fips = county_fips != ""
+            valid_fips = known_fips & np.isin(county_fips, county_fips_codes.index)
+            if valid_fips.any():
+                county_name = county_fips_codes.loc[
+                    county_fips[valid_fips],
+                    "county_name",
+                ]
+                state_code = county_fips_codes.loc[county_fips[valid_fips], "state"]
+                result = np.array(result, copy=True)
+                result[valid_fips] = map_county_string_to_enum(
+                    county_name,
+                    state_code,
+                ).to_numpy()
+            return result
 
         return household("first_county_in_state", period)

--- a/policyengine_us/variables/household/demographic/geographic/county/county.py
+++ b/policyengine_us/variables/household/demographic/geographic/county/county.py
@@ -31,30 +31,28 @@ class county(Variable):
             if len(known_periods) > 0:
                 last_known_period = sorted(known_periods)[-1]
                 return holder.get_array(last_known_period)
+            return household("first_county_in_state", period)
 
         # First look if county FIPS is provided; if so, map to county name
         county_fips: "pd.Series[str]" | None = household("county_fips", period)
 
-        if not simulation.is_over_dataset:
-            COUNTY_FIPS_DATASET: "pd.DataFrame" = load_county_fips_dataset()
+        COUNTY_FIPS_DATASET: "pd.DataFrame" = load_county_fips_dataset()
 
-            # Decode FIPS codes
-            county_fips_codes = COUNTY_FIPS_DATASET.set_index("county_fips")
-            result = household("first_county_in_state", period)
-            county_fips = np.asarray(county_fips).astype(str)
-            known_fips = county_fips != ""
-            valid_fips = known_fips & np.isin(county_fips, county_fips_codes.index)
-            if valid_fips.any():
-                county_name = county_fips_codes.loc[
-                    county_fips[valid_fips],
-                    "county_name",
-                ]
-                state_code = county_fips_codes.loc[county_fips[valid_fips], "state"]
-                result = np.array(result, copy=True)
-                result[valid_fips] = map_county_string_to_enum(
-                    county_name,
-                    state_code,
-                ).to_numpy()
-            return result
-
-        return household("first_county_in_state", period)
+        # Decode FIPS codes
+        county_fips_codes = COUNTY_FIPS_DATASET.set_index("county_fips")
+        result = household("first_county_in_state", period)
+        county_fips = np.asarray(county_fips).astype(str)
+        known_fips = county_fips != ""
+        valid_fips = known_fips & np.isin(county_fips, county_fips_codes.index)
+        if valid_fips.any():
+            county_name = county_fips_codes.loc[
+                county_fips[valid_fips],
+                "county_name",
+            ]
+            state_code = county_fips_codes.loc[county_fips[valid_fips], "state"]
+            result = np.array(result, copy=True)
+            result[valid_fips] = map_county_string_to_enum(
+                county_name,
+                state_code,
+            ).to_numpy()
+        return result

--- a/policyengine_us/variables/household/demographic/household/household_vehicle_value.py
+++ b/policyengine_us/variables/household/demographic/household/household_vehicle_value.py
@@ -6,3 +6,4 @@ class household_vehicles_value(Variable):
     entity = Household
     label = "Value of vehicles owned"
     definition_period = YEAR
+    quantity_type = STOCK

--- a/policyengine_us/variables/household/expense/tax/taxable_estate_value.py
+++ b/policyengine_us/variables/household/expense/tax/taxable_estate_value.py
@@ -6,5 +6,6 @@ class taxable_estate_value(Variable):
     entity = Person
     label = "Taxable estate value"
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/uscode/text/26/2001#b_1"

--- a/policyengine_us/variables/household/income/person/general/personal_property.py
+++ b/policyengine_us/variables/household/income/person/general/personal_property.py
@@ -6,4 +6,5 @@ class personal_property(Variable):
     entity = Person
     label = "Personal property value"
     unit = USD
+    quantity_type = STOCK
     definition_period = YEAR

--- a/policyengine_us/variables/household/income/person/self_employment/sstb_unadjusted_basis_qualified_property.py
+++ b/policyengine_us/variables/household/income/person/self_employment/sstb_unadjusted_basis_qualified_property.py
@@ -6,6 +6,7 @@ class sstb_unadjusted_basis_qualified_property(Variable):
     entity = Person
     label = "SSTB allocable UBIA of qualified property"
     unit = USD
+    quantity_type = STOCK
     documentation = (
         "Portion of unadjusted_basis_qualified_property allocable to "
         "specified service trades or businesses for section 199A. Used to "

--- a/policyengine_us/variables/household/income/person/self_employment/unadjusted_basis_qualified_property.py
+++ b/policyengine_us/variables/household/income/person/self_employment/unadjusted_basis_qualified_property.py
@@ -6,6 +6,7 @@ class unadjusted_basis_qualified_property(Variable):
     entity = Person
     label = "Unadjusted basis for qualified property"
     unit = USD
+    quantity_type = STOCK
     documentation = "Share of unadjusted basis upon acquisition of all property held by qualified pass-through businesses."
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/uscode/text/26/199A#b_6"

--- a/uv.lock
+++ b/uv.lock
@@ -2974,7 +2974,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.690.0"
+version = "1.691.7"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Mark household asset, property value, SNAP asset, Pell asset, and selected state asset variables as stock quantities so monthly formulas do not divide balances by 12.
- Remove an Illinois AABD vehicle-value workaround that multiplied a vehicle stock by 12.
- Model Texas SNAP BBCE excess vehicle value in the TANF non-cash asset test and remove the stale "not modeled" note.
- Periodize the Texas vehicle exemption at $15,000 before September 1, 2023 and $22,500 afterward, citing Texas HB 1287 and the Texas Works Handbook.
- Add regression coverage for SNAP asset stocks and Texas BBCE vehicle assets.

Fixes #8300.

## Context
PolicyBench error review found cases where SNAP categorical eligibility used monthly TANF non-cash asset tests. Because asset balances were treated as annual flows, a $15,000 asset balance appeared as $1,250 in monthly formulas and could incorrectly pass state asset tests.

The same review also surfaced a separate Texas SNAP BBCE gap: PE-US documented that excess vehicle value above the Texas vehicle exemption was not modeled for the TANF non-cash asset test used by SNAP BBCE. This PR models excess vehicle value using household vehicle value and the Texas exemption. The current Texas exemption is $22,500 for the first vehicle under HB 1287, effective September 1, 2023; $15,000 remains as the historical pre-HB 1287 value.

PolicyEngine Core already preserves stock quantities across periods when variables declare `quantity_type = STOCK`, so the period-handling fix is in PE-US rather than core.

Related PolicyBench prompt follow-up: PolicyEngine/policybench#19.

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_asset_test.yaml policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/snap_assets.yaml -c policyengine_us`
- `uv run --frozen python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility -c policyengine_us`
- `uv run --frozen python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/dc/dhs/ccsp/eligibility/dc_ccsp_asset_eligible.yaml policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/asset/il_aabd_asset_value_eligible.yaml policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/asset/il_aabd_countable_vehicle_value.yaml policyengine_us/tests/policy/baseline/gov/states/il/hfs/hbwd/asset/il_hbwd_countable_assets.yaml policyengine_us/tests/policy/baseline/gov/states/il/hfs/hbwd/eligibility/il_hbwd_asset_eligible.yaml policyengine_us/tests/policy/baseline/gov/states/ma/dta/tcap/eaedc/eligibility/financial/ma_eaedc_assets_limit_eligible.yaml policyengine_us/tests/policy/baseline/gov/states/ma/eec/ccfa/eligibility/ma_ccfa_asset_eligible.yaml -c policyengine_us`
- `uv run --frozen python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/tn/dhs/ff/tn_ff_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/states/wa/dshs/tanf/wa_tanf_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/states/tx/tanf/resources/tx_tanf_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/states/wi/dcf/works/wi_works_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/local/ca/la/general_relief/eligible/la_general_relief_motor_vehicle_value_eligible.yaml policyengine_us/tests/policy/baseline/gov/local/ca/riv/general_relief/ca_riv_general_relief_countable_vehicle_value.yaml policyengine_us/tests/policy/baseline/gov/states/ca/cdss/tanf/cash/eligibility/ca_tanf_vehicle_value_eligible.yaml policyengine_us/tests/policy/baseline/gov/states/ca/cdss/capi/resources/ca_capi_countable_vehicle_value.yaml policyengine_us/tests/policy/baseline/gov/states/ca/cdss/capi/resources/ca_capi_resources.yaml policyengine_us/tests/policy/baseline/gov/states/mt/dhs/tanf/eligibility/mt_tanf_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/states/nm/hca/nm_works/resources/nm_works_countable_non_liquid_resources.yaml policyengine_us/tests/policy/baseline/gov/states/nm/hca/nm_works/resources/nm_works_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/states/dc/dhs/tanf/eligibility/dc_tanf_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/states/in/fssa/tanf/resources/in_tanf_countable_resources.yaml -c policyengine_us`
- `uv run --frozen python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/local/ca/ala/eligibility/ca_ala_general_assistance_personal_property_eligible.yaml policyengine_us/tests/policy/baseline/gov/local/ca/la/general_relief/eligible/la_general_relief_personal_property_eligible.yaml policyengine_us/tests/policy/baseline/gov/local/ca/la/general_relief/eligible/la_general_relief_home_value_eligible.yaml policyengine_us/tests/policy/baseline/gov/states/wa/dshs/tanf/wa_tanf_countable_resources.yaml policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/credits/sctc/wv_sctc.yaml policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/exemptions/homestead_exemption/wv_homestead_exemption.yaml policyengine_us/tests/policy/baseline/gov/irs/integration/qbid.yaml policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/qualified_business_income_deduction_person.yaml policyengine_us/tests/policy/baseline/gov/irs/tax/estate/estate_tax.yaml policyengine_us/tests/policy/baseline/gov/irs/tax/estate/estate_tax_before_credits.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/estate/estate_tax_credit.yaml -c policyengine_us`
- `uv run --frozen ruff format --check`
- `uv run --frozen ruff check`
