### PR TITLE
Add Medicaid CE SNAP/TANF pass-through

### DIFF
--- a/changelog.d/added/issue-8267-medicaid-ce-pass-through.md
+++ b/changelog.d/added/issue-8267-medicaid-ce-pass-through.md
@@ -1,0 +1,1 @@
+Added Medicaid community engagement pass-through eligibility for SNAP and TANF work-compliance determinations.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
@@ -194,6 +194,7 @@
   input:
     medicaid_category: ADULT
     immigration_status: CITIZEN
+    medicaid_community_engagement_pass_through_eligible: false
   output:
     is_medicaid_eligible: false
 

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.yaml
@@ -1,0 +1,98 @@
+- name: Case 1, SNAP household member subject to work rules passes through.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        weekly_hours_worked_before_lsr: 35
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 100
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    medicaid_community_engagement_pass_through_eligible: true
+
+- name: Case 2, TANF work compliance passes through without SNAP.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        weekly_hours_worked_before_lsr: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        is_tanf_enrolled: true
+        meets_tanf_work_requirements: true
+    households:
+      household:
+        members: [person1]
+        state_code: DC
+  output:
+    medicaid_community_engagement_pass_through_eligible: true
+
+- name: Case 3, no SNAP or TANF pass-through fails.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        weekly_hours_worked_before_lsr: 35
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    medicaid_community_engagement_pass_through_eligible: false
+
+- name: Case 4, SNAP member exempt from work registration does not pass through.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_disabled: true
+        weekly_hours_worked_before_lsr: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 100
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    medicaid_community_engagement_pass_through_eligible: false
+
+- name: Case 5, child in SNAP household is exempt from work rules.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        weekly_hours_worked_before_lsr: 35
+      person2:
+        age: 10
+        is_tax_unit_dependent: true
+        weekly_hours_worked_before_lsr: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 100
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    medicaid_community_engagement_pass_through_eligible: [true, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -16,6 +16,7 @@
   period: 2026
   input:
     age: 19
+    medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: false
 
@@ -24,6 +25,7 @@
   input:
     age: 30
     monthly_hours_worked: 79
+    medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: false
 
@@ -52,10 +54,12 @@
         age: 30
         is_tax_unit_head_or_spouse: true
         monthly_hours_worked: 80
+        medicaid_community_engagement_pass_through_eligible: false
       person2:
         age: 30
         is_tax_unit_head_or_spouse: true
         monthly_hours_worked: 79
+        medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: [true, false]
 
@@ -81,9 +85,11 @@
         age: 30
         is_tax_unit_head_or_spouse: true
         monthly_hours_worked: 0
+        medicaid_community_engagement_pass_through_eligible: false
       person2:
         age: 14
         is_tax_unit_dependent: true
+        medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: [false, true]
 
@@ -135,3 +141,21 @@
     has_indian_health_service_coverage_at_interview: true
   output:
     medicaid_work_requirement_eligible: true
+
+- name: Case 16, pass-through satisfies Medicaid work requirement.
+  period: 2026
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    medicaid_community_engagement_pass_through_eligible: true
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 17, no direct hours or pass-through fails.
+  period: 2026
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.yaml
@@ -1,0 +1,68 @@
+- name: Case 1, DC TANF work compliance is reused.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        is_tax_unit_head_or_spouse: true
+        weekly_hours_worked: 30
+      person2:
+        is_tax_unit_head_or_spouse: true
+        weekly_hours_worked: 5
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: DC
+  output:
+    meets_tanf_work_requirements: true
+
+- name: Case 2, Montana TANF work compliance is reused.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        weekly_hours_worked: 33
+      person2:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        weekly_hours_worked: 33
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MT
+  output:
+    meets_tanf_work_requirements: true
+
+- name: Case 3, no modeled state TANF work compliance defaults false.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        weekly_hours_worked: 40
+    spm_units:
+      spm_unit:
+        members: [person1]
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    meets_tanf_work_requirements: false

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.py
@@ -1,0 +1,47 @@
+from policyengine_us.model_api import *
+
+
+class medicaid_community_engagement_pass_through_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Medicaid community engagement pass-through eligibility"
+    definition_period = MONTH
+    reference = (
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6",
+    )
+
+    def formula(person, period, parameters):
+        snap_work = parameters(period).gov.usda.snap.work_requirements
+        snap = person.spm_unit("snap", period) > 0
+        tanf = person.spm_unit("is_tanf_enrolled", period)
+
+        age = person("monthly_age", period)
+        snap_age_exempt = snap_work.general.age_threshold.exempted.calc(age)
+        snap_non_age_exempt = person("is_snap_work_registration_exempt_non_age", period)
+        general_work_compliant = person("meets_snap_general_work_requirements", period)
+        abawd_work_compliant = person("meets_snap_abawd_work_requirements", period)
+        hr1_in_effect = person("is_snap_abawd_hr1_in_effect", period)
+        pre_hr1_abawd = parameters("2025-06-01").gov.usda.snap.work_requirements.abawd
+        is_dependent = person("is_tax_unit_dependent", period)
+        dependent_age_threshold = where(
+            hr1_in_effect,
+            snap_work.abawd.age_threshold.dependent,
+            pre_hr1_abawd.age_threshold.dependent,
+        )
+        has_dependent_child = person.spm_unit.any(
+            is_dependent & (age < dependent_age_threshold)
+        )
+        snap_work_compliant = where(
+            has_dependent_child,
+            general_work_compliant,
+            general_work_compliant & abawd_work_compliant,
+        )
+        snap_pass_through = (
+            snap & ~snap_age_exempt & ~snap_non_age_exempt & snap_work_compliant
+        )
+
+        tanf_pass_through = tanf & person.spm_unit(
+            "meets_tanf_work_requirements", period
+        )
+        return snap_pass_through | tanf_pass_through

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -27,6 +27,10 @@ class medicaid_work_requirement_eligible(Variable):
         is_enrolled_at_least_half_time = person(
             "is_full_time_student", period
         ) | person("is_part_time_college_student", period)
+        pass_through_eligible = person(
+            "medicaid_community_engagement_pass_through_eligible",
+            period.first_month,
+        )
         # Pregnant or postpartum medical assistance.
         is_pregnant_or_postpartum = person("is_pregnant_for_medicaid_nfc", period)
         # Has attained age of 19 and is under 65 is require to work p.693 (bb)
@@ -65,6 +69,7 @@ class medicaid_work_requirement_eligible(Variable):
         )
         exempted_from_work = (
             is_enrolled_at_least_half_time
+            | pass_through_eligible
             | is_pregnant_or_postpartum
             | former_foster_care_youth
             | has_ihs_coverage

--- a/policyengine_us/variables/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.py
+++ b/policyengine_us/variables/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+STATE_TANF_WORK_REQUIREMENT_VARIABLES = [
+    "dc_tanf_meets_work_requirements",
+    "mt_tanf_meets_work_requirements",
+]
+
+
+class meets_tanf_work_requirements(Variable):
+    value_type = bool
+    entity = SPMUnit
+    label = "TANF work requirement compliance"
+    definition_period = MONTH
+    reference = (
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6",
+    )
+
+    def formula(spm_unit, period, parameters):
+        return add(spm_unit, period, STATE_TANF_WORK_REQUIREMENT_VARIABLES) > 0


### PR DESCRIPTION
## Summary

Fixes PolicyEngine/policyengine-us#8267 by adding a Medicaid community engagement pass-through for SNAP and TANF work-compliance determinations.

## Regulatory Authority

- H.R. 1, 119th Congress, section 71119, adding Social Security Act section 1902(xx).
- CMS CMCS Informational Bulletin, December 8, 2025: https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6

## Implementation

- Adds `medicaid_community_engagement_pass_through_eligible`, a monthly person-level Medicaid CE primitive.
- Uses person-level SNAP work primitives instead of the household-wide `meets_snap_work_requirements` output, avoiding the issue #8139 dependency.
- Adds `meets_tanf_work_requirements`, an SPM-unit bridge over existing DC and Montana TANF work-compliance variables.
- Wires the pass-through into `medicaid_work_requirement_eligible` through `period.first_month`.

## Requirements Coverage

| Requirement | Coverage |
|---|---|
| Medicaid CE pass-through primitive | `medicaid_community_engagement_pass_through_eligible` |
| SNAP-only pass-through | SNAP receipt plus person-level SNAP work compliance tests |
| TANF-only pass-through | `is_tanf_enrolled` plus `meets_tanf_work_requirements` tests |
| No-pass-through cases | SNAP/TANF negative tests and Medicaid work requirement false paths |
| Avoid #8139 dependency | Does not consume `meets_snap_work_requirements` |

## Not Modeled

- Application or renewal lookback periods.
- CMS reliable-data verification workflows.
- New TANF work-requirement formulas for states without existing state TANF work variables.
- SNAP household-wide work-requirement bug #8139.

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml policyengine_us/tests/policy/baseline/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.yaml -c policyengine_us`
  - 25 passed.
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml policyengine_us/tests/policy/baseline/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.yaml -c policyengine_us`
  - 47 passed.
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs -c policyengine_us`
  - 607 passed.
- `uv run --extra dev ruff format policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.py policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py policyengine_us/variables/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.py`
  - 3 files left unchanged.
- `uv run --extra dev ruff check policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.py policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py policyengine_us/variables/gov/hhs/tanf/cash/eligibility/meets_tanf_work_requirements.py`
  - All checks passed.
- `uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_system_import.py -q`
  - 10 passed.
- `git diff --check upstream/main...HEAD`
  - Passed.
