### PR TITLE
Harden long-run dollar input uprating

### DIFF
--- a/changelog.d/longrun-dollar-input-uprating.fixed.md
+++ b/changelog.d/longrun-dollar-input-uprating.fixed.md
@@ -1,0 +1,1 @@
+Extend long-run dollar-input upraters through 2100 and limit the Trustees core threshold reform to federal wage-indexed tax parameters.

--- a/policyengine_us/parameters/uprating_extensions.py
+++ b/policyengine_us/parameters/uprating_extensions.py
@@ -6,6 +6,20 @@ from policyengine_us.model_api import *
 from policyengine_core.periods import instant
 
 
+LONG_RUN_CBO_INCOME_BY_SOURCE_PARAMETERS = (
+    "adjusted_gross_income",
+    "employment_income",
+    "taxable_interest_and_ordinary_dividends",
+    "qualified_dividend_income",
+    "net_capital_gain",
+    "self_employment_income",
+    "taxable_pension_income",
+    "taxable_social_security",
+    "irs_other_income",
+    "above_the_line_deductions",
+)
+
+
 def get_irs_cpi(parameters: ParameterNode, year: int) -> float:
     """Calculate IRS CPI based on Chained CPI-U average from Sep to Aug."""
     cpi = parameters.gov.bls.cpi.c_cpi_u
@@ -220,5 +234,27 @@ def set_all_uprating_parameters(parameters: ParameterNode) -> ParameterNode:
         period_month=1,
         period_day=1,
     )
+
+    # CMS per-capita out-of-pocket medical spending (January values, last
+    # projection year 2035). Health expense inputs use this as their uprater.
+    extend_parameter_values(
+        parameters.calibration.gov.hhs.cms.moop_per_capita,
+        last_projected_year=2035,
+        end_year=END_YEAR,
+        period_month=1,
+        period_day=1,
+    )
+
+    # CBO income-by-source aggregates are used directly and as anchors for
+    # SOI-based income upraters. Extending them in the baseline path keeps
+    # long-run nominal data aging independent of scenario-specific reforms.
+    for parameter_name in LONG_RUN_CBO_INCOME_BY_SOURCE_PARAMETERS:
+        extend_parameter_values(
+            getattr(parameters.calibration.gov.cbo.income_by_source, parameter_name),
+            last_projected_year=2036,
+            end_year=END_YEAR,
+            period_month=1,
+            period_day=1,
+        )
 
     return parameters

--- a/policyengine_us/reforms/ssa/trustees_core_thresholds.py
+++ b/policyengine_us/reforms/ssa/trustees_core_thresholds.py
@@ -4,10 +4,6 @@ import math
 from typing import Any
 
 from policyengine_us.model_api import Reform
-from policyengine_us.reforms.ssa.trustees_2025 import (
-    TRUSTEES_2025_NAWI_ASSUMPTION,
-    apply_trustees_2025_economic_assumptions,
-)
 
 
 TRUSTEES_CORE_THRESHOLD_ASSUMPTION: dict[str, Any] = {
@@ -25,8 +21,7 @@ TRUSTEES_CORE_THRESHOLD_ASSUMPTION: dict[str, Any] = {
         "all_gov_irs_uprating_parameters",
     ],
     "uprating_parameter": "gov.irs.uprating",
-    "economic_assumption": TRUSTEES_2025_NAWI_ASSUMPTION["name"],
-    "income_uprating_assumption": "trustees-2025-soi-income-nawi-v1",
+    "wage_index": "gov.ssa.nawi",
     "not_default_current_law": True,
 }
 
@@ -152,11 +147,6 @@ def create_trustees_core_thresholds_reform(
     def modify_parameters(parameters):
         if not _parameters_have_long_run_projection(parameters, end_year):
             return parameters
-
-        apply_trustees_2025_economic_assumptions(
-            parameters,
-            end_year=end_year,
-        )
 
         seen = set()
         for root in _federal_income_tax_roots(parameters):

--- a/policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py
+++ b/policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py
@@ -2,6 +2,7 @@
 
 from policyengine_us.system import system
 from policyengine_us.parameters.uprating_extensions import (
+    LONG_RUN_CBO_INCOME_BY_SOURCE_PARAMETERS,
     round_social_security_payroll_cap,
 )
 
@@ -54,6 +55,115 @@ def test_all_uprating_factors_extend_to_2100():
         assert abs(growth_rate_1 - growth_rate_2) < 0.001, (
             f"{name} growth rate should be consistent: {growth_rate_1:.5f} vs {growth_rate_2:.5f}"
         )
+
+
+def test_cbo_income_by_source_anchors_extend_to_2100():
+    """CBO income-source anchors should not flatten after the budget window."""
+    income_by_source = PARAMETERS.calibration.gov.cbo.income_by_source
+
+    for parameter_name in LONG_RUN_CBO_INCOME_BY_SOURCE_PARAMETERS:
+        parameter = getattr(income_by_source, parameter_name)
+        values = [parameter(f"{year}-01-01") for year in [2036, 2050, 2075, 2100]]
+
+        for value in values:
+            assert value > 0, f"{parameter_name} should stay positive"
+        for previous, current in zip(values, values[1:]):
+            assert current != previous, f"{parameter_name} should extend after 2036"
+
+
+def test_cms_moop_per_capita_extends_to_2100():
+    """Health expense input upraters should not flatten after 2035."""
+    parameter = PARAMETERS.calibration.gov.hhs.cms.moop_per_capita
+
+    assert parameter("2036-01-01") > parameter("2035-01-01")
+    assert parameter("2100-01-01") > parameter("2036-01-01")
+
+
+def test_soi_income_upraters_extend_without_trustees_reform():
+    """SOI income upraters should inherit baseline long-run CBO extensions."""
+    soi = PARAMETERS.calibration.gov.irs.soi
+
+    for parameter_name in [
+        "employment_income",
+        "self_employment_income",
+        "qualified_dividend_income",
+        "taxable_interest_income",
+        "taxable_pension_income",
+        "tax_exempt_pension_income",
+        "social_security",
+    ]:
+        parameter = getattr(soi, parameter_name)
+        assert parameter("2037-01-01") > parameter("2036-01-01")
+        assert parameter("2100-01-01") > parameter("2036-01-01")
+
+
+def test_retirement_distribution_inputs_use_pension_upraters():
+    """Retirement account components should age with pension income, not AGI."""
+    taxable_uprater = "calibration.gov.irs.soi.taxable_pension_income"
+    tax_exempt_uprater = "calibration.gov.irs.soi.tax_exempt_pension_income"
+
+    for variable_name in [
+        "csrs_retirement_pay",
+        "keogh_distributions",
+        "military_retirement_pay",
+        "military_retirement_pay_survivors",
+        "pension_survivors",
+        "retirement_benefits_from_ss_exempt_employment",
+        "taxable_ira_distributions",
+        "taxable_401k_distributions",
+        "taxable_403b_distributions",
+        "taxable_federal_pension_income",
+        "taxable_public_pension_income",
+        "taxable_sep_distributions",
+        "taxable_private_pension_income",
+    ]:
+        assert system.variables[variable_name].uprating == taxable_uprater
+
+    for variable_name in [
+        "tax_exempt_ira_distributions",
+        "tax_exempt_401k_distributions",
+        "tax_exempt_403b_distributions",
+        "tax_exempt_public_pension_income",
+        "tax_exempt_sep_distributions",
+        "tax_exempt_private_pension_income",
+    ]:
+        assert system.variables[variable_name].uprating == tax_exempt_uprater
+
+
+def test_float_dollar_inputs_have_long_run_upraters():
+    """Every float USD input should have a resolvable non-flat 2100 uprater."""
+    missing = []
+    unresolvable = []
+    flat = []
+
+    for variable in system.variables.values():
+        if not (
+            variable.is_input_variable()
+            and variable.value_type is float
+            and variable.unit == "currency-USD"
+        ):
+            continue
+
+        if variable.uprating is None:
+            missing.append(variable.name)
+            continue
+
+        parameter = PARAMETERS
+        try:
+            for path_part in variable.uprating.split("."):
+                parameter = getattr(parameter, path_part)
+            value_2036 = float(parameter("2036-01-01"))
+            value_2100 = float(parameter("2100-01-01"))
+        except (AttributeError, TypeError, ValueError):
+            unresolvable.append((variable.name, variable.uprating))
+            continue
+
+        if value_2036 == value_2100:
+            flat.append((variable.name, variable.uprating))
+
+    assert missing == []
+    assert unresolvable == []
+    assert flat == []
 
 
 def test_ssa_nawi_and_payroll_cap_extend_to_2100():

--- a/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
+++ b/policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py
@@ -1,17 +1,7 @@
 import math
 from functools import lru_cache
 
-import pytest
-
 from policyengine_us import CountryTaxBenefitSystem
-from policyengine_us.parameters.uprating_extensions import (
-    round_social_security_payroll_cap,
-)
-from policyengine_us.reforms.ssa.trustees_2025 import (
-    TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT,
-    TRUSTEES_2025_NAWI_ASSUMPTION,
-    TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS,
-)
 from policyengine_us.reforms.ssa.trustees_core_thresholds import (
     TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
     create_trustees_core_thresholds_reform,
@@ -34,14 +24,9 @@ def test_metadata_marks_trustees_core_thresholds_as_explicit_assumption():
     )
     assert TRUSTEES_CORE_THRESHOLD_ASSUMPTION["not_default_current_law"] is True
     assert TRUSTEES_CORE_THRESHOLD_ASSUMPTION["start_year"] == 2035
-    assert (
-        TRUSTEES_CORE_THRESHOLD_ASSUMPTION["economic_assumption"]
-        == TRUSTEES_2025_NAWI_ASSUMPTION["name"]
-    )
-    assert (
-        TRUSTEES_CORE_THRESHOLD_ASSUMPTION["income_uprating_assumption"]
-        == "trustees-2025-soi-income-nawi-v1"
-    )
+    assert "economic_assumption" not in TRUSTEES_CORE_THRESHOLD_ASSUMPTION
+    assert "income_uprating_assumption" not in TRUSTEES_CORE_THRESHOLD_ASSUMPTION
+    assert TRUSTEES_CORE_THRESHOLD_ASSUMPTION["wage_index"] == "gov.ssa.nawi"
     assert (
         "all_gov_irs_uprating_parameters"
         in TRUSTEES_CORE_THRESHOLD_ASSUMPTION["parameter_groups"]
@@ -52,59 +37,53 @@ def test_metadata_marks_trustees_core_thresholds_as_explicit_assumption():
     assert "OACT email clarification" in TRUSTEES_CORE_THRESHOLD_ASSUMPTION["source"]
 
 
-def test_reform_applies_trustees_2025_nawi_path():
+def test_reform_leaves_long_run_economic_assumptions_unchanged():
     baseline = _parameters()
     reformed = _trustees_parameters()
 
-    baseline_nawi = baseline.gov.ssa.nawi
-    reformed_nawi = reformed.gov.ssa.nawi
+    assert reformed.gov.ssa.nawi("2100-01-01") == baseline.gov.ssa.nawi("2100-01-01")
+    assert reformed.gov.irs.payroll.social_security.cap(
+        "2100-01-01"
+    ) == baseline.gov.irs.payroll.social_security.cap("2100-01-01")
 
-    assert reformed_nawi("2033-01-01") == baseline_nawi("2033-01-01")
-    for year in [2034, 2035, 2040, 2100]:
-        growth = float(reformed_nawi(f"{year}-01-01")) / float(
-            reformed_nawi(f"{year - 1}-01-01")
-        )
-        expected_growth = 1 + TRUSTEES_2025_AVERAGE_WAGE_GROWTH_PCT[year] / 100
-        assert growth == pytest.approx(expected_growth)
-
-
-def test_reform_recomputes_payroll_cap_from_trustees_2025_nawi_path():
-    reformed = _trustees_parameters()
-    nawi = reformed.gov.ssa.nawi
-    payroll_cap = reformed.gov.irs.payroll.social_security.cap
-
-    for year in [2036, 2040, 2100]:
-        current_cap = payroll_cap(f"{year - 1}-01-01")
-        expected_cap = round_social_security_payroll_cap(
-            current_cap * nawi(f"{year - 2}-01-01") / nawi(f"{year - 3}-01-01")
-        )
-        assert payroll_cap(f"{year}-01-01") == expected_cap
-
-
-def test_reform_extends_soi_income_upraters_from_trustees_2025_nawi_path():
-    baseline = _parameters()
-    reformed = _trustees_parameters()
-
-    assert "employment_income" in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS
-    assert "social_security" in TRUSTEES_2025_SOI_INCOME_UPRATING_PARAMETERS
-
-    nawi = reformed.gov.ssa.nawi
     for parameter_name in [
         "employment_income",
-        "self_employment_income",
         "social_security",
+        "taxable_pension_income",
     ]:
         baseline_parameter = getattr(baseline.calibration.gov.irs.soi, parameter_name)
         reformed_parameter = getattr(reformed.calibration.gov.irs.soi, parameter_name)
+        assert reformed_parameter("2100-01-01") == baseline_parameter("2100-01-01")
 
-        assert reformed_parameter("2036-01-01") == baseline_parameter("2036-01-01")
-        assert reformed_parameter("2075-01-01") > baseline_parameter("2075-01-01")
 
-        growth = float(reformed_parameter("2075-01-01")) / float(
-            reformed_parameter("2074-01-01")
+def test_reform_only_changes_federal_irs_uprating_parameters():
+    baseline = _parameters()
+    reformed = _trustees_parameters()
+    reformed_parameters_by_name = {
+        parameter.name: parameter
+        for parameter in [reformed, *reformed.get_descendants()]
+        if parameter.__class__.__name__ == "Parameter"
+    }
+    changed_names = []
+
+    for parameter in [baseline, *baseline.get_descendants()]:
+        if parameter.__class__.__name__ != "Parameter":
+            continue
+
+        reformed_parameter = reformed_parameters_by_name[parameter.name]
+
+        if parameter("2100-01-01") == reformed_parameter("2100-01-01"):
+            continue
+
+        uprating = parameter.metadata.get("uprating")
+        uprating_parameter = (
+            uprating.get("parameter") if isinstance(uprating, dict) else uprating
         )
-        expected_growth = float(nawi("2075-01-01")) / float(nawi("2074-01-01"))
-        assert growth == pytest.approx(expected_growth)
+        assert parameter.name.startswith("gov.irs.")
+        assert uprating_parameter == "gov.irs.uprating"
+        changed_names.append(parameter.name)
+
+    assert changed_names
 
 
 def test_social_security_components_use_aggregate_ss_uprater():

--- a/policyengine_us/tools/default_uprating.py
+++ b/policyengine_us/tools/default_uprating.py
@@ -1,3 +1,10 @@
+from policyengine_us.model_api import USD
+
+
+DEFAULT_DOLLAR_INPUT_UPRATING = (
+    "calibration.gov.cbo.income_by_source.adjusted_gross_income"
+)
+
 INPUT_VARIABLES = [
     "veterans_benefits",
     "other_credits",
@@ -96,14 +103,19 @@ INPUT_VARIABLES = [
 ]
 
 
+def _is_float_dollar_input(variable) -> bool:
+    return (
+        variable.is_input_variable()
+        and variable.value_type is float
+        and variable.unit == USD
+    )
+
+
 def add_default_uprating(system):
     for variable in system.variables.values():
-        if (
-            (variable.name in INPUT_VARIABLES)
-            and (variable.uprating is None)
-            and variable.is_input_variable()
-        ):
-            variable.uprating = (
-                "calibration.gov.cbo.income_by_source.adjusted_gross_income"
-            )
+        should_default = variable.is_input_variable() and (
+            variable.name in INPUT_VARIABLES or _is_float_dollar_input(variable)
+        )
+        if should_default and variable.uprating is None:
+            variable.uprating = DEFAULT_DOLLAR_INPUT_UPRATING
         system.variables[variable.name] = variable

--- a/policyengine_us/variables/household/income/person/retirement/csrs_retirement_pay.py
+++ b/policyengine_us/variables/household/income/person/retirement/csrs_retirement_pay.py
@@ -11,3 +11,4 @@ class csrs_retirement_pay(Variable):
         "Retirement income from the federal Civil Service Retirement System."
     )
     reference = "https://tax.vermont.gov/individuals/seniors-and-retirees"  # Exemption for Civil Service Retirement System (CSRS)
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/keogh_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/keogh_distributions.py
@@ -7,3 +7,4 @@ class keogh_distributions(Variable):
     label = "Keogh plan distributions"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/military_retirement_pay.py
+++ b/policyengine_us/variables/household/income/person/retirement/military_retirement_pay.py
@@ -9,3 +9,4 @@ class military_retirement_pay(Variable):
     definition_period = YEAR
     documentation = "The benefits received under a United States military retirement plan, including survivor benefits."
     reference = "https://militarypay.defense.gov/Pay/Retirement/"
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/military_retirement_pay_survivors.py
+++ b/policyengine_us/variables/household/income/person/retirement/military_retirement_pay_survivors.py
@@ -7,3 +7,4 @@ class military_retirement_pay_survivors(Variable):
     label = "Military retirement income paid to surviving spouses"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/pension_survivors.py
+++ b/policyengine_us/variables/household/income/person/retirement/pension_survivors.py
@@ -7,3 +7,4 @@ class pension_survivors(Variable):
     definition_period = YEAR
     label = "Pension and annuity income from survivors benefits"
     unit = USD
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/retirement_benefits_from_ss_exempt_employment.py
+++ b/policyengine_us/variables/household/income/person/retirement/retirement_benefits_from_ss_exempt_employment.py
@@ -11,3 +11,4 @@ class retirement_benefits_from_ss_exempt_employment(Variable):
     )
     reference = "https://www.michigan.gov/taxes/-/media/Project/Websites/taxes/Forms/2022/2022-IIT-Forms/BOOK_MI-1040.pdf#page=18"
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/tax_exempt_401k_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/tax_exempt_401k_distributions.py
@@ -8,3 +8,4 @@ class tax_exempt_401k_distributions(Variable):
     unit = USD
     documentation = "Tax-exempt distributions from 401(k) accounts (typically Roth)."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.tax_exempt_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/tax_exempt_403b_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/tax_exempt_403b_distributions.py
@@ -8,3 +8,4 @@ class tax_exempt_403b_distributions(Variable):
     unit = USD
     documentation = "Tax-exempt distributions from 403(b) accounts (typically Roth)."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.tax_exempt_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/tax_exempt_ira_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/tax_exempt_ira_distributions.py
@@ -8,3 +8,4 @@ class tax_exempt_ira_distributions(Variable):
     unit = USD
     documentation = "Tax-exempt distributions from individual retirement accounts (qualifying Roth distributions)."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.tax_exempt_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/tax_exempt_private_pension_income.py
+++ b/policyengine_us/variables/household/income/person/retirement/tax_exempt_private_pension_income.py
@@ -8,3 +8,4 @@ class tax_exempt_private_pension_income(Variable):
     unit = USD
     documentation = "Tax-exempt income from non-government employee pensions."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.tax_exempt_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/tax_exempt_public_pension_income.py
+++ b/policyengine_us/variables/household/income/person/retirement/tax_exempt_public_pension_income.py
@@ -8,3 +8,4 @@ class tax_exempt_public_pension_income(Variable):
     unit = USD
     documentation = "Tax-exempt income from government employee pensions."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.tax_exempt_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/tax_exempt_sep_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/tax_exempt_sep_distributions.py
@@ -7,3 +7,4 @@ class tax_exempt_sep_distributions(Variable):
     label = "tax-exempt SEP distributions"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.tax_exempt_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/taxable_401k_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/taxable_401k_distributions.py
@@ -8,3 +8,4 @@ class taxable_401k_distributions(Variable):
     unit = USD
     documentation = "Taxable distributions from 401k accounts (typically traditional)."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/taxable_403b_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/taxable_403b_distributions.py
@@ -8,3 +8,4 @@ class taxable_403b_distributions(Variable):
     unit = USD
     documentation = "Taxable distributions from 403b accounts (typically traditional)."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/taxable_federal_pension_income.py
+++ b/policyengine_us/variables/household/income/person/retirement/taxable_federal_pension_income.py
@@ -7,3 +7,4 @@ class taxable_federal_pension_income(Variable):
     label = "Taxable federal pension income"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/taxable_ira_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/taxable_ira_distributions.py
@@ -8,3 +8,4 @@ class taxable_ira_distributions(Variable):
     unit = USD
     documentation = "Taxable distributions from individual retirement accounts (typically traditional IRAs)."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/taxable_private_pension_income.py
+++ b/policyengine_us/variables/household/income/person/retirement/taxable_private_pension_income.py
@@ -8,3 +8,4 @@ class taxable_private_pension_income(Variable):
     unit = USD
     documentation = "Taxable income from non-government employee pensions."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/taxable_public_pension_income.py
+++ b/policyengine_us/variables/household/income/person/retirement/taxable_public_pension_income.py
@@ -8,3 +8,4 @@ class taxable_public_pension_income(Variable):
     unit = USD
     documentation = "Taxable income from government employee pensions."
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/policyengine_us/variables/household/income/person/retirement/taxable_sep_distributions.py
+++ b/policyengine_us/variables/household/income/person/retirement/taxable_sep_distributions.py
@@ -7,3 +7,4 @@ class taxable_sep_distributions(Variable):
     label = "taxable SEP distributions"
     unit = USD
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.taxable_pension_income"

--- a/uv.lock
+++ b/uv.lock
@@ -2974,7 +2974,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.692.1"
+version = "1.693.1"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary
- extend baseline long-run CBO income-by-source anchors and CMS MOOP uprating through 2100
- give all float USD input variables a resolvable non-flat default uprater while keeping the default limited to input variables
- assign retirement and pension input components to taxable or tax-exempt pension SOI upraters instead of the AGI fallback
- narrow the Trustees core threshold reform so it only wage-indexes federal `gov.irs` parameters using `gov.irs.uprating`; it no longer restates NAWI, payroll cap, or SOI income assumptions

## Validation
- `uv run --locked pytest policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py -q`
- `uv run --locked ruff check policyengine_us/parameters/uprating_extensions.py policyengine_us/tools/default_uprating.py policyengine_us/reforms/ssa/trustees_core_thresholds.py policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py policyengine_us/variables/household/income/person/retirement`
- `git diff --check`
- sanity script confirmed baseline employment and taxable pension SOI upraters rise through 2100, retirement inputs use pension upraters, and Trustees core threshold reform leaves NAWI unchanged while changing federal standard deduction values
- independent subagent review found no behavioral regressions after the retirement-uprater expansion

## Notes
- GitNexus checks could not run in this worktree: `npx -y gitnexus status`, `gitnexus impact`, and `gitnexus detect_changes` all fail with `Cannot destructure property 'package' of 'node.target' as it is null.`\n- ChatGPT Pro external review produced no concrete blocker beyond the semantic residual risk that AGI remains a fallback for inputs without better source-specific upraters. The added tests lock down that the fallback is non-flat and resolvable through 2100.\n