### PR TITLE
Compute capped SPM housing subsidy

### DIFF
--- a/changelog.d/spm-housing-subsidy-formula.changed.md
+++ b/changelog.d/spm-housing-subsidy-formula.changed.md
@@ -1,0 +1,1 @@
+Compute the Supplemental Poverty Measure capped housing subsidy from housing assistance, the SPM threshold housing portion, and HUD tenant payment.

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_capped_housing_subsidy.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_capped_housing_subsidy.yaml
@@ -1,0 +1,29 @@
+- name: Housing subsidy is capped at the SPM housing need less tenant payment.
+  period: 2024
+  input:
+    spm_unit_spm_threshold_housing_portion: 17_720
+    is_eligible_for_housing_assistance: true
+    hud_hap: 30_000
+    hud_ttp: 10_000
+  output:
+    spm_unit_capped_housing_subsidy: 7_720
+
+- name: Housing subsidy is not reduced when below the SPM cap.
+  period: 2024
+  input:
+    spm_unit_spm_threshold_housing_portion: 17_720
+    is_eligible_for_housing_assistance: true
+    hud_hap: 5_000
+    hud_ttp: 10_000
+  output:
+    spm_unit_capped_housing_subsidy: 5_000
+
+- name: Housing subsidy cap floors at zero.
+  period: 2024
+  input:
+    spm_unit_spm_threshold_housing_portion: 4_000
+    is_eligible_for_housing_assistance: true
+    hud_hap: 5_000
+    hud_ttp: 5_000
+  output:
+    spm_unit_capped_housing_subsidy: 0

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_spm_threshold_housing_portion.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_spm_threshold_housing_portion.yaml
@@ -1,0 +1,13 @@
+- name: Housing portion isolates the geographically adjusted housing share.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    # Renter housing share is 0.443. A 1.5 local-rent ratio implies:
+    # geoadj = 1 - 0.443 + 0.443 * 1.5 = 1.2215.
+    # For a $40,000 unadjusted threshold, the adjusted threshold is $48,860
+    # and the adjusted housing portion is $40,000 * 0.443 * 1.5 = $26,580.
+    spm_unit_unadjusted_spm_threshold: 40_000
+    spm_unit_geographic_adjustment: 1.2215
+    spm_unit_tenure_type: RENTER
+  output:
+    spm_unit_spm_threshold_housing_portion: 26_580

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/test_spm_unit_spm_threshold.py
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/test_spm_unit_spm_threshold.py
@@ -14,7 +14,7 @@ Verifies that:
 import numpy as np
 import pytest
 from policyengine_us import Simulation
-from policyengine_us.variables.household.income.spm_unit.spm_unit_spm_threshold import (
+from policyengine_us.variables.household.income.spm_unit.spm_unit_reference_spm_threshold import (
     LATEST_PUBLISHED_SPM_THRESHOLD_YEAR,
     _reference_threshold_array,
 )
@@ -23,7 +23,7 @@ from policyengine_us.variables.household.income.spm_unit.spm_unit_tenure_type im
 )
 from spm_calculator.equivalence_scale import spm_equivalence_scale
 from spm_calculator.forecast import HISTORICAL_THRESHOLDS
-from spm_calculator.geoadj import get_cd_geoadj
+from spm_calculator.geoadj import get_cd_geoadj, get_housing_share
 
 
 def _cpi_u():
@@ -108,7 +108,11 @@ def test_formula_respects_composition_change_between_years():
 
     sim = Simulation(situation=situation)
     expected = current_base * current_equiv
+    got_reference = float(sim.calculate("spm_unit_reference_spm_threshold", YEAR)[0])
+    got_unadjusted = float(sim.calculate("spm_unit_unadjusted_spm_threshold", YEAR)[0])
     got = float(sim.calculate("spm_unit_spm_threshold", YEAR)[0])
+    assert got_reference == pytest.approx(current_base, rel=1e-4)
+    assert got_unadjusted == pytest.approx(expected, rel=1e-4)
     assert got == pytest.approx(expected, rel=1e-4)
 
 
@@ -158,7 +162,19 @@ def test_formula_uses_congressional_district_geographic_adjustment():
 
     sim = Simulation(situation=situation)
     got = float(sim.calculate("spm_unit_spm_threshold", YEAR)[0])
-    expected = base * equiv * geoadj
+    got_unadjusted = float(sim.calculate("spm_unit_unadjusted_spm_threshold", YEAR)[0])
+    got_housing_portion = float(
+        sim.calculate("spm_unit_spm_threshold_housing_portion", YEAR)[0]
+    )
+    unadjusted = base * equiv
+    housing_share = get_housing_share("owner_with_mortgage")
+    expected_housing_portion = unadjusted * (geoadj + housing_share - 1)
+    expected = unadjusted * geoadj
+    assert got_unadjusted == pytest.approx(unadjusted, rel=1e-5)
+    assert got_housing_portion == pytest.approx(
+        expected_housing_portion,
+        rel=1e-5,
+    )
     assert got == pytest.approx(expected, rel=1e-5)
 
 

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_capped_housing_subsidy.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_capped_housing_subsidy.py
@@ -7,4 +7,14 @@ class spm_unit_capped_housing_subsidy(Variable):
     label = "Housing subsidies"
     definition_period = YEAR
     unit = USD
-    uprating = "gov.bls.cpi.cpi_u"
+    reference = "https://www2.census.gov/programs-surveys/supplemental-poverty-measure/datasets/spm/spm_techdoc.pdf"
+
+    def formula(spm_unit, period, parameters):
+        housing_assistance = spm_unit("housing_assistance", period)
+        housing_portion = spm_unit(
+            "spm_unit_spm_threshold_housing_portion",
+            period,
+        )
+        tenant_payment = spm_unit("hud_ttp", period)
+        cap = max_(housing_portion - tenant_payment, 0)
+        return min_(housing_assistance, cap)

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_reference_spm_threshold.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_reference_spm_threshold.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+from policyengine_us.model_api import *
+from policyengine_us.variables.household.income.spm_unit.spm_unit_tenure_type import (
+    SPMUnitTenureType,
+)
+from spm_calculator.forecast import (
+    HISTORICAL_THRESHOLDS,
+    get_latest_published_year,
+)
+
+
+LATEST_PUBLISHED_SPM_THRESHOLD_YEAR = get_latest_published_year()
+
+
+def _reference_threshold_array(tenure, year: int, cpi_u_parameter):
+    """Published Betson reference thresholds for ``year``, uprated past
+    the latest BLS-published year using PolicyEngine's CPI-U parameter.
+
+    The published values and three-tenure structure come from
+    ``spm-calculator`` so there is one source of truth across the
+    PolicyEngine stack.
+    """
+    if year <= LATEST_PUBLISHED_SPM_THRESHOLD_YEAR:
+        thresholds = HISTORICAL_THRESHOLDS[year]
+    else:
+        factor = float(
+            cpi_u_parameter(f"{year}-02-01")
+            / cpi_u_parameter(f"{LATEST_PUBLISHED_SPM_THRESHOLD_YEAR}-02-01")
+        )
+        thresholds = {
+            k: v * factor
+            for k, v in HISTORICAL_THRESHOLDS[
+                LATEST_PUBLISHED_SPM_THRESHOLD_YEAR
+            ].items()
+        }
+
+    values = np.full(len(tenure), thresholds["renter"], dtype=float)
+    values = np.where(
+        tenure == SPMUnitTenureType.OWNER_WITH_MORTGAGE,
+        thresholds["owner_with_mortgage"],
+        values,
+    )
+    values = np.where(
+        tenure == SPMUnitTenureType.OWNER_WITHOUT_MORTGAGE,
+        thresholds["owner_without_mortgage"],
+        values,
+    )
+    return values
+
+
+class spm_unit_reference_spm_threshold(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "SPM unit reference SPM poverty threshold"
+    documentation = "SPM reference threshold by tenure, before equivalence-scale and geographic adjustments."
+    definition_period = YEAR
+    unit = USD
+
+    def formula_2015(spm_unit, period, parameters):
+        cpi_u = parameters.gov.bls.cpi.cpi_u
+        tenure = spm_unit("spm_unit_tenure_type", period)
+        return _reference_threshold_array(
+            tenure,
+            period.start.year,
+            cpi_u,
+        )

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_threshold.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_threshold.py
@@ -1,52 +1,4 @@
-import numpy as np
-
 from policyengine_us.model_api import *
-from policyengine_us.variables.household.income.spm_unit.spm_unit_tenure_type import (
-    SPMUnitTenureType,
-)
-from spm_calculator.equivalence_scale import spm_equivalence_scale
-from spm_calculator.forecast import (
-    HISTORICAL_THRESHOLDS,
-    get_latest_published_year,
-)
-
-LATEST_PUBLISHED_SPM_THRESHOLD_YEAR = get_latest_published_year()
-
-
-def _reference_threshold_array(tenure, year: int, cpi_u_parameter):
-    """Published Betson reference thresholds for ``year``, uprated past
-    the latest BLS-published year using PolicyEngine's CPI-U parameter.
-
-    The published values and three-tenure structure come from
-    ``spm-calculator`` so there is one source of truth across the
-    PolicyEngine stack.
-    """
-    if year <= LATEST_PUBLISHED_SPM_THRESHOLD_YEAR:
-        thresholds = HISTORICAL_THRESHOLDS[year]
-    else:
-        factor = float(
-            cpi_u_parameter(f"{year}-02-01")
-            / cpi_u_parameter(f"{LATEST_PUBLISHED_SPM_THRESHOLD_YEAR}-02-01")
-        )
-        thresholds = {
-            k: v * factor
-            for k, v in HISTORICAL_THRESHOLDS[
-                LATEST_PUBLISHED_SPM_THRESHOLD_YEAR
-            ].items()
-        }
-
-    values = np.full(len(tenure), thresholds["renter"], dtype=float)
-    values = np.where(
-        tenure == SPMUnitTenureType.OWNER_WITH_MORTGAGE,
-        thresholds["owner_with_mortgage"],
-        values,
-    )
-    values = np.where(
-        tenure == SPMUnitTenureType.OWNER_WITHOUT_MORTGAGE,
-        thresholds["owner_without_mortgage"],
-        values,
-    )
-    return values
 
 
 class spm_unit_spm_threshold(Variable):
@@ -63,21 +15,9 @@ class spm_unit_spm_threshold(Variable):
         Base reference thresholds and the Betson three-parameter
         equivalence scale come from ``spm-calculator``.
         """
-        cpi_u = parameters.gov.bls.cpi.cpi_u
-
-        current_adults = spm_unit("spm_unit_count_adults", period)
-        current_children = spm_unit("spm_unit_count_children", period)
-        current_tenure = spm_unit("spm_unit_tenure_type", period)
+        unadjusted_threshold = spm_unit(
+            "spm_unit_unadjusted_spm_threshold",
+            period,
+        )
         geoadj = spm_unit("spm_unit_geographic_adjustment", period)
-        current_base = _reference_threshold_array(
-            current_tenure,
-            period.start.year,
-            cpi_u,
-        )
-
-        current_equiv_scale = spm_equivalence_scale(
-            current_adults,
-            current_children,
-        )
-
-        return current_base * current_equiv_scale * geoadj
+        return unadjusted_threshold * geoadj

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_threshold_housing_portion.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_spm_threshold_housing_portion.py
@@ -1,0 +1,52 @@
+from policyengine_us.model_api import *
+from policyengine_us.variables.household.income.spm_unit.spm_unit_tenure_type import (
+    SPMUnitTenureType,
+)
+from spm_calculator.geoadj import get_housing_share
+
+
+SPM_TENURE_TYPE_TO_HOUSING_SHARE = {
+    SPMUnitTenureType.OWNER_WITH_MORTGAGE: get_housing_share("owner_with_mortgage"),
+    SPMUnitTenureType.OWNER_WITHOUT_MORTGAGE: get_housing_share(
+        "owner_without_mortgage"
+    ),
+    SPMUnitTenureType.RENTER: get_housing_share("renter"),
+}
+
+
+def _housing_share_array(tenure):
+    values = np.full(
+        len(tenure),
+        SPM_TENURE_TYPE_TO_HOUSING_SHARE[SPMUnitTenureType.RENTER],
+        dtype=float,
+    )
+    for tenure_type, housing_share in SPM_TENURE_TYPE_TO_HOUSING_SHARE.items():
+        values = np.where(tenure == tenure_type, housing_share, values)
+    return values
+
+
+class spm_unit_spm_threshold_housing_portion(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "SPM unit SPM threshold housing portion"
+    documentation = (
+        "Geographically adjusted housing portion of the SPM poverty threshold."
+    )
+    definition_period = YEAR
+    unit = USD
+
+    def formula_2015(spm_unit, period, parameters):
+        unadjusted_threshold = spm_unit(
+            "spm_unit_unadjusted_spm_threshold",
+            period,
+        )
+        geoadj = spm_unit("spm_unit_geographic_adjustment", period)
+        tenure = spm_unit("spm_unit_tenure_type", period)
+        housing_share = _housing_share_array(tenure)
+
+        # The threshold applies geographic adjustment only to the housing
+        # share: adjusted = unadjusted * (1 - h + h * local_rent_ratio).
+        # Since geoadj = 1 - h + h * local_rent_ratio, the adjusted housing
+        # share is h * local_rent_ratio = geoadj + h - 1.
+        geoadjusted_housing_share = geoadj + housing_share - 1
+        return unadjusted_threshold * geoadjusted_housing_share

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_unadjusted_spm_threshold.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_unadjusted_spm_threshold.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+from spm_calculator.equivalence_scale import spm_equivalence_scale
+
+
+class spm_unit_unadjusted_spm_threshold(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "SPM unit unadjusted SPM poverty threshold"
+    documentation = "SPM poverty threshold before geographic adjustment."
+    definition_period = YEAR
+    unit = USD
+
+    def formula_2015(spm_unit, period, parameters):
+        reference_threshold = spm_unit(
+            "spm_unit_reference_spm_threshold",
+            period,
+        )
+        adults = spm_unit("spm_unit_count_adults", period)
+        children = spm_unit("spm_unit_count_children", period)
+        equivalence_scale = spm_equivalence_scale(adults, children)
+        return reference_threshold * equivalence_scale

--- a/uv.lock
+++ b/uv.lock
@@ -2974,7 +2974,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.691.7"
+version = "1.692.1"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- Make `spm_unit_capped_housing_subsidy` formulaic from `housing_assistance`, the SPM housing threshold portion, and HUD tenant payment.
- Keep `housing_assistance` as the existing formula output over `hud_hap`; this PR does not make it a dataset input.
- Add focused tests for the SPM housing subsidy cap.

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hud/housing_assistance.yaml policyengine_us/tests/policy/baseline/gov/hud/integration.yaml policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_capped_housing_subsidy.yaml policyengine_us/tests/policy/baseline/household/income/spm_unit/spm_unit_benefits.yaml policyengine_us/tests/policy/baseline/household/income/household/household_benefits.yaml` (11 passed)
