### PR TITLE
Calibrate ACA take-up contract

### DIFF
--- a/changelog.d/8168.added.md
+++ b/changelog.d/8168.added.md
@@ -1,0 +1,1 @@
+Marketplace take-up can now use reported Marketplace coverage while preserving a simulated take-up switch, with selected Marketplace plan benchmark ratios documented as explicit inputs.

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/marketplace_net_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/marketplace_net_premium.yaml
@@ -55,3 +55,31 @@
     selected_marketplace_plan_premium_proxy: 5_000
     used_aca_ptc: 3_000
     marketplace_net_premium: 2_000
+
+- name: Reported unsubsidized Marketplace buyer pays selected plan premium when simulated take-up is disabled.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        has_marketplace_health_coverage_at_interview: true
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 5
+        slcsp: 10_000
+        selected_marketplace_plan_benchmark_ratio: 0.8
+        simulated_aca_take_up_if_eligible: false
+  output:
+    pays_aca_premium: [true]
+    takes_up_aca_if_eligible: true
+    is_aca_ptc_eligible: [false]
+    selected_marketplace_plan_premium_proxy: 8_000
+    used_aca_ptc: 0
+    marketplace_net_premium: 8_000

--- a/policyengine_us/tests/policy/baseline/gov/aca/takes_up_aca_if_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/takes_up_aca_if_eligible.yaml
@@ -1,0 +1,46 @@
+- name: Case 1, default simulated Marketplace take-up preserves existing ACA take-up behavior.
+  period: 2026
+  output:
+    simulated_aca_take_up_if_eligible: true
+    takes_up_aca_if_eligible: true
+
+- name: Case 2, reported Marketplace coverage triggers take-up when simulated take-up is disabled.
+  period: 2026
+  input:
+    people:
+      person1:
+        has_marketplace_health_coverage_at_interview: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        simulated_aca_take_up_if_eligible: false
+  output:
+    takes_up_aca_if_eligible: true
+
+- name: Case 3, no reported Marketplace coverage means no take-up when simulated take-up is disabled.
+  period: 2026
+  input:
+    people:
+      person1:
+        has_marketplace_health_coverage_at_interview: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        simulated_aca_take_up_if_eligible: false
+  output:
+    takes_up_aca_if_eligible: false
+
+- name: Case 4, reported Marketplace coverage for one member triggers tax-unit take-up.
+  period: 2026
+  input:
+    people:
+      person1:
+        has_marketplace_health_coverage_at_interview: false
+      person2:
+        has_marketplace_health_coverage_at_interview: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        simulated_aca_take_up_if_eligible: false
+  output:
+    takes_up_aca_if_eligible: true

--- a/policyengine_us/variables/gov/aca/ptc/selected_marketplace_plan_benchmark_ratio.py
+++ b/policyengine_us/variables/gov/aca/ptc/selected_marketplace_plan_benchmark_ratio.py
@@ -8,3 +8,9 @@ class selected_marketplace_plan_benchmark_ratio(Variable):
     unit = "/1"
     definition_period = YEAR
     default_value = 1.0
+    documentation = (
+        "Ratio of the selected Marketplace plan gross premium to the second "
+        "lowest cost silver plan benchmark premium. This is an explicit "
+        "user- or data-supplied input; when absent, the model assumes the "
+        "selected plan premium equals the benchmark premium."
+    )

--- a/policyengine_us/variables/gov/aca/simulated_aca_take_up_if_eligible.py
+++ b/policyengine_us/variables/gov/aca/simulated_aca_take_up_if_eligible.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class simulated_aca_take_up_if_eligible(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Whether a tax unit is simulated to take up ACA if eligible"
+    definition_period = YEAR
+    default_value = True
+    documentation = (
+        "Data-supplied or reform-responsive Marketplace take-up switch for "
+        "tax units without reported Marketplace coverage at interview. "
+        "Population data should write this input rather than the formula-owned "
+        "takes_up_aca_if_eligible variable."
+    )

--- a/policyengine_us/variables/gov/aca/takes_up_aca_if_eligible.py
+++ b/policyengine_us/variables/gov/aca/takes_up_aca_if_eligible.py
@@ -7,3 +7,17 @@ class takes_up_aca_if_eligible(Variable):
     label = "Whether an eligible tax unit takes up ACA"
     definition_period = YEAR
     default_value = True
+    documentation = (
+        "Whether the tax unit takes up Marketplace coverage when otherwise "
+        "eligible. Reported Marketplace coverage at interview is treated as "
+        "observed take-up; otherwise take-up follows the data-supplied or "
+        "simulated take-up switch."
+    )
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        reported_marketplace_coverage = tax_unit.any(
+            person("has_marketplace_health_coverage_at_interview", period)
+        )
+        simulated_take_up = tax_unit("simulated_aca_take_up_if_eligible", period)
+        return reported_marketplace_coverage | simulated_take_up


### PR DESCRIPTION
## Summary

- derive `takes_up_aca_if_eligible` from reported Marketplace coverage or a data-supplied/simulated take-up switch
- add `simulated_aca_take_up_if_eligible` so Populace and other datasets can provide calibrated non-reported Marketplace take-up without writing the final formula-owned take-up variable
- document `selected_marketplace_plan_benchmark_ratio` as an explicit user/data input, defaulting to the benchmark-plan assumption when absent
- add tests for observed Marketplace take-up and an unsubsidized reported Marketplace buyer using a selected-plan ratio below the benchmark

Closes #8168.

## Data framework note

Under the Populace-style contract, `has_marketplace_health_coverage_at_interview` remains the observed coverage input, `simulated_aca_take_up_if_eligible` is the data-supplied/calibrated take-up input for tax units without reported Marketplace coverage, and `takes_up_aca_if_eligible` is computed by PolicyEngine-US. Populace should therefore write `simulated_aca_take_up_if_eligible`, not `takes_up_aca_if_eligible`, once this lands.

## Tests

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/takes_up_aca_if_eligible.yaml policyengine_us/tests/policy/baseline/gov/aca/person_receives_aca.yaml policyengine_us/tests/policy/baseline/gov/aca/ptc/marketplace_net_premium.yaml policyengine_us/tests/policy/baseline/gov/aca/ptc/selected_marketplace_plan_premium_proxy.yaml policyengine_us/tests/policy/baseline/gov/aca/ptc/used_aca_ptc.yaml policyengine_us/tests/policy/baseline/gov/aca/ptc/assigned_aca_ptc.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca -c policyengine_us`
- `uv run pytest policyengine_us/tests/test_parameter_files.py -q`
- `uv run --extra dev ruff check policyengine_us/variables/gov/aca policyengine_us/tests/policy/baseline/gov/aca`
- `uv run --extra dev ruff format --check policyengine_us/variables/gov/aca/takes_up_aca_if_eligible.py policyengine_us/variables/gov/aca/simulated_aca_take_up_if_eligible.py policyengine_us/variables/gov/aca/ptc/selected_marketplace_plan_benchmark_ratio.py`
- `git diff --check`
