### PR TITLE
Gate housing assistance on take-up and FMR payment standards

### DIFF
--- a/changelog.d/housing-assistance-takeup-fmr.changed.md
+++ b/changelog.d/housing-assistance-takeup-fmr.changed.md
@@ -1,0 +1,1 @@
+Gate housing assistance on a take-up input and use HUD Fair Market Rent as the national payment-standard fallback.

--- a/policyengine_us/tests/policy/baseline/gov/hud/housing_assistance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hud/housing_assistance.yaml
@@ -13,3 +13,12 @@
     hud_hap: 1
   output:
     housing_assistance: 0
+
+- name: Zero if eligible but not taking up housing assistance.
+  period: 2022
+  input:
+    is_eligible_for_housing_assistance: true
+    takes_up_housing_assistance_if_eligible: false
+    hud_hap: 1
+  output:
+    housing_assistance: 0

--- a/policyengine_us/tests/policy/baseline/gov/hud/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hud/integration.yaml
@@ -57,3 +57,31 @@
     # Eligibility
     hud_income_level: ESPECIALLY_LOW
     housing_assistance: 5_988
+
+- name: Housing assistance for a reported recipient outside LA uses FMR-backed payment standard.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 12_000
+        pre_subsidy_rent: 24_000
+    households:
+      household:
+        county_fips: "06001"
+        bedrooms: 2
+        tenant_pays_utilities: false
+        members: [person1]
+    spm_units:
+      spm_unit:
+        members: [person1]
+        receives_housing_assistance: true
+  output:
+    pha_payment_standard: 32_184
+    hud_annual_income: 12_000
+    hud_ttp: 3_600
+    hud_max_subsidy: 28_584
+    hud_gross_rent: 24_000
+    hud_hap: 20_400
+    housing_assistance: 20_400

--- a/policyengine_us/tests/policy/baseline/gov/hud/pha_payment_standard.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hud/pha_payment_standard.yaml
@@ -33,3 +33,19 @@
     in_la: true
   output:
     pha_payment_standard: 6_086 * 12
+
+- name: Alameda County 2BR FY2025 falls back to HUD Fair Market Rent
+  period: 2025
+  input:
+    county_fips: "06001"
+    bedrooms: 2
+  output:
+    pha_payment_standard: 32_184
+
+- name: LA County 2BR FY2025 keeps the local payment standard
+  period: 2025
+  input:
+    county_fips: "06037"
+    bedrooms: 2
+  output:
+    pha_payment_standard: 2_666 * 12

--- a/policyengine_us/variables/gov/hud/housing_assistance.py
+++ b/policyengine_us/variables/gov/hud/housing_assistance.py
@@ -9,4 +9,10 @@ class housing_assistance(Variable):
     documentation = "Housing assistance"
     definition_period = YEAR
     defined_for = "is_eligible_for_housing_assistance"
-    adds = ["hud_hap"]
+
+    def formula(spm_unit, period, parameters):
+        if parameters(period).gov.hud.abolition:
+            return 0
+
+        takes_up = spm_unit("takes_up_housing_assistance_if_eligible", period)
+        return spm_unit("hud_hap", period) * takes_up

--- a/policyengine_us/variables/gov/hud/pha_payment_standard.py
+++ b/policyengine_us/variables/gov/hud/pha_payment_standard.py
@@ -11,11 +11,13 @@ class pha_payment_standard(Variable):
     reference = "https://www.law.cornell.edu/cfr/text/24/982.503"
 
     def formula(household, period, parameters):
-        # Only Los Angeles County for now.
+        # Use actual local payment standards where encoded, otherwise fall
+        # back to HUD Fair Market Rent as a national proxy.
         # https://www.lacda.org/docs/librariesprovider25/section-8-program/shared-document---payment-standard---vash/hcv-ehv-vash-payment-standards.pdf
         household_bedrooms = household("bedrooms", period)
         is_sro = household("is_sro", period)
         in_la = household("in_la", period)
+        hud_fair_market_rent = household("hud_fair_market_rent", period)
         la_amount = select(
             [
                 is_sro,
@@ -31,4 +33,5 @@ class pha_payment_standard(Variable):
             [1_380, 1_840, 2_096, 2_666, 3_465, 3_804, 4_374, 4_945, 5_515],
             default=6_086,  # 8 bedrooms
         )
-        return in_la * la_amount * MONTHS_IN_YEAR
+        la_payment_standard = la_amount * MONTHS_IN_YEAR
+        return where(in_la, la_payment_standard, hud_fair_market_rent)

--- a/policyengine_us/variables/gov/hud/takes_up_housing_assistance_if_eligible.py
+++ b/policyengine_us/variables/gov/hud/takes_up_housing_assistance_if_eligible.py
@@ -1,0 +1,9 @@
+from policyengine_us.model_api import *
+
+
+class takes_up_housing_assistance_if_eligible(Variable):
+    value_type = bool
+    entity = SPMUnit
+    label = "Whether an eligible SPM unit takes up housing assistance"
+    definition_period = YEAR
+    default_value = True


### PR DESCRIPTION
## Summary

Adds the model-side inputs needed for housing assistance to be calculated from formulas instead of imported Census SPM formula outputs.

## Changes

- Adds `takes_up_housing_assistance_if_eligible` as an SPM-unit input, defaulting to true for household calculations.
- Gates `housing_assistance` on that take-up input and respects the HUD abolition parameter.
- Uses encoded LA payment standards where available, otherwise falls back to `hud_fair_market_rent` as a national proxy for `pha_payment_standard`.
- Adds HUD integration coverage for a reported recipient outside LA receiving an FMR-backed subsidy.

## Notes

This is the required `policyengine-us` side before `policyengine-us-data` can safely generate and export the new take-up input. The data-side branch is prepared locally but should bump its `policyengine-us` pin after this lands and releases.

## Test plan

- [x] `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hud/housing_assistance.yaml -c policyengine_us` — 3 passed
- [x] `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hud/pha_payment_standard.yaml -c policyengine_us` — 6 passed
- [x] `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hud/integration.yaml -c policyengine_us` — 3 passed
- [x] `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hud -c policyengine_us` — 79 passed
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check policyengine_us/variables/gov/hud/housing_assistance.py policyengine_us/variables/gov/hud/pha_payment_standard.py policyengine_us/variables/gov/hud/takes_up_housing_assistance_if_eligible.py`
- [x] Smoke simulation: Alameda 2BR reported recipient gets `pha_payment_standard=32184`, `housing_assistance=20400`; take-up false gives `housing_assistance=0`.
