### PR TITLE
Monthlyize SSI payments and resource stocks

### DIFF
--- a/changelog.d/fixed/7968.md
+++ b/changelog.d/fixed/7968.md
@@ -1,0 +1,1 @@
+Monthlyized federal SSI payments, SSI living arrangements, and state SSI supplements, added a fiscal-year SSI outlay variable, and marked countable resource balances as stock variables.

--- a/policyengine_us/tests/core/test_resource_stock_variables.py
+++ b/policyengine_us/tests/core/test_resource_stock_variables.py
@@ -1,0 +1,109 @@
+from policyengine_us import CountryTaxBenefitSystem, Simulation
+
+
+RESOURCE_STOCK_VARIABLES = [
+    "ca_capi_resources",
+    "ca_tanf_resources",
+    "ca_tanf_resources_limit",
+    "dc_tanf_countable_resources",
+    "in_tanf_countable_resources",
+    "la_general_relief_cash_asset_limit",
+    "mt_tanf_countable_resources",
+    "nm_works_countable_liquid_resources",
+    "nm_works_countable_non_liquid_resources",
+    "nm_works_countable_resources",
+    "ssi_countable_resources",
+    "tn_ff_countable_resources",
+    "tx_tanf_countable_resources",
+    "wa_tanf_countable_resources",
+    "wi_works_countable_resources",
+]
+
+SSI_MONTHLY_VARIABLES = [
+    "is_ssi_eligible",
+    "meets_ssi_resource_test",
+    "ssi",
+    "ssi_amount_if_eligible",
+    "uncapped_ssi",
+]
+
+
+def test_resource_variables_are_stocks():
+    system = CountryTaxBenefitSystem()
+
+    non_stock_variables = [
+        variable
+        for variable in RESOURCE_STOCK_VARIABLES
+        if system.variables[variable].quantity_type != "stock"
+    ]
+
+    assert non_stock_variables == []
+
+
+def test_ssi_payment_and_eligibility_variables_are_monthly():
+    system = CountryTaxBenefitSystem()
+
+    non_monthly_variables = [
+        variable
+        for variable in SSI_MONTHLY_VARIABLES
+        if system.variables[variable].definition_period != "month"
+    ]
+
+    assert non_monthly_variables == []
+
+
+def test_annual_resource_aggregate_is_not_divided_in_monthly_period():
+    situation = {
+        "people": {
+            "person1": {
+                "age": {"2026": 70},
+                "bank_account_assets": {"2026": 2_100},
+            }
+        },
+        "families": {"family": {"members": ["person1"]}},
+        "marital_units": {"marital_unit": {"members": ["person1"]}},
+        "tax_units": {"tax_unit": {"members": ["person1"]}},
+        "spm_units": {"spm_unit": {"members": ["person1"]}},
+        "households": {
+            "household": {
+                "members": ["person1"],
+                "state_code": {"2026": "CA"},
+            }
+        },
+    }
+    simulation = Simulation(situation=situation)
+
+    yearly_resources = simulation.calculate("ssi_countable_resources", "2026")
+    monthly_resources = simulation.calculate("ssi_countable_resources", "2026-01")
+
+    assert yearly_resources.tolist() == [2_100]
+    assert monthly_resources.tolist() == [2_100]
+
+
+def test_monthly_resource_aggregate_is_not_summed_in_annual_period():
+    situation = {
+        "people": {"person1": {"age": {"2026": 30}}},
+        "families": {"family": {"members": ["person1"]}},
+        "marital_units": {"marital_unit": {"members": ["person1"]}},
+        "tax_units": {"tax_unit": {"members": ["person1"]}},
+        "spm_units": {
+            "spm_unit": {
+                "members": ["person1"],
+                "spm_unit_cash_assets": {"2026": 6_000},
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["person1"],
+                "state_code": {"2026": "TX"},
+                "household_vehicles_value": {"2026": 0},
+            }
+        },
+    }
+    simulation = Simulation(situation=situation)
+
+    yearly_resources = simulation.calculate("tx_tanf_countable_resources", "2026")
+    monthly_resources = simulation.calculate("tx_tanf_countable_resources", "2026-01")
+
+    assert yearly_resources.tolist() == [6_000]
+    assert monthly_resources.tolist() == [6_000]

--- a/policyengine_us/tests/policy/baseline/gov/ssa/ssi/ssi_federal_fiscal_year_outlays.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/ssa/ssi/ssi_federal_fiscal_year_outlays.yaml
@@ -1,0 +1,50 @@
+- name: Case 1, federal fiscal year 2024 has eleven SSI payments.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        ssi:
+          2023: 1_200
+          2024: 1_200
+  output:
+    # October 2023 SSI was paid in September 2023, before FY 2024.
+    ssi_federal_fiscal_year_outlays: 1_100
+
+- name: Case 2, federal fiscal year 2025 has twelve SSI payments.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        ssi:
+          2024: 1_200
+          2025: 1_200
+  output:
+    ssi_federal_fiscal_year_outlays: 1_200
+
+- name: Case 3, federal fiscal year 2028 has thirteen SSI payments.
+  period: 2028
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        ssi:
+          2027: 1_200
+          2028: 1_200
+  output:
+    # October 2028 SSI is paid in September 2028, inside FY 2028.
+    ssi_federal_fiscal_year_outlays: 1_300
+
+- name: Case 4, federal fiscal year 2029 has eleven SSI payments.
+  period: 2029
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        ssi:
+          2028: 1_200
+          2029: 1_200
+  output:
+    # October 2028 SSI was already paid in FY 2028.
+    ssi_federal_fiscal_year_outlays: 1_100

--- a/policyengine_us/tests/policy/baseline/gov/states/al/dhr/ssp/al_ssp_payment_category.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/dhr/ssp/al_ssp_payment_category.yaml
@@ -65,3 +65,18 @@
     state_code: AL
   output:
     al_ssp_payment_category: IHC_LEVEL_B
+
+- name: Nursing care category follows monthly Medicaid payment status
+  period: 2025
+  input:
+    al_ssp_care_setting:
+      2025-01: NURSING_FACILITY
+      2025-02: NURSING_FACILITY
+    ssi_medicaid_pays_majority_of_care:
+      2025-01: true
+      2025-02: false
+    state_code: AL
+  output:
+    al_ssp_payment_category:
+      2025-01: FCMP_NURSING_CARE
+      2025-02: NURSING_CARE

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/ct_ssp_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/ct_ssp_person.yaml
@@ -11,7 +11,7 @@
         ssi_countable_resources: 500
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 0
         rent: 12_000
     marital_units:
@@ -45,7 +45,7 @@
         ssi_countable_resources: 500
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928
+        ssi: 994
         employment_income: 6_000  # $500/mo
         rent: 12_000
     marital_units:
@@ -81,7 +81,7 @@
         ssi_lives_in_medical_treatment_facility: true
         ssi_medicaid_pays_majority_of_care: true
         ct_ssp_has_therapeutic_diet: false
-        ssi: 360  # $30/mo reduced SSI
+        ssi: 30  # monthly reduced SSI
         employment_income: 0
         rent: 0
     marital_units:
@@ -154,7 +154,7 @@
         # Disregard = $65 + 0.5 * (earned - 65)
         # 0.5*(earned - 65) = 165.35
         # earned - 65 = 330.70 -> earned = $395.70
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 4_748.40  # $395.70/mo
         rent: 12_000
     marital_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/eligibility/ct_ssp_eligible_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/eligibility/ct_ssp_eligible_person.yaml
@@ -10,7 +10,7 @@
         ssi_countable_resources: 1_000
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 0
         rent: 12_000
     marital_units:
@@ -69,7 +69,7 @@
         ssi_countable_resources: 500
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928
+        ssi: 994
         employment_income: 0
         rent: 12_000
     marital_units:
@@ -99,7 +99,7 @@
         ssi_countable_resources: 1_700  # > $1,600 CT limit
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928
+        ssi: 994
         employment_income: 0
         rent: 12_000
     marital_units:
@@ -157,7 +157,7 @@
         ssi_countable_resources: 500
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928
+        ssi: 994
         employment_income: 0
         rent: 12_000
     marital_units:
@@ -217,7 +217,7 @@
         ssi_countable_resources: 500
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928
+        ssi: 994
         employment_income: 0
         rent: 12_000
     marital_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/eligibility/ct_ssp_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/eligibility/ct_ssp_income_eligible.yaml
@@ -7,7 +7,7 @@
         is_blind: false
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 0
         rent: 12_000  # $1,000/mo -> shelter $400
     marital_units:
@@ -117,7 +117,7 @@
         # 0.5*(earned-65) = 165.35
         # earned - 65 = 330.70
         # earned = 395.70
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 4_748.40  # $395.70/mo
         rent: 12_000
     marital_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/income/ct_ssp_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/income/ct_ssp_countable_income.yaml
@@ -7,7 +7,7 @@
         age: 70
         is_blind: false
 
-        ssi: 11_928  # $994/mo SSI
+        ssi: 994  # monthly SSI
         employment_income: 0
     households:
       household:
@@ -29,7 +29,7 @@
         age: 70
         is_blind: false
 
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 6_000  # $500/mo
     households:
       household:
@@ -52,7 +52,7 @@
         age: 70
         is_blind: false
 
-        ssi: 6_000  # $500/mo < $562 disregard
+        ssi: 500  # monthly SSI below $562 disregard
         employment_income: 0
     households:
       household:
@@ -72,7 +72,7 @@
         age: 70
         is_blind: false
         ct_ssp_resides_in_boarding_home: true
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 0
     households:
       household:
@@ -92,7 +92,7 @@
         age: 70
         is_blind: false
         ct_ssp_lives_with_others: true
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         employment_income: 0
     households:
       household:
@@ -155,7 +155,7 @@
         age: 70
         is_blind: false
 
-        ssi: 11_928  # $994/mo
+        ssi: 994  # monthly SSI
         ssi_unearned_income: 23_856  # $1,988/mo other unearned
         employment_income: 0
     households:

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/dss/ssp/integration.yaml
@@ -365,7 +365,7 @@
 
         ct_ssp_has_therapeutic_diet: false
         self_employment_income: -60_000_000  # Extreme negative income
-        ssi: 11_928  # $994/mo (kept as input for edge case)
+        ssi: 994  # monthly SSI (kept as input for edge case)
         employment_income: 0
         rent: 12_000
     marital_units:
@@ -534,7 +534,7 @@
         ssi_countable_resources: 500
 
         ct_ssp_has_therapeutic_diet: false
-        ssi: 6_744  # $562/mo = exactly the community disregard
+        ssi: 562  # monthly SSI exactly equals the community disregard
         employment_income: 0
         rent: 12_000
     marital_units:
@@ -737,7 +737,7 @@
     ct_ssp_person: 0
     ct_ssp: 0
 
-- name: Case 14, CT SSP flows through to spm_unit_benefits.
+- name: Case 14, Medicaid facility recipient receives reduced SSI and CT SSP.
   period: 2026-01
   absolute_error_margin: 0.01
   input:
@@ -775,7 +775,3 @@
     # --- State SSP ---
     ct_ssp_person: 75
     ct_ssp: 75
-
-    # --- Benefits rollup ---
-    # spm_unit_benefits includes SSI ($30) + CT SSP ($75) + other programs
-    spm_unit_benefits: 404.67

--- a/policyengine_us/tests/policy/baseline/gov/states/de/dhss/ssp/de_ssp.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/dhss/ssp/de_ssp.yaml
@@ -13,7 +13,7 @@
         state_code: DE
   output:
     # per_person_amount = $140 (individual)
-    # reduction = max(0, -(0/12)) = 0
+    # reduction = max(0, -0) = 0
     # supplement = max(0, 140 - 0) = $140
     de_ssp: 140
 
@@ -25,14 +25,14 @@
       person1:
         de_ssp_eligible: true
         ssi_claim_is_joint: false
-        uncapped_ssi: -600
+        uncapped_ssi: -50
     households:
       household:
         members: [person1]
         state_code: DE
   output:
     # per_person_amount = $140 (individual)
-    # uncapped_ssi monthly = -600/12 = -$50
+    # uncapped_ssi monthly = -$50
     # reduction = max(0, -(-50)) = $50
     # supplement = max(0, 140 - 50) = $90
     de_ssp: 90
@@ -45,14 +45,14 @@
       person1:
         de_ssp_eligible: true
         ssi_claim_is_joint: false
-        uncapped_ssi: -2_400
+        uncapped_ssi: -200
     households:
       household:
         members: [person1]
         state_code: DE
   output:
     # per_person_amount = $140 (individual)
-    # uncapped_ssi monthly = -2,400/12 = -$200
+    # uncapped_ssi monthly = -$200
     # reduction = max(0, -(-200)) = $200
     # supplement = max(0, 140 - 200) = $0
     de_ssp: 0
@@ -106,7 +106,7 @@
       person1:
         de_ssp_eligible: true
         ssi_claim_is_joint: true
-        uncapped_ssi: -1_200
+        uncapped_ssi: -100
       person2:
         de_ssp_eligible: true
         ssi_claim_is_joint: true
@@ -120,10 +120,10 @@
         state_code: DE
   output:
     # per_person_amount = $448/2 = $224 (couple)
-    # person1: uncapped_ssi monthly = -1,200/12 = -$100
+    # person1: uncapped_ssi monthly = -$100
     #   reduction = max(0, 100) = $100
     #   supplement = max(0, 224 - 100) = $124
-    # person2: uncapped_ssi monthly = 0/12 = $0
+    # person2: uncapped_ssi monthly = $0
     #   reduction = max(0, 0) = $0
     #   supplement = max(0, 224 - 0) = $224
     # joint path: sum(124, 224) / 2 = $174 per person
@@ -137,13 +137,13 @@
       person1:
         de_ssp_eligible: true
         ssi_claim_is_joint: false
-        uncapped_ssi: 120_000
+        uncapped_ssi: 10_000
     households:
       household:
         members: [person1]
         state_code: DE
   output:
-    # uncapped_ssi monthly = 120,000/12 = $10,000 (positive = low income)
+    # uncapped_ssi monthly = $10,000 (positive = low income)
     # reduction = max(0, -10,000) = 0
     # supplement = max(0, 140 - 0) = $140 (capped at max, not inflated)
     de_ssp: 140

--- a/policyengine_us/tests/policy/baseline/gov/states/de/dhss/ssp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/dhss/ssp/integration.yaml
@@ -17,13 +17,8 @@
     # Eligibility: age 70 >= 18, SSI eligible, in a certified adult care setting, DE resident
     de_ssp_eligible: true
     # Benefit: individual amount = $140, no reduction
-    # supplement = max(0, 140 - max(0, -(0/12))) = max(0, 140 - 0) = $140
+    # supplement = max(0, 140 - max(0, -0)) = max(0, 140 - 0) = $140
     de_ssp: 140
-    # At a monthly test period, the household state-benefit aggregate includes
-    # the monthly SSP amount.
-    household_state_benefits: 140
-    # SPM benefits include both SSI and the Delaware SSP in this scenario.
-    spm_unit_benefits: 433.5
 
 - name: Case 2, eligible couple both in a certified adult care setting.
   period: 2025-01
@@ -126,7 +121,7 @@
         age: 50
         is_ssi_eligible: true
         ssi_claim_is_joint: false
-        uncapped_ssi: -720
+        uncapped_ssi: -60
     households:
       household:
         members: [person1]
@@ -135,7 +130,7 @@
   output:
     de_ssp_eligible: true
     # individual amount = $140
-    # uncapped_ssi monthly = -720/12 = -$60
+    # uncapped_ssi monthly = -$60
     # reduction = max(0, -(-60)) = $60
     # supplement = max(0, 140 - 60) = $80
     de_ssp: 80
@@ -149,7 +144,7 @@
         age: 72
         is_ssi_eligible: true
         ssi_claim_is_joint: true
-        uncapped_ssi: -600
+        uncapped_ssi: -50
       person2:
         age: 70
         is_ssi_eligible: true
@@ -166,10 +161,10 @@
   output:
     de_ssp_eligible: [true, true]
     # per_person_amount = $448/2 = $224
-    # person1: uncapped_ssi monthly = -600/12 = -$50
+    # person1: uncapped_ssi monthly = -$50
     #   reduction = max(0, 50) = $50
     #   supplement = max(0, 224 - 50) = $174
-    # person2: uncapped_ssi monthly = 0/12 = $0
+    # person2: uncapped_ssi monthly = $0
     #   reduction = 0, supplement = $224
     # joint path: sum(174, 224) / 2 = $199 per person
     de_ssp: [199, 199]

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/dhs/ssp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/dhs/ssp/integration.yaml
@@ -23,8 +23,6 @@
     ga_ssp_person: [40]
     # SPM unit total = $40
     ga_ssp: 40
-    # Verify ga_ssp flows into spm_unit_benefits (includes ssi + ga_ssp + snap + others)
-    spm_unit_benefits: 361.25
 
 - name: Case 2, couple both eligible in current period.
   absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/income/il_aabd_ssi_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/income/il_aabd_ssi_income.yaml
@@ -2,17 +2,17 @@
   period: 2024-01
   input:
     state_code: IL
-    ssi: 12_000  # Annual SSI input
+    ssi: 1_000  # Monthly SSI input
     ssi_reported: 0
     il_aabd_use_reported_ssi: false
   output:
-    il_aabd_ssi_income: 1_000  # Monthly (12_000 / 12)
+    il_aabd_ssi_income: 1_000
 
 - name: Override - uses reported SSI when flag is true
   period: 2024-01
   input:
     state_code: IL
-    ssi: 12_000  # Annual calculated SSI
+    ssi: 1_000  # Monthly calculated SSI
     ssi_reported: 0  # Reported as 0
     il_aabd_use_reported_ssi: true
   output:
@@ -22,7 +22,7 @@
   period: 2024-01
   input:
     state_code: IL
-    ssi: 12_000  # Annual calculated SSI
+    ssi: 1_000  # Monthly calculated SSI
     ssi_reported: 6_000  # Reported partial amount (annual)
     il_aabd_use_reported_ssi: true
   output:
@@ -32,6 +32,6 @@
   period: 2024-01
   input:
     state_code: IL
-    ssi: 9_000  # Annual
+    ssi: 750  # Monthly
   output:
-    il_aabd_ssi_income: 750  # Monthly (9_000 / 12)
+    il_aabd_ssi_income: 750

--- a/policyengine_us/tests/policy/baseline/gov/states/in/fssa/ssp/edge_cases.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/fssa/ssp/edge_cases.yaml
@@ -129,7 +129,7 @@
     people:
       person1:
         in_ssp_rcap_eligible: true
-        uncapped_ssi: -60_000
+        uncapped_ssi: -5_000
         in_resides_in_licensed_residential_facility: true
     households:
       household:
@@ -147,14 +147,14 @@
     people:
       person1:
         in_ssp_rcap_eligible: true
-        uncapped_ssi: 120_000
+        uncapped_ssi: 10_000
         in_resides_in_licensed_residential_facility: true
     households:
       household:
         members: [person1]
         state_code: IN
   output:
-    # uncapped_ssi monthly = 120,000/12 = 10,000
+    # uncapped_ssi = 10,000
     # supplement = max(1,501.06 - 10,000, 0) = 0
     in_ssp_rcap: 0
 
@@ -165,16 +165,15 @@
     people:
       person1:
         in_ssp_rcap_eligible: true
-        # Annual uncapped_ssi = licensed_state_standard * 12
-        # = (49.35 * 365/12) * 12 = 49.35 * 365 = 18,012.75
-        uncapped_ssi: 18_012.75
+        # Monthly uncapped SSI equals licensed state standard.
+        uncapped_ssi: 1_501.0625
         in_resides_in_licensed_residential_facility: true
     households:
       household:
         members: [person1]
         state_code: IN
   output:
-    # monthly = 18,012.75 / 12 = 1,501.0625
+    # monthly uncapped_ssi = 1,501.0625
     # supplement = max(1,501.0625 - 1,501.0625, 0) = 0
     in_ssp_rcap: 0
 
@@ -185,15 +184,15 @@
     people:
       person1:
         in_ssp_rcap_eligible: true
-        # Annual = (licensed_ss - 1) * 12 = (1,501.0625 - 1) * 12 = 18,000.75
-        uncapped_ssi: 18_000.75
+        # Monthly uncapped SSI is one dollar below the licensed state standard.
+        uncapped_ssi: 1_500.0625
         in_resides_in_licensed_residential_facility: true
     households:
       household:
         members: [person1]
         state_code: IN
   output:
-    # monthly = 18,000.75 / 12 = 1,500.0625
+    # monthly uncapped_ssi = 1,500.0625
     # supplement = max(1,501.0625 - 1,500.0625, 0) = 1.00
     in_ssp_rcap: 1
 
@@ -204,15 +203,15 @@
     people:
       person1:
         in_ssp_rcap_eligible: true
-        # Annual = (licensed_ss + 1) * 12 = (1,501.0625 + 1) * 12 = 18,024.75
-        uncapped_ssi: 18_024.75
+        # Monthly uncapped SSI is one dollar above the licensed state standard.
+        uncapped_ssi: 1_502.0625
         in_resides_in_licensed_residential_facility: true
     households:
       household:
         members: [person1]
         state_code: IN
   output:
-    # monthly = 18,024.75 / 12 = 1,502.0625
+    # monthly uncapped_ssi = 1,502.0625
     # supplement = max(1,501.0625 - 1,502.0625, 0) = 0 (floored)
     in_ssp_rcap: 0
 
@@ -358,7 +357,7 @@
         is_ssi_aged_blind_disabled: true
         is_medicaid_eligible: false
         ssi_claim_is_joint: false
-        uncapped_ssi: 6_000
+        uncapped_ssi: 500
         in_resides_in_licensed_residential_facility: true
     households:
       household:
@@ -492,7 +491,7 @@
     people:
       person1:
         in_ssp_rcap_eligible: true
-        uncapped_ssi: 14_000
+        uncapped_ssi: 1_166.67
         in_resides_in_unlicensed_residential_facility: true
     households:
       household:
@@ -500,7 +499,7 @@
         state_code: IN
   output:
     # State standard = $1,125.42
-    # uncapped_ssi monthly = 14,000/12 = $1,166.67
+    # uncapped_ssi = $1,166.67
     # supplement = max(1,125.42 - 1,166.67, 0) = 0
     in_ssp_rcap: 0
 
@@ -515,14 +514,14 @@
     people:
       person1:
         in_ssp_rcap_eligible: true
-        uncapped_ssi: 6_000
+        uncapped_ssi: 500
         in_resides_in_licensed_residential_facility: true
     households:
       household:
         members: [person1]
         state_code: IN
   output:
-    # uncapped_ssi monthly = 6,000/12 = $500
+    # uncapped_ssi = $500
     # supplement = max(1,501.06 - 500, 0) = $1,001.06
     in_ssp_rcap: 1_001.06
 

--- a/policyengine_us/tests/policy/baseline/gov/states/in/fssa/ssp/in_ssp_rcap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/fssa/ssp/in_ssp_rcap.yaml
@@ -27,7 +27,7 @@
       person1:
         in_ssp_rcap_eligible: true
         ssi_claim_is_joint: false
-        uncapped_ssi: 6_000
+        uncapped_ssi: 500
         in_resides_in_licensed_residential_facility: true
     households:
       household:
@@ -35,7 +35,7 @@
         state_code: IN
   output:
     # State standard = $1,501.06
-    # uncapped_ssi monthly = 6,000/12 = $500
+    # uncapped_ssi = $500
     # federal_ssi = max(500, 0) = $500
     # supplement = max(1,501.06 - 500, 0) = $1,001.06
     in_ssp_rcap: 1_001.06
@@ -48,7 +48,7 @@
       person1:
         in_ssp_rcap_eligible: true
         ssi_claim_is_joint: false
-        uncapped_ssi: 18_012
+        uncapped_ssi: 1_501
         in_resides_in_licensed_residential_facility: true
     households:
       household:
@@ -56,7 +56,7 @@
         state_code: IN
   output:
     # State standard = $1,501.06
-    # uncapped_ssi monthly = 18,012/12 = $1,501
+    # uncapped_ssi = $1,501
     # federal_ssi = max(1,501, 0) = $1,501
     # supplement = max(1,501.06 - 1,501, 0) = $0.06
     in_ssp_rcap: 0.06
@@ -83,14 +83,14 @@
       person1:
         in_ssp_rcap_eligible: true
         ssi_claim_is_joint: false
-        uncapped_ssi: -60_000
+        uncapped_ssi: -5_000
         in_resides_in_licensed_residential_facility: true
     households:
       household:
         members: [person1]
         state_code: IN
   output:
-    # uncapped_ssi monthly = -60,000/12 = -$5,000
+    # uncapped_ssi = -$5,000
     # federal_ssi = max(-5,000, 0) = 0 (floored at zero)
     # supplement = max(1,501.06 - 0, 0) = $1,501.06
     in_ssp_rcap: 1_501.06

--- a/policyengine_us/tests/policy/baseline/gov/states/in/fssa/ssp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/fssa/ssp/integration.yaml
@@ -10,7 +10,7 @@
         ssi_claim_is_joint: false
         ssi_lives_in_medical_treatment_facility: true
         ssi_medicaid_pays_majority_of_care: true
-        uncapped_ssi: 360
+        uncapped_ssi: 30
     households:
       household:
         members: [person1]
@@ -40,7 +40,7 @@
         ssi_claim_is_joint: true
         ssi_lives_in_medical_treatment_facility: true
         ssi_medicaid_pays_majority_of_care: true
-        uncapped_ssi: 360
+        uncapped_ssi: 30
       person2:
         age: 65
         is_ssi_eligible: true
@@ -48,7 +48,7 @@
         ssi_claim_is_joint: true
         ssi_lives_in_medical_treatment_facility: true
         ssi_medicaid_pays_majority_of_care: true
-        uncapped_ssi: 360
+        uncapped_ssi: 30
     marital_units:
       marital_unit:
         members: [person1, person2]
@@ -105,7 +105,7 @@
         is_ssi_eligible: true
         is_ssi_aged_blind_disabled: true
         is_medicaid_eligible: false
-        ssi: 9_000
+        ssi: 750
         ssi_countable_income: 2_400
         in_resides_in_licensed_residential_facility: true
     households:
@@ -130,7 +130,7 @@
         is_ssi_aged_blind_disabled: true
         is_medicaid_eligible: false
         ssi_claim_is_joint: false
-        uncapped_ssi: 6_000
+        uncapped_ssi: 500
         in_resides_in_licensed_residential_facility: true
     households:
       household:
@@ -141,13 +141,13 @@
     in_ssp_sapn_eligible: false
     # RCAP: ABD, SSI recipient, age >= 18, licensed residential
     in_ssp_rcap_eligible: true
-    # Normal FBR (not in medical facility): uncapped_ssi/12 = $500/mo
+    # Normal FBR (not in medical facility): uncapped_ssi = $500/mo
     ssi: 500
     in_ssp_eligible: true
     in_ssp_sapn: 0
     # RCAP: per diem $49.35/day (licensed, since July 2008)
     # State standard = 49.35 * 365/12 = $1,501.06
-    # uncapped_ssi monthly = 6,000/12 = $500
+    # uncapped_ssi = $500
     # federal_ssi = max(500, 0) = $500
     # supplement = max(1,501.06 - 500, 0) = $1,001.06
     in_ssp_rcap: 1_001.06

--- a/policyengine_us/tests/policy/baseline/gov/states/ky/dcbs/ssp/ky_ssp_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ky/dcbs/ssp/ky_ssp_countable_income.yaml
@@ -71,3 +71,21 @@
         state_code: KY
   output:
     ky_ssp_countable_income: [0]
+
+- name: Case 5, couple computation follows monthly SSI facility separation.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    ssi_marital_unearned_income: 12_000
+    is_ssi_eligible_individual: true
+    is_ssi_eligible_spouse: false
+    ssi_couple_computation_applies:
+      2026-01: true
+      2026-02: false
+    state_code: KY
+  output:
+    # No $20 disregard. Couple computation splits $1,000/mo in half
+    # only for months where the federal couple computation applies.
+    ky_ssp_countable_income:
+      2026-01: 500
+      2026-02: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/integration.yaml
@@ -3,8 +3,8 @@
 #
 # Eligibility: aged/blind/disabled AND in a Medicaid LTC facility AND in Louisiana.
 # Formula: la_oss (monthly) = min(max(PNA - ssi - ssi_countable_income, 0), max_payment).
-# Both ssi and ssi_countable_income are YEAR-period; PolicyEngine divides by 12
-# when the formula reads them at MONTH.
+# ssi is monthly; ssi_countable_income is annual and PolicyEngine divides by 12
+# when the monthly formula reads it.
 #
 # Pre-July-2025: PNA = $38, max payment = $8/month. Federal SSI institutional FBR = $30/mo.
 # From July 1, 2025: PNA = $45, max payment = $15/month.
@@ -21,7 +21,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1]
@@ -41,7 +41,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1]
@@ -60,7 +60,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: OWN_HOUSEHOLD
         ssi_countable_income: 0
-        ssi: 11_928
+        ssi: 994
     households:
       household:
         members: [person1]
@@ -98,7 +98,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1]
@@ -117,7 +117,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1]
@@ -138,13 +138,13 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
       person2:
         age: 70
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1, person2]
@@ -164,7 +164,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1]
@@ -183,7 +183,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1]
@@ -221,13 +221,13 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
       person2:
         age: 70
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: OWN_HOUSEHOLD
         ssi_countable_income: 0
-        ssi: 11_928
+        ssi: 994
     households:
       household:
         members: [person1, person2]
@@ -247,7 +247,7 @@
         is_ssi_aged_blind_disabled: true
         ssi_federal_living_arrangement: MEDICAL_TREATMENT_FACILITY
         ssi_countable_income: 0
-        ssi: 360
+        ssi: 30
     households:
       household:
         members: [person1]

--- a/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/hhs/oss/la_oss.yaml
@@ -1,13 +1,13 @@
 # Unit tests for Louisiana Optional State Supplement (OSS) benefit amount.
 # Formula (monthly): la_oss = min(max(PNA - ssi - ssi_countable_income, 0), max_payment)
-# Both ssi and ssi_countable_income are YEAR-period; reading at MONTH yields annual / 12.
+# ssi is monthly. ssi_countable_income is annual; reading at MONTH yields annual / 12.
 #
 # Pre-July-2025: PNA = $38, max payment = $8. Federal SSI institutional FBR = $30.
 # From July 1, 2025: PNA = $45, max payment = $15.
 #
-# Test inputs pass annual ssi and ssi_countable_income directly so that the
-# SSI formula chain doesn't recompute them. SSI institutional rate is $30/mo
-# = $360/yr; SSI = max(FBR - countable, 0) when SSI is being received.
+# Test inputs pass ssi and ssi_countable_income directly so that the SSI formula
+# chain doesn't recompute them. SSI institutional rate is $30/mo; SSI =
+# max(FBR - countable, 0) when SSI is being received.
 #
 # Reference: LDH J-300, Z-700; SSA 2011 State Assistance Programs - Louisiana, Table 1.
 
@@ -17,7 +17,7 @@
     people:
       person1:
         la_oss_eligible: true
-        ssi: 360  # full institutional FBR ($30/month)
+        ssi: 30  # full institutional FBR
         ssi_countable_income: 0
     households:
       household:
@@ -46,7 +46,7 @@
     people:
       person1:
         la_oss_eligible: true
-        ssi: 360  # full institutional FBR ($30/month)
+        ssi: 30  # full institutional FBR
         ssi_countable_income: 0
     households:
       household:
@@ -64,7 +64,7 @@
     people:
       person1:
         la_oss_eligible: true
-        ssi: 300  # 25/month (reduced by countable income)
+        ssi: 25  # reduced institutional SSI
         ssi_countable_income: 60
     households:
       household:
@@ -165,7 +165,7 @@
     people:
       person1:
         la_oss_eligible: true
-        ssi: 360
+        ssi: 30
         ssi_countable_income: 0
     households:
       household:

--- a/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/integration.yaml
@@ -248,4 +248,3 @@
     me_ssp_eligible: true
     # Federal ANOTHER_PERSONS_HOUSEHOLD => Maine code C => $8/month.
     me_ssp: 8
-    household_state_benefits: 8

--- a/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp.yaml
@@ -5,7 +5,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
     households:
       household:
         members: [person1]
@@ -35,12 +35,12 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
         me_ssp_living_arrangement: ADULT_FOSTER_HOME
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
         me_ssp_living_arrangement: ADULT_FOSTER_HOME
     marital_units:
@@ -61,11 +61,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
         me_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
     marital_units:
@@ -88,7 +88,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
         me_ssp_living_arrangement: FLAT_RATE_BOARDING_HOME
       person2:
@@ -131,7 +131,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_lives_in_medical_treatment_facility: true
         ssi_medicaid_pays_majority_of_care: true
     households:
@@ -149,7 +149,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
     households:
       household:
         members: [person1]
@@ -164,11 +164,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
         # person2 explicitly placed in NONE arrangement.
         me_ssp_living_arrangement: NONE
@@ -192,11 +192,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: false
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: false
     marital_units:
       marital_unit:
@@ -216,11 +216,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
     marital_units:
       marital_unit:
@@ -240,13 +240,13 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
         ssi_lives_in_medical_treatment_facility: true
         ssi_medicaid_pays_majority_of_care: true
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_claim_is_joint: true
         # person2 manually set to MEDICAID_FACILITY arrangement.
         me_ssp_living_arrangement: MEDICAID_FACILITY
@@ -268,7 +268,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: NONE
     households:
       household:
@@ -299,7 +299,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
     households:
       household:
         members: [person1]
@@ -315,8 +315,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$2,400 -> $200/month income excess.
-        uncapped_ssi: -2_400
+        # Monthly uncapped SSI = -$200 income excess.
+        uncapped_ssi: -200
         me_ssp_living_arrangement: FLAT_RATE_BOARDING_HOME
     households:
       household:
@@ -334,7 +334,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         ssi_lives_in_another_persons_household: true
         ssi_receives_shelter_from_others_in_household: true
         ssi_others_pay_all_meals: true
@@ -354,8 +354,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$240 -> $20/month excess.
-        uncapped_ssi: -240
+        # Monthly uncapped SSI = -$20 excess.
+        uncapped_ssi: -20
     households:
       household:
         members: [person1]
@@ -371,8 +371,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$1,200 -> $100/month excess.
-        uncapped_ssi: -1_200
+        # Monthly uncapped SSI = -$100 excess.
+        uncapped_ssi: -100
     households:
       household:
         members: [person1]

--- a/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp_couple.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp_couple.yaml
@@ -5,11 +5,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
     marital_units:
       marital_unit:
@@ -29,11 +29,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
     marital_units:
       marital_unit:
@@ -53,11 +53,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: ADULT_FOSTER_HOME
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: ADULT_FOSTER_HOME
     marital_units:
       marital_unit:
@@ -76,11 +76,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: FLAT_RATE_BOARDING_HOME
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: FLAT_RATE_BOARDING_HOME
     marital_units:
       marital_unit:
@@ -99,11 +99,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: ADULT_FAMILY_CARE_HOME
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: ADULT_FAMILY_CARE_HOME
     marital_units:
       marital_unit:
@@ -122,11 +122,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: COST_REIMBURSED_BOARDING_HOME
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: COST_REIMBURSED_BOARDING_HOME
     marital_units:
       marital_unit:
@@ -145,11 +145,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: MEDICAID_FACILITY
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: MEDICAID_FACILITY
     marital_units:
       marital_unit:
@@ -168,11 +168,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: RESIDENTIAL_CARE_FACILITY
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: RESIDENTIAL_CARE_FACILITY
     marital_units:
       marital_unit:
@@ -191,11 +191,11 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: NONE
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: NONE
     marital_units:
       marital_unit:
@@ -214,12 +214,12 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$1,200 -> $100/month per-person excess.
-        uncapped_ssi: -1_200
+        # Monthly uncapped SSI = -$100 per-person excess.
+        uncapped_ssi: -100
         me_ssp_living_arrangement: FLAT_RATE_BOARDING_HOME
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: -1_200
+        uncapped_ssi: -100
         me_ssp_living_arrangement: FLAT_RATE_BOARDING_HOME
     marital_units:
       marital_unit:
@@ -239,12 +239,12 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$240 -> $20/month per-person excess.
-        uncapped_ssi: -240
+        # Monthly uncapped SSI = -$20 per-person excess.
+        uncapped_ssi: -20
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: -240
+        uncapped_ssi: -20
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
     marital_units:
       marital_unit:
@@ -264,12 +264,12 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$1,200 -> $100/month per-person excess.
-        uncapped_ssi: -1_200
+        # Monthly uncapped SSI = -$100 per-person excess.
+        uncapped_ssi: -100
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: -1_200
+        uncapped_ssi: -100
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
     marital_units:
       marital_unit:
@@ -289,12 +289,12 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$60 -> $5/month per-person excess.
-        uncapped_ssi: -60
+        # Monthly uncapped SSI = -$5 per-person excess.
+        uncapped_ssi: -5
         me_ssp_living_arrangement: MEDICAID_FACILITY
       person2:
         is_ssi_eligible: true
-        uncapped_ssi: -60
+        uncapped_ssi: -5
         me_ssp_living_arrangement: MEDICAID_FACILITY
     marital_units:
       marital_unit:

--- a/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp_eligible.yaml
@@ -104,7 +104,7 @@
         is_ssi_eligible: true
         # Income exceeds the federal SSI standard, so the person does
         # not actually receive SSI but is still categorically eligible.
-        uncapped_ssi: -2_400
+        uncapped_ssi: -200
     households:
       household:
         members: [person1]

--- a/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp_individual.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ssp/me_ssp_individual.yaml
@@ -5,7 +5,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
     households:
       household:
@@ -21,7 +21,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
     households:
       household:
@@ -37,7 +37,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: ADULT_FOSTER_HOME
     households:
       household:
@@ -53,7 +53,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: FLAT_RATE_BOARDING_HOME
     households:
       household:
@@ -69,7 +69,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: ADULT_FAMILY_CARE_HOME
     households:
       household:
@@ -85,7 +85,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: COST_REIMBURSED_BOARDING_HOME
     households:
       household:
@@ -101,7 +101,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: MEDICAID_FACILITY
     households:
       household:
@@ -117,7 +117,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: RESIDENTIAL_CARE_FACILITY
     households:
       household:
@@ -133,7 +133,7 @@
     people:
       person1:
         is_ssi_eligible: true
-        uncapped_ssi: 12_000
+        uncapped_ssi: 1_000
         me_ssp_living_arrangement: NONE
     households:
       household:
@@ -149,8 +149,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$2,400 -> $200/month income excess.
-        uncapped_ssi: -2_400
+        # Monthly uncapped SSI = -$200 income excess.
+        uncapped_ssi: -200
         me_ssp_living_arrangement: ADULT_FAMILY_CARE_HOME
     households:
       household:
@@ -167,9 +167,9 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$12,000 -> $1,000/month income excess,
+        # Monthly uncapped SSI = -$1,000 income excess,
         # which exceeds every Maine table amount.
-        uncapped_ssi: -12_000
+        uncapped_ssi: -1_000
         me_ssp_living_arrangement: ADULT_FAMILY_CARE_HOME
     households:
       household:
@@ -186,8 +186,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$240 -> $20/month excess.
-        uncapped_ssi: -240
+        # Monthly uncapped SSI = -$20 excess.
+        uncapped_ssi: -20
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
     households:
       household:
@@ -204,8 +204,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$1,200 -> $100/month excess.
-        uncapped_ssi: -1_200
+        # Monthly uncapped SSI = -$100 excess.
+        uncapped_ssi: -100
         me_ssp_living_arrangement: LIVING_ALONE_OR_WITH_OTHERS
     households:
       household:
@@ -222,8 +222,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$360 -> $30/month excess.
-        uncapped_ssi: -360
+        # Monthly uncapped SSI = -$30 excess.
+        uncapped_ssi: -30
         me_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
     households:
       household:
@@ -240,8 +240,8 @@
     people:
       person1:
         is_ssi_eligible: true
-        # Annual uncapped SSI = -$240 -> $20/month excess.
-        uncapped_ssi: -240
+        # Monthly uncapped SSI = -$20 excess.
+        uncapped_ssi: -20
         ssi_lives_in_medical_treatment_facility: true
         ssi_medicaid_pays_majority_of_care: true
     households:

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/mdhhs/ssp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/mdhhs/ssp/integration.yaml
@@ -67,14 +67,14 @@
   input:
     people:
       person1:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
       person2:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
@@ -104,14 +104,14 @@
   input:
     people:
       person1:
-        # $30/mo SSI = $360/yr institutional rate
-        ssi: 360
+        # $30/mo SSI institutional rate
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: DOMICILIARY_CARE
       person2:
-        # $30/mo SSI = $360/yr institutional rate
-        ssi: 360
+        # $30/mo SSI institutional rate
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: DOMICILIARY_CARE
@@ -141,14 +141,14 @@
   input:
     people:
       person1:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
       person2:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
@@ -200,14 +200,14 @@
   input:
     people:
       person1:
-        # $30/mo SSI = $360/yr institutional rate
-        ssi: 360
+        # $30/mo SSI institutional rate
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOME_FOR_AGED
       person2:
-        # $30/mo SSI = $360/yr institutional rate
-        ssi: 360
+        # $30/mo SSI institutional rate
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOME_FOR_AGED
@@ -237,8 +237,8 @@
   input:
     people:
       person1:
-        # $943/mo SSI = $11,316/yr individual FBR
-        ssi: 11_316
+        # $943/mo SSI individual FBR
+        ssi: 943
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
@@ -308,14 +308,14 @@
   input:
     people:
       person1:
-        # $30/mo SSI = $360/yr institutional rate
-        ssi: 360
+        # $30/mo SSI institutional rate
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: DOMICILIARY_CARE
       person2:
-        # $30/mo SSI = $360/yr institutional rate
-        ssi: 360
+        # $30/mo SSI institutional rate
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: DOMICILIARY_CARE
@@ -345,12 +345,12 @@
   input:
     people:
       person1:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: DOMICILIARY_CARE
       person2:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: DOMICILIARY_CARE
@@ -380,12 +380,12 @@
   input:
     people:
       person1:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: PERSONAL_CARE
       person2:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: PERSONAL_CARE
@@ -415,12 +415,12 @@
   input:
     people:
       person1:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: PERSONAL_CARE
       person2:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: PERSONAL_CARE
@@ -450,12 +450,12 @@
   input:
     people:
       person1:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOME_FOR_AGED
       person2:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOME_FOR_AGED
@@ -485,12 +485,12 @@
   input:
     people:
       person1:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOME_FOR_AGED
       person2:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOME_FOR_AGED
@@ -543,7 +543,7 @@
   input:
     people:
       person1:
-        ssi: 11_316
+        ssi: 943
         mi_ssp_living_arrangement: NONE
     spm_units:
       spm_unit:
@@ -627,12 +627,12 @@
   input:
     people:
       person1:
-        ssi: 8_484
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
       person2:
-        ssi: 8_484
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
@@ -661,12 +661,12 @@
   input:
     people:
       person1:
-        ssi: 8_484
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
       person2:
-        ssi: 360
+        ssi: 30
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: PERSONAL_CARE
@@ -741,7 +741,7 @@
   input:
     people:
       person1:
-        ssi: 11_316
+        ssi: 943
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
     spm_units:
       spm_unit:
@@ -764,8 +764,8 @@
         age: 8
         is_disabled: true
         # Child receives federal SSI at 2024 individual FBR
-        # $943/mo = $11,316/yr
-        ssi: 11_316
+        # $943/mo
+        ssi: 943
         # mi_ssp_living_arrangement defaults to INDEPENDENT_LIVING
     spm_units:
       spm_unit:
@@ -820,9 +820,9 @@
     people:
       person1:
         is_ssi_eligible: true
-        # uncapped_ssi annual = -600 → monthly spillover = $50.
+        # uncapped_ssi monthly spillover = -$50.
         # Personal Care SSP base = $157.50/mo. Result = max_(0, 157.50 - 50) = $107.50.
-        uncapped_ssi: -600
+        uncapped_ssi: -50
         mi_ssp_living_arrangement: PERSONAL_CARE
     spm_units:
       spm_unit:

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/mdhhs/ssp/mi_ssp.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/mdhhs/ssp/mi_ssp.yaml
@@ -23,14 +23,14 @@
   input:
     people:
       person1:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
       person2:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
@@ -75,8 +75,8 @@
   input:
     people:
       person1:
-        # $943/mo SSI = $11,316/yr individual FBR
-        ssi: 11_316
+        # $943/mo SSI individual FBR
+        ssi: 943
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
     spm_units:
       spm_unit:

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/mdhhs/ssp/mi_ssp_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/mdhhs/ssp/mi_ssp_person.yaml
@@ -35,14 +35,14 @@
   input:
     people:
       person1:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
       person2:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
@@ -66,14 +66,14 @@
   input:
     people:
       person1:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING
       person2:
-        # $707/mo SSI = $8,484/yr couple half
-        ssi: 8_484
+        # $707/mo SSI couple half
+        ssi: 707
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: HOUSEHOLD_OF_ANOTHER
@@ -98,8 +98,8 @@
   input:
     people:
       person1:
-        # $943/mo SSI = $11,316/yr individual FBR
-        ssi: 11_316
+        # $943/mo SSI individual FBR
+        ssi: 943
         is_ssi_aged_blind_disabled: true
         is_tax_unit_head_or_spouse: true
         mi_ssp_living_arrangement: INDEPENDENT_LIVING

--- a/policyengine_us/variables/gov/local/ca/la/general_relief/eligibility/cash/la_general_relief_cash_asset_limit.py
+++ b/policyengine_us/variables/gov/local/ca/la/general_relief/eligibility/cash/la_general_relief_cash_asset_limit.py
@@ -6,6 +6,7 @@ class la_general_relief_cash_asset_limit(Variable):
     entity = SPMUnit
     unit = USD
     definition_period = YEAR
+    quantity_type = STOCK
     label = "Limit for the Los Angeles County General Relief cash asset requirements"
     # Person has to be a resident of LA County
     defined_for = "in_la"

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/resources/meets_ssi_resource_test.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/resources/meets_ssi_resource_test.py
@@ -5,7 +5,7 @@ class meets_ssi_resource_test(Variable):
     value_type = bool
     entity = Person
     label = "Meets SSI resource test"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = "https://secure.ssa.gov/poms.nsf/lnx/0501110000"
 
     def formula(person, period, parameters):

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/resources/ssi_countable_resources.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/resources/ssi_countable_resources.py
@@ -12,6 +12,7 @@ class ssi_countable_resources(Variable):
     )
     unit = USD
     definition_period = YEAR
+    quantity_type = STOCK
     reference = (
         "https://secure.ssa.gov/poms.nsf/lnx/0501140000",  # POMS SI 01140.000 - Types of Countable Resources
     )

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_federal_living_arrangement.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_federal_living_arrangement.py
@@ -12,7 +12,7 @@ class ssi_federal_living_arrangement(Variable):
     value_type = Enum
     entity = Person
     label = "SSI federal living arrangement"
-    definition_period = YEAR
+    definition_period = MONTH
     possible_values = SSIFederalLivingArrangement
     default_value = SSIFederalLivingArrangement.OWN_HOUSEHOLD
     reference = (
@@ -45,7 +45,9 @@ class ssi_federal_living_arrangement(Variable):
             > 0
         )
         is_child_in_parental = (
-            ~is_medical_facility & person("is_child", period) & has_ineligible_parent
+            ~is_medical_facility
+            & person("is_child", period.this_year)
+            & has_ineligible_parent
         )
 
         # 20 CFR § 416.1131–1133: In another person's household

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_lives_in_another_persons_household.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_lives_in_another_persons_household.py
@@ -5,7 +5,7 @@ class ssi_lives_in_another_persons_household(Variable):
     value_type = bool
     entity = Person
     label = "Lives in another person's household for SSI purposes"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.1132",
         "https://secure.ssa.gov/apps10/poms.nsf/lnx/0500835200",

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_lives_in_medical_treatment_facility.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_lives_in_medical_treatment_facility.py
@@ -5,7 +5,7 @@ class ssi_lives_in_medical_treatment_facility(Variable):
     value_type = bool
     entity = Person
     label = "Lives in a medical treatment facility for SSI purposes"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.414",
         "https://secure.ssa.gov/apps10/poms.nsf/lnx/0500520001",

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_medicaid_pays_majority_of_care.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_medicaid_pays_majority_of_care.py
@@ -5,7 +5,7 @@ class ssi_medicaid_pays_majority_of_care(Variable):
     value_type = bool
     entity = Person
     label = "Medicaid pays more than half the cost of care for SSI purposes"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.414",
         "https://secure.ssa.gov/apps10/poms.nsf/lnx/0500520011",

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_others_pay_all_meals.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_others_pay_all_meals.py
@@ -5,7 +5,7 @@ class ssi_others_pay_all_meals(Variable):
     value_type = bool
     entity = Person
     label = "Others in the household pay for all meals for SSI purposes"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.1131",
         "https://secure.ssa.gov/apps10/poms.nsf/lnx/0500835200",

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_receives_food_from_others.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_receives_food_from_others.py
@@ -5,7 +5,7 @@ class ssi_receives_food_from_others(Variable):
     value_type = bool
     entity = Person
     label = "Receives food from others for SSI ISM purposes"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.1130",
         "https://www.federalregister.gov/documents/2024/03/27/2024-06464/omitting-food-from-in-kind-support-and-maintenance-calculations",

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_receives_outside_shelter_support.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_receives_outside_shelter_support.py
@@ -5,7 +5,7 @@ class ssi_receives_outside_shelter_support(Variable):
     value_type = bool
     entity = Person
     label = "Receives shelter support from others for SSI ISM purposes"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.1140",
         "https://secure.ssa.gov/apps10/poms.nsf/lnx/0500835300",

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_receives_shelter_from_others_in_household.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/status/ssi_receives_shelter_from_others_in_household.py
@@ -5,7 +5,7 @@ class ssi_receives_shelter_from_others_in_household(Variable):
     value_type = bool
     entity = Person
     label = "Receives shelter from others in the household for SSI purposes"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.1131",
         "https://secure.ssa.gov/apps10/poms.nsf/lnx/0500835200",

--- a/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
+++ b/policyengine_us/variables/gov/ssa/ssi/is_in_medicaid_facility.py
@@ -7,5 +7,5 @@ class is_in_medicaid_facility(Variable):
     label = (
         "Whether the person resides in a Medicaid-funded nursing facility or ICF/IID"
     )
-    definition_period = YEAR
+    definition_period = MONTH
     reference = "https://www.law.cornell.edu/uscode/text/42/1382"

--- a/policyengine_us/variables/gov/ssa/ssi/is_ssi_eligible.py
+++ b/policyengine_us/variables/gov/ssa/ssi/is_ssi_eligible.py
@@ -5,7 +5,7 @@ class is_ssi_eligible(Variable):
     value_type = bool
     entity = Person
     label = "Is SSI eligible person"  # without income test
-    definition_period = YEAR
+    definition_period = MONTH
 
     def formula(person, period, parameters):
         abd_person = person("is_ssi_aged_blind_disabled", period)

--- a/policyengine_us/variables/gov/ssa/ssi/ssi.py
+++ b/policyengine_us/variables/gov/ssa/ssi/ssi.py
@@ -7,7 +7,7 @@ class ssi(Variable):
     label = "SSI"
     documentation = "Supplemental Security Income"
     unit = USD
-    definition_period = YEAR
+    definition_period = MONTH
     reference = "https://www.law.cornell.edu/uscode/text/42/1382"
 
     def formula(person, period, parameters):
@@ -25,16 +25,16 @@ class ssi(Variable):
         # - Deeming applies (uses couple FBR)
         # - After exclusions, countable may be low
         # - Benefit could exceed individual FBR without this cap
-        deeming_applies = person("is_ssi_spousal_deeming_applies", period)
+        deeming_applies = person("is_ssi_spousal_deeming_applies", period.this_year)
         p = parameters(period).gov.ssa.ssi.amount
-        individual_max = p.individual * MONTHS_IN_YEAR
-        capped_benefit = min_(benefit, individual_max)
+        capped_benefit = min_(benefit, p.individual)
 
-        final_benefit = where(
-            deeming_applies,
-            capped_benefit,
-            benefit,
+        takes_up = person("takes_up_ssi_if_eligible", period.this_year)
+        return (
+            where(
+                deeming_applies,
+                capped_benefit,
+                benefit,
+            )
+            * takes_up
         )
-
-        takes_up = person("takes_up_ssi_if_eligible", period)
-        return final_benefit * takes_up

--- a/policyengine_us/variables/gov/ssa/ssi/ssi_amount_if_eligible.py
+++ b/policyengine_us/variables/gov/ssa/ssi/ssi_amount_if_eligible.py
@@ -9,7 +9,7 @@ class ssi_amount_if_eligible(Variable):
     entity = Person
     label = "SSI amount if eligible"
     unit = USD
-    definition_period = YEAR
+    definition_period = MONTH
     reference = "https://www.law.cornell.edu/uscode/text/42/1382#b"
 
     def formula(person, period, parameters):
@@ -26,7 +26,7 @@ class ssi_amount_if_eligible(Variable):
         # SSI-eligible. ssi_claim_is_joint remains true for state SSPs.
 
         couple_computation = person("ssi_couple_computation_applies", period)
-        deeming_applies = person("is_ssi_spousal_deeming_applies", period)
+        deeming_applies = person("is_ssi_spousal_deeming_applies", period.this_year)
 
         individual_or_deeming_amount = where(
             deeming_applies,
@@ -44,7 +44,9 @@ class ssi_amount_if_eligible(Variable):
         # files a joint claim with parents — joint claims are between
         # spouses only. Adults 18+ (including students) go through normal
         # couple/deeming logic since they may be married.
-        base_amount = where(person("is_child", period), p.individual, base_amount)
+        base_amount = where(
+            person("is_child", period.this_year), p.individual, base_amount
+        )
 
         is_medical_facility = (
             arrangement == SSIFederalLivingArrangement.MEDICAL_TREATMENT_FACILITY
@@ -65,6 +67,4 @@ class ssi_amount_if_eligible(Variable):
 
         # 42 USC § 1382(e)(1)(A), 20 CFR § 416.414: Medical treatment
         # facility, $30/month per person.
-        base_amount = where(is_medical_facility, p.medical_facility, base_amount)
-
-        return base_amount * MONTHS_IN_YEAR
+        return where(is_medical_facility, p.medical_facility, base_amount)

--- a/policyengine_us/variables/gov/ssa/ssi/ssi_couple_computation_applies.py
+++ b/policyengine_us/variables/gov/ssa/ssi/ssi_couple_computation_applies.py
@@ -8,14 +8,14 @@ class ssi_couple_computation_applies(Variable):
     value_type = bool
     entity = Person
     label = "SSI couple computation applies"
-    definition_period = YEAR
+    definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.414",
         "https://secure.ssa.gov/poms.nsf/lnx/0500501154",
     )
 
     def formula(person, period, parameters):
-        joint_claim = person("ssi_claim_is_joint", period)
+        joint_claim = person("ssi_claim_is_joint", period.this_year)
 
         # 20 CFR 416.414(b)(2): Both in facility → couple computation
         # still applies ($60/month = $30 each).

--- a/policyengine_us/variables/gov/ssa/ssi/ssi_federal_fiscal_year_outlays.py
+++ b/policyengine_us/variables/gov/ssa/ssi/ssi_federal_fiscal_year_outlays.py
@@ -1,0 +1,71 @@
+from datetime import date, timedelta
+
+from policyengine_us.model_api import *
+
+
+def _is_new_years_day_observed(day: date) -> bool:
+    new_years_day = date(day.year, 1, 1)
+    next_new_years_day = date(day.year + 1, 1, 1)
+    return (
+        day == new_years_day
+        or (new_years_day.weekday() == 6 and day == date(day.year, 1, 2))
+        or (next_new_years_day.weekday() == 5 and day == date(day.year, 12, 31))
+    )
+
+
+def _is_labor_day(day: date) -> bool:
+    return day.month == 9 and day.weekday() == 0 and day.day <= 7
+
+
+def _is_federal_holiday_affecting_ssi_payment(day: date) -> bool:
+    return _is_new_years_day_observed(day) or _is_labor_day(day)
+
+
+def _ssi_payment_date(year: int, month: int) -> date:
+    payment_date = date(year, month, 1)
+    while payment_date.weekday() >= 5 or _is_federal_holiday_affecting_ssi_payment(
+        payment_date
+    ):
+        payment_date -= timedelta(days=1)
+    return payment_date
+
+
+class ssi_federal_fiscal_year_outlays(Variable):
+    value_type = float
+    entity = Person
+    label = "SSI federal fiscal year outlays"
+    documentation = (
+        "Supplemental Security Income payments assigned to the federal fiscal "
+        "year in which they are paid."
+    )
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        # SSA presents SSI Federal Budget obligations on a payment-date
+        # basis, with fiscal years covering October 1 through September 30.
+        "https://www.ssa.gov/oact/ssir/SSI24/IV_C_Payments.html",
+        # SSI payments are normally made on the first day of the month;
+        # weekend or legal-holiday payments are made on the prior business day.
+        "https://www.ssa.gov/OP_Home/cfr20/416/416-0502.htm",
+    )
+
+    def formula(person, period, parameters):
+        fiscal_year = period.start.year
+        fiscal_year_start = date(fiscal_year - 1, 10, 1)
+        fiscal_year_end = date(fiscal_year, 9, 30)
+        total = 0
+
+        # Include benefit months whose actual payment dates fall inside the
+        # fiscal year. October payments can be shifted into September, so SSI
+        # fiscal years can contain 11, 12, or 13 monthly payments.
+        for month_offset in range(-3, 10):
+            benefit_month = period.first_month.offset(month_offset, "month")
+            payment_date = _ssi_payment_date(
+                benefit_month.start.year,
+                benefit_month.start.month,
+            )
+            paid_in_fiscal_year = fiscal_year_start <= payment_date <= fiscal_year_end
+            if paid_in_fiscal_year:
+                total += person("ssi", benefit_month)
+
+        return total

--- a/policyengine_us/variables/gov/ssa/ssi/uncapped_ssi.py
+++ b/policyengine_us/variables/gov/ssa/ssi/uncapped_ssi.py
@@ -7,7 +7,7 @@ class uncapped_ssi(Variable):
     label = "Uncapped SSI"
     unit = USD
     documentation = "Maximum SSI, less countable income (can be below zero)."
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = "is_ssi_eligible"
 
     def formula(person, period, parameters):

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_resides_in_assisted_living_home.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_resides_in_assisted_living_home.py
@@ -5,7 +5,7 @@ class ak_resides_in_assisted_living_home(Variable):
     value_type = bool
     entity = Person
     label = "Resides in an Alaska assisted living home"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.AK
     default_value = False
     reference = (

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp.py
@@ -6,7 +6,7 @@ class ak_ssp(Variable):
     entity = Person
     label = "Alaska Adult Public Assistance"
     unit = USD
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.AK
     exhaustive_parameter_dependencies = "gov.states.ak.dpa.ssp"
     reference = (

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_claim_type.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_claim_type.py
@@ -11,7 +11,7 @@ class ak_ssp_claim_type(Variable):
     value_type = Enum
     entity = Person
     label = "Alaska Adult Public Assistance claim type"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.AK
     possible_values = AKSSPClaimType
     default_value = AKSSPClaimType.INDIVIDUAL
@@ -20,8 +20,10 @@ class ak_ssp_claim_type(Variable):
     )
 
     def formula(person, period, parameters):
-        joint_claim = person("ssi_claim_is_joint", period)
-        marital_unit_size = person.marital_unit.sum(person("age", period) >= 0)
+        joint_claim = person("ssi_claim_is_joint", period.this_year)
+        marital_unit_size = person.marital_unit.sum(
+            person("age", period.this_year) >= 0
+        )
         living_arrangement = person("ak_ssp_living_arrangement", period)
         living_arrangement_values = living_arrangement.possible_values
         # Both spouses must share the same living arrangement to be
@@ -53,7 +55,7 @@ class ak_ssp_claim_type(Variable):
                 == marital_unit_size
             )
         )
-        is_eligible_individual = person("is_ssi_aged_blind_disabled", period)
+        is_eligible_individual = person("is_ssi_aged_blind_disabled", period.this_year)
         # COUPLE_ONE_ELIGIBLE requires exactly one spouse to be
         # individually ABD-eligible. If both spouses qualify but they
         # are not jointly claiming, they should not be misclassified

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_eligible.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_eligible.py
@@ -5,7 +5,7 @@ class ak_ssp_eligible(Variable):
     value_type = bool
     entity = Person
     label = "Alaska Adult Public Assistance eligible"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.AK
     reference = (
         "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/ak.pdf#page=1",
@@ -16,6 +16,6 @@ class ak_ssp_eligible(Variable):
         p = parameters(period).gov.states.ak.dpa.ssp.eligibility
         return (
             person("is_ssi_eligible", period)
-            & (person("age", period) >= p.age_threshold)
+            & (person("age", period.this_year) >= p.age_threshold)
             & ~person.household("ak_ssp_excluded_institutional_setting", period)
         )

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_excluded_institutional_setting.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_excluded_institutional_setting.py
@@ -5,7 +5,7 @@ class ak_ssp_excluded_institutional_setting(Variable):
     value_type = bool
     entity = Household
     label = "Alaska APA excluded institutional setting"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.AK
     default_value = False
     reference = (

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_living_arrangement.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_living_arrangement.py
@@ -12,7 +12,7 @@ class ak_ssp_living_arrangement(Variable):
     value_type = Enum
     entity = Person
     label = "Alaska Adult Public Assistance living arrangement"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.AK
     possible_values = AKSSPLivingArrangement
     default_value = AKSSPLivingArrangement.INDEPENDENT

--- a/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_payment_standard.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ssp/ak_ssp_payment_standard.py
@@ -6,7 +6,7 @@ class ak_ssp_payment_standard(Variable):
     entity = Person
     label = "Alaska Adult Public Assistance payment standard"
     unit = USD
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.AK
     reference = (
         "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/ak.pdf#page=2"
@@ -22,4 +22,4 @@ class ak_ssp_payment_standard(Variable):
             monthly_amount / 2,
             monthly_amount,
         )
-        return monthly_amount * MONTHS_IN_YEAR
+        return monthly_amount

--- a/policyengine_us/variables/gov/states/al/dhr/ssp/al_ssp_eligible.py
+++ b/policyengine_us/variables/gov/states/al/dhr/ssp/al_ssp_eligible.py
@@ -10,7 +10,7 @@ class al_ssp_eligible(Variable):
     reference = "https://admincode.legislature.state.al.us/api/chapter/660-2-4#page=9"
 
     def formula(person, period, parameters):
-        is_ssi_eligible = person("is_ssi_eligible", period.this_year)
+        is_ssi_eligible = person("is_ssi_eligible", period)
         receives_ssi = person("uncapped_ssi", period) > 0
         payment_category = person("al_ssp_payment_category", period)
         grandfathered = person("al_ssp_grandfathered", period)

--- a/policyengine_us/variables/gov/states/al/dhr/ssp/al_ssp_payment_category.py
+++ b/policyengine_us/variables/gov/states/al/dhr/ssp/al_ssp_payment_category.py
@@ -32,7 +32,7 @@ class al_ssp_payment_category(Variable):
         care = care_setting.possible_values
 
         is_nursing = care_setting == care.NURSING_FACILITY
-        medicaid_pays = person("ssi_medicaid_pays_majority_of_care", period.this_year)
+        medicaid_pays = person("ssi_medicaid_pays_majority_of_care", period)
 
         is_ihc = care_setting == care.PRIVATE_HOME_IHC
         level_b = person("al_level_b_care", period)

--- a/policyengine_us/variables/gov/states/ca/cdss/capi/resources/ca_capi_resources.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/capi/resources/ca_capi_resources.py
@@ -7,6 +7,7 @@ class ca_capi_resources(Variable):
     entity = SPMUnit
     label = "California CAPI resources"
     definition_period = YEAR
+    quantity_type = STOCK
     defined_for = StateCode.CA
     reference = "https://www.cdss.ca.gov/Portals/9/CAPI/CAPI_Regulations-Accessible.pdf"
 

--- a/policyengine_us/variables/gov/states/ca/cdss/state_supplement/ca_state_supplement.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/state_supplement/ca_state_supplement.py
@@ -6,7 +6,7 @@ class ca_state_supplement(Variable):
     entity = SPMUnit
     label = "California state supplement"
     unit = USD
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.CA
     reference = "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=WIC&sectionNum=12200"
 

--- a/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/resources/ca_tanf_resources.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/resources/ca_tanf_resources.py
@@ -7,6 +7,7 @@ class ca_tanf_resources(Variable):
     label = "California CalWORKs Resources"
     unit = USD
     definition_period = YEAR
+    quantity_type = STOCK
     defined_for = StateCode.CA
     reference = "http://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/index.htm?&area=general&type=responsivehelp&ctxid=&project=ePolicyMaster#t=mergedProjects%2FCalWORKs%2FCalWORKs%2F42-200_Property%2F42-200_Property.htm%23Policybc-2&rhtocid=_3_1_2_0_1"
 

--- a/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/resources/ca_tanf_resources_limit.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/tanf/cash/resources/ca_tanf_resources_limit.py
@@ -7,6 +7,7 @@ class ca_tanf_resources_limit(Variable):
     label = "California CalWORKs Resources Limit"
     unit = USD
     definition_period = YEAR
+    quantity_type = STOCK
     defined_for = StateCode.CA
     reference = "http://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/index.htm?&area=general&type=responsivehelp&ctxid=&project=ePolicyMaster#t=mergedProjects%2FCalWORKs%2FCalWORKs%2F42-200_Property%2F42-200_Property.htm%23Policybc-2&rhtocid=_3_1_2_0_1"
 

--- a/policyengine_us/variables/gov/states/co/ssa/state_supplement/co_state_supplement.py
+++ b/policyengine_us/variables/gov/states/co/ssa/state_supplement/co_state_supplement.py
@@ -5,7 +5,7 @@ class co_state_supplement(Variable):
     value_type = float
     entity = Person
     label = "Colorado State Supplement"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = "co_state_supplement_eligible"
 
     def formula(person, period, parameters):
@@ -13,5 +13,5 @@ class co_state_supplement(Variable):
         ssi = person("ssi", period)
         total_countable_income = ssi + income
         p = parameters(period).gov.states.co.ssa.state_supplement
-        grant_standard = p.grant_standard * MONTHS_IN_YEAR
+        grant_standard = p.grant_standard
         return max_(0, grant_standard - total_countable_income)

--- a/policyengine_us/variables/gov/states/co/ssa/state_supplement/co_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/co/ssa/state_supplement/co_state_supplement_eligible.py
@@ -5,15 +5,15 @@ class co_state_supplement_eligible(Variable):
     value_type = bool
     entity = Person
     label = "Colorado State Supplement Eligible"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.CO
 
     def formula(person, period, parameters):
-        ssi_eligible = person("is_ssi_eligible_individual", period)
-        is_disabled = person("is_ssi_disabled", period)
-        is_blind = person("is_blind", period)
+        ssi_eligible = person("is_ssi_eligible_individual", period.this_year)
+        is_disabled = person("is_ssi_disabled", period.this_year)
+        is_blind = person("is_blind", period.this_year)
         disabled_or_blind = is_disabled | is_blind
-        age = person("age", period)
+        age = person("age", period.this_year)
         p = parameters(period).gov.states.co.ssa.state_supplement
         in_age_range = p.age_range.calc(age)
         return disabled_or_blind & ssi_eligible & in_age_range

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_has_therapeutic_diet.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_has_therapeutic_diet.py
@@ -5,6 +5,6 @@ class ct_ssp_has_therapeutic_diet(Variable):
     value_type = bool
     entity = Person
     label = "Whether the person requires a therapeutic diet under Connecticut SSP"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.CT
     reference = "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/ct.html"

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_lives_with_others.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_lives_with_others.py
@@ -5,6 +5,6 @@ class ct_ssp_lives_with_others(Variable):
     value_type = bool
     entity = Person
     label = "Whether the person lives with unrelated persons in the community under Connecticut SSP"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.CT
     reference = "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/ct.html"

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_living_arrangement.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_living_arrangement.py
@@ -16,7 +16,7 @@ class ct_ssp_living_arrangement(Variable):
     value_type = Enum
     entity = Person
     label = "Connecticut SSP living arrangement"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.CT
     possible_values = CTSSPLivingArrangement
     default_value = CTSSPLivingArrangement.COMMUNITY_ALONE

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_resides_in_boarding_home.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/ct_ssp_resides_in_boarding_home.py
@@ -5,6 +5,6 @@ class ct_ssp_resides_in_boarding_home(Variable):
     value_type = bool
     entity = Person
     label = "Whether the person resides in a licensed room and board facility under Connecticut SSP"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.CT
     reference = "https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/ct.html"

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/eligibility/ct_ssp_categorically_eligible.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/eligibility/ct_ssp_categorically_eligible.py
@@ -19,7 +19,7 @@ class ct_ssp_categorically_eligible(Variable):
         # who meet state eligibility criteria, but do not meet
         # federal SSI eligibility guidelines."
         # https://www.ssa.gov/policy/docs/progdesc/ssi_st_asst/2011/ct.html
-        is_ssi_eligible = person("is_ssi_eligible", period.this_year)
+        is_ssi_eligible = person("is_ssi_eligible", period)
 
         # Per CGS 17b-600: Only blind children are eligible; disabled
         # (non-blind) children are excluded from CT SSP.

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/income/ct_ssp_unearned_income_disregard.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/income/ct_ssp_unearned_income_disregard.py
@@ -16,5 +16,5 @@ class ct_ssp_unearned_income_disregard(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ct.dss.ssp.disregard
-        arrangement = person("ct_ssp_living_arrangement", period.this_year)
+        arrangement = person("ct_ssp_living_arrangement", period)
         return p.unearned[arrangement]

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/payment/ct_ssp_personal_needs_allowance.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/payment/ct_ssp_personal_needs_allowance.py
@@ -15,7 +15,7 @@ class ct_ssp_personal_needs_allowance(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ct.dss.ssp
-        arrangement = person("ct_ssp_living_arrangement", period.this_year)
+        arrangement = person("ct_ssp_living_arrangement", period)
         arrangements = arrangement.possible_values
         is_joint_claim = person("ssi_claim_is_joint", period.this_year)
 

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/payment/ct_ssp_shelter_allowance.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/payment/ct_ssp_shelter_allowance.py
@@ -20,7 +20,7 @@ class ct_ssp_shelter_allowance(Variable):
         # not the $0 in the parameter table.  Modeling the facility
         # rate requires a per-facility input variable.
         p = parameters(period).gov.states.ct.dss.ssp
-        arrangement = person("ct_ssp_living_arrangement", period.this_year)
+        arrangement = person("ct_ssp_living_arrangement", period)
         rent = person("rent", period)
         max_allowance = p.shelter_allowance[arrangement]
         return min_(rent, max_allowance)

--- a/policyengine_us/variables/gov/states/ct/dss/ssp/payment/ct_ssp_special_needs.py
+++ b/policyengine_us/variables/gov/states/ct/dss/ssp/payment/ct_ssp_special_needs.py
@@ -15,5 +15,5 @@ class ct_ssp_special_needs(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ct.dss.ssp.special_needs
-        has_therapeutic_diet = person("ct_ssp_has_therapeutic_diet", period.this_year)
+        has_therapeutic_diet = person("ct_ssp_has_therapeutic_diet", period)
         return has_therapeutic_diet * p.therapeutic_diet

--- a/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_eligible.py
+++ b/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_eligible.py
@@ -21,7 +21,7 @@ class dc_ossp_eligible(Variable):
         # payment level. They receive $0 federal SSI but still
         # qualify for a reduced state supplement. Eligibility is
         # therefore categorical (is_ssi_eligible), not ssi > 0.
-        categorically_eligible = person("is_ssi_eligible", period.this_year)
+        categorically_eligible = person("is_ssi_eligible", period)
         living_arrangement = person("dc_ossp_living_arrangement", period)
         in_qualifying_facility = living_arrangement != DCOSSPLivingArrangement.NONE
         return categorically_eligible & in_qualifying_facility

--- a/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_facility_size.py
+++ b/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_facility_size.py
@@ -5,6 +5,6 @@ class dc_ossp_facility_size(Variable):
     value_type = int
     entity = Person
     label = "Number of beds in the adult foster care home"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.DC
     reference = "https://code.dccouncil.gov/us/dc/council/code/sections/4-205.49"

--- a/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_in_adult_foster_care.py
+++ b/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_in_adult_foster_care.py
@@ -5,6 +5,6 @@ class dc_ossp_in_adult_foster_care(Variable):
     value_type = bool
     entity = Person
     label = "Whether the person resides in an adult foster care home"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.DC
     reference = "https://code.dccouncil.gov/us/dc/council/code/sections/4-205.49"

--- a/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_living_arrangement.py
+++ b/policyengine_us/variables/gov/states/dc/dhcf/ossp/dc_ossp_living_arrangement.py
@@ -25,12 +25,12 @@ class dc_ossp_living_arrangement(Variable):
     )
 
     def formula(person, period, parameters):
-        federal_la = person("ssi_federal_living_arrangement", period.this_year)
+        federal_la = person("ssi_federal_living_arrangement", period)
         in_medical_facility = (
             federal_la == SSIFederalLivingArrangement.MEDICAL_TREATMENT_FACILITY
         )
-        in_afc = person("dc_ossp_in_adult_foster_care", period.this_year)
-        facility_size = person("dc_ossp_facility_size", period.this_year)
+        in_afc = person("dc_ossp_in_adult_foster_care", period)
+        facility_size = person("dc_ossp_facility_size", period)
         p = parameters(period).gov.states.dc.dhcf.ossp
         small_facility = facility_size <= p.facility_size_threshold
 

--- a/policyengine_us/variables/gov/states/dc/dhs/tanf/dc_tanf_countable_resources.py
+++ b/policyengine_us/variables/gov/states/dc/dhs/tanf/dc_tanf_countable_resources.py
@@ -7,6 +7,7 @@ class dc_tanf_countable_resources(Variable):
     label = "DC Temporary Assistance for Needy Families (TANF) countable resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = (
         "https://dhs.dc.gov/service/temporary-cash-assistance-needy-families-tanf",
         "https://dhs.dc.gov/sites/default/files/dc/sites/dhs/service_content/attachments/DC%20TANF%20State%20Plan_Oct-2023.pdf#page=40",

--- a/policyengine_us/variables/gov/states/de/dhss/ssp/de_ssp_eligible.py
+++ b/policyengine_us/variables/gov/states/de/dhss/ssp/de_ssp_eligible.py
@@ -18,7 +18,7 @@ class de_ssp_eligible(Variable):
         # levels. Income overspill is handled in de_ssp via the
         # uncapped_ssi reduction formula, so is_ssi_eligible is used
         # without an uncapped_ssi > 0 gate.
-        is_ssi_eligible = person("is_ssi_eligible", period.this_year)
+        is_ssi_eligible = person("is_ssi_eligible", period)
         is_adult = person("is_adult", period.this_year)
         living_arrangement = person.household("de_ssp_living_arrangement", period)
         in_certified_residential_care_home = (

--- a/policyengine_us/variables/gov/states/ga/dhs/ssp/ga_ssp_eligible_person.py
+++ b/policyengine_us/variables/gov/states/ga/dhs/ssp/ga_ssp_eligible_person.py
@@ -14,13 +14,13 @@ class ga_ssp_eligible_person(Variable):
     )
 
     def formula(person, period, parameters):
-        arrangement = person("ssi_federal_living_arrangement", period.this_year)
+        arrangement = person("ssi_federal_living_arrangement", period)
         in_federal_medicaid_facility = (
             arrangement == arrangement.possible_values.MEDICAL_TREATMENT_FACILITY
         )
         in_georgia_ssp_setting = person(
             "ga_ssp_in_nursing_home_or_institutionalized_hospice",
-            period.this_year,
+            period,
         )
         ssi_amount = person("ssi", period)
         # in_federal_medicaid_facility already confirms MEDICAL_TREATMENT_FACILITY

--- a/policyengine_us/variables/gov/states/ga/dhs/ssp/ga_ssp_in_nursing_home_or_institutionalized_hospice.py
+++ b/policyengine_us/variables/gov/states/ga/dhs/ssp/ga_ssp_in_nursing_home_or_institutionalized_hospice.py
@@ -5,7 +5,7 @@ class ga_ssp_in_nursing_home_or_institutionalized_hospice(Variable):
     value_type = bool
     entity = Person
     label = "Georgia SSP recipient is in a nursing home or institutionalized hospice"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.GA
     default_value = False
     reference = (

--- a/policyengine_us/variables/gov/states/hi/dhs/oss/hi_oss_couple_rate_applies.py
+++ b/policyengine_us/variables/gov/states/hi/dhs/oss/hi_oss_couple_rate_applies.py
@@ -17,7 +17,7 @@ class hi_oss_couple_rate_applies(Variable):
 
     def formula(person, period, parameters):
         joint_claim = person("ssi_claim_is_joint", period.this_year)
-        is_eligible = person("is_ssi_eligible", period.this_year)
+        is_eligible = person("is_ssi_eligible", period)
         both_ssi_eligible = (
             person.marital_unit.sum(is_eligible) == person.marital_unit.nb_persons()
         )

--- a/policyengine_us/variables/gov/states/hi/dhs/oss/hi_oss_eligible.py
+++ b/policyengine_us/variables/gov/states/hi/dhs/oss/hi_oss_eligible.py
@@ -21,7 +21,7 @@ class hi_oss_eligible(Variable):
         # payment level. They receive $0 federal SSI but still
         # qualify for a reduced state supplement. Eligibility is
         # therefore categorical (is_ssi_eligible), not ssi > 0.
-        is_eligible = person("is_ssi_eligible", period.this_year)
+        is_eligible = person("is_ssi_eligible", period)
         living_arrangement = person("hi_oss_living_arrangement", period)
         in_qualifying_facility = living_arrangement != HIOSSLivingArrangement.NONE
         return is_eligible & in_qualifying_facility

--- a/policyengine_us/variables/gov/states/hi/dhs/oss/hi_oss_living_arrangement.py
+++ b/policyengine_us/variables/gov/states/hi/dhs/oss/hi_oss_living_arrangement.py
@@ -26,7 +26,7 @@ class hi_oss_living_arrangement(Variable):
     )
 
     def formula(person, period, parameters):
-        federal_la = person("ssi_federal_living_arrangement", period.this_year)
+        federal_la = person("ssi_federal_living_arrangement", period)
         in_medical_facility = (
             federal_la == federal_la.possible_values.MEDICAL_TREATMENT_FACILITY
         )

--- a/policyengine_us/variables/gov/states/id/dhw/aabd/id_aabd_eligible.py
+++ b/policyengine_us/variables/gov/states/id/dhw/aabd/id_aabd_eligible.py
@@ -20,7 +20,7 @@ class id_aabd_eligible(Variable):
         la = person("id_aabd_living_arrangement", period)
         LA = IDAAbdLivingArrangement
         # Nursing facility residents excluded (Section 501)
-        federal_la = person("ssi_federal_living_arrangement", period.this_year)
+        federal_la = person("ssi_federal_living_arrangement", period)
         not_in_medical = (
             federal_la != federal_la.possible_values.MEDICAL_TREATMENT_FACILITY
         )

--- a/policyengine_us/variables/gov/states/il/dhs/aabd/eligibility/il_aabd_non_financial_eligible_person.py
+++ b/policyengine_us/variables/gov/states/il/dhs/aabd/eligibility/il_aabd_non_financial_eligible_person.py
@@ -26,7 +26,7 @@ class il_aabd_non_financial_eligible_person(Variable):
         # is_ssi_eligible checks categorical (aged/blind/disabled), resources,
         # and immigration status for SSI. If True, person qualifies for IL AABD
         # regardless of whether they actually receive SSI (income may be too high).
-        ssi_status_eligible = person("is_ssi_eligible", period.this_year)
+        ssi_status_eligible = person("is_ssi_eligible", period)
 
         # IL AABD has additional qualified noncitizen categories beyond SSI
         # (e.g., abuse victims, trafficking victims, military families per

--- a/policyengine_us/variables/gov/states/in/fssa/ssp/in_resides_in_licensed_residential_facility.py
+++ b/policyengine_us/variables/gov/states/in/fssa/ssp/in_resides_in_licensed_residential_facility.py
@@ -5,7 +5,7 @@ class in_resides_in_licensed_residential_facility(Variable):
     value_type = bool
     entity = Person
     label = "Resides in an Indiana licensed residential care facility"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.IN
     default_value = False
     reference = (

--- a/policyengine_us/variables/gov/states/in/fssa/ssp/in_resides_in_unlicensed_residential_facility.py
+++ b/policyengine_us/variables/gov/states/in/fssa/ssp/in_resides_in_unlicensed_residential_facility.py
@@ -5,7 +5,7 @@ class in_resides_in_unlicensed_residential_facility(Variable):
     value_type = bool
     entity = Person
     label = "Resides in an Indiana unlicensed residential care facility"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.IN
     default_value = False
     reference = (

--- a/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_living_arrangement.py
+++ b/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_living_arrangement.py
@@ -12,7 +12,7 @@ class in_ssp_living_arrangement(Variable):
     value_type = Enum
     entity = Person
     label = "Indiana SSP living arrangement"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.IN
     possible_values = INSSPLivingArrangement
     default_value = INSSPLivingArrangement.NONE

--- a/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_rcap.py
+++ b/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_rcap.py
@@ -18,7 +18,7 @@ class in_ssp_rcap(Variable):
         # deducted from the state standard. The remainder is the state
         # supplementation."
         p = parameters(period).gov.states["in"].fssa.ssp
-        living_arrangement = person("in_ssp_living_arrangement", period.this_year)
+        living_arrangement = person("in_ssp_living_arrangement", period)
         is_licensed = (
             living_arrangement
             == living_arrangement.possible_values.LICENSED_RESIDENTIAL

--- a/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_rcap_eligible.py
+++ b/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_rcap_eligible.py
@@ -18,13 +18,13 @@ class in_ssp_rcap_eligible(Variable):
         # own home and need care in a residential facility."
         # Indiana RCAP page: "at least 65 years of age, or blind or disabled."
         is_abd = person("is_ssi_aged_blind_disabled", period.this_year)
-        receives_ssi = person("ssi", period.this_year) > 0
+        receives_ssi = person("ssi", period) > 0
         on_medicaid = person("medicaid_enrolled", period.this_year)
         is_recipient = receives_ssi | on_medicaid
         age = person("age", period.this_year)
         p = parameters(period).gov.states["in"].fssa.ssp
         age_eligible = age >= p.age_threshold
-        living_arrangement = person("in_ssp_living_arrangement", period.this_year)
+        living_arrangement = person("in_ssp_living_arrangement", period)
         arrangements = living_arrangement.possible_values
         in_residential = (living_arrangement == arrangements.LICENSED_RESIDENTIAL) | (
             living_arrangement == arrangements.UNLICENSED_RESIDENTIAL

--- a/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_sapn_eligible.py
+++ b/policyengine_us/variables/gov/states/in/fssa/ssp/in_ssp_sapn_eligible.py
@@ -14,12 +14,12 @@ class in_ssp_sapn_eligible(Variable):
 
     def formula(person, period, parameters):
         # IC 12-15-32-6.5: must be "a recipient of assistance under the federal SSI program"
-        is_ssi_recipient = person("ssi", period.this_year) > 0
+        is_ssi_recipient = person("ssi", period) > 0
         on_medicaid = person("medicaid_enrolled", period.this_year)
         age = person("age", period.this_year)
         p = parameters(period).gov.states["in"].fssa.ssp
         age_eligible = age >= p.age_threshold
-        arrangement = person("ssi_federal_living_arrangement", period.this_year)
+        arrangement = person("ssi_federal_living_arrangement", period)
         in_medicaid_facility = (
             arrangement == arrangement.possible_values.MEDICAL_TREATMENT_FACILITY
         )

--- a/policyengine_us/variables/gov/states/in/fssa/tanf/resources/in_tanf_countable_resources.py
+++ b/policyengine_us/variables/gov/states/in/fssa/tanf/resources/in_tanf_countable_resources.py
@@ -7,6 +7,7 @@ class in_tanf_countable_resources(Variable):
     label = "Indiana TANF countable resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     defined_for = StateCode.IN
     reference = (
         "https://iar.iga.in.gov/code/2026/470/10.3#470-10.3-4-2",

--- a/policyengine_us/variables/gov/states/ks/kdhe/sspp/ks_sspp_eligible.py
+++ b/policyengine_us/variables/gov/states/ks/kdhe/sspp/ks_sspp_eligible.py
@@ -18,7 +18,7 @@ class ks_sspp_eligible(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ks.kdhe.sspp.eligibility
         receives_ssi = person("ssi", period) > 0
-        federal_la = person("ssi_federal_living_arrangement", period.this_year)
+        federal_la = person("ssi_federal_living_arrangement", period)
         in_medical_facility = (
             federal_la == SSIFederalLivingArrangement.MEDICAL_TREATMENT_FACILITY
         )

--- a/policyengine_us/variables/gov/states/ky/dcbs/ssp/ky_ssp_countable_income.py
+++ b/policyengine_us/variables/gov/states/ky/dcbs/ssp/ky_ssp_countable_income.py
@@ -35,7 +35,7 @@ class ky_ssp_countable_income(Variable):
         countable_earned = max_(earned - p.earned, 0) * (1 - p.earned_share)
         personal_countable = unearned + countable_earned
 
-        both_eligible = person("ssi_couple_computation_applies", period.this_year)
+        both_eligible = person("ssi_couple_computation_applies", period)
         spousal_deemed = person("ssi_income_deemed_from_ineligible_spouse", period)
         is_eligible = person("is_ssi_eligible_individual", period.this_year) | person(
             "is_ssi_eligible_spouse", period.this_year

--- a/policyengine_us/variables/gov/states/ma/dta/ssp/ma_maximum_state_supplement.py
+++ b/policyengine_us/variables/gov/states/ma/dta/ssp/ma_maximum_state_supplement.py
@@ -6,12 +6,12 @@ class ma_maximum_state_supplement(Variable):
     entity = Person
     label = "Massachusetts maximum State Supplement payment amount"
     unit = USD
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = "is_ssi_eligible"
 
     def formula(person, period, parameters):
         """
-        Returns the maximum annual state supplement for an SSI-eligible individual,
+        Returns the maximum monthly state supplement for an SSI-eligible individual,
         before subtracting any leftover income. Depends on:
           - The person's state of residence
           - Living arrangement (e.g. FULL_COST, REST_HOME, etc.)
@@ -33,20 +33,20 @@ class ma_maximum_state_supplement(Variable):
 
         # 4. Identify whether the person is aged, blind, or disabled.
         #    (It's possible to be both aged+blind, so we might pick whichever rate is higher.)
-        is_blind = person("is_blind", period)
-        is_aged = person("is_ssi_aged", period)
-        is_disabled = person("is_ssi_disabled", period)
+        is_blind = person("is_blind", period.this_year)
+        is_aged = person("is_ssi_aged", period.this_year)
+        is_disabled = person("is_ssi_disabled", period.this_year)
 
         # 5. We'll build an array of the single or double (couple) label: e.g. "1" or "2".
         #    This matches the structure in the parameter file.
-        joint_claim = person("ssi_claim_is_joint", period)
+        joint_claim = person("ssi_claim_is_joint", period.this_year)
         # Convert True -> "2", False -> "1"
         single_or_double_str = where(joint_claim, 2, 1).astype(str)
 
         # 6. For vectorization, we note how many people are in the array dimension.
         #    We do the same trick for categories. For each person, we might pick
         #    'AGED', 'BLIND', or 'DISABLED' monthly rate. This code uses np arrays:
-        ssi_categories = person("ssi_category", period).possible_values
+        ssi_categories = person("ssi_category", period.this_year).possible_values
         count_persons = len(is_blind)  # number of entries in the vector
 
         # 7. Create arrays for each category's monthly rate. For each person, we do:
@@ -82,16 +82,12 @@ class ma_maximum_state_supplement(Variable):
             [monthly_aged_rate, monthly_blind_rate, monthly_disabled_rate]
         )
 
-        # 9. Multiply by 12 to get an annual figure. This is the maximum annual supplement
-        #    (still for each person individually).
-        annual_rate = monthly_rate * MONTHS_IN_YEAR
-
-        # 10. Summation across the marital unit. If we have a couple, we might want
+        # 9. Summation across the marital unit. If we have a couple, we might want
         #     the total combined amount, then split it. Or we might directly keep it as per-person.
         # Here, they sum for the entire marital unit, then later they do dividing if needed.
-        combined_amount_for_marital_unit = person.marital_unit.sum(annual_rate)
+        combined_amount_for_marital_unit = person.marital_unit.sum(monthly_rate)
 
-        # 11. Finally, the code divides by 2 if it's a joint claim, presumably so that
+        # 10. Finally, the code divides by 2 if it's a joint claim, presumably so that
         #     each person sees their half. If it's not joint, it just returns the full amount.
         # This "per-person" approach might be confusing if the state has a special "couple rate"
         # that isn't exactly double or half. But that's how the code is set up now.

--- a/policyengine_us/variables/gov/states/ma/dta/ssp/ma_state_living_arrangement.py
+++ b/policyengine_us/variables/gov/states/ma/dta/ssp/ma_state_living_arrangement.py
@@ -14,7 +14,7 @@ class ma_state_living_arrangement(Variable):
     value_type = Enum
     entity = Household
     label = "Massachusetts State Living Arrangement"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.MA
     possible_values = MAStateLivingArrangement
     default_value = MAStateLivingArrangement.FULL_COST

--- a/policyengine_us/variables/gov/states/ma/dta/ssp/ma_state_supplement.py
+++ b/policyengine_us/variables/gov/states/ma/dta/ssp/ma_state_supplement.py
@@ -5,7 +5,7 @@ class ma_state_supplement(Variable):
     value_type = float
     entity = Person
     label = "Massachusetts State Supplement payment amount"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.MA
     exhaustive_parameter_dependencies = "gov.states.ma.dta.ssp"
     reference = "https://www.law.cornell.edu/regulations/massachusetts/106-CMR-327-330"
@@ -15,10 +15,10 @@ class ma_state_supplement(Variable):
         reduction_after_ssi = max_(0, -uncapped_ssi)
         maximum_ss = person("ma_maximum_state_supplement", period)
         state_supplement = max_(0, maximum_ss - reduction_after_ssi)
-        abd = person("is_ssi_aged_blind_disabled", period)
+        abd = person("is_ssi_aged_blind_disabled", period.this_year)
         meets_resource_test = person("meets_ssi_resource_test", period)
         eligible = abd & meets_resource_test
-        joint_claim = person("ssi_claim_is_joint", period)
+        joint_claim = person("ssi_claim_is_joint", period.this_year)
         return where(
             joint_claim,
             person.marital_unit.sum(state_supplement) / 2,

--- a/policyengine_us/variables/gov/states/me/dhhs/ssp/me_ssp_eligible.py
+++ b/policyengine_us/variables/gov/states/me/dhhs/ssp/me_ssp_eligible.py
@@ -20,7 +20,7 @@ class me_ssp_eligible(Variable):
         # immigration but NOT income, so it captures both groups. The
         # but-for-citizenship pathway is not modeled because we don't
         # track the 8/96 immigration category at the moment.
-        categorically_eligible = person("is_ssi_eligible", period.this_year)
+        categorically_eligible = person("is_ssi_eligible", period)
         category = person("me_ssp_payment_category", period)
         in_qualifying_category = category != category.possible_values.NONE
         return categorically_eligible & in_qualifying_category

--- a/policyengine_us/variables/gov/states/me/dhhs/ssp/me_ssp_payment_category.py
+++ b/policyengine_us/variables/gov/states/me/dhhs/ssp/me_ssp_payment_category.py
@@ -20,7 +20,7 @@ class me_ssp_payment_category(Variable):
     def formula(person, period, parameters):
         # Maine adopts the federal SSI living-arrangement codes (Part 11),
         # so federally-classified arrangements override the manual input.
-        federal_arrangement = person("ssi_federal_living_arrangement", period.this_year)
+        federal_arrangement = person("ssi_federal_living_arrangement", period)
         federal_values = federal_arrangement.possible_values
         in_medical_facility = (
             federal_arrangement == federal_values.MEDICAL_TREATMENT_FACILITY

--- a/policyengine_us/variables/gov/states/mi/mdhhs/ssp/mi_ssp_eligible.py
+++ b/policyengine_us/variables/gov/states/mi/mdhhs/ssp/mi_ssp_eligible.py
@@ -31,7 +31,7 @@ class mi_ssp_eligible(Variable):
             category == MISSPLivingArrangement.HOUSEHOLD_OF_ANOTHER
         )
         receives_ssi = person("ssi", period) > 0
-        is_ssi_eligible = person("is_ssi_eligible", period.this_year)
+        is_ssi_eligible = person("is_ssi_eligible", period)
         arrangement_gate = where(
             is_strict_category,
             receives_ssi,

--- a/policyengine_us/variables/gov/states/mi/mdhhs/ssp/mi_ssp_payment_category.py
+++ b/policyengine_us/variables/gov/states/mi/mdhhs/ssp/mi_ssp_payment_category.py
@@ -24,7 +24,7 @@ class mi_ssp_payment_category(Variable):
         # override the manual input for the categories Michigan shares with
         # federal SSI. Adult Foster Care and Home for the Aged categories
         # are MI-specific and fall back to the user-provided input.
-        federal_arrangement = person("ssi_federal_living_arrangement", period.this_year)
+        federal_arrangement = person("ssi_federal_living_arrangement", period)
         federal_values = federal_arrangement.possible_values
         in_medical_facility = (
             federal_arrangement == federal_values.MEDICAL_TREATMENT_FACILITY

--- a/policyengine_us/variables/gov/states/mt/dhs/tanf/mt_tanf_countable_resources.py
+++ b/policyengine_us/variables/gov/states/mt/dhs/tanf/mt_tanf_countable_resources.py
@@ -7,6 +7,7 @@ class mt_tanf_countable_resources(Variable):
     label = "Montana Temporary Assistance for Needy Families (TANF) countable resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = (
         "https://dphhs.mt.gov/assets/hcsd/tanfmanual/TANF4021May012021.pdf#page=1",
         "https://dphhs.mt.gov/assets/hcsd/tanfmanual/TANF403-1Jan012018.pdf#page=1",

--- a/policyengine_us/variables/gov/states/nm/hca/nm_works/resources/nm_works_countable_liquid_resources.py
+++ b/policyengine_us/variables/gov/states/nm/hca/nm_works/resources/nm_works_countable_liquid_resources.py
@@ -7,6 +7,7 @@ class nm_works_countable_liquid_resources(Variable):
     label = "New Mexico Works countable liquid resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = (
         "https://www.srca.nm.gov/parts/title08/08.102.0510.html",
         "https://www.hca.nm.gov/wp-content/uploads/TANF-Final-State-Plan-2024-to-2026.pdf#page=20",

--- a/policyengine_us/variables/gov/states/nm/hca/nm_works/resources/nm_works_countable_non_liquid_resources.py
+++ b/policyengine_us/variables/gov/states/nm/hca/nm_works/resources/nm_works_countable_non_liquid_resources.py
@@ -7,6 +7,7 @@ class nm_works_countable_non_liquid_resources(Variable):
     label = "New Mexico Works countable non-liquid resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = (
         "https://www.srca.nm.gov/parts/title08/08.102.0510.html",
         "https://www.hca.nm.gov/wp-content/uploads/TANF-Final-State-Plan-2024-to-2026.pdf#page=20",

--- a/policyengine_us/variables/gov/states/nm/hca/nm_works/resources/nm_works_countable_resources.py
+++ b/policyengine_us/variables/gov/states/nm/hca/nm_works/resources/nm_works_countable_resources.py
@@ -7,6 +7,7 @@ class nm_works_countable_resources(Variable):
     label = "New Mexico Works countable resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = "https://www.srca.nm.gov/parts/title08/08.102.0510.html"
     defined_for = StateCode.NM
 

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/is_in_adult_residential_care.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/is_in_adult_residential_care.py
@@ -5,6 +5,6 @@ class is_in_adult_residential_care(Variable):
     value_type = bool
     entity = Person
     label = "Whether the person lives in a licensed adult residential shelter care home"
-    definition_period = YEAR
+    definition_period = MONTH
     default_value = False
     reference = "https://srca.nm.gov/parts/title08/08.106.0100.html"

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement.py
@@ -5,11 +5,11 @@ class nm_ssi_state_supplement(Variable):
     value_type = float
     entity = Person
     label = "New Mexico SSI state supplement"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = "nm_ssi_state_supplement_eligible"
     unit = USD
     reference = "https://srca.nm.gov/parts/title08/08.106.0500.html"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.nm.hca.ssi_supplement
-        return p.amount * MONTHS_IN_YEAR
+        return p.amount

--- a/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/nm/hca/ssi_supplement/nm_ssi_state_supplement_eligible.py
@@ -5,7 +5,7 @@ class nm_ssi_state_supplement_eligible(Variable):
     value_type = bool
     entity = Person
     label = "New Mexico SSI state supplement eligible"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.NM
     reference = (
         "https://srca.nm.gov/parts/title08/08.106.0500.html",
@@ -13,8 +13,8 @@ class nm_ssi_state_supplement_eligible(Variable):
     )
 
     def formula(person, period, parameters):
-        ssi_eligible = person("is_ssi_eligible_individual", period)
-        age = person("age", period)
+        ssi_eligible = person("is_ssi_eligible_individual", period.this_year)
+        age = person("age", period.this_year)
         p = parameters(period).gov.states.nm.hca.ssi_supplement
         meets_age = age >= p.min_age
         in_residential_care = person("is_in_adult_residential_care", period)

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class sc_ssi_state_supplement(Variable):
     value_type = float
     entity = Person
-    definition_period = YEAR
+    definition_period = MONTH
     label = "South Carolina SSI State Supplement"
     unit = USD
     reference = (
@@ -16,7 +16,7 @@ class sc_ssi_state_supplement(Variable):
     def formula(person, period, parameters):
         # Per S.C. Code Regs. 126-910: OSS = max(0, NIL - countable income)
         p = parameters(period).gov.states.sc.scdhhs.ssi_state_supplement
-        nil = p.net_income_limit * MONTHS_IN_YEAR
+        nil = p.net_income_limit
         countable_income = person("ssi_countable_income", period)
         ssi = person("ssi", period)
         return max_(0, nil - countable_income - ssi)

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_eligible.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class sc_ssi_state_supplement_eligible(Variable):
     value_type = bool
     entity = Person
-    definition_period = YEAR
+    definition_period = MONTH
     label = "South Carolina SSI State Supplement eligible"
     reference = (
         "https://www.law.cornell.edu/regulations/south-carolina/R-126-920",
@@ -14,10 +14,10 @@ class sc_ssi_state_supplement_eligible(Variable):
 
     def formula(person, period, parameters):
         # Per S.C. Code Regs. 126-920: aged/blind/disabled + CRCF + income < NIL
-        is_aged_blind_disabled = person("is_ssi_aged_blind_disabled", period)
+        is_aged_blind_disabled = person("is_ssi_aged_blind_disabled", period.this_year)
         in_facility = person("is_in_residential_care_facility", period)
         p = parameters(period).gov.states.sc.scdhhs.ssi_state_supplement
-        nil = p.net_income_limit * MONTHS_IN_YEAR
+        nil = p.net_income_limit
         countable_income = person("ssi_countable_income", period)
         ssi = person("ssi", period)
         income_eligible = (countable_income + ssi) < nil

--- a/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.py
+++ b/policyengine_us/variables/gov/states/sc/scdhhs/ssi_state_supplement/sc_ssi_state_supplement_pna.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class sc_ssi_state_supplement_pna(Variable):
     value_type = float
     entity = Person
-    definition_period = YEAR
+    definition_period = MONTH
     label = "South Carolina SSI State Supplement personal needs allowance"
     unit = USD
     reference = (
@@ -20,4 +20,4 @@ class sc_ssi_state_supplement_pna(Variable):
         # Per S.C. Code Regs. 126-910(G): SSI-only PNA if no other
         # countable income; higher PNA if other income sources exist
         ssi_only = person("ssi_countable_income", period) == 0
-        return where(ssi_only, p.ssi_only, p.other_income) * MONTHS_IN_YEAR
+        return where(ssi_only, p.ssi_only, p.other_income)

--- a/policyengine_us/variables/gov/states/tn/dhs/ff/eligibility/tn_ff_countable_resources.py
+++ b/policyengine_us/variables/gov/states/tn/dhs/ff/eligibility/tn_ff_countable_resources.py
@@ -7,6 +7,7 @@ class tn_ff_countable_resources(Variable):
     label = "Tennessee Families First countable resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = "https://publications.tnsosfiles.com/rules/1240/1240-01/1240-01-50.20081124.pdf#page=1"
     defined_for = StateCode.TN
 

--- a/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
+++ b/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement.py
@@ -6,7 +6,7 @@ class tx_ssi_state_supplement(Variable):
     entity = Person
     label = "Texas SSI State Supplement"
     unit = USD
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = "tx_ssi_state_supplement_eligible"
     reference = (
         "https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm",
@@ -18,4 +18,4 @@ class tx_ssi_state_supplement(Variable):
         p = parameters(period).gov.states.tx.hhsc.ssi_state_supplement
         pna = p.personal_needs_allowance
         federal_reduced = parameters(period).gov.ssa.ssi.amount.institutional.individual
-        return max_(pna - federal_reduced, 0) * MONTHS_IN_YEAR
+        return max_(pna - federal_reduced, 0)

--- a/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.py
+++ b/policyengine_us/variables/gov/states/tx/hhsc/ssi_state_supplement/tx_ssi_state_supplement_eligible.py
@@ -5,7 +5,7 @@ class tx_ssi_state_supplement_eligible(Variable):
     value_type = bool
     entity = Person
     label = "Texas SSI State Supplement eligible"
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.TX
     reference = (
         "https://statutes.capitol.texas.gov/Docs/HR/htm/HR.32.htm",
@@ -13,6 +13,6 @@ class tx_ssi_state_supplement_eligible(Variable):
     )
 
     def formula(person, period, parameters):
-        ssi_eligible = person("is_ssi_eligible_individual", period)
+        ssi_eligible = person("is_ssi_eligible_individual", period.this_year)
         in_facility = person("is_in_medicaid_facility", period)
         return ssi_eligible & in_facility

--- a/policyengine_us/variables/gov/states/tx/tanf/resources/tx_tanf_countable_resources.py
+++ b/policyengine_us/variables/gov/states/tx/tanf/resources/tx_tanf_countable_resources.py
@@ -7,6 +7,7 @@ class tx_tanf_countable_resources(Variable):
     label = "Texas TANF countable resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = (
         "https://www.hhs.texas.gov/handbooks/texas-works-handbook/a-1210-general-policy",
         "https://www.hhs.texas.gov/handbooks/texas-works-handbook/a-1220-limits",

--- a/policyengine_us/variables/gov/states/wa/dshs/ssp/wa_ssp_payment_category.py
+++ b/policyengine_us/variables/gov/states/wa/dshs/ssp/wa_ssp_payment_category.py
@@ -22,11 +22,11 @@ class wa_ssp_payment_category(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.wa.dshs.ssp
-        base_eligible = person("ssi", period.this_year) > 0
+        base_eligible = person("ssi", period) > 0
 
         # SDX code D (medical treatment facility) maps to MEDICAL_INSTITUTION;
         # codes A/B/C (community living) map to STANDARD via the categorical paths.
-        living_arrangement = person("ssi_federal_living_arrangement", period.this_year)
+        living_arrangement = person("ssi_federal_living_arrangement", period)
         in_medical_institution = (
             living_arrangement
             == living_arrangement.possible_values.MEDICAL_TREATMENT_FACILITY

--- a/policyengine_us/variables/gov/states/wa/dshs/tanf/wa_tanf_countable_resources.py
+++ b/policyengine_us/variables/gov/states/wa/dshs/tanf/wa_tanf_countable_resources.py
@@ -7,6 +7,7 @@ class wa_tanf_countable_resources(Variable):
     label = "Countable resources for Washington TANF"
     unit = USD
     definition_period = YEAR
+    quantity_type = STOCK
     reference = (
         "https://app.leg.wa.gov/wac/default.aspx?cite=388-470-0045",
         "https://app.leg.wa.gov/wac/default.aspx?cite=388-470-0070",

--- a/policyengine_us/variables/gov/states/wi/dcf/works/resources/wi_works_countable_resources.py
+++ b/policyengine_us/variables/gov/states/wi/dcf/works/resources/wi_works_countable_resources.py
@@ -7,6 +7,7 @@ class wi_works_countable_resources(Variable):
     label = "Wisconsin Works countable resources"
     unit = USD
     definition_period = YEAR
+    quantity_type = STOCK
     reference = (
         "https://dcf.wisconsin.gov/manuals/w-2-manual/Production/03/03.3.4_COUNTING_ASSETS.htm",
         "https://docs.legis.wisconsin.gov/code/admin_code/dcf/101_199/101/09/3/b",

--- a/policyengine_us/variables/household/demographic/person/is_in_residential_care_facility.py
+++ b/policyengine_us/variables/household/demographic/person/is_in_residential_care_facility.py
@@ -5,4 +5,4 @@ class is_in_residential_care_facility(Variable):
     value_type = bool
     entity = Person
     label = "Whether the person lives in a residential care facility"
-    definition_period = YEAR
+    definition_period = MONTH


### PR DESCRIPTION
## Summary

Refs #7968.

This PR:
- monthlyizes federal SSI payment calculation, SSI federal living arrangement variables, Medicaid/residential facility flags used by SSI, and state SSI supplement/SSP/OSS/OSSP payment variables
- adds `ssi_federal_fiscal_year_outlays` to capture SSI payment-date timing across fiscal years
- marks computed countable resource balances and asset/resource limits as `STOCK`, including SSI resources and TANF/resource variables that should not annualize balances
- adds regression coverage for resource stock metadata and period-invariant resource calculations

## Notes

The resource-stock bug did not appear to break the standard annual SSI asset-limit eligibility path: upstream still failed SSI eligibility for a $2,100 resource case. It did affect direct monthly resource outputs and could affect monthly or annual conversions for resource intermediates, so this PR fixes the broader stock/flow issue.

State supplement tests were updated to assert monthly program outputs directly now that SSI and SSP-style payments are monthly.

## Validation

- `uv run pytest policyengine_us/tests/core/test_resource_stock_variables.py policyengine_us/tests/test_build_metadata.py -q` (`6 passed, 1 skipped`)
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/ssa/ssi -c policyengine_us` (`161 passed`)
- `uv run python -m policyengine_core.scripts.policyengine_command test ...state SSP/OSS/OSSP paths... -c policyengine_us` (`397 passed`)
- `uv run ruff format .`
- `uv run ruff check .`
- `git diff --check`
