### PR TITLE
Fix Idaho OBBBA Schedule 1-A deduction sunset

### DIFF
--- a/changelog.d/8299.fixed.md
+++ b/changelog.d/8299.fixed.md
@@ -1,0 +1,1 @@
+Fixed Idaho's OBBBA Schedule 1-A deduction conformity after 2028.

--- a/policyengine_us/parameters/gov/states/id/tax/income/deductions/qualified_business_income_and_federal_schedule_1a_deductions.yaml
+++ b/policyengine_us/parameters/gov/states/id/tax/income/deductions/qualified_business_income_and_federal_schedule_1a_deductions.yaml
@@ -1,0 +1,22 @@
+description: Idaho allows these qualified business income and federal Schedule 1-A deductions.
+values:
+  2018-01-01:
+    - qualified_business_income_deduction
+  2025-01-01:
+    - qualified_business_income_deduction
+    - id_additional_senior_deduction
+    - tip_income_deduction
+    - overtime_income_deduction
+    - auto_loan_interest_deduction
+  2029-01-01:
+    - qualified_business_income_deduction
+
+metadata:
+  unit: list
+  period: year
+  label: Idaho qualified business income and federal Schedule 1-A deductions
+  reference:
+    - title: Idaho Tax Commission - Update on filing 2025 Idaho income taxes now that conformity is law
+      href: https://tax.idaho.gov/pressrelease/update-on-filing-2025-idaho-income-taxes-now-that-conformity-is-law/
+    - title: H.R.1 - One Big Beautiful Bill Act
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1/text

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.yaml
@@ -6,3 +6,33 @@
     state_code: ID
   output:
     id_qualified_business_income_and_federal_schedule_1a_deductions: 11_000
+
+- name: Idaho excludes temporary federal Schedule 1-A deductions after 2028.
+  period: 2029
+  input:
+    people:
+      person1:
+        age: 66
+        is_tax_unit_head: true
+        is_tax_unit_head_or_spouse: true
+        ssn_card_type: CITIZEN
+        employment_income: 120_000
+        tip_income: 10_000
+        treasury_tipped_occupation_code: 102
+        fsla_overtime_premium: 10_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+        adjusted_gross_income: 120_000
+    households:
+      household:
+        members: [person1]
+        state_code: ID
+        auto_loan_interest: 10_000
+  output:
+    tip_income_deduction: 10_000
+    overtime_income_deduction: 10_000
+    additional_senior_deduction: 3_300
+    auto_loan_interest_deduction: 6_000
+    id_qualified_business_income_and_federal_schedule_1a_deductions: 0

--- a/policyengine_us/variables/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.py
@@ -13,10 +13,7 @@ class id_qualified_business_income_and_federal_schedule_1a_deductions(Variable):
         "https://tax.idaho.gov/pressrelease/update-on-filing-2025-idaho-income-taxes-now-that-conformity-is-law/",
     )
 
-    adds = [
-        "qualified_business_income_deduction",
-        "id_additional_senior_deduction",
-        "tip_income_deduction",
-        "overtime_income_deduction",
-        "auto_loan_interest_deduction",
-    ]
+    adds = (
+        "gov.states.id.tax.income.deductions"
+        ".qualified_business_income_and_federal_schedule_1a_deductions"
+    )


### PR DESCRIPTION
## Summary

- Move Idaho QBI and federal Schedule 1-A deductions into a periodized Idaho parameter list.
- Remove the temporary OBBBA Schedule 1-A deductions from Idaho beginning in 2029 without zeroing the federal deduction variables.
- Add a 2029 regression test showing federal temporary deductions can still calculate while Idaho excludes them.

Fixes #8295.

## Validation

- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.py`
- `uv run ruff format --check policyengine_us/variables/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.py`