### PR TITLE
Add Medicaid CE exclusion inputs

### DIFF
--- a/changelog.d/fixed/medicaid-ce-exclusions.md
+++ b/changelog.d/fixed/medicaid-ce-exclusions.md
@@ -1,1 +1,1 @@
-Add Medicaid community engagement exclusions for recent incarceration and American Indian or Alaska Native status.
+Add a Medicaid community engagement exclusion input for American Indian or Alaska Native status.

--- a/changelog.d/fixed/medicaid-ce-exclusions.md
+++ b/changelog.d/fixed/medicaid-ce-exclusions.md
@@ -1,0 +1,1 @@
+Add Medicaid community engagement exclusions for recent incarceration and American Indian or Alaska Native status.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -205,3 +205,20 @@
     was_recently_incarcerated_for_medicaid_ce: false
   output:
     medicaid_work_requirement_eligible: false
+
+- name: Case 23, American Indian or Alaska Native adult is excluded from the work requirement.
+  period: 2027
+  input:
+    age: 30
+    is_american_indian_or_alaska_native_for_medicaid_ce: true
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 24, adult remains ineligible without the AIAN exclusion.
+  period: 2027
+  input:
+    age: 30
+    is_american_indian_or_alaska_native_for_medicaid_ce: false
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: false

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_american_indian_or_alaska_native_for_medicaid_ce.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_american_indian_or_alaska_native_for_medicaid_ce.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class is_american_indian_or_alaska_native_for_medicaid_ce(Variable):
+    value_type = bool
+    entity = Person
+    label = "American Indian or Alaska Native for Medicaid community engagement"
+    documentation = (
+        "Whether this person qualifies for the Medicaid community engagement "
+        "American Indian or Alaska Native exclusion, including Indian, Urban "
+        "Indian, California Indian, or other Indian Health Service eligibility "
+        "status."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=5",
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+    )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -42,6 +42,9 @@ class medicaid_work_requirement_eligible(Variable):
             age < p.former_foster_care_age_limit
         )
         # American Indian or Alaska Native / IHS eligibility exclusion.
+        is_aian_exempt = person(
+            "is_american_indian_or_alaska_native_for_medicaid_ce", period
+        )
         has_ihs_coverage = person(
             "has_indian_health_service_coverage_at_interview", period
         )
@@ -76,6 +79,7 @@ class medicaid_work_requirement_eligible(Variable):
             | pass_through_eligible
             | is_pregnant_or_postpartum
             | former_foster_care_youth
+            | is_aian_exempt
             | has_ihs_coverage
             | medicare_eligible
             | has_disabled


### PR DESCRIPTION
## Summary

Closes #8268.
Closes #8269.

This builds on the merged Medicaid CE base from #8257 by adding two explicit exclusion inputs:

- `was_recently_incarcerated_for_medicaid_ce`, covering people who were inmates of a public institution during the three-month lookback described by CMS.
- `is_american_indian_or_alaska_native_for_medicaid_ce`, covering the Medicaid CE American Indian or Alaska Native exclusion, including Indian, Urban Indian, California Indian, or other Indian Health Service eligibility status.

The existing IHS coverage proxy remains in the rollup; the new AI/AN input avoids using household geography such as `is_on_tribal_land` as a person-level proxy.

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml -c policyengine_us`
  - 18 passed.
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml -c policyengine_us`
  - 40 passed.
- `uv run --extra dev ruff format .`
- `uv run --extra dev ruff check .`
- `uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_system_import.py -q`
  - 9 passed.
- `git diff --check`

## References

- CMS CMCS Informational Bulletin, Dec. 8, 2025: https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf
- Public Law 119-21, section 71119: https://www.congress.gov/bill/119th-congress/house-bill/1/text
