### PR TITLE
Fix California HSA taxable wages

### DIFF
--- a/changelog.d/fixed/8376.md
+++ b/changelog.d/fixed/8376.md
@@ -1,0 +1,1 @@
+California now adds back Health Savings Account contributions for state income tax and payroll-tax wage bases.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/ca_hsa_addition.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/ca_hsa_addition.yaml
@@ -1,0 +1,36 @@
+- name: Case 1, California adds back payroll and above-the-line HSA contributions.
+  period: 2026
+  input:
+    people:
+      person1:
+        health_savings_account_payroll_contributions: 3_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 40_000
+        health_savings_account_ald: 2_000
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    ca_hsa_addition: 5_000
+    ca_additions: 5_000
+    ca_agi: 45_000
+
+- name: Case 2, HSA contributions do not create a California addition outside California.
+  period: 2026
+  input:
+    people:
+      person1:
+        health_savings_account_payroll_contributions: 3_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        health_savings_account_ald: 2_000
+    households:
+      household:
+        members: [person1]
+        state_code: OR
+  output:
+    ca_hsa_addition: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll/ca_payroll_tax_gross_wages.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll/ca_payroll_tax_gross_wages.yaml
@@ -1,0 +1,20 @@
+- name: Case 1, California payroll wages add back HSA payroll contributions.
+  period: 2026
+  input:
+    employment_income: 6_000
+    pre_tax_health_insurance_premiums: 1_000
+    health_savings_account_payroll_contributions: 1_000
+    state_code: CA
+  output:
+    payroll_tax_gross_wages: 4_000
+    ca_payroll_tax_gross_wages: 5_000
+
+- name: Case 2, California payroll wages do not exceed gross employment income.
+  period: 2026
+  input:
+    employment_income: 1_000
+    health_savings_account_payroll_contributions: 2_000
+    state_code: CA
+  output:
+    payroll_tax_gross_wages: 0
+    ca_payroll_tax_gross_wages: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll/disability/ca_employee_state_disability_insurance_contribution.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll/disability/ca_employee_state_disability_insurance_contribution.yaml
@@ -1,0 +1,9 @@
+- name: Case 1, California SDI uses the California HSA addback wage base.
+  period: 2026
+  input:
+    employment_income: 6_000
+    pre_tax_health_insurance_premiums: 1_000
+    health_savings_account_payroll_contributions: 1_000
+    state_code: CA
+  output:
+    ca_employee_state_disability_insurance_contribution: 65

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.yaml
@@ -1,0 +1,9 @@
+- name: Case 1, California unemployment taxable earnings add back HSA payroll contributions.
+  period: 2026
+  input:
+    employment_income: 6_000
+    pre_tax_health_insurance_premiums: 1_000
+    health_savings_account_payroll_contributions: 1_000
+    state_code: CA
+  output:
+    taxable_earnings_for_state_unemployment_tax: 5_000

--- a/policyengine_us/variables/gov/states/ca/tax/income/ca_additions.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/ca_additions.py
@@ -9,3 +9,4 @@ class ca_additions(Variable):
     definition_period = YEAR
     reference = "https://www.ftb.ca.gov/forms/2021/2021-540.pdf"
     defined_for = StateCode.CA
+    adds = ["ca_hsa_addition"]

--- a/policyengine_us/variables/gov/states/ca/tax/income/ca_hsa_addition.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/ca_hsa_addition.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class ca_hsa_addition(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "California HSA addition"
+    documentation = (
+        "Health Savings Account contributions federally excluded from AGI but "
+        "added back for California income tax."
+    )
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.CA
+    reference = "https://www.ftb.ca.gov/forms/2025/2025-1005-publication.pdf#page=10"
+
+    def formula(tax_unit, period, parameters):
+        payroll_contributions = add(
+            tax_unit, period, ["health_savings_account_payroll_contributions"]
+        )
+        return payroll_contributions + tax_unit("health_savings_account_ald", period)

--- a/policyengine_us/variables/gov/states/ca/tax/payroll/ca_payroll_tax_gross_wages.py
+++ b/policyengine_us/variables/gov/states/ca/tax/payroll/ca_payroll_tax_gross_wages.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class ca_payroll_tax_gross_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "California payroll tax gross wages"
+    documentation = (
+        "Wages subject to California payroll taxes, including HSA payroll "
+        "contributions that are excluded from the federal FICA wage base."
+    )
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.CA
+    reference = "https://edd.ca.gov/siteassets/files/pdf_pub_ctr/de231tp.pdf#page=7"
+
+    def formula(person, period, parameters):
+        return max_(
+            0,
+            min_(
+                person("employment_income", period),
+                person("payroll_tax_gross_wages", period)
+                + person("health_savings_account_payroll_contributions", period),
+            ),
+        )

--- a/policyengine_us/variables/gov/states/ca/tax/payroll/disability/ca_employee_state_disability_insurance_contribution.py
+++ b/policyengine_us/variables/gov/states/ca/tax/payroll/disability/ca_employee_state_disability_insurance_contribution.py
@@ -15,4 +15,4 @@ class ca_employee_state_disability_insurance_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.ca.tax.payroll.disability.employee_rate
-        return rate * person("payroll_tax_gross_wages", period)
+        return rate * person("ca_payroll_tax_gross_wages", period)

--- a/policyengine_us/variables/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.py
+++ b/policyengine_us/variables/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.py
@@ -19,4 +19,13 @@ class taxable_earnings_for_state_unemployment_tax(Variable):
         wage_base = select_state_unemployment_tax_parameter(
             person, period, parameters, "taxable_wage_base"
         )
-        return min_(person("payroll_tax_gross_wages", period), wage_base)
+        state_code = person.household("state_code_str", period)
+        payroll_tax_gross_wages = person("payroll_tax_gross_wages", period)
+        return min_(
+            where(
+                state_code == "CA",
+                person("ca_payroll_tax_gross_wages", period),
+                payroll_tax_gross_wages,
+            ),
+            wage_base,
+        )


### PR DESCRIPTION
Fixes #8376.

## Summary
- Adds `ca_hsa_addition` so California AGI adds back HSA payroll contributions and above-the-line HSA deductions excluded federally.
- Adds `ca_payroll_tax_gross_wages` and uses it for CA SDI plus CA UI/ETT taxable earnings, matching EDD treatment of HSA payments as subject to UI, ETT, SDI, PIT withholding, and PIT wages.
- Adds regression tests and a changelog entry.

## Sources and Payroll Base Audit
- California income tax: FTB Pub. 1005 2025, Health Savings Accounts: https://www.ftb.ca.gov/forms/2025/2025-1005-publication.pdf#page=10
- California payroll taxes: EDD DE231TP, HSA taxability rows: https://edd.ca.gov/siteassets/files/pdf_pub_ctr/de231tp.pdf#page=7
- Checked the modeled state payroll hooks. This PR only changes CA because the issue is CA-specific; I opened #8379 for the broader gross/state-UI vs FICA wage-base audit instead of mixing that cleanup into this PR.

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/ca_hsa_addition.yaml policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll/ca_payroll_tax_gross_wages.yaml policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll/disability/ca_employee_state_disability_insurance_contribution.yaml policyengine_us/tests/policy/baseline/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.yaml`
- `uv run python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/irs/payroll policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll policyengine_us/tests/policy/baseline/gov/states/tax/payroll`
- `uv run ruff check policyengine_us/variables/gov/states/ca/tax/income/ca_hsa_addition.py policyengine_us/variables/gov/states/ca/tax/payroll/ca_payroll_tax_gross_wages.py policyengine_us/variables/gov/states/ca/tax/income/ca_additions.py policyengine_us/variables/gov/states/ca/tax/payroll/disability/ca_employee_state_disability_insurance_contribution.py policyengine_us/variables/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.py`
- `git diff --check`