### PR TITLE
Add Medicaid long-term care home equity limit

### DIFF
--- a/changelog.d/5984.added.md
+++ b/changelog.d/5984.added.md
@@ -1,0 +1,1 @@
+Added the Medicaid long-term care home equity limit from H.R. 1.

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/long_term_care/home_equity/agricultural_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/long_term_care/home_equity/agricultural_limit.yaml
@@ -1,0 +1,27 @@
+description: The Department of Health and Human Services limits agricultural home equity to this amount for Medicaid long-term care eligibility.
+values:
+  2025-01-01: 1_097_000
+  2026-01-01: 1_130_000
+  2027-01-01: 1_159_000
+  2028-01-01: 1_189_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: Medicaid long-term care agricultural home equity limit
+  uprating:
+    parameter: gov.bls.cpi.cpi_u
+    rounding:
+      type: nearest
+      interval: 1_000
+  reference:
+    - title: Updated 2025 SSI and Spousal Impoverishment Standards
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib05282025.pdf
+    - title: 2026 SSI, Spousal Impoverishment, and Medicare Savings Program Resource Standards
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib04272026.pdf
+    - title: CMCS Informational Bulletin, Dec. 9, 2025
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib12092025.pdf#page=3
+    - title: CMCS Informational Bulletin, Nov. 18, 2025
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib11182025.pdf#page=8
+    - title: H.R. 1, 119th Congress, Sec. 71108 - Revising home equity limit for determining eligibility for long-term care services under the Medicaid program
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1/text

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/long_term_care/home_equity/family_exception/child_age_threshold.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/long_term_care/home_equity/family_exception/child_age_threshold.yaml
@@ -1,0 +1,11 @@
+description: The Department of Health and Human Services exempts Medicaid long-term care applicants with a resident child below this age from the home equity limit.
+values:
+  0000-01-01: 21
+
+metadata:
+  unit: year
+  period: year
+  label: Medicaid long-term care home equity family exception child age threshold
+  reference:
+    - title: 42 U.S. Code § 1396p(f)(2) - Home equity limit family exception
+      href: https://www.law.cornell.edu/uscode/text/42/1396p#f_2

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/long_term_care/home_equity/limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/long_term_care/home_equity/limit.yaml
@@ -1,0 +1,20 @@
+description: The Department of Health and Human Services limits non-agricultural home equity to this amount for Medicaid long-term care eligibility.
+values:
+  2025-01-01: 1_097_000
+  2026-01-01: 1_130_000
+  2027-01-01: 1_159_000
+  2028-01-01: 1_000_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: Medicaid long-term care non-agricultural home equity limit
+  reference:
+    - title: Updated 2025 SSI and Spousal Impoverishment Standards
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib05282025.pdf
+    - title: 2026 SSI, Spousal Impoverishment, and Medicare Savings Program Resource Standards
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib04272026.pdf
+    - title: H.R. 1, 119th Congress, Sec. 71108 - Revising home equity limit for determining eligibility for long-term care services under the Medicaid program
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1/text
+    - title: CMCS Informational Bulletin, Nov. 18, 2025
+      href: https://www.medicaid.gov/federal-policy-guidance/downloads/cib11182025.pdf#page=8

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
@@ -213,3 +213,43 @@
     employment_income: 6_960
   output:
     is_medicaid_eligible: true
+
+- name: Case 9, long-term care home equity cap does not remove ordinary Medicaid eligibility.
+  period: 2028
+  input:
+    age: 65
+    medicaid_category: SENIOR_OR_DISABLED
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_001
+  output:
+    is_medicaid_eligible: true
+
+- name: Case 10, senior long-term care applicant at the home equity limit remains Medicaid eligible.
+  period: 2028
+  input:
+    age: 65
+    medicaid_category: SENIOR_OR_DISABLED
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_000
+  output:
+    is_medicaid_eligible: true
+
+- name: Case 11, senior long-term care applicant above the home equity limit with a resident spouse is eligible.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        medicaid_category: SENIOR_OR_DISABLED
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 64
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    is_medicaid_eligible: [true, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_eligible.yaml
@@ -1,0 +1,29 @@
+- name: Case 1, Medicaid long-term care applicant above the home equity limit is ineligible for long-term care.
+  period: 2028
+  input:
+    medicaid_category: SENIOR_OR_DISABLED
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_001
+  output:
+    is_medicaid_eligible: true
+    is_medicaid_long_term_care_eligible: false
+
+- name: Case 2, Medicaid long-term care applicant at the home equity limit is eligible for long-term care.
+  period: 2028
+  input:
+    medicaid_category: SENIOR_OR_DISABLED
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_000
+  output:
+    is_medicaid_eligible: true
+    is_medicaid_long_term_care_eligible: true
+
+- name: Case 3, person not otherwise Medicaid eligible is not eligible for long-term care services.
+  period: 2028
+  input:
+    medicaid_category: NONE
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_000
+  output:
+    is_medicaid_eligible: false
+    is_medicaid_long_term_care_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_home_equity_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_home_equity_eligible.yaml
@@ -1,0 +1,297 @@
+- name: Case 1, long-term care recipient at the home equity limit is eligible.
+  period: 2028
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_000
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: true
+
+- name: Case 2, long-term care recipient above the home equity limit is ineligible.
+  period: 2028
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_001
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: false
+
+- name: Case 3, current-law home equity limit applies before 2028.
+  period: 2026
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_130_001
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: false
+
+- name: Case 3b, current-law home equity limit uprates in 2027.
+  period: 2027
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_159_000
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: true
+
+- name: Case 4, home equity limit does not apply without long-term care services.
+  period: 2028
+  input:
+    receives_medicaid_long_term_care_services: false
+    home_equity: 1_000_001
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: true
+
+- name: Case 5, agricultural home at the agricultural home equity limit remains eligible.
+  period: 2028
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_is_on_agricultural_land: true
+    home_equity: 1_189_000
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: true
+
+- name: Case 6, Medicaid facility resident above the home equity limit is ineligible.
+  period: 2028
+  input:
+    is_in_medicaid_facility: true
+    home_equity: 1_000_001
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: false
+
+- name: Case 7, resident spouse exception applies above the home equity limit.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 64
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+  output:
+    medicaid_home_equity_limit_family_exception: [true, false]
+    is_medicaid_long_term_care_home_equity_eligible: [true, true]
+
+- name: Case 8, resident child exception applies above the home equity limit.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+  output:
+    medicaid_home_equity_limit_family_exception: [true, false]
+    is_medicaid_long_term_care_home_equity_eligible: [true, true]
+
+- name: Case 9, agricultural home above the agricultural home equity limit is ineligible.
+  period: 2028
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_is_on_agricultural_land: true
+    home_equity: 1_189_001
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: false
+
+- name: Case 10, adult child at the family exception age threshold does not qualify.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        is_separated: true
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 21
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+  output:
+    medicaid_home_equity_limit_family_exception: [false, false]
+    is_medicaid_long_term_care_home_equity_eligible: [false, true]
+
+- name: Case 11, resident disabled adult child exception applies above the home equity limit.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 30
+        is_disabled: true
+        is_related_to_head_or_spouse: true
+    tax_units:
+      tax_unit1:
+        members: [person1]
+      tax_unit2:
+        members: [person2]
+    households:
+      household:
+        members: [person1, person2]
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+  output:
+    medicaid_home_equity_limit_family_exception: [true, false]
+    is_medicaid_long_term_care_home_equity_eligible: [true, true]
+
+- name: Case 12, disabled adult child receiving long-term care still triggers the family exception.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 30
+        is_disabled: true
+        is_related_to_head_or_spouse: true
+        receives_medicaid_long_term_care_services: true
+    tax_units:
+      tax_unit1:
+        members: [person1]
+      tax_unit2:
+        members: [person2]
+    households:
+      household:
+        members: [person1, person2]
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+  output:
+    medicaid_home_equity_limit_family_exception: [true, false]
+    is_medicaid_long_term_care_home_equity_eligible: [true, true]
+
+- name: Case 13, unrelated disabled housemate does not trigger the family exception.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 30
+        is_disabled: true
+        is_related_to_head_or_spouse: false
+    tax_units:
+      tax_unit1:
+        members: [person1]
+      tax_unit2:
+        members: [person2]
+    households:
+      household:
+        members: [person1, person2]
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+  output:
+    medicaid_home_equity_limit_family_exception: [false, false]
+    is_medicaid_long_term_care_home_equity_eligible: [false, true]
+
+- name: Case 14, dependent long-term care recipient does not qualify through a parent's spouse.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 17
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 45
+      person3:
+        age: 44
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+  output:
+    medicaid_home_equity_limit_family_exception: [false, false, false]
+    is_medicaid_long_term_care_home_equity_eligible: [false, true, true]
+
+- name: Case 15, adult non-spouse relative does not trigger the spouse exception.
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 65
+        receives_medicaid_long_term_care_services: true
+        home_equity: 1_000_001
+      person2:
+        age: 30
+        is_related_to_head_or_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+  output:
+    medicaid_home_equity_limit_family_exception: [false, false]
+    is_medicaid_long_term_care_home_equity_eligible: [false, true]
+
+- name: Case 16, non-agricultural home equity remains capped at one million after 2028.
+  period: 2029
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_equity: 1_000_001
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: false
+
+- name: Case 17, agricultural home equity limit continues to uprate after 2028.
+  period: 2029
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_is_on_agricultural_land: true
+    home_equity: 1_217_000
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: true
+
+- name: Case 18, agricultural home above the 2029 uprated limit is ineligible.
+  period: 2029
+  input:
+    receives_medicaid_long_term_care_services: true
+    home_is_on_agricultural_land: true
+    home_equity: 1_217_001
+  output:
+    is_medicaid_long_term_care_home_equity_eligible: false

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_eligible.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class is_medicaid_long_term_care_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Medicaid long-term care services"
+    definition_period = YEAR
+    documentation = (
+        "Whether this person is eligible for Medicaid long-term care services "
+        "after applying the long-term-care-specific home equity limit. This "
+        "does not determine ordinary Medicaid eligibility."
+    )
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/42/1396p#f",
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+    )
+
+    def formula(person, period, parameters):
+        return (
+            person("is_medicaid_eligible", period)
+            & person("receives_medicaid_long_term_care_services", period)
+            & person("is_medicaid_long_term_care_home_equity_eligible", period)
+        )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_home_equity_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_home_equity_eligible.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class is_medicaid_long_term_care_home_equity_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Medicaid long-term care home equity eligible"
+    definition_period = YEAR
+    reference = "https://www.congress.gov/bill/119th-congress/house-bill/1/text"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.hhs.medicaid.eligibility.long_term_care
+        receives_long_term_care = person(
+            "receives_medicaid_long_term_care_services", period
+        )
+        home_is_agricultural = person("home_is_on_agricultural_land", period)
+        family_exception = person("medicaid_home_equity_limit_family_exception", period)
+        home_equity = person("home_equity", period)
+        home_equity_limit = where(
+            home_is_agricultural,
+            p.home_equity.agricultural_limit,
+            p.home_equity.limit,
+        )
+        return (
+            ~receives_long_term_care
+            | family_exception
+            | (home_equity <= home_equity_limit)
+        )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_home_equity_limit_family_exception.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_home_equity_limit_family_exception.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class medicaid_home_equity_limit_family_exception(Variable):
+    value_type = bool
+    entity = Person
+    label = "Medicaid home equity limit family exception"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/42/1396p#f_2"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.hhs.medicaid.eligibility.long_term_care
+        receives_long_term_care = person(
+            "receives_medicaid_long_term_care_services", period
+        )
+        is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        has_resident_spouse = person.marital_unit.nb_persons() == 2
+        # The model does not have pairwise parent-child identifiers.
+        # Treat related household members as the resident child proxy.
+        qualifying_resident_child = person("is_related_to_head_or_spouse", period) & (
+            (person("age", period) < p.home_equity.family_exception.child_age_threshold)
+            | person("is_blind", period)
+            | person("is_disabled", period)
+            | person("is_permanently_and_totally_disabled", period)
+        )
+        has_resident_child = (
+            person.household.sum(qualifying_resident_child) > qualifying_resident_child
+        )
+        return receives_long_term_care & (
+            has_resident_spouse | (is_head_or_spouse & has_resident_child)
+        )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/receives_medicaid_long_term_care_services.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/receives_medicaid_long_term_care_services.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class receives_medicaid_long_term_care_services(Variable):
+    value_type = bool
+    entity = Person
+    label = "Receives Medicaid long-term care services"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/42/1396p#f"
+
+    def formula(person, period, parameters):
+        return person("is_in_medicaid_facility", period)

--- a/policyengine_us/variables/household/assets/home_equity.py
+++ b/policyengine_us/variables/household/assets/home_equity.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class home_equity(Variable):
+    value_type = float
+    entity = Person
+    label = "Home equity"
+    documentation = "Equity interest in a primary residence."
+    unit = USD
+    quantity_type = STOCK
+    definition_period = YEAR

--- a/policyengine_us/variables/household/assets/home_is_on_agricultural_land.py
+++ b/policyengine_us/variables/household/assets/home_is_on_agricultural_land.py
@@ -1,0 +1,9 @@
+from policyengine_us.model_api import *
+
+
+class home_is_on_agricultural_land(Variable):
+    value_type = bool
+    entity = Person
+    label = "Home is on agricultural land"
+    definition_period = YEAR
+    reference = "https://www.congress.gov/bill/119th-congress/house-bill/1/text"


### PR DESCRIPTION
Closes #5984.

## Summary
- Add the 2028 Medicaid long-term care home-equity cap from H.R. 1 Sec. 71108.
- Apply the cap to Medicaid eligibility for long-term care recipients, with the agricultural-lot exception.
- Add home-equity inputs and targeted Medicaid eligibility tests.

## Tests
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_long_term_care_home_equity_eligible.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml -c policyengine_us
- uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_system_import.py -q