### PR TITLE
Fix NY Child Health Plus full-premium tier

### DIFF
--- a/changelog.d/fixed/8097.md
+++ b/changelog.d/fixed/8097.md
@@ -1,0 +1,1 @@
+Fixed New York Child Health Plus premiums above 400 percent FPL.

--- a/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
+++ b/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
@@ -12,6 +12,10 @@ metadata:
       href: https://web.archive.org/web/20200118155511/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
     - title: Child Health Plus page captured February 2023 (restructured schedule)
       href: https://web.archive.org/web/20230207084107/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: New York Child Health Plus CY 2025 Rate Development, CY 2025 Rate Summary
+      href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY25/NY%20CY25%20CHPlus%20Rate%20Presentation%20-%202024.11.08.pdf#page=14
+    - title: New York Child Health Plus CY 2026 Rate Development, CY 2026 Rate Summary
+      href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY26/NY%20CY26%20CHPlus%20Rate%20Presentation%20-%202025.11.10_FINAL.pdf#page=16
 brackets:
   - threshold:
       2020-01-01: -.inf
@@ -51,3 +55,6 @@ brackets:
     amount:
       2020-01-01: 180
       2023-02-01: 0
+      2024-01-01: 801.18
+      2025-01-01: 817.05
+      2026-01-01: 810.42

--- a/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
+++ b/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
@@ -1,4 +1,4 @@
-description: New York caps the total Child Health Plus monthly premium per family at three children's worth, based on the tax unit's modified adjusted gross income as a fraction of the federal poverty line.
+description: New York caps the total subsidized Child Health Plus monthly premium per family at three children's worth, based on the tax unit's modified adjusted gross income as a fraction of the federal poverty line.
 metadata:
   type: single_amount
   threshold_unit: /1
@@ -55,6 +55,4 @@ brackets:
     amount:
       2020-01-01: 180
       2023-02-01: 0
-      2024-01-01: 801.18
-      2025-01-01: 817.05
-      2026-01-01: 810.42
+      2024-01-01: .inf

--- a/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/per_child.yaml
+++ b/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/per_child.yaml
@@ -14,6 +14,10 @@ metadata:
       href: https://web.archive.org/web/20230207084107/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
     - title: Child Health Plus page captured February 2024 (first page using "Effective for applications received on or after" caption)
       href: https://web.archive.org/web/20240229061759/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: New York Child Health Plus CY 2025 Rate Development, CY 2025 Rate Summary
+      href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY25/NY%20CY25%20CHPlus%20Rate%20Presentation%20-%202024.11.08.pdf#page=14
+    - title: New York Child Health Plus CY 2026 Rate Development, CY 2026 Rate Summary
+      href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY26/NY%20CY26%20CHPlus%20Rate%20Presentation%20-%202025.11.10_FINAL.pdf#page=16
 brackets:
   - threshold:
       2020-01-01: -.inf
@@ -53,3 +57,6 @@ brackets:
     amount:
       2020-01-01: 60
       2023-02-01: 0
+      2024-01-01: 267.06
+      2025-01-01: 272.35
+      2026-01-01: 270.14

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
@@ -79,7 +79,7 @@
   output:
     ny_chip_premium: 1620
 
-- name: Case 5, New York Child Health Plus above 400 percent FPL pays the representative full premium.
+- name: Case 5, New York Child Health Plus above 400 percent FPL pays the representative full premium per child.
   period: 2026
   input:
     people:
@@ -104,7 +104,7 @@
         members: [person1, person2, person3, person4]
         state_code: NY
   output:
-    ny_chip_premium: 9_725.04
+    ny_chip_premium: 12_966.72
 
 - name: Case 6, New York Child Health Plus above 400 percent FPL with one child pays the per-child full premium.
   period: 2026

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
@@ -78,3 +78,30 @@
         state_code: NY
   output:
     ny_chip_premium: 1620
+
+- name: Case 5, New York Child Health Plus above 400 percent FPL pays the representative full premium.
+  period: 2026
+  input:
+    people:
+      person1:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+      person2:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+      person3:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+      person4:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        tax_unit_medicaid_income_level: 4.10
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: NY
+  output:
+    ny_chip_premium: 9_725.04

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
@@ -105,3 +105,21 @@
         state_code: NY
   output:
     ny_chip_premium: 9_725.04
+
+- name: Case 6, New York Child Health Plus above 400 percent FPL with one child pays the per-child full premium.
+  period: 2026
+  input:
+    people:
+      person1:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        tax_unit_medicaid_income_level: 4.10
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    ny_chip_premium: 3_241.68

--- a/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
+++ b/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
@@ -8,11 +8,11 @@ class ny_chip_premium(Variable):
     unit = USD
     documentation = (
         "Annual New York Child Health Plus (separate CHIP) premium paid by "
-        "the tax unit. Per-child monthly premium capped at a three-child "
-        "family maximum, tiered by the tax unit's income as a fraction of "
-        "the federal poverty line. Families above 400 percent FPL pay a "
-        "statewide average full plan premium, because the actual premium "
-        "varies by health plan."
+        "the tax unit. Subsidized per-child monthly premiums are capped at "
+        "a three-child family maximum and tiered by the tax unit's income "
+        "as a fraction of the federal poverty line. Families above 400 "
+        "percent FPL pay an uncapped statewide average full plan premium, "
+        "because the actual premium varies by health plan."
     )
     definition_period = YEAR
     defined_for = StateCode.NY

--- a/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
+++ b/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
@@ -10,8 +10,9 @@ class ny_chip_premium(Variable):
         "Annual New York Child Health Plus (separate CHIP) premium paid by "
         "the tax unit. Per-child monthly premium capped at a three-child "
         "family maximum, tiered by the tax unit's income as a fraction of "
-        "the federal poverty line. Families above 400 percent FPL pay the "
-        "full plan cost, which varies by health plan and is not modeled."
+        "the federal poverty line. Families above 400 percent FPL pay a "
+        "statewide average full plan premium, because the actual premium "
+        "varies by health plan."
     )
     definition_period = YEAR
     defined_for = StateCode.NY


### PR DESCRIPTION
## Summary
- Fill New York Child Health Plus premiums above 400% FPL with statewide full-premium PMPM proxies from CHPlus rate-development decks
- Preserve the existing three-child family cap for the representative full-premium tier
- Add a regression test for the >400% FPL case

Fixes #8097.

## Tests
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml -c policyengine_us
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/chip/chip_premium.yaml -c policyengine_us
- uv run pytest policyengine_us/tests/test_parameter_files.py -q
- uv run --extra dev ruff check policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
- uv run --extra dev ruff format --check policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
- git diff --check