### PR TITLE
Keep SSI SGA screen separate from disability criteria

### DIFF
--- a/changelog.d/fixed/ssi-disability-sga.md
+++ b/changelog.d/fixed/ssi-disability-sga.md
@@ -1,0 +1,1 @@
+Keep the SSI substantial gainful activity screen separate from the data-backed SSI disability criteria variable.

--- a/policyengine_us/tests/policy/baseline/gov/ssa/ssi/is_ssi_disabled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/ssa/ssi/is_ssi_disabled.yaml
@@ -59,6 +59,15 @@
   output:
     is_ssi_disabled: true
 
+- name: Data-provided SSI disability criteria remains subject to SGA
+  period: 2024
+  input:
+    meets_ssi_disability_criteria: true
+    is_disabled: false
+    ssi_engaged_in_sga: true
+  output:
+    is_ssi_disabled: false
+
 - name: Data-provided SSI disability criteria can exclude broad disability
   period: 2024
   input:

--- a/policyengine_us/tests/policy/baseline/gov/ssa/ssi/meets_ssi_disability_criteria.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/ssa/ssi/meets_ssi_disability_criteria.yaml
@@ -12,7 +12,7 @@
     is_disabled: true
     ssi_engaged_in_sga: true
   output:
-    meets_ssi_disability_criteria: false
+    meets_ssi_disability_criteria: true
 
 - name: Case 3, not disabled and not engaged in substantial gainful activity.
   period: 2024

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/is_ssi_disabled.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/is_ssi_disabled.py
@@ -10,4 +10,6 @@ class is_ssi_disabled(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/42/1382c#a_3_A"
 
     def formula(person, period, parameters):
-        return person("meets_ssi_disability_criteria", period)
+        meets_disability_criteria = person("meets_ssi_disability_criteria", period)
+        engaged_in_sga = person("ssi_engaged_in_sga", period)
+        return meets_disability_criteria & ~engaged_in_sga

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/meets_ssi_disability_criteria.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/meets_ssi_disability_criteria.py
@@ -5,11 +5,12 @@ class meets_ssi_disability_criteria(Variable):
     value_type = bool
     entity = Person
     definition_period = YEAR
-    documentation = "Indicates whether a person meets the Supplemental Security Income disability criteria"
+    documentation = (
+        "Indicates whether a person meets the Supplemental Security Income "
+        "disability criteria before the substantial gainful activity screen"
+    )
     label = "Meets SSI disability criteria"
     reference = "https://www.law.cornell.edu/uscode/text/42/1382c#a_3_A"
 
     def formula(person, period, parameters):
-        is_disabled = person("is_disabled", period)
-        engaged_in_sga = person("ssi_engaged_in_sga", period)
-        return is_disabled & ~engaged_in_sga
+        return person("is_disabled", period)


### PR DESCRIPTION
## Summary
- keeps meets_ssi_disability_criteria as a static/data-backed disability criteria indicator before SGA
- applies ssi_engaged_in_sga in is_ssi_disabled so the SGA screen remains dynamic in microsimulations and reforms
- adds coverage that data-provided disability criteria still fails SSI disabled status when the person is engaged in SGA

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/ssa/ssi/meets_ssi_disability_criteria.yaml policyengine_us/tests/policy/baseline/gov/ssa/ssi/is_ssi_disabled.yaml -c policyengine_us
- uv run python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/ssa/ssi --mode per-subdir
- uv run ruff format/check on touched Python files

## Notes
This follow-up fixes the contract needed by policyengine-us-data: the dataset should impute the disability-status signal, while PolicyEngine-US applies the current SGA rule separately.
