### PR TITLE
Fix EITC earned income self-employment netting

### DIFF
--- a/changelog.d/8337.fixed.md
+++ b/changelog.d/8337.fixed.md
@@ -1,0 +1,1 @@
+Fix EITC earned income calculations for self-employment loss netting.

--- a/policyengine_us/tests/core/test_vectorized_reductions.py
+++ b/policyengine_us/tests/core/test_vectorized_reductions.py
@@ -86,6 +86,72 @@ def test_has_qdiv_or_ltcg_reduces_per_tax_unit_not_across_simulation():
     ]
 
 
+def test_eitc_earned_income_reduces_per_tax_unit_not_across_simulation():
+    simulation = Simulation(
+        situation={
+            "people": {
+                "person1": {
+                    "age": {"2026": 35},
+                    "employment_income": {"2026": 5_000},
+                },
+                "person2": {
+                    "age": {"2026": 35},
+                    "self_employment_income": {"2026": -6_000},
+                },
+                "person3": {
+                    "age": {"2026": 35},
+                    "employment_income": {"2026": 2_000},
+                },
+                "person4": {
+                    "age": {"2026": 35},
+                    "employment_income": {"2026": 8_000},
+                    "farm_operations_income": {"2026": -10_000},
+                },
+            },
+            "tax_units": {
+                "tax_unit1": {"members": ["person1", "person2"]},
+                "tax_unit2": {"members": ["person3"]},
+                "tax_unit3": {"members": ["person4"]},
+            },
+            "spm_units": {
+                "spm_unit1": {"members": ["person1", "person2"]},
+                "spm_unit2": {"members": ["person3"]},
+                "spm_unit3": {"members": ["person4"]},
+            },
+            "families": {
+                "family1": {"members": ["person1", "person2"]},
+                "family2": {"members": ["person3"]},
+                "family3": {"members": ["person4"]},
+            },
+            "marital_units": {
+                "marital_unit1": {"members": ["person1", "person2"]},
+                "marital_unit2": {"members": ["person3"]},
+                "marital_unit3": {"members": ["person4"]},
+            },
+            "households": {
+                "household1": {
+                    "members": ["person1", "person2"],
+                    "state_code": {"2026": "CA"},
+                },
+                "household2": {
+                    "members": ["person3"],
+                    "state_code": {"2026": "CA"},
+                },
+                "household3": {
+                    "members": ["person4"],
+                    "state_code": {"2026": "CA"},
+                },
+            },
+        }
+    )
+
+    assert simulation.calculate("eitc_earned_income", 2026).tolist() == [
+        0,
+        2_000,
+        0,
+    ]
+
+
 def test_numpy_any_all_outputs_specify_axis_or_stay_in_control_flow():
     variables_dir = Path(__file__).parents[2] / "variables"
     offenders = []

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable/ctc_phase_in.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable/ctc_phase_in.yaml
@@ -1,7 +1,7 @@
 - name: No income, two children
   period: 2023
   input:
-    filer_adjusted_earnings: 0
+    eitc_earned_income: 0
     ctc_social_security_tax: 100_000
     eitc: 0
     ctc_qualifying_children: 2
@@ -11,7 +11,7 @@
 - name: Income below phase-in start, two children
   period: 2023
   input:
-    filer_adjusted_earnings: 2_000
+    eitc_earned_income: 2_000
     ctc_social_security_tax: 100_000
     eitc: 0
     ctc_qualifying_children: 2
@@ -21,7 +21,7 @@
 - name: Income Above phase-in start, two children
   period: 2023
   input:
-    filer_adjusted_earnings: 8_000
+    eitc_earned_income: 8_000
     ctc_social_security_tax: 100_000
     eitc: 0
     ctc_qualifying_children: 2
@@ -31,7 +31,7 @@
 - name: Income Above phase-in start, two children
   period: 2023
   input:
-    filer_adjusted_earnings: 8_000
+    eitc_earned_income: 8_000
     ctc_social_security_tax: 100_000
     eitc: 0
     ctc_qualifying_children: 2
@@ -41,7 +41,7 @@
 - name: Income Above phase-in start, three children
   period: 2023
   input:
-    filer_adjusted_earnings: 8_000
+    eitc_earned_income: 8_000
     ctc_social_security_tax: 20_000
     eitc: 0
     ctc_qualifying_children: 3
@@ -51,7 +51,7 @@
 - name: Income Above phase-in start, three children with EITC
   period: 2023
   input:
-    filer_adjusted_earnings: 8_000
+    eitc_earned_income: 8_000
     ctc_social_security_tax: 20_000
     eitc: 19_900
     ctc_qualifying_children: 3

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable/ctc_phase_in_relevant_earnings.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable/ctc_phase_in_relevant_earnings.yaml
@@ -1,14 +1,14 @@
 - name: Income below threshold
   period: 2023
   input:
-    filer_adjusted_earnings: 1_000
+    eitc_earned_income: 1_000
   output:
     ctc_phase_in_relevant_earnings: 0
 
 - name: Income above threshold
   period: 2023
   input:
-    filer_adjusted_earnings: 5_000
+    eitc_earned_income: 5_000
   output:
     ctc_phase_in_relevant_earnings: 375
 
@@ -32,7 +32,7 @@
   output:
     # SE tax = 20000 * 0.9235 * 0.153 = 2825.91
     # Half of SE tax = 1412.96
-    # filer_adjusted_earnings = 20000 - 1412.96 = 18587.04
+    # eitc_earned_income = 20000 - 1412.96 = 18587.04
     # Phase-in = (18587.04 - 2500) * 0.15 = 2413.06
     ctc_phase_in_relevant_earnings: 2413.06
 
@@ -54,6 +54,6 @@
         members: [person, child]
         state_code: TX
   output:
-    # No SE income, so filer_adjusted_earnings = 20000
+    # No SE income, so eitc_earned_income = 20000
     # Phase-in = (20000 - 2500) * 0.15 = 2625
     ctc_phase_in_relevant_earnings: 2625

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/earned_income/eitc_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/earned_income/eitc_earned_income.yaml
@@ -1,0 +1,58 @@
+- name: Joint filers net self-employment loss against wages
+  period: 2026
+  input:
+    people:
+      head:
+        age: 35
+        employment_income: 5_000
+      spouse:
+        age: 35
+        self_employment_income: -6_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+  output:
+    eitc_earned_income: 0
+    eitc_phased_in: 0
+
+- name: Self-employment tax deduction reduces positive self-employment earnings
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 35
+        self_employment_income: 20_000
+    tax_units:
+      tax_unit:
+        members: [person]
+  output:
+    eitc_earned_income: 18_587.05
+
+- name: Partnership self-employment income counts for EITC earned income
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        age: 35
+        partnership_se_income: 10_000
+    tax_units:
+      tax_unit:
+        members: [person]
+  output:
+    eitc_earned_income: 9_293.52
+
+- name: Farm operations loss nets against wages for EITC earned income
+  period: 2026
+  input:
+    people:
+      person:
+        age: 35
+        employment_income: 8_000
+        farm_operations_income: -10_000
+    tax_units:
+      tax_unit:
+        members: [person]
+  output:
+    eitc_earned_income: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
@@ -95,6 +95,7 @@
     state_code: WA
     age_head: 20
     eitc: 0
+    eitc_earned_income: 10_000
     filer_adjusted_earnings: 10_000
     eitc_child_count: 0
   output:
@@ -109,6 +110,7 @@
     state_code: WA
     age_head: 18
     eitc: 0
+    eitc_earned_income: 10_000
     filer_adjusted_earnings: 10_000
     eitc_child_count: 0
   output:
@@ -121,6 +123,7 @@
     state_code: WA
     age_head: 17
     eitc: 0
+    eitc_earned_income: 10_000
     filer_adjusted_earnings: 10_000
     eitc_child_count: 0
   output:
@@ -145,6 +148,7 @@
     state_code: WA
     age_head: 20
     eitc: 0
+    eitc_earned_income: 10_000
     filer_adjusted_earnings: 10_000
     eitc_child_count: 0
   output:
@@ -170,6 +174,7 @@
     state_code: WA
     age_head: 20
     eitc: 0
+    eitc_earned_income: 10_000
     filer_adjusted_earnings: 10_000
     tax_exempt_interest_income: 100_000
     eitc_child_count: 0
@@ -185,6 +190,7 @@
     age_spouse: 22
     eitc: 0
     filing_status: JOINT
+    eitc_earned_income: 10_000
     filer_adjusted_earnings: 10_000
     eitc_child_count: 0
   output:

--- a/policyengine_us/tests/policy/contrib/harris/lift/middle_class_tax_credit.yaml
+++ b/policyengine_us/tests/policy/contrib/harris/lift/middle_class_tax_credit.yaml
@@ -36,6 +36,7 @@
       tax_unit:
         members: [person1, person2]
         adjusted_gross_income: 0
+        eitc_earned_income: 4_000
         filing_status: HEAD_OF_HOUSEHOLD
         eitc: 0
   output:

--- a/policyengine_us/variables/gov/irs/credits/ctc/refundable/ctc_phase_in_relevant_earnings.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/refundable/ctc_phase_in_relevant_earnings.py
@@ -20,6 +20,6 @@ class ctc_phase_in_relevant_earnings(Variable):
         # as earned income "within the meaning of section 32", which per
         # IRC 32(c)(2)(A)(ii) is determined "with regard to the deduction
         # allowed to the taxpayer by section 164(f)" (half of SE tax).
-        earnings = tax_unit("filer_adjusted_earnings", period)
+        earnings = tax_unit("eitc_earned_income", period)
         earnings_over_threshold = max_(0, earnings - ctc.refundable.phase_in.threshold)
         return earnings_over_threshold * ctc.refundable.phase_in.rate

--- a/policyengine_us/variables/gov/irs/credits/earned_income/eitc_earned_income.py
+++ b/policyengine_us/variables/gov/irs/credits/earned_income/eitc_earned_income.py
@@ -1,0 +1,30 @@
+from policyengine_us.model_api import *
+
+
+class eitc_earned_income(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Earned income for the EITC"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/26/32#c_2",
+        "https://www.irs.gov/instructions/i1040gi",
+    )
+
+    def formula(tax_unit, period, parameters):
+        earned_income_sources = [
+            "employment_income",
+            "self_employment_income",
+            "sstb_self_employment_income",
+            "farm_operations_income",
+            "partnership_se_income",
+        ]
+        gross_earned_income = sum(
+            tax_unit_non_dep_sum(source, tax_unit, period)
+            for source in earned_income_sources
+        )
+        self_employment_tax_ald = tax_unit_non_dep_sum(
+            "self_employment_tax_ald_person", tax_unit, period
+        )
+        return max_(0, gross_earned_income - self_employment_tax_ald)

--- a/policyengine_us/variables/gov/irs/credits/earned_income/eitc_phased_in.py
+++ b/policyengine_us/variables/gov/irs/credits/earned_income/eitc_phased_in.py
@@ -12,6 +12,6 @@ class eitc_phased_in(Variable):
     def formula(tax_unit, period, parameters):
         maximum = tax_unit("eitc_maximum", period)
         phase_in_rate = tax_unit("eitc_phase_in_rate", period)
-        earnings = tax_unit("filer_adjusted_earnings", period)
+        earnings = tax_unit("eitc_earned_income", period)
         phased_in_amount = earnings * phase_in_rate
         return min_(maximum, phased_in_amount)

--- a/policyengine_us/variables/gov/irs/credits/earned_income/eitc_reduction.py
+++ b/policyengine_us/variables/gov/irs/credits/earned_income/eitc_reduction.py
@@ -10,7 +10,7 @@ class eitc_reduction(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/26/32#a_2"
 
     def formula(tax_unit, period, parameters):
-        earnings = tax_unit("filer_adjusted_earnings", period)
+        earnings = tax_unit("eitc_earned_income", period)
         agi = tax_unit("adjusted_gross_income", period)
         highest_income_variable = max_(earnings, agi)
         phase_out_start = tax_unit("eitc_phase_out_start", period)


### PR DESCRIPTION
## Summary

- Add a dedicated `eitc_earned_income` variable that nets wages and self-employment sources at the tax-unit level before subtracting the deductible self-employment tax amount.
- Use `eitc_earned_income` for federal EITC phase-in/reduction and ACTC phase-in earnings.
- Add regressions for joint filers with self-employment losses, positive self-employment earnings, partnership SE income, and farm operations losses.

Closes #8334

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/credits/earned_income -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable -c policyengine_us`
- `uv run ruff check policyengine_us/variables/gov/irs/credits/earned_income/eitc_earned_income.py policyengine_us/variables/gov/irs/credits/earned_income/eitc_phased_in.py policyengine_us/variables/gov/irs/credits/earned_income/eitc_reduction.py policyengine_us/variables/gov/irs/credits/ctc/refundable/ctc_phase_in_relevant_earnings.py`
- `uv run ruff format --check policyengine_us/variables/gov/irs/credits/earned_income/eitc_earned_income.py policyengine_us/variables/gov/irs/credits/earned_income/eitc_phased_in.py policyengine_us/variables/gov/irs/credits/earned_income/eitc_reduction.py policyengine_us/variables/gov/irs/credits/ctc/refundable/ctc_phase_in_relevant_earnings.py`