### PR TITLE
Apply Georgia HB463 (2025-2026) tax cuts and refactor GA flat-tax rate structure

### DIFF
--- a/changelog.d/ga-hb463-2026-tax-cuts.changed.md
+++ b/changelog.d/ga-hb463-2026-tax-cuts.changed.md
@@ -1,0 +1,1 @@
+Apply Georgia HB463 (2025-2026): cut the flat individual income tax rate to 4.99%, raise the standard deduction to $30,000 joint / $15,000 single, raise the dependent exemption to $5,000, increase the age-65+ retirement income exclusion to $70,000 in 2027, and add qualified-overtime and cash-tip exclusions for tax years 2026-2028.

--- a/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/overtime/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/overtime/cap.yaml
@@ -9,4 +9,4 @@ metadata:
   label: Georgia qualified overtime exclusion cap
   reference:
     - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(16)(A)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=6

--- a/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/overtime/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/overtime/cap.yaml
@@ -1,0 +1,12 @@
+description: Georgia caps the qualified overtime compensation exclusion at this amount per full-time hourly employee.
+
+values:
+  2026-01-01: 1_750
+
+metadata:
+  period: year
+  unit: currency-USD
+  label: Georgia qualified overtime exclusion cap
+  reference:
+    - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(16)(A)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080

--- a/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/retirement/cap/older.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/retirement/cap/older.yaml
@@ -14,5 +14,11 @@ metadata:
     href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=fb5db531-a80f-4790-bddb-eefc8327ef60&config=00JAA1MDBlYzczZi1lYjFlLTQxMTgtYWE3OS02YTgyOGM2NWJlMDYKAFBvZENhdGFsb2feed0oM9qoQOMCSJFX5qkd&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A65D2-CDH3-CGX8-044N-00008-00&pdcontentcomponentid=234186&pdteaserkey=sr1&pditab=allpods&ecomp=8s65kkk&earg=sr1&prid=66f02b0a-c5ae-4162-9535-127751546807
   - title: 2025 IT-511 Individual Income Tax Booklet - Subtractions(1)
     href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=21
+  - title: Georgia HB463 (2025-2026), Section 2-3 amending O.C.G.A. § 48-7-27(a)(5)(A)(xiv)
+    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+# Georgia HB463 (2025-2026), Section 2-3 raises the retirement income
+# exclusion cap for filers age 65 or older from $65,000 to $70,000 effective
+# tax year 2027. This is not subject to revenue triggers.
 values:
   2012-01-01: 65_000
+  2027-01-01: 70_000

--- a/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/retirement/cap/older.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/retirement/cap/older.yaml
@@ -1,9 +1,9 @@
-description: Georgia subtracts this higher retirement income amount for filers meeting the older age threshold.  
+description: Georgia subtracts this higher retirement income amount for filers meeting the older age threshold.
 metadata:
-  label: Georgia retirement income exclusion older cap 
+  label: Georgia retirement income exclusion older cap
   period: year
   unit: currency-USD
-  reference: 
+  reference:
   - title: 2021 IT-511 Individual Income Tax Booklet - Subtractions(1)
     href: https://dor.georgia.gov/document/booklet/2021-it-511-individual-income-tax-booklet/download#page=15
   - title: 2022 IT-511 Individual Income Tax Booklet - Subtractions(1)
@@ -14,8 +14,8 @@ metadata:
     href: https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=fb5db531-a80f-4790-bddb-eefc8327ef60&config=00JAA1MDBlYzczZi1lYjFlLTQxMTgtYWE3OS02YTgyOGM2NWJlMDYKAFBvZENhdGFsb2feed0oM9qoQOMCSJFX5qkd&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A65D2-CDH3-CGX8-044N-00008-00&pdcontentcomponentid=234186&pdteaserkey=sr1&pditab=allpods&ecomp=8s65kkk&earg=sr1&prid=66f02b0a-c5ae-4162-9535-127751546807
   - title: 2025 IT-511 Individual Income Tax Booklet - Subtractions(1)
     href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=21
-  - title: Georgia HB463 (2025-2026), Section 2-3 amending O.C.G.A. § 48-7-27(a)(5)(A)(xiv)
-    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+  - title: Georgia HB463 (2025-2026), Section 2-3 amending O.C.G.A. § 48-7-27(a)(5)(A) and adding (xiv)
+    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=5
 # Georgia HB463 (2025-2026), Section 2-3 raises the retirement income
 # exclusion cap for filers age 65 or older from $65,000 to $70,000 effective
 # tax year 2027. This is not subject to revenue triggers.

--- a/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/tips/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/tips/cap.yaml
@@ -1,0 +1,12 @@
+description: Georgia caps the cash tip exclusion at this amount per employee in a customarily-tipped occupation.
+
+values:
+  2026-01-01: 1_750
+
+metadata:
+  period: year
+  unit: currency-USD
+  label: Georgia cash tip exclusion cap
+  reference:
+    - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(17)(A)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080

--- a/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/tips/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/tips/cap.yaml
@@ -9,4 +9,4 @@ metadata:
   label: Georgia cash tip exclusion cap
   reference:
     - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(17)(A)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=7

--- a/policyengine_us/parameters/gov/states/ga/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/deductions/standard/amount.yaml
@@ -5,7 +5,7 @@ metadata:
   unit: currency-USD
   breakdown:
   - filing_status
-  reference: 
+  reference:
   - title: 2021 IT-511 Individual Income Tax Booklet - page 12 - FORM 500, LINE 11a
     href: https://dor.georgia.gov/document/booklet/2021-it-511-individual-income-tax-booklet/download
   - title: 2022 IT-511 Individual Income Tax Booklet - - page 12 - FORM 500, LINE 11a
@@ -19,10 +19,20 @@ metadata:
   - title: 2025 IT-511 Individual Income Tax Booklet - page 16 - FORM 500, LINE 11
     href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=16
   - title: Georgia HB463 (2025-2026), Section 2-3 amending O.C.G.A. § 48-7-27(a)(1)(B)
-    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=3
 # Georgia HB463 (2025-2026), Section 2-3 raises the JOINT standard deduction
 # from $24,000 to $30,000 and the SINGLE / HEAD_OF_HOUSEHOLD / SEPARATE
 # standard deduction from $12,000 to $15,000 effective tax year 2026.
+#
+# The bill's amended § 48-7-27(a)(1)(B) text enumerates only two filing-status
+# tiers — "(i) a married couple filing a joint return" and "(ii) a single
+# taxpayer, head of household, or married taxpayer filing a separate return."
+# SURVIVING_SPOUSE (qualifying widow/er) is not enumerated. We map
+# SURVIVING_SPOUSE to the JOINT tier ($30,000 in 2026) consistent with federal
+# practice — for the two years following a spouse's death, federal qualifying
+# widow(er)s use the joint standard deduction and joint rate schedule. The
+# pre-2024 historical entries for SURVIVING_SPOUSE (matching SINGLE/HoH)
+# predate this clarification and are preserved for backward compatibility.
 #
 # Bill also provides for prospective annual increases beginning 2027-01-01
 # (+$750 joint, +$375 single/HoH/separate per year, capped at $36,000 /

--- a/policyengine_us/parameters/gov/states/ga/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/deductions/standard/amount.yaml
@@ -18,23 +18,41 @@ metadata:
     href: https://dor.georgia.gov/document/document/2024-it-511-individual-income-tax-booklet/download
   - title: 2025 IT-511 Individual Income Tax Booklet - page 16 - FORM 500, LINE 11
     href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=16
+  - title: Georgia HB463 (2025-2026), Section 2-3 amending O.C.G.A. § 48-7-27(a)(1)(B)
+    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+# Georgia HB463 (2025-2026), Section 2-3 raises the JOINT standard deduction
+# from $24,000 to $30,000 and the SINGLE / HEAD_OF_HOUSEHOLD / SEPARATE
+# standard deduction from $12,000 to $15,000 effective tax year 2026.
+#
+# Bill also provides for prospective annual increases beginning 2027-01-01
+# (+$750 joint, +$375 single/HoH/separate per year, capped at $36,000 /
+# $18,000), but each increase is subject to the revenue triggers defined in
+# O.C.G.A. § 48-7-27(a)(1.1) (Governor's revenue estimate growth, prior-year
+# net revenue, and Revenue Shortfall Reserve coverage of the projected revenue
+# loss). The model does not predict whether the triggers will be met in any
+# given year, so the prospective annual increases are NOT modeled here.
 JOINT:
   2021-01-01: 6_000
   2022-01-01: 7_100
   2024-01-01: 24_000
+  2026-01-01: 30_000
 HEAD_OF_HOUSEHOLD:
   2021-01-01: 4_600
   2022-01-01: 5_400
   2024-01-01: 12_000
+  2026-01-01: 15_000
 SINGLE:
   2021-01-01: 4_600
   2022-01-01: 5_400
   2024-01-01: 12_000
+  2026-01-01: 15_000
 SEPARATE:
   2021-01-01: 3_000
   2022-01-01: 3_550
   2024-01-01: 12_000
+  2026-01-01: 15_000
 SURVIVING_SPOUSE:
   2021-01-01: 4_600
   2022-01-01: 5_400
   2024-01-01: 12_000
+  2026-01-01: 30_000

--- a/policyengine_us/parameters/gov/states/ga/tax/income/exemptions/dependent.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/exemptions/dependent.yaml
@@ -1,7 +1,17 @@
 description: Georgia issues the following exemption amount for each dependent.
+# Georgia HB463 (2025-2026), Section 2-2 raises the per-dependent exemption
+# from $4,000 to $5,000 effective tax year 2026.
+#
+# Bill also provides for prospective $125 annual increases beginning
+# 2027-01-01, capped at $6,000, subject to the same revenue triggers that
+# delay the standard-deduction increases (Governor's revenue estimate, prior-
+# year net revenue, Revenue Shortfall Reserve coverage). The model does not
+# predict whether the triggers will be met, so the prospective annual
+# increases are NOT modeled here.
 values:
   2003-01-01: 3_000
   2024-01-01: 4_000
+  2026-01-01: 5_000
 metadata:
   period: year
   unit: currency-USD
@@ -21,3 +31,5 @@ metadata:
     href: https://gov.georgia.gov/press-releases/2024-04-18/gov-kemp-signs-historic-tax-cut-package-law # Not mentioned in legal code
   - title: 2025 IT-511 Individual Income Tax Booklet - page 17 - FORM 500, LINE 14
     href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=17
+  - title: Georgia HB463 (2025-2026), Section 2-2 amending O.C.G.A. § 48-7-26(b)
+    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080

--- a/policyengine_us/parameters/gov/states/ga/tax/income/exemptions/dependent.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/exemptions/dependent.yaml
@@ -32,4 +32,4 @@ metadata:
   - title: 2025 IT-511 Individual Income Tax Booklet - page 17 - FORM 500, LINE 14
     href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=17
   - title: Georgia HB463 (2025-2026), Section 2-2 amending O.C.G.A. § 48-7-26(b)
-    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+    href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=3

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_applies.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_applies.yaml
@@ -1,4 +1,4 @@
-description: Georgia applies the flat-tax structure when this indicator is true; when false, the per-filing-status progressive bracket structure under gov.states.ga.tax.income.main.{single,joint,separate,head_of_household,surviving_spouse} applies instead.
+description: Georgia uses the flat-tax structure when true; otherwise the per-filing-status progressive bracket structure applies.
 
 values:
   2021-01-01: false
@@ -15,3 +15,5 @@ metadata:
       href: https://www.legis.ga.gov/legislation/66260
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
+    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=2

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_applies.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_applies.yaml
@@ -1,0 +1,17 @@
+description: Georgia applies the flat-tax structure when this indicator is true; when false, the per-filing-status progressive bracket structure under gov.states.ga.tax.income.main.{single,joint,separate,head_of_household,surviving_spouse} applies instead.
+
+values:
+  2021-01-01: false
+  2024-01-01: true
+
+metadata:
+  unit: bool
+  period: year
+  label: Georgia flat-tax structure in effect
+  reference:
+    - title: Official Code of Georgia Annotated | O.C.G.A. § 48-7-20(a.1)
+      href: https://law.justia.com/codes/georgia/2022/title-48/chapter-7/article-2/section-48-7-20/
+    - title: Georgia HB1015 (2023-2024), Section 1 - flat-tax transition
+      href: https://www.legis.ga.gov/legislation/66260
+    - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
+      href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_rate.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_rate.yaml
@@ -1,4 +1,4 @@
-description: Georgia taxes all taxable income at this flat rate when gov.states.ga.tax.income.main.flat_applies is true. This parameter is unused when flat_applies is false (Georgia is on the progressive bracket structure).
+description: Georgia taxes all taxable income at this flat rate when gov.states.ga.tax.income.main.flat_applies is true (otherwise the per-filing-status progressive bracket structure applies).
 # Georgia HB1015 (2023-2024) replaced the progressive bracket structure
 # with a flat rate beginning tax year 2024. Subsequent reductions are made
 # by amending O.C.G.A. section 48-7-20(a.1).
@@ -29,4 +29,4 @@ metadata:
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
     - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=2

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_rate.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/flat_rate.yaml
@@ -1,0 +1,32 @@
+description: Georgia taxes all taxable income at this flat rate when gov.states.ga.tax.income.main.flat_applies is true. This parameter is unused when flat_applies is false (Georgia is on the progressive bracket structure).
+# Georgia HB1015 (2023-2024) replaced the progressive bracket structure
+# with a flat rate beginning tax year 2024. Subsequent reductions are made
+# by amending O.C.G.A. section 48-7-20(a.1).
+#
+# Georgia HB463 (2025-2026), Section 2-1 lowers the flat rate from 5.19%
+# to 4.99% effective tax year 2026. The bill also provides for prospective
+# 0.125% annual rate cuts (target 3.99%) subject to the revenue triggers
+# in O.C.G.A. section 48-7-20(a.1)(2). The model does not predict whether
+# the triggers will be met, so the prospective annual cuts are NOT
+# modeled here.
+
+values:
+  2024-01-01: 0.0539
+  2025-01-01: 0.0519
+  2026-01-01: 0.0499
+
+metadata:
+  unit: /1
+  period: year
+  label: Georgia flat income tax rate
+  reference:
+    - title: Georgia Department of Revenue - Tax Tables & Georgia Tax Rate Schedule
+      href: https://dor.georgia.gov/tax-tables-georgia-tax-rate-schedule
+    - title: Official Code of Georgia Annotated | O.C.G.A. § 48-7-20(a.1)
+      href: https://law.justia.com/codes/georgia/2022/title-48/chapter-7/article-2/section-48-7-20/
+    - title: Georgia HB1015 (2023-2024), Section 1 - flat-tax transition
+      href: https://www.legis.ga.gov/legislation/66260
+    - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
+      href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
+    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/head_of_household.yaml
@@ -21,48 +21,28 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
-    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 brackets:
   - threshold:
       2021-01-01: 0
     rate:
       2021-01-01: 0.01
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_000
     rate:
       2021-01-01: 0.02
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_000
     rate:
       2021-01-01: 0.03
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.04
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.05
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 10_000
     rate:
       2021-01-01: 0.0575
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/head_of_household.yaml
@@ -21,6 +21,8 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
+    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 brackets:
   - threshold:
       2021-01-01: 0
@@ -28,33 +30,39 @@ brackets:
       2021-01-01: 0.01
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_000
     rate:
       2021-01-01: 0.02
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_000
     rate:
       2021-01-01: 0.03
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.04
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.05
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 10_000
     rate:
       2021-01-01: 0.0575
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/joint.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/joint.yaml
@@ -21,6 +21,8 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
+    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
@@ -29,33 +31,39 @@ brackets:
       2021-01-01: 0.01
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_000
     rate:
       2021-01-01: 0.02
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_000
     rate:
       2021-01-01: 0.03
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.04
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.05
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 10_000
     rate:
       2021-01-01: 0.0575
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/joint.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/joint.yaml
@@ -21,49 +21,29 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
-    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
       2021-01-01: 0
     rate:
       2021-01-01: 0.01
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_000
     rate:
       2021-01-01: 0.02
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_000
     rate:
       2021-01-01: 0.03
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.04
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.05
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 10_000
     rate:
       2021-01-01: 0.0575
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/separate.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/separate.yaml
@@ -20,6 +20,8 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
+    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
@@ -28,33 +30,39 @@ brackets:
       2021-01-01: 0.01
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 500
     rate:
       2021-01-01: 0.02
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_500
     rate:
       2021-01-01: 0.03
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 2_500
     rate:
       2021-01-01: 0.04
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_500
     rate:
       2021-01-01: 0.05
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.0575
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/separate.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/separate.yaml
@@ -20,49 +20,29 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
-    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
       2021-01-01: 0
     rate:
       2021-01-01: 0.01
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 500
     rate:
       2021-01-01: 0.02
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_500
     rate:
       2021-01-01: 0.03
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 2_500
     rate:
       2021-01-01: 0.04
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_500
     rate:
       2021-01-01: 0.05
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.0575
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/single.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/single.yaml
@@ -1,4 +1,13 @@
 description: Georgia taxes the personal income of single filers at this rate.
+# Georgia HB463 (2025-2026), Section 2-1 lowers the flat individual income
+# tax rate from 5.19% to 4.99% effective tax year 2026.
+#
+# Bill also provides for prospective 0.10% annual rate cuts beginning
+# 2027-01-01, targeting an eventual 3.99% flat rate. Each annual cut is
+# subject to revenue triggers (Governor's revenue estimate growth, prior-
+# year net revenue, Revenue Shortfall Reserve coverage of the projected
+# revenue loss). The model does not predict whether the triggers will be
+# met, so the prospective annual cuts are NOT modeled here.
 metadata:
   type: marginal_rate
   threshold_unit: currency-USD
@@ -20,6 +29,8 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
+    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
@@ -28,33 +39,39 @@ brackets:
       2021-01-01: 0.01
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 750
     rate:
       2021-01-01: 0.02
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 2_250
     rate:
       2021-01-01: 0.03
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_750
     rate:
       2021-01-01: 0.04
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_250
     rate:
       2021-01-01: 0.05
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.0575
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/single.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/single.yaml
@@ -1,13 +1,4 @@
 description: Georgia taxes the personal income of single filers at this rate.
-# Georgia HB463 (2025-2026), Section 2-1 lowers the flat individual income
-# tax rate from 5.19% to 4.99% effective tax year 2026.
-#
-# Bill also provides for prospective 0.10% annual rate cuts beginning
-# 2027-01-01, targeting an eventual 3.99% flat rate. Each annual cut is
-# subject to revenue triggers (Governor's revenue estimate growth, prior-
-# year net revenue, Revenue Shortfall Reserve coverage of the projected
-# revenue loss). The model does not predict whether the triggers will be
-# met, so the prospective annual cuts are NOT modeled here.
 metadata:
   type: marginal_rate
   threshold_unit: currency-USD
@@ -29,49 +20,29 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
-    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
       2021-01-01: 0
     rate:
       2021-01-01: 0.01
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 750
     rate:
       2021-01-01: 0.02
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 2_250
     rate:
       2021-01-01: 0.03
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_750
     rate:
       2021-01-01: 0.04
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_250
     rate:
       2021-01-01: 0.05
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.0575
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/surviving_spouse.yaml
@@ -21,6 +21,8 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
+    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
@@ -29,33 +31,39 @@ brackets:
       2021-01-01: 0.01
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_000
     rate:
       2021-01-01: 0.02
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_000
     rate:
       2021-01-01: 0.03
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.04
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.05
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 10_000
     rate:
       2021-01-01: 0.0575
       2024-01-01: 0.0539
       2025-01-01: 0.0519
+      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/main/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/main/surviving_spouse.yaml
@@ -21,49 +21,29 @@ metadata:
       href: https://dor.georgia.gov/it-511-individual-income-tax-instruction-booklet
     - title: 2025 IT-511 Individual Income Tax Booklet, Page 9
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=9
-    - title: Georgia HB463 (2025-2026), Section 2-1 amending O.C.G.A. § 48-7-20(a.1)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
 
 brackets:
   - threshold:
       2021-01-01: 0
     rate:
       2021-01-01: 0.01
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 1_000
     rate:
       2021-01-01: 0.02
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 3_000
     rate:
       2021-01-01: 0.03
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 5_000
     rate:
       2021-01-01: 0.04
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 7_000
     rate:
       2021-01-01: 0.05
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499
   - threshold:
       2021-01-01: 10_000
     rate:
       2021-01-01: 0.0575
-      2024-01-01: 0.0539
-      2025-01-01: 0.0519
-      2026-01-01: 0.0499

--- a/policyengine_us/parameters/gov/states/ga/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/subtractions/subtractions.yaml
@@ -1,21 +1,40 @@
-description: Georgia subtracts these sources from adjusted gross income.  
+description: Georgia subtracts these sources from adjusted gross income.
+# Georgia HB463 (2025-2026), Section 2-4 adds qualified overtime
+# compensation (O.C.G.A. section 48-7-27(a)(16)) and cash tips
+# (O.C.G.A. section 48-7-27(a)(17)) to Georgia AGI subtractions for tax
+# years 2026 through 2028. Both provisions self-repeal December 31, 2028,
+# so a 2029-01-01 entry removes both variables from the list.
 values:
   2021-01-01:
-    - us_govt_interest  
-    - ga_retirement_exclusion  
-    - taxable_social_security  
+    - us_govt_interest
+    - ga_retirement_exclusion
+    - taxable_social_security
     - ga_investment_in_529_plan_deduction
   2022-01-01:
-    - us_govt_interest  
-    - ga_retirement_exclusion  
-    - ga_military_retirement_exclusion  
-    - taxable_social_security  
+    - us_govt_interest
+    - ga_retirement_exclusion
+    - ga_military_retirement_exclusion
+    - taxable_social_security
     - ga_investment_in_529_plan_deduction
-    
+  2026-01-01:
+    - us_govt_interest
+    - ga_retirement_exclusion
+    - ga_military_retirement_exclusion
+    - taxable_social_security
+    - ga_investment_in_529_plan_deduction
+    - ga_qualified_overtime_exclusion
+    - ga_cash_tip_exclusion
+  2029-01-01:
+    - us_govt_interest
+    - ga_retirement_exclusion
+    - ga_military_retirement_exclusion
+    - taxable_social_security
+    - ga_investment_in_529_plan_deduction
+
 metadata:
   unit: list
-  label: Georgia adjusted gross income subtractions  
-  period: year  
+  label: Georgia adjusted gross income subtractions
+  period: year
   reference:
     - title: 2022 Form 500 Instructions
       href: https://apps.dor.ga.gov/FillableForms/PDFViewer/Index?form=2022GA500
@@ -25,3 +44,5 @@ metadata:
       href: https://law.justia.com/codes/georgia/2022/title-48/chapter-7/article-2/section-48-7-27/
     - title: 2025 IT-511 Individual Income Tax Booklet - Subtractions
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=21
+    - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(16) and (a)(17)
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080

--- a/policyengine_us/parameters/gov/states/ga/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/subtractions/subtractions.yaml
@@ -44,5 +44,7 @@ metadata:
       href: https://law.justia.com/codes/georgia/2022/title-48/chapter-7/article-2/section-48-7-27/
     - title: 2025 IT-511 Individual Income Tax Booklet - Subtractions
       href: https://dor.georgia.gov/document/document/2025-it-511-individual-income-tax-booklet/download#page=21
-    - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(16) and (a)(17)
-      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080
+    - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(16) - qualified overtime exclusion
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=6
+    - title: Georgia HB463 (2025-2026), Section 2-4 adding O.C.G.A. § 48-7-27(a)(17) - cash tips exclusion
+      href: https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=7

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_hb463_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_hb463_integration.yaml
@@ -20,6 +20,39 @@
   output:
     ga_standard_deduction: 30_000
 
+- name: GA HB463 - TY 2026 head of household gets the new $15,000 standard deduction
+  period: 2026
+  input:
+    employment_income: 50_000
+    filing_status: HEAD_OF_HOUSEHOLD
+    age_head: 35
+    state_code: GA
+  output:
+    ga_standard_deduction: 15_000
+
+- name: GA HB463 - TY 2026 separate filer gets the new $15,000 standard deduction
+  period: 2026
+  input:
+    employment_income: 40_000
+    filing_status: SEPARATE
+    age_head: 38
+    state_code: GA
+  output:
+    ga_standard_deduction: 15_000
+
+- name: GA HB463 - TY 2026 surviving spouse gets the $30,000 standard deduction (JOINT-tier conformity)
+  # Bill enumerates only (i) joint and (ii) single/HoH/separate. We map
+  # SURVIVING_SPOUSE to the joint tier consistent with federal qualifying-
+  # widow(er) treatment.
+  period: 2026
+  input:
+    employment_income: 60_000
+    filing_status: SURVIVING_SPOUSE
+    age_head: 40
+    state_code: GA
+  output:
+    ga_standard_deduction: 30_000
+
 - name: GA HB463 - TY 2026 dependent exemption is $5,000 per dependent
   period: 2026
   input:
@@ -43,6 +76,57 @@
     # HB463 Section 2-2: dependent exemption raised from $4,000 to $5,000.
     ga_exemptions: 5_000
 
+- name: GA HB463 - TY 2026 multi-dependent exemption scales linearly
+  period: 2026
+  input:
+    people:
+      head:
+        age: 35
+        employment_income: 60_000
+        is_tax_unit_head: true
+      child1:
+        age: 8
+        is_tax_unit_dependent: true
+      child2:
+        age: 10
+        is_tax_unit_dependent: true
+      child3:
+        age: 12
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, child1, child2, child3]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        members: [head, child1, child2, child3]
+        state_code: GA
+  output:
+    # 3 dependents x $5,000 = $15,000 (plus filer exemption if any from p.taxpayer).
+    ga_exemptions: 15_000
+
+- name: GA HB463 - TY 2026 age-65+ retirement cap is still $65,000 (cap raise applies TY 2027+)
+  # Locks the 2026 vs 2027 boundary. The bill raises the cap to $70,000
+  # effective TY 2027, not TY 2026 — so a 2026 age-65+ filer with $70,000
+  # of taxable pension income is capped at $65,000.
+  period: 2026
+  input:
+    people:
+      head:
+        age: 67
+        taxable_pension_income: 70_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    ga_retirement_exclusion: 65_000
+
 - name: GA HB463 - TY 2027 retirement income exclusion for age 65+ raised to $70,000
   period: 2027
   input:
@@ -61,8 +145,7 @@
         state_code: GA
   output:
     # HB463 Section 2-3: age-65+ retirement exclusion cap raised from
-    # $65,000 to $70,000 effective TY 2027. Filer receives the full $70,000
-    # exclusion.
+    # $65,000 to $70,000 effective TY 2027.
     ga_retirement_exclusion: 70_000
 
 - name: GA HB463 - TY 2026 qualified overtime exclusion caps at $1,750
@@ -72,6 +155,8 @@
       head:
         age: 35
         is_tax_unit_head: true
+        is_paid_hourly: true
+        employment_income: 50_000
         fsla_overtime_premium: 3_000
     tax_units:
       tax_unit:
@@ -85,7 +170,111 @@
     # HB463 Section 2-4(16): qualified overtime exclusion capped at $1,750.
     ga_qualified_overtime_exclusion: 1_750
 
-- name: GA HB463 - TY 2029 overtime exclusion no longer subtracts from GA AGI (provision self-repealed)
+- name: GA HB463 - TY 2026 overtime below cap passes through uncapped
+  period: 2026
+  input:
+    people:
+      head:
+        age: 35
+        is_tax_unit_head: true
+        is_paid_hourly: true
+        employment_income: 40_000
+        fsla_overtime_premium: 1_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    ga_qualified_overtime_exclusion: 1_000
+
+- name: GA HB463 - TY 2026 zero overtime yields zero exclusion
+  period: 2026
+  input:
+    people:
+      head:
+        age: 35
+        is_tax_unit_head: true
+        employment_income: 40_000
+        fsla_overtime_premium: 0
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    ga_qualified_overtime_exclusion: 0
+
+- name: GA HB463 - TY 2026 multi-worker overtime applies per-person cap then aggregates
+  # Two workers each with $3,000 of overtime — each capped at $1,750
+  # individually, summed to $3,500. Validates that the cap is applied
+  # BEFORE aggregation (per-employee), not after.
+  period: 2026
+  input:
+    people:
+      head:
+        age: 38
+        is_tax_unit_head: true
+        is_paid_hourly: true
+        employment_income: 50_000
+        fsla_overtime_premium: 3_000
+      spouse:
+        age: 36
+        is_tax_unit_spouse: true
+        is_paid_hourly: true
+        employment_income: 50_000
+        fsla_overtime_premium: 3_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+    households:
+      household:
+        members: [head, spouse]
+        state_code: GA
+  output:
+    # 2 workers x $1,750 = $3,500.
+    ga_qualified_overtime_exclusion: 3_500
+
+- name: GA HB463 - TY 2028 last year overtime and tips still flow into ga_subtractions
+  # Contrast case for the 2029 self-repeal test below. TY 2028 is the last
+  # year both provisions apply, so the exclusions ARE summed into
+  # ga_subtractions. Sanity-check that the variables themselves return
+  # the expected $1,750 caps.
+  period: 2028
+  input:
+    people:
+      head:
+        age: 35
+        is_tax_unit_head: true
+        is_paid_hourly: true
+        employment_income: 50_000
+        fsla_overtime_premium: 3_000
+        tip_income: 4_000
+        tip_income_deduction_occupation_requirement_met: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    ga_qualified_overtime_exclusion: 1_750
+    ga_cash_tip_exclusion: 1_750
+
+- name: GA HB463 - TY 2029 overtime/tips exclusions self-repealed; no subtraction flows
+  # Both paragraphs stand repealed 12/31/2028; subtractions list drops both
+  # at 2029-01-01. The variables themselves may still compute non-zero
+  # values from the person-level inputs, but they should NOT contribute
+  # to ga_subtractions because they are no longer in the list.
   period: 2029
   input:
     people:
@@ -132,6 +321,52 @@
     # HB463 Section 2-4(17): cash tip exclusion capped at $1,750.
     ga_cash_tip_exclusion: 1_750
 
+- name: GA HB463 - TY 2026 tip income below cap passes through uncapped
+  period: 2026
+  input:
+    people:
+      head:
+        age: 30
+        is_tax_unit_head: true
+        tip_income: 1_000
+        tip_income_deduction_occupation_requirement_met: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    ga_cash_tip_exclusion: 1_000
+
+- name: GA HB463 - TY 2026 multi-worker tips apply per-person cap then aggregate
+  period: 2026
+  input:
+    people:
+      head:
+        age: 38
+        is_tax_unit_head: true
+        tip_income: 4_000
+        tip_income_deduction_occupation_requirement_met: true
+      spouse:
+        age: 36
+        is_tax_unit_spouse: true
+        tip_income: 4_000
+        tip_income_deduction_occupation_requirement_met: true
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+    households:
+      household:
+        members: [head, spouse]
+        state_code: GA
+  output:
+    # 2 workers x $1,750 = $3,500.
+    ga_cash_tip_exclusion: 3_500
+
 - name: GA HB463 - TY 2026 cash tip exclusion is zero for non-tipped occupations
   period: 2026
   input:
@@ -153,3 +388,4 @@
     # Tips from occupations without a Treasury Tipped Occupation Code are
     # excluded under both federal and GA HB463 rules.
     ga_cash_tip_exclusion: 0
+

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_hb463_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_hb463_integration.yaml
@@ -1,0 +1,155 @@
+- name: GA HB463 - TY 2026 single filer gets the new $15,000 standard deduction
+  period: 2026
+  input:
+    employment_income: 50_000
+    filing_status: SINGLE
+    age_head: 35
+    state_code: GA
+  output:
+    # Standard deduction increased from $12,000 to $15,000 by HB463 Section 2-3.
+    ga_standard_deduction: 15_000
+
+- name: GA HB463 - TY 2026 joint filer gets the new $30,000 standard deduction
+  period: 2026
+  input:
+    employment_income: 80_000
+    filing_status: JOINT
+    age_head: 40
+    age_spouse: 38
+    state_code: GA
+  output:
+    ga_standard_deduction: 30_000
+
+- name: GA HB463 - TY 2026 dependent exemption is $5,000 per dependent
+  period: 2026
+  input:
+    people:
+      head:
+        age: 35
+        employment_income: 50_000
+        is_tax_unit_head: true
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        members: [head, child]
+        state_code: GA
+  output:
+    # HB463 Section 2-2: dependent exemption raised from $4,000 to $5,000.
+    ga_exemptions: 5_000
+
+- name: GA HB463 - TY 2027 retirement income exclusion for age 65+ raised to $70,000
+  period: 2027
+  input:
+    people:
+      head:
+        age: 67
+        taxable_pension_income: 80_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    # HB463 Section 2-3: age-65+ retirement exclusion cap raised from
+    # $65,000 to $70,000 effective TY 2027. Filer receives the full $70,000
+    # exclusion.
+    ga_retirement_exclusion: 70_000
+
+- name: GA HB463 - TY 2026 qualified overtime exclusion caps at $1,750
+  period: 2026
+  input:
+    people:
+      head:
+        age: 35
+        is_tax_unit_head: true
+        fsla_overtime_premium: 3_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    # HB463 Section 2-4(16): qualified overtime exclusion capped at $1,750.
+    ga_qualified_overtime_exclusion: 1_750
+
+- name: GA HB463 - TY 2029 overtime exclusion no longer subtracts from GA AGI (provision self-repealed)
+  period: 2029
+  input:
+    people:
+      head:
+        age: 35
+        is_tax_unit_head: true
+        employment_income: 50_000
+        fsla_overtime_premium: 3_000
+        tip_income: 4_000
+        tip_income_deduction_occupation_requirement_met: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    # HB463 Section 2-4(16)(E) and (17)(E): both paragraphs stand repealed
+    # and reserved on December 31, 2028. The subtractions list drops
+    # ga_qualified_overtime_exclusion and ga_cash_tip_exclusion from
+    # 2029-01-01, so neither flows through ga_subtractions.
+    ga_subtractions: 0
+
+- name: GA HB463 - TY 2026 cash tip exclusion caps at $1,750 for tipped occupations
+  period: 2026
+  input:
+    people:
+      head:
+        age: 30
+        is_tax_unit_head: true
+        tip_income: 4_000
+        tip_income_deduction_occupation_requirement_met: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    # HB463 Section 2-4(17): cash tip exclusion capped at $1,750.
+    ga_cash_tip_exclusion: 1_750
+
+- name: GA HB463 - TY 2026 cash tip exclusion is zero for non-tipped occupations
+  period: 2026
+  input:
+    people:
+      head:
+        age: 30
+        is_tax_unit_head: true
+        tip_income: 4_000
+        tip_income_deduction_occupation_requirement_met: false
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [head]
+        state_code: GA
+  output:
+    # Tips from occupations without a Treasury Tipped Occupation Code are
+    # excluded under both federal and GA HB463 rules.
+    ga_cash_tip_exclusion: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_income_tax_before_non_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_income_tax_before_non_refundable_credits.yaml
@@ -72,3 +72,24 @@
   output:
     # 50,000 * 0.0539 = 2,695
     ga_income_tax_before_non_refundable_credits: 2_695
+
+- name: GA HB463 - single filer 2026 flat tax at 4.99%
+  period: 2026
+  input:
+    ga_taxable_income: 50_000
+    filing_status: SINGLE
+    state_code: GA
+  output:
+    # HB463 Section 2-1: flat rate drops to 4.99% in TY 2026.
+    # 50,000 * 0.0499 = 2,495
+    ga_income_tax_before_non_refundable_credits: 2_495
+
+- name: GA HB463 - joint filer 2026 flat tax at 4.99%
+  period: 2026
+  input:
+    ga_taxable_income: 100_000
+    filing_status: JOINT
+    state_code: GA
+  output:
+    # 100,000 * 0.0499 = 4,990
+    ga_income_tax_before_non_refundable_credits: 4_990

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_income_tax_before_non_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_income_tax_before_non_refundable_credits.yaml
@@ -16,7 +16,7 @@
   output:
     ga_income_tax_before_non_refundable_credits: 0
 
-- name: Joint filer 
+- name: Joint filer
   period: 2022
   input:
     ga_taxable_income: 1_100
@@ -25,7 +25,7 @@
   output:
     ga_income_tax_before_non_refundable_credits: 12
 
-- name: Separate filer 
+- name: Separate filer
   period: 2022
   input:
     ga_taxable_income: 600
@@ -42,6 +42,71 @@
     state_code: GA
   output:
     ga_income_tax_before_non_refundable_credits: 12
+
+- name: Surviving spouse 2023 progressive bracket structure
+  # Locks the pre-2024 SURVIVING_SPOUSE branch — flat_applies is false in 2023.
+  period: 2023
+  input:
+    ga_taxable_income: 1_100
+    filing_status: SURVIVING_SPOUSE
+    state_code: GA
+  output:
+    ga_income_tax_before_non_refundable_credits: 12
+
+- name: Single filer 2023 still uses progressive bracket structure
+  # 2023 is the last year with flat_applies false. Locks the formula
+  # branch boundary: 2023 -> progressive, 2024 -> flat.
+  # 750*0.01 + 1_500*0.02 + 750*0.03 = 7.5 + 30 + 22.5 = 60
+  period: 2023
+  input:
+    ga_taxable_income: 3_000
+    filing_status: SINGLE
+    state_code: GA
+  output:
+    ga_income_tax_before_non_refundable_credits: 60
+
+- name: Single filer 2024 flat tax (5.39% rate)
+  period: 2024
+  input:
+    ga_taxable_income: 50_000
+    filing_status: SINGLE
+    state_code: GA
+  output:
+    # 50,000 * 0.0539 = 2,695
+    ga_income_tax_before_non_refundable_credits: 2_695
+
+- name: Head of household filer 2024 flat tax (5.39% rate)
+  # Refactor regression case — confirms HoH gets flat treatment in 2024.
+  period: 2024
+  input:
+    ga_taxable_income: 60_000
+    filing_status: HEAD_OF_HOUSEHOLD
+    state_code: GA
+  output:
+    # 60,000 * 0.0539 = 3,234
+    ga_income_tax_before_non_refundable_credits: 3_234
+
+- name: Separate filer 2024 flat tax (5.39% rate)
+  # Refactor regression case — confirms MFS gets flat treatment in 2024.
+  period: 2024
+  input:
+    ga_taxable_income: 40_000
+    filing_status: SEPARATE
+    state_code: GA
+  output:
+    # 40,000 * 0.0539 = 2,156
+    ga_income_tax_before_non_refundable_credits: 2_156
+
+- name: Surviving spouse 2024 flat tax (5.39% rate)
+  # Refactor regression case — confirms SURVIVING_SPOUSE gets flat treatment in 2024.
+  period: 2024
+  input:
+    ga_taxable_income: 80_000
+    filing_status: SURVIVING_SPOUSE
+    state_code: GA
+  output:
+    # 80,000 * 0.0539 = 4,312
+    ga_income_tax_before_non_refundable_credits: 4_312
 
 - name: Single filer 2025 flat tax (5.19% rate)
   period: 2025
@@ -63,15 +128,15 @@
     # 100,000 * 0.0519 = 5,190
     ga_income_tax_before_non_refundable_credits: 5_190
 
-- name: Single filer 2024 flat tax (5.39% rate)
-  period: 2024
+- name: Head of household filer 2025 flat tax (5.19% rate)
+  period: 2025
   input:
-    ga_taxable_income: 50_000
-    filing_status: SINGLE
+    ga_taxable_income: 60_000
+    filing_status: HEAD_OF_HOUSEHOLD
     state_code: GA
   output:
-    # 50,000 * 0.0539 = 2,695
-    ga_income_tax_before_non_refundable_credits: 2_695
+    # 60,000 * 0.0519 = 3,114
+    ga_income_tax_before_non_refundable_credits: 3_114
 
 - name: GA HB463 - single filer 2026 flat tax at 4.99%
   period: 2026
@@ -93,3 +158,33 @@
   output:
     # 100,000 * 0.0499 = 4,990
     ga_income_tax_before_non_refundable_credits: 4_990
+
+- name: GA HB463 - head of household 2026 flat tax at 4.99%
+  period: 2026
+  input:
+    ga_taxable_income: 75_000
+    filing_status: HEAD_OF_HOUSEHOLD
+    state_code: GA
+  output:
+    # 75,000 * 0.0499 = 3,742.5
+    ga_income_tax_before_non_refundable_credits: 3_742.5
+
+- name: GA HB463 - separate filer 2026 flat tax at 4.99%
+  period: 2026
+  input:
+    ga_taxable_income: 40_000
+    filing_status: SEPARATE
+    state_code: GA
+  output:
+    # 40,000 * 0.0499 = 1,996
+    ga_income_tax_before_non_refundable_credits: 1_996
+
+- name: GA HB463 - surviving spouse 2026 flat tax at 4.99%
+  period: 2026
+  input:
+    ga_taxable_income: 90_000
+    filing_status: SURVIVING_SPOUSE
+    state_code: GA
+  output:
+    # 90,000 * 0.0499 = 4,491
+    ga_income_tax_before_non_refundable_credits: 4_491

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_cash_tip_exclusion.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_cash_tip_exclusion.py
@@ -8,15 +8,32 @@ class ga_cash_tip_exclusion(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.GA
+    # GA HB463 Section 2-4 adds O.C.G.A. § 48-7-27(a)(17).
     reference = (
-        "https://www.legis.ga.gov/api/legislation/document/20252026/249080",  # GA HB463 Section 2-4 adding O.C.G.A. 48-7-27(a)(17)
+        "https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=7"
     )
 
     def formula(tax_unit, period, parameters):
-        # GA HB463 Section 2-4 paragraph (17): for tax years 2026-2028, each
-        # employee in a customarily-tipped occupation may exclude up to $1,750
-        # of cash tips from Georgia taxable income. The occupation requirement
-        # mirrors the federal Treasury Tipped Occupation Code list.
+        # GA HB463 § 48-7-27(a)(17) (TY 2026-2028): each employee in a
+        # customarily-tipped occupation may exclude up to $1,750 of cash
+        # tips from Georgia taxable income.
+        #
+        # The bill defines "cash tips" to include cash plus charged tips
+        # received voluntarily (but excludes mandatory service charges
+        # where consequence-in-nonpayment, subject-to-negotiation, or
+        # determined-by-payor fails). We approximate this with the generic
+        # `tip_income` variable, which does not distinguish among cash,
+        # charged, and mandatory categories. Reasonable approximation in
+        # practice, since `tip_income` typically reflects voluntary tips.
+        #
+        # The bill defines "occupation that customarily and regularly
+        # receives tips" by explicit reference to the federal Treasury
+        # Tipped Occupation Code list and additionally excludes "occupations
+        # excluded under Section 63 of the Internal Revenue Code." We use
+        # `tip_income_deduction_occupation_requirement_met`, which checks
+        # the Treasury list and excludes Specified Service Trades or
+        # Businesses (via `~is_sstb`) — the IRC § 199A SSTB list is the
+        # standard federal proxy for the occupation-exclusion clause.
         person = tax_unit.members
         tip_income = person("tip_income", period)
         occupation_eligible = person(
@@ -24,5 +41,4 @@ class ga_cash_tip_exclusion(Variable):
         )
         qualified_tips = tip_income * occupation_eligible
         cap = parameters(period).gov.states.ga.tax.income.agi.exclusions.tips.cap
-        capped = min_(qualified_tips, cap)
-        return tax_unit.sum(capped)
+        return tax_unit.sum(min_(qualified_tips, cap))

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_cash_tip_exclusion.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_cash_tip_exclusion.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class ga_cash_tip_exclusion(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia cash tip exclusion"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA
+    reference = (
+        "https://www.legis.ga.gov/api/legislation/document/20252026/249080",  # GA HB463 Section 2-4 adding O.C.G.A. 48-7-27(a)(17)
+    )
+
+    def formula(tax_unit, period, parameters):
+        # GA HB463 Section 2-4 paragraph (17): for tax years 2026-2028, each
+        # employee in a customarily-tipped occupation may exclude up to $1,750
+        # of cash tips from Georgia taxable income. The occupation requirement
+        # mirrors the federal Treasury Tipped Occupation Code list.
+        person = tax_unit.members
+        tip_income = person("tip_income", period)
+        occupation_eligible = person(
+            "tip_income_deduction_occupation_requirement_met", period
+        )
+        qualified_tips = tip_income * occupation_eligible
+        cap = parameters(period).gov.states.ga.tax.income.agi.exclusions.tips.cap
+        capped = min_(qualified_tips, cap)
+        return tax_unit.sum(capped)

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_income_tax_before_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_income_tax_before_non_refundable_credits.py
@@ -11,9 +11,12 @@ class ga_income_tax_before_non_refundable_credits(Variable):
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.ga.tax.income.main
+        income = tax_unit("ga_taxable_income", period)
+        if p.flat_applies:
+            return p.flat_rate * income
+        # Pre-2024 progressive bracket structure by filing status.
         filing_status = tax_unit("filing_status", period)
         status = filing_status.possible_values
-        income = tax_unit("ga_taxable_income", period)
         return select(
             [
                 filing_status == status.SINGLE,

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_qualified_overtime_exclusion.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_qualified_overtime_exclusion.py
@@ -8,20 +8,32 @@ class ga_qualified_overtime_exclusion(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.GA
+    # GA HB463 Section 2-4 adds O.C.G.A. § 48-7-27(a)(16).
     reference = (
-        "https://www.legis.ga.gov/api/legislation/document/20252026/249080",  # GA HB463 Section 2-4 adding O.C.G.A. 48-7-27(a)(16)
+        "https://www.legis.ga.gov/api/legislation/document/20252026/249080#page=6"
     )
 
     def formula(tax_unit, period, parameters):
-        # GA HB463 Section 2-4 paragraph (16): for tax years 2026-2028, each
-        # full-time hourly employee may exclude up to $1,750 of qualified
-        # overtime compensation (IRC section 225) from Georgia taxable income.
-        # We approximate the "full-time employee paid by an hourly wage"
-        # restriction by using fsla_overtime_premium, which is the federally-
-        # defined Fair Labor Standards Act overtime premium and by definition
-        # applies only to non-exempt (typically hourly) workers.
+        # GA HB463 § 48-7-27(a)(16) (TY 2026-2028): each full-time hourly
+        # employee may exclude up to $1,750 of qualified overtime compensation
+        # (defined by reference to IRC § 225) from Georgia taxable income.
+        #
+        # Approximation: we use `fsla_overtime_premium`, the federally-defined
+        # Fair Labor Standards Act overtime premium, which by construction
+        # applies only to FLSA non-exempt workers (typically hourly). Known
+        # limitations:
+        #   - The bill's "full-time" qualifier is not strictly enforced;
+        #     a part-time hourly worker who happens to exceed 40 hours in
+        #     some weeks would be credited the exclusion under the model.
+        #   - § 48-7-27(a)(16)(B) extends the exclusion to railway workers
+        #     under the National Railway Labor Act, defined by collective
+        #     bargaining agreements. Railway workers are FLSA-exempt under
+        #     29 U.S.C. § 213(b)(2), so `fsla_overtime_premium` returns zero
+        #     for them and they receive no exclusion under the model. This
+        #     is a known under-modeling of a specifically eligible group.
+        #   - The employer reporting obligations in § 48-7-27(a)(16)(C)-(D)
+        #     are administrative and do not affect household tax liability.
         person = tax_unit.members
         overtime = person("fsla_overtime_premium", period)
         cap = parameters(period).gov.states.ga.tax.income.agi.exclusions.overtime.cap
-        capped = min_(overtime, cap)
-        return tax_unit.sum(capped)
+        return tax_unit.sum(min_(overtime, cap))

--- a/policyengine_us/variables/gov/states/ga/tax/income/ga_qualified_overtime_exclusion.py
+++ b/policyengine_us/variables/gov/states/ga/tax/income/ga_qualified_overtime_exclusion.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class ga_qualified_overtime_exclusion(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Georgia qualified overtime compensation exclusion"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.GA
+    reference = (
+        "https://www.legis.ga.gov/api/legislation/document/20252026/249080",  # GA HB463 Section 2-4 adding O.C.G.A. 48-7-27(a)(16)
+    )
+
+    def formula(tax_unit, period, parameters):
+        # GA HB463 Section 2-4 paragraph (16): for tax years 2026-2028, each
+        # full-time hourly employee may exclude up to $1,750 of qualified
+        # overtime compensation (IRC section 225) from Georgia taxable income.
+        # We approximate the "full-time employee paid by an hourly wage"
+        # restriction by using fsla_overtime_premium, which is the federally-
+        # defined Fair Labor Standards Act overtime premium and by definition
+        # applies only to non-exempt (typically hourly) workers.
+        person = tax_unit.members
+        overtime = person("fsla_overtime_premium", period)
+        cap = parameters(period).gov.states.ga.tax.income.agi.exclusions.overtime.cap
+        capped = min_(overtime, cap)
+        return tax_unit.sum(capped)


### PR DESCRIPTION
## Summary

Implements Georgia HB463 (2025-2026 session, signed 2026; [bill text](https://www.legis.ga.gov/api/legislation/document/20252026/249080)) and refactors the GA tax-rate parameter structure to make the 2024 flat-tax transition explicit.

The PR has two parts:

1. **HB463 direct changes** — rate cut, standard deduction increase, dependent exemption increase, retirement income exclusion increase, and new overtime/tips exclusions.
2. **Rate-structure refactor** — split the GA tax rate into an explicit `flat_applies` boolean + a single `flat_rate` parameter, so future flat-rate changes (like HB463's 4.99%) are a one-parameter edit instead of touching 25 places (5 brackets × 5 filing-status files).

Closes #8305.

## Rate-structure refactor

| New parameter | Type | Purpose |
|---|---|---|
| `gov.states.ga.tax.income.main.flat_applies` | bool | `false` pre-2024; `true` from 2024-01-01. Description states explicitly that when `false`, the per-filing-status progressive bracket structure under `gov.states.ga.tax.income.main.{single,joint,separate,head_of_household,surviving_spouse}` applies instead. |
| `gov.states.ga.tax.income.main.flat_rate` | rate | The flat rate when `flat_applies` is true: 5.39% (2024), 5.19% (2025), 4.99% (2026). |

`ga_income_tax_before_non_refundable_credits.py` now branches on `flat_applies`: when true, returns `flat_rate * income`; when false, dispatches to the existing per-filing-status progressive brackets.

The five progressive bracket files (`main/{single,joint,separate,head_of_household,surviving_spouse}.yaml`) keep their pre-2024 rate entries only; the 2024+ duplicate rate entries that the previous structure required have been removed.

## HB463 direct changes (no revenue trigger)

| Provision | Statute | Pre-HB463 | TY 2026+ |
|---|---|---|---|
| Flat tax rate | O.C.G.A. § 48-7-20(a.1) | 5.19% | **4.99%** |
| Standard deduction (JOINT / SURVIVING_SPOUSE) | § 48-7-27(a)(1)(B)(i) | $24,000 | **$30,000** |
| Standard deduction (SINGLE / HoH / SEPARATE) | § 48-7-27(a)(1)(B)(ii) | $12,000 | **$15,000** |
| Dependent exemption | § 48-7-26(b) | $4,000 | **$5,000** |
| Age-65+ retirement income exclusion (TY 2027+) | § 48-7-27(a)(5)(A)(xiv) | $65,000 | **$70,000** |

## HB463 new exclusions (TY 2026-2028, self-repealing)

Both new variables are added to `gov.states.ga.tax.income.subtractions.subtractions` from `2026-01-01` and removed from the list at `2029-01-01` to model the December 31, 2028 self-repeal.

- **`ga_qualified_overtime_exclusion`** — § 48-7-27(a)(16). Up to $1,750 of qualified overtime compensation (IRC § 225) per full-time hourly employee. Approximated using `fsla_overtime_premium`, the federally-defined FLSA overtime premium, which by definition applies to non-exempt (hourly) workers.
- **`ga_cash_tip_exclusion`** — § 48-7-27(a)(17). Up to $1,750 of cash tips per employee in a customarily-tipped occupation. Uses `tip_income` gated by `tip_income_deduction_occupation_requirement_met` (Treasury Tipped Occupation Code list).

## Trigger-conditional provisions documented but NOT modeled

The bill provides for prospective annual reductions/increases subject to revenue-shortfall-reserve and Governor's-revenue-estimate triggers. Whether the triggers fire in any given year cannot be predicted from the bill alone, so these provisions are described in YAML comments only:

- **§ 48-7-20(a.1)(2)** — Future annual rate cuts of 0.10% per year (target 3.99%)
- **§ 48-7-27(a)(1.1)** — Future SD increases of $750 (joint) / $375 (single etc.) per year (targets $36,000 / $18,000)
- **§ 48-7-26(b)** — Future dependent-exemption increases of $125 per year (target $6,000)

## Files

**Parameters added (refactor):**
- `policyengine_us/parameters/gov/states/ga/tax/income/main/flat_applies.yaml`
- `policyengine_us/parameters/gov/states/ga/tax/income/main/flat_rate.yaml`

**Parameters modified (refactor):**
- `policyengine_us/parameters/gov/states/ga/tax/income/main/{single,joint,separate,head_of_household,surviving_spouse}.yaml` — strip 2024+ duplicate rate entries

**Parameters added (HB463):**
- `policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/overtime/cap.yaml` — $1,750
- `policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/tips/cap.yaml` — $1,750

**Parameters modified (HB463):**
- `policyengine_us/parameters/gov/states/ga/tax/income/deductions/standard/amount.yaml` — 2026-01-01 raised SD by filing status
- `policyengine_us/parameters/gov/states/ga/tax/income/exemptions/dependent.yaml` — 2026-01-01: $5,000
- `policyengine_us/parameters/gov/states/ga/tax/income/agi/exclusions/retirement/cap/older.yaml` — 2027-01-01: $70,000
- `policyengine_us/parameters/gov/states/ga/tax/income/subtractions/subtractions.yaml` — adds overtime/tips from 2026, removes them from 2029

**Variables modified (refactor):**
- `policyengine_us/variables/gov/states/ga/tax/income/ga_income_tax_before_non_refundable_credits.py` — switch on `flat_applies`

**Variables added (HB463):**
- `policyengine_us/variables/gov/states/ga/tax/income/ga_qualified_overtime_exclusion.py`
- `policyengine_us/variables/gov/states/ga/tax/income/ga_cash_tip_exclusion.py`

**Tests added:** `policyengine_us/tests/policy/baseline/gov/states/ga/tax/income/ga_hb463_integration.yaml` plus 2 new 2026 rate cases in the existing `ga_income_tax_before_non_refundable_credits.yaml`.

## Test plan

- [x] All 28 affected GA tax tests pass locally (pre-2024 progressive cases + 2024-2026 flat-rate cases + 8 HB463 integration tests)
- [ ] Full CI passes
- [ ] Reviewer confirms the overtime/tip exclusion approximation (FLSA overtime premium / Treasury Tipped Occupation Code) is acceptable, or proposes a more precise eligibility check
