### PR TITLE
Add BEA NIPA proprietors income variable

### DIFF
--- a/changelog.d/nipa-income-variables.added.md
+++ b/changelog.d/nipa-income-variables.added.md
@@ -1,0 +1,1 @@
+Added a BEA NIPA proprietors' income mapping variable.

--- a/policyengine_us/tests/variables/gov/bea/nipa/nipa_proprietors_income.yaml
+++ b/policyengine_us/tests/variables/gov/bea/nipa/nipa_proprietors_income.yaml
@@ -1,0 +1,8 @@
+- name: NIPA proprietors' income mapping.
+  period: 2024
+  input:
+    self_employment_income_before_lsr: 3_000
+    farm_income: 1_000
+    partnership_s_corp_income: 2_000
+  output:
+    nipa_proprietors_income: 6_000

--- a/policyengine_us/variables/gov/bea/nipa/nipa_proprietors_income.py
+++ b/policyengine_us/variables/gov/bea/nipa/nipa_proprietors_income.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class nipa_proprietors_income(Variable):
+    value_type = float
+    entity = Person
+    label = "NIPA proprietors' income"
+    documentation = (
+        "PolicyEngine person-level mapping for BEA NIPA proprietors' "
+        "income with inventory valuation and capital consumption "
+        "adjustments, Table 2.1 line 9, using the closest additive "
+        "microdata concepts."
+    )
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.bea.gov/itable/national-gdp-and-personal-income"
+    adds = [
+        "self_employment_income_before_lsr",
+        "farm_income",
+        "partnership_s_corp_income",
+    ]


### PR DESCRIPTION
## Summary
- Adds a person-level BEA NIPA mapping variable for proprietors' income.
- Uses `adds` so this is a derived calibration concept, not an uprated leaf input.
- Keeps wages, interest, and dividends on existing variables: `employment_income_before_lsr`, `interest_income`, and `dividend_income`.

## Tests
- `uv run ruff format --check policyengine_us/variables/gov/bea/nipa policyengine_us/tests/variables/gov/bea/nipa`
- `uv run ruff check policyengine_us/variables/gov/bea/nipa`
- `uv run python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/variables/gov/bea/nipa/nipa_proprietors_income.yaml`