### PR TITLE
Add SSI disability criteria variable

### DIFF
--- a/changelog.d/ssi-disability-status-variable.added.md
+++ b/changelog.d/ssi-disability-status-variable.added.md
@@ -1,0 +1,1 @@
+Added a data-overridable SSI disability criteria variable for calibrated SSI simulations.

--- a/policyengine_us/tests/policy/baseline/gov/ssa/ssi/is_ssi_disabled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/ssa/ssi/is_ssi_disabled.yaml
@@ -49,3 +49,21 @@
     ssi_engaged_in_sga: false
   output:
     is_ssi_disabled: false
+
+- name: Data-provided SSI disability criteria can identify SSI disability
+  period: 2024
+  input:
+    meets_ssi_disability_criteria: true
+    is_disabled: false
+    ssi_engaged_in_sga: false
+  output:
+    is_ssi_disabled: true
+
+- name: Data-provided SSI disability criteria can exclude broad disability
+  period: 2024
+  input:
+    meets_ssi_disability_criteria: false
+    is_disabled: true
+    ssi_engaged_in_sga: false
+  output:
+    is_ssi_disabled: false

--- a/policyengine_us/tests/policy/baseline/gov/ssa/ssi/meets_ssi_disability_criteria.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/ssa/ssi/meets_ssi_disability_criteria.yaml
@@ -1,0 +1,23 @@
+- name: Case 1, disabled and not engaged in substantial gainful activity.
+  period: 2024
+  input:
+    is_disabled: true
+    ssi_engaged_in_sga: false
+  output:
+    meets_ssi_disability_criteria: true
+
+- name: Case 2, disabled but engaged in substantial gainful activity.
+  period: 2024
+  input:
+    is_disabled: true
+    ssi_engaged_in_sga: true
+  output:
+    meets_ssi_disability_criteria: false
+
+- name: Case 3, not disabled and not engaged in substantial gainful activity.
+  period: 2024
+  input:
+    is_disabled: false
+    ssi_engaged_in_sga: false
+  output:
+    meets_ssi_disability_criteria: false

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/is_ssi_disabled.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/is_ssi_disabled.py
@@ -10,7 +10,4 @@ class is_ssi_disabled(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/42/1382c#a_3_A"
 
     def formula(person, period, parameters):
-        # Earnings in excess of the Substantial Gainful Activity threshold disqualify from either case.
-        is_disabled = person("is_disabled", period)
-        engaged_in_ssa = person("ssi_engaged_in_sga", period)
-        return is_disabled & ~engaged_in_ssa
+        return person("meets_ssi_disability_criteria", period)

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/meets_ssi_disability_criteria.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/meets_ssi_disability_criteria.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class meets_ssi_disability_criteria(Variable):
+    value_type = bool
+    entity = Person
+    definition_period = YEAR
+    documentation = "Indicates whether a person meets the Supplemental Security Income disability criteria"
+    label = "Meets SSI disability criteria"
+    reference = "https://www.law.cornell.edu/uscode/text/42/1382c#a_3_A"
+
+    def formula(person, period, parameters):
+        is_disabled = person("is_disabled", period)
+        engaged_in_sga = person("ssi_engaged_in_sga", period)
+        return is_disabled & ~engaged_in_sga


### PR DESCRIPTION
## Summary
- Add `meets_ssi_disability_criteria` as a data-overridable person variable for SSI disability status.
- Keep the current fallback behavior: broad `is_disabled` and not `ssi_engaged_in_sga`.
- Make `is_ssi_disabled` delegate to the new variable so US-data can later provide calibrated latent SSI disability status.

## Why
Asset-limit reforms need a data-backed way to distinguish broad CPS disability from likely SSI disability criteria. Without this, reforms can overstate new SSI participation and downstream Medicaid effects. This is the PolicyEngine-US contract needed before `policyengine-us-data` can impute the variable from SIPP/CPS predictors and publish it in enhanced CPS.

Related: PolicyEngine/policyengine-us#1043, PolicyEngine/policyengine-us-data#1094.

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/ssa/ssi/meets_ssi_disability_criteria.yaml policyengine_us/tests/policy/baseline/gov/ssa/ssi/is_ssi_disabled.yaml -c policyengine_us`
- `uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/ssa/ssi --mode per-subdir`
- `uv run ruff format --check policyengine_us/variables/gov/ssa/ssi/eligibility/status/meets_ssi_disability_criteria.py policyengine_us/variables/gov/ssa/ssi/eligibility/status/is_ssi_disabled.py`
- `uv run ruff check policyengine_us/variables/gov/ssa/ssi/eligibility/status/meets_ssi_disability_criteria.py policyengine_us/variables/gov/ssa/ssi/eligibility/status/is_ssi_disabled.py`