### PR TITLE
Model Medicaid CE recent incarceration exception

### DIFF
--- a/changelog.d/8268.fixed.md
+++ b/changelog.d/8268.fixed.md
@@ -1,0 +1,1 @@
+Model the recent incarceration exception for Medicaid community engagement requirements.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -176,3 +176,32 @@
     medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: false
+
+- name: Case 20, current incarceration exempts a person from Medicaid work requirements.
+  period: 2026
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    is_incarcerated: true
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 21, recent incarceration exempts a person from Medicaid work requirements.
+  period: 2026
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    was_recently_incarcerated_for_medicaid_ce: true
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 22, no incarceration exception leaves a nonworking person ineligible.
+  period: 2026
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    medicaid_community_engagement_pass_through_eligible: false
+    is_incarcerated: false
+    was_recently_incarcerated_for_medicaid_ce: false
+  output:
+    medicaid_work_requirement_eligible: false

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -61,7 +61,11 @@ class medicaid_work_requirement_eligible(Variable):
         is_blind = person("is_blind", period)
         is_incapable_of_self_care = person("is_incapable_of_self_care", period)
         eligible_disabled = is_blind | is_disabled | is_incapable_of_self_care
+        # Current and recent incarceration exclusions/exceptions.
         is_incarcerated = person("is_incarcerated", period)
+        was_recently_incarcerated = person(
+            "was_recently_incarcerated_for_medicaid_ce", period
+        )
         # parent, guardian, caretaker of a dependent child 13 years of age or under  p.694 (III)
         child_age_eligible = age <= p.dependent_age_limit
         has_eligible_dependent_child = person.tax_unit.any(
@@ -78,6 +82,7 @@ class medicaid_work_requirement_eligible(Variable):
             | eligible_veteran
             | eligible_disabled
             | is_incarcerated
+            | was_recently_incarcerated
         )
         meets_base_requirement = (
             meets_monthly_work_hours | meets_monthly_income | exempted_from_work

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/was_recently_incarcerated_for_medicaid_ce.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/was_recently_incarcerated_for_medicaid_ce.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class was_recently_incarcerated_for_medicaid_ce(Variable):
+    value_type = bool
+    entity = Person
+    label = "Was recently incarcerated for Medicaid community engagement"
+    documentation = (
+        "Whether the person was an inmate of a public institution at any point "
+        "during the three-month period relevant to the Medicaid community "
+        "engagement incarceration exception."
+    )
+    definition_period = YEAR
+    default_value = False
+    reference = (
+        "https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=238",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/"
+        "cib12082025.pdf#page=6",
+    )


### PR DESCRIPTION
## Summary

Fixes #8268 by modeling the Medicaid community engagement incarceration exclusion/exception.

## Regulatory Authority

- Public Law 119-21, Section 71119, mandatory exceptions: https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=238
- Public Law 119-21, Section 71119, specified excluded individuals: https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=242
- CMS CMCS Informational Bulletin, December 8, 2025: https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6

## Modeled Scope

| Requirement | Implementation | Tests |
|---|---|---|
| Current inmate exclusion | `medicaid_work_requirement_eligible` reads existing `is_incarcerated` | Case 10 |
| Three-month recent-incarceration exception | New `was_recently_incarcerated_for_medicaid_ce` input and CE rollup condition | Case 11 |
| No incarceration fallback | No current/recent incarceration leaves nonworking adult ineligible | Case 12 |

## Not Modeled

- Date-based application-month lookback logic.
- Operational verification or documentation workflows.

## Validation

- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml -c policyengine_us -v`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility -c policyengine_us`
- `uv run --extra dev ruff format .`
- `uv run --extra dev ruff check .`

## Files Added

- `policyengine_us/variables/gov/hhs/medicaid/eligibility/was_recently_incarcerated_for_medicaid_ce.py`
- `changelog.d/8268.fixed.md`
- `sources/working_references.md`
