### PR TITLE
Add Medicaid optional eligibility pathways

### DIFF
--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/covered.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/covered.yaml
@@ -11,6 +11,7 @@ values:
     - is_ssi_recipient_for_medicaid
     - is_optional_senior_or_disabled_for_medicaid
     - is_medically_needy_for_medicaid
+    - is_working_disabled_buy_in_for_medicaid
 metadata:
   unit: list
   label: "Medicaid categories"

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/classification/section_1634.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/classification/section_1634.yaml
@@ -1,0 +1,113 @@
+description: Whether the state has a Section 1634 agreement for SSI-recipient Medicaid determinations.
+metadata:
+  unit: bool
+  period: year
+  label: Medicaid SSI-recipient Section 1634 state
+  breakdown:
+    - state_code
+  reference:
+    - title: SSA POMS SI 01715.010 Medicaid and the Supplemental Security Income Program
+      href: https://secure.ssa.gov/apps10/poms.nsf/lnx/0501715010
+
+AK:
+  2024-01-01: false
+AL:
+  2024-01-01: true
+AR:
+  2024-01-01: true
+AZ:
+  2024-01-01: true
+CA:
+  2024-01-01: true
+CO:
+  2024-01-01: true
+CT:
+  2024-01-01: false
+DC:
+  2024-01-01: true
+DE:
+  2024-01-01: true
+FL:
+  2024-01-01: true
+GA:
+  2024-01-01: true
+HI:
+  2024-01-01: false
+IA:
+  2024-01-01: true
+ID:
+  2024-01-01: false
+IL:
+  2024-01-01: false
+IN:
+  2024-01-01: true
+KS:
+  2024-01-01: false
+KY:
+  2024-01-01: true
+LA:
+  2024-01-01: true
+MA:
+  2024-01-01: true
+MD:
+  2024-01-01: true
+ME:
+  2024-01-01: true
+MI:
+  2024-01-01: true
+MN:
+  2024-01-01: false
+MO:
+  2024-01-01: false
+MS:
+  2024-01-01: true
+MT:
+  2024-01-01: true
+NC:
+  2024-01-01: true
+ND:
+  2024-01-01: false
+NE:
+  2024-01-01: false
+NH:
+  2024-01-01: false
+NJ:
+  2024-01-01: true
+NM:
+  2024-01-01: true
+NV:
+  2024-01-01: false
+NY:
+  2024-01-01: true
+OH:
+  2024-01-01: true
+OK:
+  2024-01-01: false
+OR:
+  2024-01-01: false
+PA:
+  2024-01-01: true
+RI:
+  2024-01-01: true
+SC:
+  2024-01-01: true
+SD:
+  2024-01-01: true
+TN:
+  2024-01-01: true
+TX:
+  2024-01-01: true
+UT:
+  2024-01-01: false
+VA:
+  2024-01-01: false
+VT:
+  2024-01-01: true
+WA:
+  2024-01-01: true
+WI:
+  2024-01-01: true
+WV:
+  2024-01-01: true
+WY:
+  2024-01-01: true

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/classification/section_209b.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/classification/section_209b.yaml
@@ -1,0 +1,113 @@
+description: Whether the state uses Section 209(b) criteria for SSI-recipient Medicaid determinations.
+metadata:
+  unit: bool
+  period: year
+  label: Medicaid SSI-recipient Section 209(b) state
+  breakdown:
+    - state_code
+  reference:
+    - title: SSA POMS SI 01715.010 Medicaid and the Supplemental Security Income Program
+      href: https://secure.ssa.gov/apps10/poms.nsf/lnx/0501715010
+
+AK:
+  2024-01-01: false
+AL:
+  2024-01-01: false
+AR:
+  2024-01-01: false
+AZ:
+  2024-01-01: false
+CA:
+  2024-01-01: false
+CO:
+  2024-01-01: false
+CT:
+  2024-01-01: true
+DC:
+  2024-01-01: false
+DE:
+  2024-01-01: false
+FL:
+  2024-01-01: false
+GA:
+  2024-01-01: false
+HI:
+  2024-01-01: true
+IA:
+  2024-01-01: false
+ID:
+  2024-01-01: false
+IL:
+  2024-01-01: true
+IN:
+  2024-01-01: false
+KS:
+  2024-01-01: false
+KY:
+  2024-01-01: false
+LA:
+  2024-01-01: false
+MA:
+  2024-01-01: false
+MD:
+  2024-01-01: false
+ME:
+  2024-01-01: false
+MI:
+  2024-01-01: false
+MN:
+  2024-01-01: true
+MO:
+  2024-01-01: true
+MS:
+  2024-01-01: false
+MT:
+  2024-01-01: false
+NC:
+  2024-01-01: false
+ND:
+  2024-01-01: true
+NE:
+  2024-01-01: false
+NH:
+  2024-01-01: true
+NJ:
+  2024-01-01: false
+NM:
+  2024-01-01: false
+NV:
+  2024-01-01: false
+NY:
+  2024-01-01: false
+OH:
+  2024-01-01: false
+OK:
+  2024-01-01: false
+OR:
+  2024-01-01: false
+PA:
+  2024-01-01: false
+RI:
+  2024-01-01: false
+SC:
+  2024-01-01: false
+SD:
+  2024-01-01: false
+TN:
+  2024-01-01: false
+TX:
+  2024-01-01: false
+UT:
+  2024-01-01: false
+VA:
+  2024-01-01: true
+VT:
+  2024-01-01: false
+WA:
+  2024-01-01: false
+WI:
+  2024-01-01: false
+WV:
+  2024-01-01: false
+WY:
+  2024-01-01: false

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/classification/ssi_criteria.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/classification/ssi_criteria.yaml
@@ -1,0 +1,113 @@
+description: Whether the state uses SSI criteria for SSI-recipient Medicaid determinations without a Section 1634 agreement.
+metadata:
+  unit: bool
+  period: year
+  label: Medicaid SSI-recipient SSI-criteria state
+  breakdown:
+    - state_code
+  reference:
+    - title: SSA POMS SI 01715.010 Medicaid and the Supplemental Security Income Program
+      href: https://secure.ssa.gov/apps10/poms.nsf/lnx/0501715010
+
+AK:
+  2024-01-01: true
+AL:
+  2024-01-01: false
+AR:
+  2024-01-01: false
+AZ:
+  2024-01-01: false
+CA:
+  2024-01-01: false
+CO:
+  2024-01-01: false
+CT:
+  2024-01-01: false
+DC:
+  2024-01-01: false
+DE:
+  2024-01-01: false
+FL:
+  2024-01-01: false
+GA:
+  2024-01-01: false
+HI:
+  2024-01-01: false
+IA:
+  2024-01-01: false
+ID:
+  2024-01-01: true
+IL:
+  2024-01-01: false
+IN:
+  2024-01-01: false
+KS:
+  2024-01-01: true
+KY:
+  2024-01-01: false
+LA:
+  2024-01-01: false
+MA:
+  2024-01-01: false
+MD:
+  2024-01-01: false
+ME:
+  2024-01-01: false
+MI:
+  2024-01-01: false
+MN:
+  2024-01-01: false
+MO:
+  2024-01-01: false
+MS:
+  2024-01-01: false
+MT:
+  2024-01-01: false
+NC:
+  2024-01-01: false
+ND:
+  2024-01-01: false
+NE:
+  2024-01-01: true
+NH:
+  2024-01-01: false
+NJ:
+  2024-01-01: false
+NM:
+  2024-01-01: false
+NV:
+  2024-01-01: true
+NY:
+  2024-01-01: false
+OH:
+  2024-01-01: false
+OK:
+  2024-01-01: true
+OR:
+  2024-01-01: true
+PA:
+  2024-01-01: false
+RI:
+  2024-01-01: false
+SC:
+  2024-01-01: false
+SD:
+  2024-01-01: false
+TN:
+  2024-01-01: false
+TX:
+  2024-01-01: false
+UT:
+  2024-01-01: true
+VA:
+  2024-01-01: false
+VT:
+  2024-01-01: false
+WA:
+  2024-01-01: false
+WI:
+  2024-01-01: false
+WV:
+  2024-01-01: false
+WY:
+  2024-01-01: false

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/is_covered.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/ssi_recipient/is_covered.yaml
@@ -6,6 +6,8 @@ metadata:
   breakdown:
   - state_code
   reference:
+    - title: SSA POMS SI 01715.010 Medicaid and the Supplemental Security Income Program
+      href: https://secure.ssa.gov/apps10/poms.nsf/lnx/0501715010
     - title: 42 U.S. Code § 1396(f)
       href: https://www.law.cornell.edu/uscode/text/42/1396a#f
 
@@ -82,7 +84,7 @@ NY:
 OH:
   2021-01-01: true
 OK:
-  2021-01-01: false
+  2021-01-01: true
 OR:
   2021-01-01: true
 PA:

--- a/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/asset/additional_person.yaml
+++ b/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/asset/additional_person.yaml
@@ -1,0 +1,11 @@
+description: California increases the asset limit by this amount for each additional person under the Medi-Cal 250 Percent Working Disabled Program.
+values:
+  2022-07-01: 65_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: California 250 Percent Working Disabled Program additional-person asset limit
+  reference:
+    - title: Working Disabled Program | Department of Health Care Services
+      href: https://www.dhcs.ca.gov/services/working-disabled-program/

--- a/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/asset/base.yaml
+++ b/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/asset/base.yaml
@@ -1,0 +1,17 @@
+description: California limits assets to this amount for one person under the Medi-Cal 250 Percent Working Disabled Program.
+values:
+  2022-07-01: 130_000
+  2024-01-01: .inf
+  2026-01-01: 130_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: California 250 Percent Working Disabled Program one-person asset limit
+  reference:
+    - title: Working Disabled Program | Department of Health Care Services
+      href: https://www.dhcs.ca.gov/services/working-disabled-program/
+    - title: Asset Elimination for Non-MAGI Medi-Cal
+      href: https://www.dhcs.ca.gov/services/medi-cal/eligibility/Documents/Eligibility-and-Enrollment-Plan-Asset-Test-Changes-for-Non-MAGI-MC.pdf
+    - title: Medi-Cal Program Changes 2026-2028 | Department of Health Care Services
+      href: https://www.dhcs.ca.gov/medi-cal/help/medi-cal-changes/

--- a/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/asset/max_people.yaml
+++ b/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/asset/max_people.yaml
@@ -1,0 +1,11 @@
+description: California caps the asset-limit family size at this many people under the Medi-Cal 250 Percent Working Disabled Program.
+values:
+  2022-07-01: 10
+
+metadata:
+  unit: person
+  period: year
+  label: California 250 Percent Working Disabled Program asset-limit family size cap
+  reference:
+    - title: Working Disabled Program | Department of Health Care Services
+      href: https://www.dhcs.ca.gov/services/working-disabled-program/

--- a/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/income/limit.yaml
+++ b/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/income/limit.yaml
@@ -1,0 +1,13 @@
+description: California limits net family income to this share of the federal poverty level under the Medi-Cal 250 Percent Working Disabled Program.
+values:
+  2000-04-01: 2.5
+
+metadata:
+  unit: /1
+  period: year
+  label: California 250 Percent Working Disabled Program income limit
+  reference:
+    - title: Working Disabled Program | Department of Health Care Services
+      href: https://www.dhcs.ca.gov/services/working-disabled-program/
+    - title: 250% Working Disabled Program | Los Angeles County Department of Public Social Services
+      href: https://my.dpss.lacounty.gov/public/en/home/epolicy/program/medi-cal/non-magi/250-percent-wdp.html

--- a/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/income/sources/disability.yaml
+++ b/policyengine_us/parameters/gov/states/ca/chhs/wdp/eligibility/income/sources/disability.yaml
@@ -1,0 +1,16 @@
+description: California excludes these disability income sources under the Medi-Cal 250 Percent Working Disabled Program.
+values:
+  2000-04-01:
+    - social_security_disability
+    - disability_benefits
+    - workers_compensation
+
+metadata:
+  unit: list
+  period: year
+  label: California 250 Percent Working Disabled Program disability income sources
+  reference:
+    - title: 250% Working Disabled Program | Los Angeles County Department of Public Social Services
+      href: https://my.dpss.lacounty.gov/public/en/home/epolicy/program/medi-cal/non-magi/250-percent-wdp.html
+    - title: 250% Working Disabled Program | Santa Clara County Social Services Agency
+      href: https://stgenssa.sccgov.org/debs/program_handbooks/medi-cal/assets/26250WDP/250WDP.htm

--- a/policyengine_us/parameters/gov/states/ca/chhs/wdp/premium/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ca/chhs/wdp/premium/amount.yaml
@@ -1,0 +1,11 @@
+description: California sets the Medi-Cal 250 Percent Working Disabled Program premium to this amount.
+values:
+  2022-07-01: 0
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: California 250 Percent Working Disabled Program premium
+  reference:
+    - title: Working Disabled Program | Department of Health Care Services
+      href: https://www.dhcs.ca.gov/services/working-disabled-program/

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
@@ -1,0 +1,22 @@
+- name: Case 1, medically needy maps to aged or disabled.
+  period: 2026
+  input:
+    medicaid_category: MEDICALLY_NEEDY
+  output:
+    medicaid_group: AGED_DISABLED
+
+- name: Case 2, working disabled Buy-In maps to aged or disabled.
+  period: 2026
+  input:
+    medicaid_category: WORKING_DISABLED_BUY_IN
+  output:
+    medicaid_group: AGED_DISABLED
+
+- name: Case 3, adult category takes priority over raw Buy-In eligibility for spending group.
+  period: 2026
+  input:
+    is_adult_for_medicaid: true
+    is_working_disabled_buy_in_for_medicaid: true
+  output:
+    medicaid_category: ADULT
+    medicaid_group: EXPANSION_ADULT

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_ssi_recipient_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_ssi_recipient_for_medicaid.yaml
@@ -12,3 +12,19 @@
     state_code: CT
   output:
     is_ssi_recipient_for_medicaid: false
+
+- name: Case 1, SSI recipient in Alaska qualifies through SSI criteria.
+  period: 2026
+  input:
+    ssi: 1
+    state_code: AK
+  output:
+    is_ssi_recipient_for_medicaid: true
+
+- name: Case 2, SSI recipient in Oklahoma qualifies through SSI criteria.
+  period: 2026
+  input:
+    ssi: 1
+    state_code: OK
+  output:
+    is_ssi_recipient_for_medicaid: true

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.yaml
@@ -1,0 +1,13 @@
+- name: Case 1, California WDP qualifies as working disabled Buy-In.
+  period: 2026
+  input:
+    ca_wdp_eligible: true
+  output:
+    is_working_disabled_buy_in_for_medicaid: true
+
+- name: Case 2, no state Buy-In pathway defaults to false.
+  period: 2026
+  input:
+    ca_wdp_eligible: false
+  output:
+    is_working_disabled_buy_in_for_medicaid: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_category.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_category.yaml
@@ -1,0 +1,23 @@
+- name: Case 1, medically needy category.
+  period: 2026
+  input:
+    is_adult_for_medicaid: false
+    is_medically_needy_for_medicaid: true
+  output:
+    medicaid_category: MEDICALLY_NEEDY
+
+- name: Case 2, working disabled Buy-In category.
+  period: 2026
+  input:
+    is_adult_for_medicaid: false
+    is_working_disabled_buy_in_for_medicaid: true
+  output:
+    medicaid_category: WORKING_DISABLED_BUY_IN
+
+- name: Case 3, mandatory adult category takes priority over Buy-In.
+  period: 2026
+  input:
+    is_adult_for_medicaid: true
+    is_working_disabled_buy_in_for_medicaid: true
+  output:
+    medicaid_category: ADULT

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_ssi_recipient_state_classification.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_ssi_recipient_state_classification.yaml
@@ -1,0 +1,27 @@
+- name: Case 1, California is a Section 1634 state.
+  period: 2026
+  input:
+    state_code: CA
+  output:
+    medicaid_ssi_recipient_state_classification: SECTION_1634
+
+- name: Case 2, Alaska is an SSI-criteria state.
+  period: 2026
+  input:
+    state_code: AK
+  output:
+    medicaid_ssi_recipient_state_classification: SSI_CRITERIA
+
+- name: Case 3, Oklahoma is an SSI-criteria state.
+  period: 2026
+  input:
+    state_code: OK
+  output:
+    medicaid_ssi_recipient_state_classification: SSI_CRITERIA
+
+- name: Case 4, Connecticut is a Section 209(b) state.
+  period: 2026
+  input:
+    state_code: CT
+  output:
+    medicaid_ssi_recipient_state_classification: SECTION_209B

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medically_needy/is_medically_needy_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medically_needy/is_medically_needy_for_medicaid.yaml
@@ -20,3 +20,31 @@
         state_code: MA
   output:
     is_medically_needy_for_medicaid: false
+
+- name: Case 1, disabled person qualifies after medical spenddown.
+  period: 2026
+  input:
+    is_disabled: true
+    is_in_medicaid_medically_needy_category: true
+    is_adult_for_medicaid: false
+    is_optional_senior_or_disabled_for_medicaid: false
+    ssi_countable_income: 12_000
+    medicaid_medically_needy_medical_expenses: 6_000
+    ssi_countable_resources: 1_000
+    state_code: MA
+  output:
+    is_medically_needy_for_medicaid: true
+
+- name: Case 2, disabled person above spenddown income limit is ineligible.
+  period: 2026
+  input:
+    is_disabled: true
+    is_in_medicaid_medically_needy_category: true
+    is_adult_for_medicaid: false
+    is_optional_senior_or_disabled_for_medicaid: false
+    ssi_countable_income: 13_000
+    medicaid_medically_needy_medical_expenses: 6_000
+    ssi_countable_resources: 1_000
+    state_code: MA
+  output:
+    is_medically_needy_for_medicaid: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
@@ -170,3 +170,21 @@
   output:
     medicaid_category: SENIOR_OR_DISABLED
     is_medicaid_eligible: true
+
+- name: Case 4, medically needy pathway makes a person Medicaid eligible.
+  period: 2026
+  input:
+    is_adult_for_medicaid: false
+    is_medically_needy_for_medicaid: true
+  output:
+    medicaid_category: MEDICALLY_NEEDY
+    is_medicaid_eligible: true
+
+- name: Case 5, working disabled Buy-In pathway makes a person Medicaid eligible.
+  period: 2026
+  input:
+    is_adult_for_medicaid: false
+    is_working_disabled_buy_in_for_medicaid: true
+  output:
+    medicaid_category: WORKING_DISABLED_BUY_IN
+    is_medicaid_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/medicaid_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/medicaid_premium.yaml
@@ -35,3 +35,10 @@
         state_code: MT
   output:
     medicaid_premium: 500
+
+- name: Case 3, federal Medicaid premium includes working disabled Buy-In premiums.
+  period: 2026
+  input:
+    medicaid_working_disabled_buy_in_premium: 420
+  output:
+    medicaid_premium: 420

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium.yaml
@@ -1,0 +1,13 @@
+- name: Case 1, tax unit sums monthly Buy-In premiums annually.
+  period: 2026
+  input:
+    people:
+      person1:
+        medicaid_working_disabled_buy_in_premium_person: 300
+      person2:
+        medicaid_working_disabled_buy_in_premium_person: 120
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    medicaid_working_disabled_buy_in_premium: 420

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/ca_wdp_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/ca_wdp_premium.yaml
@@ -1,0 +1,7 @@
+- name: Case 1, California WDP premium is zero after July 2022.
+  period: 2026-01
+  input:
+    state_code: CA
+    ca_wdp_eligible: true
+  output:
+    ca_wdp_premium: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/eligibility/ca_wdp_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/eligibility/ca_wdp_eligible.yaml
@@ -125,3 +125,45 @@
   output:
     ca_wdp_income_eligible: [false, true]
     ca_wdp_eligible: [false, false]
+
+- name: Case 9, joint tax filing alone does not trigger the married SSI SSP standard.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_disabled: true
+        employment_income: 1_000
+        pension_income: 20_000
+        ssi_countable_resources: 10_000
+        is_tax_unit_head: true
+        is_ssi_spousal_deeming_applies: false
+      person2:
+        age: 45
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CA
+  output:
+    ca_wdp_ssi_ssp_income_eligible: [false, true]
+    ca_wdp_eligible: [false, false]
+
+- name: Case 10, SSI spousal deeming triggers the married SSI SSP standard.
+  period: 2026
+  input:
+    state_code: CA
+    is_disabled: true
+    employment_income: 1_000
+    pension_income: 20_000
+    ssi_countable_resources: 10_000
+    is_ssi_spousal_deeming_applies: true
+  output:
+    ca_wdp_ssi_ssp_income_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/eligibility/ca_wdp_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/eligibility/ca_wdp_eligible.yaml
@@ -1,0 +1,127 @@
+- name: Case 1, disabled worker qualifies for the California 250 Percent Working Disabled Program.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_disabled: true
+        employment_income: 50_000
+        social_security_disability: 20_000
+        ssi_countable_resources: 10_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    ca_wdp_disability_eligible: true
+    ca_wdp_work_eligible: true
+    ca_wdp_income_eligible: true
+    ca_wdp_asset_eligible: true
+    ca_wdp_eligible: true
+    is_working_disabled_buy_in_for_medicaid: true
+    medicaid_category: WORKING_DISABLED_BUY_IN
+    is_medicaid_eligible: true
+
+- name: Case 2, worker above the income limit is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_disabled: true
+        employment_income: 100_000
+        ssi_countable_resources: 10_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    ca_wdp_income_eligible: false
+    ca_wdp_eligible: false
+
+- name: Case 3, disabled person with no work is ineligible.
+  period: 2026
+  input:
+    state_code: CA
+    is_disabled: true
+    social_security_disability: 20_000
+    ssi_countable_resources: 10_000
+  output:
+    ca_wdp_work_eligible: false
+    ca_wdp_eligible: false
+
+- name: Case 4, worker above the asset limit is ineligible.
+  period: 2026
+  input:
+    state_code: CA
+    is_disabled: true
+    employment_income: 20_000
+    ssi_countable_resources: 130_001
+  output:
+    ca_wdp_asset_eligible: false
+    ca_wdp_eligible: false
+
+- name: Case 5, assets do not affect eligibility while California asset tests are eliminated.
+  period: 2025
+  input:
+    state_code: CA
+    is_disabled: true
+    employment_income: 20_000
+    ssi_countable_resources: 1_000_000
+  output:
+    ca_wdp_asset_eligible: true
+    ca_wdp_eligible: true
+
+- name: Case 6, high non-disability unearned income fails the SSI SSP income screen.
+  period: 2026
+  input:
+    state_code: CA
+    is_disabled: true
+    employment_income: 1_000
+    pension_income: 20_000
+    ssi_countable_resources: 10_000
+  output:
+    ca_wdp_income_eligible: true
+    ca_wdp_ssi_ssp_income_eligible: false
+    ca_wdp_eligible: false
+
+- name: Case 7, undocumented workers fail the WDP immigration status screen.
+  period: 2026
+  input:
+    state_code: CA
+    is_disabled: true
+    employment_income: 20_000
+    immigration_status: UNDOCUMENTED
+    ssi_countable_resources: 10_000
+  output:
+    ca_wdp_immigration_status_eligible: false
+    ca_wdp_eligible: false
+
+- name: Case 8, adult applicant FPL unit does not increase for a dependent child.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_disabled: true
+        employment_income: 90_000
+        ssi_countable_resources: 10_000
+      person2:
+        age: 10
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CA
+  output:
+    ca_wdp_income_eligible: [false, true]
+    ca_wdp_eligible: [false, false]

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/income/ca_wdp_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp/income/ca_wdp_countable_income.yaml
@@ -1,0 +1,20 @@
+- name: Case 1, disability income is excluded from countable income.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    employment_income: 10_000
+    social_security_disability: 80_000
+  output:
+    ca_wdp_disability_income: 80_000
+    ca_wdp_countable_income: 4_490
+
+- name: Case 2, non-disability unearned income remains countable.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    employment_income: 10_000
+    social_security_retirement: 12_000
+  output:
+    ca_wdp_countable_income: 16_370

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
@@ -12,7 +12,7 @@ class MedicaidGroup(Enum):
 class medicaid_group(Variable):
     """Maps fine-grained Medicaid categories to broader spending groups
     Precedence order (highest → lowest):
-    1. Disabled / SSI / medically-needy → AGED_DISABLED
+    1. Disabled / SSI / medically-needy / Buy-In → AGED_DISABLED
     2. Pregnant                       → NON_EXPANSION_ADULT
     3. Parent                         → NON_EXPANSION_ADULT
     4. Young adult (19-20)            → NON_EXPANSION_ADULT
@@ -33,9 +33,14 @@ class medicaid_group(Variable):
         cat = person("medicaid_category", period)
         cats = cat.possible_values
 
-        # Disabled / SSI / medically-needy → AGED_DISABLED
+        # Follow the selected Medicaid category for newly modeled optional
+        # pathways so they do not override mandatory category precedence.
+        # Preserve existing raw SSI and optional aged/disabled cost grouping.
         disabled = (
             (cat == cats.SSI_RECIPIENT)
+            | (cat == cats.SENIOR_OR_DISABLED)
+            | (cat == cats.MEDICALLY_NEEDY)
+            | (cat == cats.WORKING_DISABLED_BUY_IN)
             | person("is_ssi_recipient_for_medicaid", period)
             | person("is_optional_senior_or_disabled_for_medicaid", period)
         )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_ssi_recipient_for_medicaid.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_ssi_recipient_for_medicaid.py
@@ -5,17 +5,25 @@ class is_ssi_recipient_for_medicaid(Variable):
     value_type = bool
     entity = Person
     label = "SSI recipients"
-    documentation = "Qualifies for Medicaid due to receiving SSI, or if in a 209(b) state, due to meeting that state's eligibility requirements."
+    documentation = (
+        "Qualifies for Medicaid due to receiving SSI in Section 1634 and "
+        "SSI-criteria states. Section 209(b) states are not blanket-covered "
+        "because they may apply criteria that are more restrictive than SSI."
+    )
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/uscode/text/42/1396a#f"
+    reference = (
+        "https://secure.ssa.gov/apps10/poms.nsf/lnx/0501715010",
+        "https://www.law.cornell.edu/uscode/text/42/1396a#f",
+    )
 
     def formula(person, period, parameters):
         state = person.household("state_code_str", period)
-        ma = parameters(period).gov.hhs.medicaid.eligibility.categories
-        is_covered = ma.ssi_recipient.is_covered[state] > 0
+        categories = parameters(period).gov.hhs.medicaid.eligibility.categories
+        is_covered = categories.ssi_recipient.is_covered[state].astype(bool)
+        classified = person("medicaid_ssi_recipient_state_classification", period)
+        classifications = classified.possible_values
+        covered_classification = (classified == classifications.SECTION_1634) | (
+            classified == classifications.SSI_CRITERIA
+        )
         receives_ssi = person("ssi", period) > 0
-        return receives_ssi & is_covered
-
-        # TODO: Implement the more restrictive SSI rules for the (9) states that require it. This is
-        # separate to the optional pathway for seniors and people with disabilities, which all states
-        # define as another way for seniors to qualify for Medicaid.
+        return receives_ssi & is_covered & covered_classification

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class is_working_disabled_buy_in_for_medicaid(Variable):
+    value_type = bool
+    entity = Person
+    label = "Working disabled Medicaid Buy-In"
+    documentation = (
+        "Whether this person qualifies for Medicaid through a working disabled "
+        "Buy-In pathway. Currently modeled pathways are California's 250% "
+        "Working Disabled Program and Illinois Health Benefits for Workers "
+        "with Disabilities."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.dhcs.ca.gov/services/working-disabled-program/",
+        "https://hfs.illinois.gov/medicalprograms/hbwd.html",
+    )
+
+    def formula(person, period, parameters):
+        ca_wdp_eligible = person("ca_wdp_eligible", period)
+        il_hbwd_eligible = person("il_hbwd_eligible", period.first_month)
+        return ca_wdp_eligible | il_hbwd_eligible

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
@@ -1,4 +1,3 @@
-from unicodedata import category
 from policyengine_us.model_api import *
 
 
@@ -13,6 +12,8 @@ class MedicaidCategory(Enum):
     SSI_RECIPIENT = "SSI recipient"
     SENIOR_OR_DISABLED = " Senior or disabled"
     NONE = "None"
+    MEDICALLY_NEEDY = "Medically needy"
+    WORKING_DISABLED_BUY_IN = "Working disabled Buy-In"
 
 
 class medicaid_category(Variable):
@@ -58,6 +59,11 @@ class medicaid_category(Variable):
             is_adult_for_medicaid=MedicaidCategory.ADULT,
             # 7. Optional aged/blind/disabled pathway (non-SSI)
             is_optional_senior_or_disabled_for_medicaid=MedicaidCategory.SENIOR_OR_DISABLED,
+            # 8. Medically needy/spenddown pathways for people otherwise
+            #    outside the mandatory or optional categorical pathways.
+            is_medically_needy_for_medicaid=MedicaidCategory.MEDICALLY_NEEDY,
+            # 9. Medicaid Buy-In pathways for working disabled people.
+            is_working_disabled_buy_in_for_medicaid=MedicaidCategory.WORKING_DISABLED_BUY_IN,
         )
 
         # Ensure parametric reforms to the list of categories prevent those

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_ssi_recipient_state_classification.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_ssi_recipient_state_classification.py
@@ -1,0 +1,38 @@
+from policyengine_us.model_api import *
+
+
+class MedicaidSSIRecipientStateClassification(Enum):
+    SECTION_1634 = "1634"
+    SSI_CRITERIA = "SSI criteria"
+    SECTION_209B = "209(b)"
+    UNKNOWN = "Unknown"
+
+
+class medicaid_ssi_recipient_state_classification(Variable):
+    value_type = Enum
+    possible_values = MedicaidSSIRecipientStateClassification
+    default_value = MedicaidSSIRecipientStateClassification.UNKNOWN
+    entity = Person
+    label = "Medicaid SSI-recipient state classification"
+    definition_period = YEAR
+    reference = "https://secure.ssa.gov/apps10/poms.nsf/lnx/0501715010"
+
+    def formula(person, period, parameters):
+        state = person.household("state_code_str", period)
+        classification = parameters(
+            period
+        ).gov.hhs.medicaid.eligibility.categories.ssi_recipient.classification
+
+        return select(
+            [
+                classification.section_1634[state].astype(bool),
+                classification.ssi_criteria[state].astype(bool),
+                classification.section_209b[state].astype(bool),
+            ],
+            [
+                MedicaidSSIRecipientStateClassification.SECTION_1634,
+                MedicaidSSIRecipientStateClassification.SSI_CRITERIA,
+                MedicaidSSIRecipientStateClassification.SECTION_209B,
+            ],
+            default=MedicaidSSIRecipientStateClassification.UNKNOWN,
+        )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medically_needy/is_medically_needy_for_medicaid.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medically_needy/is_medically_needy_for_medicaid.py
@@ -5,11 +5,21 @@ class is_medically_needy_for_medicaid(Variable):
     value_type = bool
     entity = Person
     label = "Medically needy"
+    documentation = (
+        "First-pass Medicaid medically needy/spenddown eligibility. This "
+        "models aged, blind, and disabled people in states with a medically "
+        "needy pathway for their category; applies state income and asset "
+        "limits; and subtracts modeled medical expenses from countable income. "
+        "It does not model non-ABD medically needy groups, state budget-period "
+        "timing, anticipated-expense rules, or state-specific spenddown "
+        "administration beyond the annual expense proxy."
+    )
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/cfr/text/42/part-435/subpart-D"
 
     def formula(person, period, parameters):
         in_category = person("is_in_medicaid_medically_needy_category", period)
+        is_aged_blind_or_disabled = person("is_ssi_aged_blind_disabled", period)
         personal_income = person("ssi_countable_income", period)
         medical_expenses = person("medicaid_medically_needy_medical_expenses", period)
         personal_assets = person("ssi_countable_resources", period)
@@ -37,4 +47,9 @@ class is_medically_needy_for_medicaid(Variable):
             if category != "is_medically_needy_for_medicaid"
         ]
         not_in_other_pathway = add(person, period, other_categories) == 0
-        return in_category & not_in_other_pathway & under_limits
+        return (
+            is_aged_blind_or_disabled
+            & in_category
+            & not_in_other_pathway
+            & under_limits
+        )

--- a/policyengine_us/variables/gov/hhs/medicaid/medicaid_premium.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/medicaid_premium.py
@@ -13,8 +13,10 @@ class medicaid_premium(Variable):
         "variables add their contributions. Michigan Healthy Michigan "
         "contributions were eliminated 2024-01-01 and Montana HELP premiums "
         "were eliminated 2023-01-01; Indiana HIP POWER Account contributions "
-        "have been paused since 2020-03-01. Schedules are still encoded for "
-        "reform analysis."
+        "have been paused since 2020-03-01. Working disabled Buy-In premiums "
+        "are routed through the Medicaid working disabled Buy-In premium "
+        "variable; California 250% Working Disabled Program premiums are zero "
+        "as of 2022-07-01. Schedules are still encoded for reform analysis."
     )
     definition_period = YEAR
     reference = "https://www.medicaid.gov/medicaid/section-1115-demonstrations/"
@@ -22,4 +24,5 @@ class medicaid_premium(Variable):
         "in_hip_power_account_contribution",
         "mi_healthy_michigan_contribution",
         "mt_help_premium",
+        "medicaid_working_disabled_buy_in_premium",
     ]

--- a/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class medicaid_working_disabled_buy_in_premium(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Medicaid working disabled Buy-In annual premium"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.dhcs.ca.gov/services/working-disabled-program/",
+        "https://hfs.illinois.gov/medicalprograms/hbwd/premiums.html",
+    )
+
+    def formula(tax_unit, period, parameters):
+        monthly_premiums = tax_unit.members(
+            "medicaid_working_disabled_buy_in_premium_person",
+            period.first_month,
+        )
+        return tax_unit.sum(monthly_premiums) * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium_person.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium_person.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class medicaid_working_disabled_buy_in_premium_person(Variable):
+    value_type = float
+    entity = Person
+    label = "Medicaid working disabled Buy-In monthly premium per person"
+    unit = USD
+    definition_period = MONTH
+    reference = (
+        "https://www.dhcs.ca.gov/services/working-disabled-program/",
+        "https://hfs.illinois.gov/medicalprograms/hbwd/premiums.html",
+    )
+
+    adds = [
+        "ca_wdp_premium",
+        "il_hbwd_premium",
+    ]

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/ca_wdp_premium.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/ca_wdp_premium.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_premium(Variable):
+    value_type = float
+    entity = Person
+    label = "California 250 Percent Working Disabled Program monthly premium"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://www.dhcs.ca.gov/services/working-disabled-program/"
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ca.chhs.wdp.premium
+        eligible = person("ca_wdp_eligible", period.this_year)
+        return eligible * p.amount

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_asset_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_asset_eligible.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_asset_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "California 250 Percent Working Disabled Program asset eligible"
+    definition_period = YEAR
+    reference = "https://www.dhcs.ca.gov/services/working-disabled-program/"
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ca.chhs.wdp.eligibility.asset
+        countable_resources = person.tax_unit.sum(
+            person("ssi_countable_resources", period)
+        )
+        tax_unit_size = person.tax_unit("tax_unit_size", period)
+        capped_size = min_(tax_unit_size, p.max_people)
+        asset_limit = p.base + max_(capped_size - 1, 0) * p.additional_person
+        return countable_resources <= asset_limit

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_disability_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_disability_eligible.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_disability_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "California 250 Percent Working Disabled Program disability eligible"
+    definition_period = YEAR
+    reference = "https://www.dhcs.ca.gov/services/working-disabled-program/"
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        is_disabled = person("is_disabled", period)
+        is_blind = person("is_blind", period)
+        receives_ssdi = person("social_security_disability", period) > 0
+        return is_disabled | is_blind | receives_ssdi

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_eligible.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "California 250 Percent Working Disabled Program eligible"
+    definition_period = YEAR
+    documentation = (
+        "Eligibility for California's 250% Working Disabled Program. The model "
+        "covers disability status without an SGA screen, paid work, net family "
+        "income below 250% FPL, a first-pass SSI/SSP income screen without "
+        "earnings, SSI/SSP immigration status, and current and historical asset "
+        "limits. County enrollment verification, full SSI/SSP deeming, and "
+        "temporary unemployment continuation are not modeled."
+    )
+    reference = (
+        "https://www.dhcs.ca.gov/services/working-disabled-program/",
+        "https://my.dpss.lacounty.gov/public/en/home/epolicy/program/medi-cal/non-magi/250-percent-wdp.html",
+    )
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        return (
+            person("ca_wdp_disability_eligible", period)
+            & person("ca_wdp_work_eligible", period)
+            & person("ca_wdp_income_eligible", period)
+            & person("ca_wdp_ssi_ssp_income_eligible", period)
+            & person("ca_wdp_immigration_status_eligible", period)
+            & person("ca_wdp_asset_eligible", period)
+        )

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_immigration_status_eligible.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_immigration_status_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = (
+        "California 250 Percent Working Disabled Program immigration status eligible"
+    )
+    definition_period = YEAR
+    documentation = (
+        "Whether this person meets the SSI/SSP immigration-status screen for "
+        "California's 250% Working Disabled Program. This is narrower than "
+        "California's broader full-scope Medi-Cal immigration rules."
+    )
+    reference = (
+        "https://stgenssa.sccgov.org/debs/program_handbooks/medi-cal/assets/26250WDP/ElgCriteria.htm",
+    )
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        qualified_noncitizen = person("is_ssi_qualified_noncitizen", period)
+        immigration_status = person("immigration_status", period)
+        citizen = immigration_status == immigration_status.possible_values.CITIZEN
+        return citizen | qualified_noncitizen

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_income_eligible.py
@@ -1,0 +1,38 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_income_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "California 250 Percent Working Disabled Program income eligible"
+    definition_period = YEAR
+    documentation = (
+        "Whether this person passes the California 250% Working Disabled "
+        "Program net family income test. This first-pass model uses the "
+        "applicant's income plus spouse income only when SSI spousal deeming "
+        "applies, and caps the FPL unit at the applicant plus spouse. Parent "
+        "deeming for child applicants is not modeled."
+    )
+    reference = "https://www.dhcs.ca.gov/services/working-disabled-program/"
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ca.chhs.wdp.eligibility.income
+        personal_income = person("ca_wdp_countable_income", period)
+        spouse_income = person.marital_unit.sum(personal_income) - personal_income
+        spousal_deeming_applies = person("is_ssi_spousal_deeming_applies", period)
+        countable_income = personal_income + where(
+            spousal_deeming_applies,
+            spouse_income,
+            0,
+        )
+
+        fpg = parameters(period).gov.hhs.fpg
+        state_group = person.household("state_group_str", period)
+        unit_size = where(spousal_deeming_applies, 2, 1)
+        fpg_amount = (
+            fpg.first_person[state_group]
+            + (unit_size - 1) * fpg.additional_person[state_group]
+        )
+        income_limit = fpg_amount * p.limit
+        return countable_income < income_limit

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_ssi_ssp_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_ssi_ssp_income_eligible.py
@@ -36,9 +36,11 @@ class ca_wdp_ssi_ssp_income_eligible(Variable):
         p = parameters(
             period.first_month
         ).gov.states.ca.cdss.state_supplement.payment_standard
-        is_joint = person.tax_unit("tax_unit_is_joint", period)
+        uses_couple_standard = person("ssi_claim_is_joint", period) | person(
+            "is_ssi_spousal_deeming_applies", period
+        )
         monthly_standard = where(
-            is_joint,
+            uses_couple_standard,
             p.aged_or_disabled.amount.married,
             p.aged_or_disabled.amount.single,
         )

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_ssi_ssp_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_ssi_ssp_income_eligible.py
@@ -1,0 +1,45 @@
+from policyengine_us.model_api import *
+from policyengine_us.variables.gov.ssa.ssi.eligibility.income._apply_ssi_exclusions import (
+    _apply_ssi_exclusions,
+)
+
+
+class ca_wdp_ssi_ssp_income_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "California 250 Percent Working Disabled Program SSI/SSP income eligible"
+    definition_period = YEAR
+    documentation = (
+        "Whether this person passes a first-pass SSI/SSP income screen for "
+        "California's 250% Working Disabled Program after disregarding modeled "
+        "earned income and modeled disability income. This approximates the "
+        "program requirement that a person would be SSI/SSP-eligible if not "
+        "for earned income; full SSI/SSP deeming is not modeled here."
+    )
+    reference = (
+        "https://www.dhcs.ca.gov/services/working-disabled-program/",
+        "https://my.dpss.lacounty.gov/public/en/home/epolicy/program/medi-cal/non-magi/250-percent-wdp.html",
+    )
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        unearned_income = person("ssi_unearned_income", period)
+        disability_income = person("ca_wdp_disability_income", period)
+        non_exempt_unearned_income = max_(unearned_income - disability_income, 0)
+        countable_unearned_income = _apply_ssi_exclusions(
+            0,
+            non_exempt_unearned_income,
+            parameters,
+            period,
+        )
+
+        p = parameters(
+            period.first_month
+        ).gov.states.ca.cdss.state_supplement.payment_standard
+        is_joint = person.tax_unit("tax_unit_is_joint", period)
+        monthly_standard = where(
+            is_joint,
+            p.aged_or_disabled.amount.married,
+            p.aged_or_disabled.amount.single,
+        )
+        return countable_unearned_income < monthly_standard * MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_work_eligible.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/eligibility/ca_wdp_work_eligible.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_work_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "California 250 Percent Working Disabled Program work eligible"
+    definition_period = YEAR
+    reference = "https://www.dhcs.ca.gov/services/working-disabled-program/"
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        return person("ca_wdp_gross_earned_income", period) > 0

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/income/ca_wdp_countable_income.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/income/ca_wdp_countable_income.py
@@ -1,0 +1,36 @@
+from policyengine_us.model_api import *
+from policyengine_us.variables.gov.ssa.ssi.eligibility.income._apply_ssi_exclusions import (
+    _apply_ssi_exclusions,
+)
+
+
+class ca_wdp_countable_income(Variable):
+    value_type = float
+    entity = Person
+    label = "California 250 Percent Working Disabled Program countable income"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "Countable income for California's 250% Working Disabled Program. "
+        "This applies SSI earned-income exclusions to earned income and "
+        "excludes modeled disability income from unearned income. Retained "
+        "earned income accounts and converted retirement-income edge cases are "
+        "not modeled."
+    )
+    reference = (
+        "https://my.dpss.lacounty.gov/public/en/home/epolicy/program/medi-cal/non-magi/250-percent-wdp.html",
+        "https://stgenssa.sccgov.org/debs/program_handbooks/medi-cal/assets/26250WDP/250WDP.htm",
+    )
+    defined_for = StateCode.CA
+
+    def formula(person, period, parameters):
+        earned_income = person("ca_wdp_gross_earned_income", period)
+        unearned_income = person("ssi_unearned_income", period)
+        disability_income = person("ca_wdp_disability_income", period)
+        non_exempt_unearned_income = max_(unearned_income - disability_income, 0)
+        return _apply_ssi_exclusions(
+            earned_income,
+            non_exempt_unearned_income,
+            parameters,
+            period,
+        )

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/income/ca_wdp_disability_income.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/income/ca_wdp_disability_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_disability_income(Variable):
+    value_type = float
+    entity = Person
+    label = "California 250 Percent Working Disabled Program disability income"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://my.dpss.lacounty.gov/public/en/home/epolicy/program/medi-cal/non-magi/250-percent-wdp.html"
+    defined_for = StateCode.CA
+
+    adds = "gov.states.ca.chhs.wdp.eligibility.income.sources.disability"

--- a/policyengine_us/variables/gov/states/ca/chhs/wdp/income/ca_wdp_gross_earned_income.py
+++ b/policyengine_us/variables/gov/states/ca/chhs/wdp/income/ca_wdp_gross_earned_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class ca_wdp_gross_earned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "California 250 Percent Working Disabled Program gross earned income"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.dhcs.ca.gov/services/working-disabled-program/"
+    defined_for = StateCode.CA
+
+    adds = "gov.ssa.ssi.income.sources.earned"


### PR DESCRIPTION
## Summary

This PR adds and wires several missing Medicaid optional eligibility pathways:

- Adds SSI-recipient state classification for Section 1634, SSI-criteria, and 209(b) states, and avoids treating 209(b) SSI receipt as automatic Medicaid eligibility.
- Wires the existing medically needy logic into Medicaid category selection, scoped to aged/blind/disabled people for this first pass.
- Adds the federal working-disabled Buy-In category and premiums aggregate, including California's 250% Working Disabled Program and existing Illinois HBWD premiums.
- Maps medically needy, SSI-recipient, and working-disabled Buy-In enrollees into the aged/disabled Medicaid cost group.

Related to #8361, #8362, and #8363.

## Microsimulation impact

Using the 2026 national default `Microsimulation`, compared with a pre-change counterfactual that removes the newly covered pathways and restores the prior Oklahoma SSI setting:

- Medicaid eligible people: +390.7k
- Medicaid enrolled people: +376.1k
- Medicaid modeled cost/benefit: +$8.41B
- ACA PTC eligible people: -341.2k
- ACA PTC: -$1.69B
- Net Medicaid + ACA PTC: +$6.72B

Pathway drivers:

- Working disabled Buy-In category: +369.2k newly eligible
- Medically needy category: +21.5k newly eligible
- Oklahoma SSI-recipient pathway: 79.3k people
- California WDP eligible: 370.2k people
- Illinois HBWD eligible, January: 5.1k people

## Validation

- `uv run ruff check policyengine_us/variables/gov/hhs/medicaid policyengine_us/variables/gov/states/ca/chhs/wdp`
- `uv run ruff format --check policyengine_us/variables/gov/hhs/medicaid policyengine_us/variables/gov/states/ca/chhs/wdp`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ca/chhs/wdp -c policyengine_us`
- `git diff --check HEAD~1 HEAD`
