### PR TITLE
Fix state payroll tax wage bases

### DIFF
--- a/changelog.d/fixed/8379.md
+++ b/changelog.d/fixed/8379.md
@@ -1,0 +1,1 @@
+State payroll taxes now use program-specific wage bases for pre-tax payroll deductions.

--- a/policyengine_us/tests/core/test_payroll_contributions.py
+++ b/policyengine_us/tests/core/test_payroll_contributions.py
@@ -16,8 +16,12 @@ def make_simulation(
     *,
     county: Optional[str] = None,
     employment_income: float = WAGES,
+    health_savings_account_payroll_contributions: float = 0,
     employer_headcount: int = 100,
     employer_quarterly_payroll_expense_override: float = -1,
+    pre_tax_health_insurance_premiums: float = 0,
+    tip_income: float = 0,
+    traditional_401k_contributions: float = 0,
 ) -> Simulation:
     household = {
         "members": ["person"],
@@ -33,9 +37,19 @@ def make_simulation(
                 "person": {
                     "age": {PERIOD: 30},
                     "employment_income": {PERIOD: employment_income},
+                    "health_savings_account_payroll_contributions": {
+                        PERIOD: health_savings_account_payroll_contributions
+                    },
                     "employer_headcount": {PERIOD: employer_headcount},
                     "employer_quarterly_payroll_expense_override": {
                         PERIOD: employer_quarterly_payroll_expense_override
+                    },
+                    "pre_tax_health_insurance_premiums": {
+                        PERIOD: pre_tax_health_insurance_premiums
+                    },
+                    "tip_income": {PERIOD: tip_income},
+                    "traditional_401k_contributions": {
+                        PERIOD: traditional_401k_contributions
                     },
                 }
             },
@@ -52,6 +66,47 @@ def calculate(sim: Simulation, variable: str) -> float:
     return sim.calculate(variable, PERIOD)[0]
 
 
+def test_employer_total_state_payroll_wage_base_defaults():
+    sim = Simulation(
+        tax_benefit_system=SYSTEM,
+        situation={
+            "people": {
+                "person": {
+                    "age": {PERIOD: 30},
+                    "employer_total_payroll_tax_gross_wages": {PERIOD: 5_000},
+                    "employer_total_taxable_earnings_for_social_security": {
+                        PERIOD: 4_000
+                    },
+                }
+            },
+            "households": {
+                "household": {
+                    "members": ["person"],
+                    "state_code": {PERIOD: "WA"},
+                }
+            },
+            "tax_units": {"tax_unit": {"members": ["person"]}},
+            "spm_units": {"spm_unit": {"members": ["person"]}},
+            "families": {"family": {"members": ["person"]}},
+            "marital_units": {"marital_unit": {"members": ["person"]}},
+        },
+    )
+
+    assert calculate(
+        sim, "employer_total_state_payroll_tax_gross_wages"
+    ) == pytest.approx(5_000)
+    assert calculate(
+        sim, "employer_total_state_payroll_tax_social_security_capped_wages"
+    ) == pytest.approx(4_000)
+    assert calculate(sim, "employer_total_income_tax_wages") == pytest.approx(5_000)
+    assert calculate(sim, "employer_total_wa_payroll_tax_gross_wages") == pytest.approx(
+        5_000
+    )
+    assert calculate(
+        sim, "employer_total_wa_payroll_tax_social_security_capped_wages"
+    ) == pytest.approx(4_000)
+
+
 def make_employer_total_simulation(
     state_code: str,
     *,
@@ -59,6 +114,11 @@ def make_employer_total_simulation(
     employer_state_unemployment_tax_rate_override: float = -1,
     employer_total_payroll_tax_gross_wages: float = WAGES,
     employer_total_taxable_earnings_for_social_security: float = WAGES,
+    employer_total_state_payroll_tax_gross_wages: float = WAGES,
+    employer_total_state_payroll_tax_social_security_capped_wages: float = WAGES,
+    employer_total_income_tax_wages: float = WAGES,
+    employer_total_wa_payroll_tax_gross_wages: float = WAGES,
+    employer_total_wa_payroll_tax_social_security_capped_wages: float = WAGES,
     employer_total_taxable_earnings_for_federal_unemployment_tax: float = 7_000,
     employer_total_taxable_earnings_for_state_unemployment_tax: float = 9_000,
     employer_ny_mctmt_zone_1_quarterly_payroll_expense: float = 0,
@@ -94,6 +154,21 @@ def make_employer_total_simulation(
                     },
                     "employer_total_taxable_earnings_for_social_security": {
                         PERIOD: employer_total_taxable_earnings_for_social_security
+                    },
+                    "employer_total_state_payroll_tax_gross_wages": {
+                        PERIOD: employer_total_state_payroll_tax_gross_wages
+                    },
+                    "employer_total_state_payroll_tax_social_security_capped_wages": {
+                        PERIOD: employer_total_state_payroll_tax_social_security_capped_wages
+                    },
+                    "employer_total_income_tax_wages": {
+                        PERIOD: employer_total_income_tax_wages
+                    },
+                    "employer_total_wa_payroll_tax_gross_wages": {
+                        PERIOD: employer_total_wa_payroll_tax_gross_wages
+                    },
+                    "employer_total_wa_payroll_tax_social_security_capped_wages": {
+                        PERIOD: employer_total_wa_payroll_tax_social_security_capped_wages
                     },
                     "employer_total_taxable_earnings_for_federal_unemployment_tax": {
                         PERIOD: employer_total_taxable_earnings_for_federal_unemployment_tax
@@ -477,6 +552,180 @@ def test_small_employer_thresholds_zero_employer_paid_leave_share(
 
 
 @pytest.mark.parametrize(
+    ("state_code", "expected"),
+    [
+        pytest.param(
+            "CO",
+            {
+                "co_employee_famli_contribution": 30.8,
+                "co_employer_famli_contribution": 30.8,
+            },
+            id="CO",
+        ),
+        pytest.param(
+            "DC",
+            {"dc_employer_paid_leave_tax": 52.5},
+            id="DC",
+        ),
+        pytest.param(
+            "MA",
+            {
+                "ma_employee_paid_leave_contribution": 32.2,
+                "ma_employer_paid_leave_contribution": 29.4,
+                "taxable_earnings_for_state_unemployment_tax": 7_000,
+            },
+            id="MA",
+        ),
+        pytest.param(
+            "ME",
+            {
+                "me_employee_paid_leave_contribution": 35,
+                "me_employer_paid_leave_contribution": 35,
+            },
+            id="ME",
+        ),
+        pytest.param(
+            "NJ",
+            {
+                "nj_employee_temporary_disability_insurance_contribution": 13.3,
+                "nj_employee_family_leave_insurance_contribution": 16.1,
+                "taxable_earnings_for_state_unemployment_tax": 7_000,
+            },
+            id="NJ",
+        ),
+        pytest.param(
+            "NY",
+            {
+                "ny_employee_paid_family_leave_contribution": 30.24,
+                "ny_employee_disability_benefits_contribution": 31.2,
+            },
+            id="NY",
+        ),
+        pytest.param(
+            "OR",
+            {
+                "or_employee_paid_leave_contribution": 42,
+                "or_employer_paid_leave_contribution": 28,
+            },
+            id="OR",
+        ),
+    ],
+)
+def test_state_payroll_gross_wage_bases_include_pre_tax_deductions(
+    state_code: str, expected: dict[str, float]
+):
+    sim = make_simulation(
+        state_code,
+        employment_income=7_000,
+        health_savings_account_payroll_contributions=1_000,
+        pre_tax_health_insurance_premiums=1_000,
+        traditional_401k_contributions=1_000,
+    )
+
+    assert calculate(sim, "payroll_tax_gross_wages") == pytest.approx(5_000)
+    assert calculate(sim, "irs_employment_income") == pytest.approx(4_000)
+    assert calculate(sim, "taxable_earnings_for_social_security") == pytest.approx(
+        5_000
+    )
+    assert calculate(sim, "state_payroll_tax_gross_wages") == pytest.approx(7_000)
+    assert calculate(
+        sim, "state_payroll_tax_social_security_capped_wages"
+    ) == pytest.approx(7_000)
+
+    for variable, amount in expected.items():
+        assert calculate(sim, variable) == pytest.approx(amount, abs=0.01)
+
+
+def test_connecticut_paid_leave_uses_fica_taxable_wages():
+    sim = make_simulation(
+        "CT",
+        employment_income=7_000,
+        health_savings_account_payroll_contributions=1_000,
+        pre_tax_health_insurance_premiums=1_000,
+        traditional_401k_contributions=1_000,
+    )
+
+    assert calculate(sim, "payroll_tax_gross_wages") == pytest.approx(5_000)
+    assert calculate(sim, "irs_employment_income") == pytest.approx(4_000)
+    assert calculate(sim, "state_payroll_tax_gross_wages") == pytest.approx(7_000)
+    assert calculate(sim, "ct_employee_paid_leave_contribution") == pytest.approx(
+        25, abs=0.01
+    )
+
+
+@pytest.mark.parametrize(
+    ("state_code", "expected"),
+    [
+        pytest.param(
+            "OR",
+            {"or_employee_statewide_transit_tax": 4},
+            id="OR",
+        ),
+        pytest.param(
+            "RI",
+            {
+                "ri_employee_temporary_disability_insurance_contribution": 44,
+                "taxable_earnings_for_state_unemployment_tax": 4_000,
+            },
+            id="RI",
+        ),
+        pytest.param(
+            "VT",
+            {
+                "vt_employee_child_care_contribution": 4.4,
+                "vt_employer_child_care_contribution": 13.2,
+            },
+            id="VT",
+        ),
+    ],
+)
+def test_state_payroll_income_tax_wage_bases_exclude_pre_tax_deductions(
+    state_code: str, expected: dict[str, float]
+):
+    sim = make_simulation(
+        state_code,
+        employment_income=7_000,
+        health_savings_account_payroll_contributions=1_000,
+        pre_tax_health_insurance_premiums=1_000,
+        traditional_401k_contributions=1_000,
+    )
+
+    assert calculate(sim, "payroll_tax_gross_wages") == pytest.approx(5_000)
+    assert calculate(sim, "irs_employment_income") == pytest.approx(4_000)
+    assert calculate(sim, "state_payroll_tax_gross_wages") == pytest.approx(7_000)
+
+    for variable, amount in expected.items():
+        assert calculate(sim, variable) == pytest.approx(amount, abs=0.01)
+
+
+def test_washington_payroll_gross_wage_base_excludes_tips_not_pre_tax_deductions():
+    sim = make_simulation(
+        "WA",
+        employment_income=8_000,
+        health_savings_account_payroll_contributions=1_000,
+        pre_tax_health_insurance_premiums=1_000,
+        tip_income=1_000,
+        traditional_401k_contributions=1_000,
+    )
+
+    assert calculate(sim, "payroll_tax_gross_wages") == pytest.approx(6_000)
+    assert calculate(sim, "irs_employment_income") == pytest.approx(5_000)
+    assert calculate(sim, "wa_payroll_tax_gross_wages") == pytest.approx(7_000)
+    assert calculate(sim, "wa_payroll_tax_social_security_capped_wages") == (
+        pytest.approx(7_000)
+    )
+    assert calculate(sim, "wa_employee_paid_leave_contribution") == pytest.approx(
+        56.51, abs=0.01
+    )
+    assert calculate(sim, "wa_employer_paid_leave_contribution") == pytest.approx(
+        22.6, abs=0.01
+    )
+    assert calculate(sim, "wa_employee_long_term_care_contribution") == pytest.approx(
+        40.6, abs=0.01
+    )
+
+
+@pytest.mark.parametrize(
     ("headcount", "expected_rate", "expected_contribution"),
     [
         pytest.param(5, 0, 0, id="small-employer-exempt"),
@@ -595,6 +844,42 @@ def test_employer_total_additional_state_payroll_tax(
         employer_headcount=headcount,
         employer_total_taxable_earnings_for_social_security=ss_taxable,
         employer_total_taxable_earnings_for_state_unemployment_tax=state_ui_taxable,
+    )
+
+    assert calculate(
+        sim, "employer_total_additional_state_payroll_tax"
+    ) == pytest.approx(expected, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    ("state_code", "expected"),
+    [
+        pytest.param("CA", 4, id="CA"),
+        pytest.param("CO", 30.8, id="CO"),
+        pytest.param("DC", 52.5, id="DC"),
+        pytest.param("DE", 20, id="DE"),
+        pytest.param("MA", 29.4, id="MA"),
+        pytest.param("ME", 35, id="ME"),
+        pytest.param("OR", 28, id="OR"),
+        pytest.param("RI", 8.4, id="RI"),
+        pytest.param("VT", 13.2, id="VT"),
+        pytest.param("WA", 22.6, id="WA"),
+    ],
+)
+def test_employer_total_additional_state_payroll_tax_uses_state_specific_wage_bases(
+    state_code: str,
+    expected: float,
+):
+    sim = make_employer_total_simulation(
+        state_code,
+        employer_total_payroll_tax_gross_wages=5_000,
+        employer_total_taxable_earnings_for_social_security=5_000,
+        employer_total_state_payroll_tax_gross_wages=7_000,
+        employer_total_state_payroll_tax_social_security_capped_wages=7_000,
+        employer_total_income_tax_wages=4_000,
+        employer_total_wa_payroll_tax_gross_wages=7_000,
+        employer_total_wa_payroll_tax_social_security_capped_wages=7_000,
+        employer_total_taxable_earnings_for_state_unemployment_tax=4_000,
     )
 
     assert calculate(

--- a/policyengine_us/variables/gov/states/co/tax/payroll/famli/co_employee_famli_contribution.py
+++ b/policyengine_us/variables/gov/states/co/tax/payroll/famli/co_employee_famli_contribution.py
@@ -12,4 +12,4 @@ class co_employee_famli_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.co.tax.payroll.famli.employee_rate
-        return rate * person("taxable_earnings_for_social_security", period)
+        return rate * person("state_payroll_tax_social_security_capped_wages", period)

--- a/policyengine_us/variables/gov/states/co/tax/payroll/famli/co_employer_famli_contribution.py
+++ b/policyengine_us/variables/gov/states/co/tax/payroll/famli/co_employer_famli_contribution.py
@@ -13,5 +13,5 @@ class co_employer_famli_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.co.tax.payroll.famli
         liable = person("employer_headcount", period) >= p.employer_headcount_threshold
-        taxable_wages = person("taxable_earnings_for_social_security", period)
+        taxable_wages = person("state_payroll_tax_social_security_capped_wages", period)
         return where(liable, p.employer_rate * taxable_wages, 0)

--- a/policyengine_us/variables/gov/states/dc/tax/payroll/paid_leave/dc_employer_paid_leave_tax.py
+++ b/policyengine_us/variables/gov/states/dc/tax/payroll/paid_leave/dc_employer_paid_leave_tax.py
@@ -12,4 +12,4 @@ class dc_employer_paid_leave_tax(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.dc.tax.payroll.paid_leave.employer_rate
-        return rate * person("payroll_tax_gross_wages", period)
+        return rate * person("state_payroll_tax_gross_wages", period)

--- a/policyengine_us/variables/gov/states/ma/tax/payroll/paid_leave/ma_employee_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/ma/tax/payroll/paid_leave/ma_employee_paid_leave_contribution.py
@@ -16,4 +16,4 @@ class ma_employee_paid_leave_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ma.tax.payroll.paid_leave
         rate = p.family_rate + p.medical_rate * p.medical_employee_share
-        return rate * person("taxable_earnings_for_social_security", period)
+        return rate * person("state_payroll_tax_social_security_capped_wages", period)

--- a/policyengine_us/variables/gov/states/ma/tax/payroll/paid_leave/ma_employer_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/ma/tax/payroll/paid_leave/ma_employer_paid_leave_contribution.py
@@ -17,5 +17,5 @@ class ma_employer_paid_leave_contribution(Variable):
         p = parameters(period).gov.states.ma.tax.payroll.paid_leave
         liable = person("employer_headcount", period) >= p.employer_headcount_threshold
         rate = p.medical_rate * (1 - p.medical_employee_share)
-        taxable_wages = person("taxable_earnings_for_social_security", period)
+        taxable_wages = person("state_payroll_tax_social_security_capped_wages", period)
         return where(liable, rate * taxable_wages, 0)

--- a/policyengine_us/variables/gov/states/me/tax/payroll/paid_leave/me_employee_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/me/tax/payroll/paid_leave/me_employee_paid_leave_contribution.py
@@ -15,4 +15,4 @@ class me_employee_paid_leave_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.me.tax.payroll.paid_leave.employee_rate
-        return rate * person("taxable_earnings_for_social_security", period)
+        return rate * person("state_payroll_tax_social_security_capped_wages", period)

--- a/policyengine_us/variables/gov/states/me/tax/payroll/paid_leave/me_employer_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/me/tax/payroll/paid_leave/me_employer_paid_leave_contribution.py
@@ -16,5 +16,5 @@ class me_employer_paid_leave_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.me.tax.payroll.paid_leave
         liable = person("employer_headcount", period) >= p.employer_headcount_threshold
-        taxable_wages = person("taxable_earnings_for_social_security", period)
+        taxable_wages = person("state_payroll_tax_social_security_capped_wages", period)
         return where(liable, p.employer_rate * taxable_wages, 0)

--- a/policyengine_us/variables/gov/states/nj/tax/payroll/family_leave_insurance/nj_employee_family_leave_insurance_contribution.py
+++ b/policyengine_us/variables/gov/states/nj/tax/payroll/family_leave_insurance/nj_employee_family_leave_insurance_contribution.py
@@ -13,7 +13,7 @@ class nj_employee_family_leave_insurance_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.nj.tax.payroll
         taxable_wages = min_(
-            person("payroll_tax_gross_wages", period),
+            person("state_payroll_tax_gross_wages", period),
             p.temporary_disability_insurance.taxable_wage_base,
         )
         return p.family_leave_insurance.employee_rate * taxable_wages

--- a/policyengine_us/variables/gov/states/nj/tax/payroll/temporary_disability_insurance/nj_employee_temporary_disability_insurance_contribution.py
+++ b/policyengine_us/variables/gov/states/nj/tax/payroll/temporary_disability_insurance/nj_employee_temporary_disability_insurance_contribution.py
@@ -15,6 +15,6 @@ class nj_employee_temporary_disability_insurance_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.nj.tax.payroll.temporary_disability_insurance
         taxable_wages = min_(
-            person("payroll_tax_gross_wages", period), p.taxable_wage_base
+            person("state_payroll_tax_gross_wages", period), p.taxable_wage_base
         )
         return p.employee_rate * taxable_wages

--- a/policyengine_us/variables/gov/states/ny/tax/payroll/disability_benefits/ny_employee_disability_benefits_contribution.py
+++ b/policyengine_us/variables/gov/states/ny/tax/payroll/disability_benefits/ny_employee_disability_benefits_contribution.py
@@ -15,5 +15,5 @@ class ny_employee_disability_benefits_contribution(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ny.tax.payroll.disability_benefits
-        uncapped = p.employee_rate * person("payroll_tax_gross_wages", period)
+        uncapped = p.employee_rate * person("state_payroll_tax_gross_wages", period)
         return min_(uncapped, p.annual_max_contribution)

--- a/policyengine_us/variables/gov/states/ny/tax/payroll/paid_family_leave/ny_employee_paid_family_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/ny/tax/payroll/paid_family_leave/ny_employee_paid_family_leave_contribution.py
@@ -12,5 +12,5 @@ class ny_employee_paid_family_leave_contribution(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ny.tax.payroll.paid_family_leave
-        uncapped = p.employee_rate * person("payroll_tax_gross_wages", period)
+        uncapped = p.employee_rate * person("state_payroll_tax_gross_wages", period)
         return min_(uncapped, p.annual_max_contribution)

--- a/policyengine_us/variables/gov/states/or/tax/payroll/paid_leave/or_employee_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/or/tax/payroll/paid_leave/or_employee_paid_leave_contribution.py
@@ -12,5 +12,5 @@ class or_employee_paid_leave_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states["or"].tax.payroll.paid_leave.employee_rate
-        taxable_wages = person("taxable_earnings_for_social_security", period)
+        taxable_wages = person("state_payroll_tax_social_security_capped_wages", period)
         return rate * taxable_wages

--- a/policyengine_us/variables/gov/states/or/tax/payroll/paid_leave/or_employer_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/or/tax/payroll/paid_leave/or_employer_paid_leave_contribution.py
@@ -13,5 +13,5 @@ class or_employer_paid_leave_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states["or"].tax.payroll.paid_leave
         liable = person("employer_headcount", period) >= p.employer_headcount_threshold
-        taxable_wages = person("taxable_earnings_for_social_security", period)
+        taxable_wages = person("state_payroll_tax_social_security_capped_wages", period)
         return where(liable, p.employer_rate * taxable_wages, 0)

--- a/policyengine_us/variables/gov/states/or/tax/payroll/statewide_transit/or_employee_statewide_transit_tax.py
+++ b/policyengine_us/variables/gov/states/or/tax/payroll/statewide_transit/or_employee_statewide_transit_tax.py
@@ -16,4 +16,4 @@ class or_employee_statewide_transit_tax(Variable):
             .gov.states["or"]
             .tax.payroll.statewide_transit.employee_rate
         )
-        return rate * person("payroll_tax_gross_wages", period)
+        return rate * person("irs_employment_income", period)

--- a/policyengine_us/variables/gov/states/ri/tax/payroll/temporary_disability_insurance/ri_employee_temporary_disability_insurance_contribution.py
+++ b/policyengine_us/variables/gov/states/ri/tax/payroll/temporary_disability_insurance/ri_employee_temporary_disability_insurance_contribution.py
@@ -13,6 +13,6 @@ class ri_employee_temporary_disability_insurance_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ri.tax.payroll.temporary_disability_insurance
         taxable_wages = min_(
-            person("payroll_tax_gross_wages", period), p.taxable_wage_base
+            person("irs_employment_income", period), p.taxable_wage_base
         )
         return p.employee_rate * taxable_wages

--- a/policyengine_us/variables/gov/states/tax/payroll/employer_total_additional_state_payroll_tax.py
+++ b/policyengine_us/variables/gov/states/tax/payroll/employer_total_additional_state_payroll_tax.py
@@ -15,12 +15,23 @@ class employer_total_additional_state_payroll_tax(Variable):
     def formula(person, period, parameters):
         state_code = person.household("state_code", period)
         headcount = person("employer_headcount", period)
-        gross_wages = person("employer_total_payroll_tax_gross_wages", period)
+        state_gross_wages = person(
+            "employer_total_state_payroll_tax_gross_wages", period
+        )
+        income_tax_wages = person("employer_total_income_tax_wages", period)
         ss_taxable = person(
             "employer_total_taxable_earnings_for_social_security", period
         )
+        state_ss_capped_wages = person(
+            "employer_total_state_payroll_tax_social_security_capped_wages",
+            period,
+        )
         state_ui_taxable = person(
             "employer_total_taxable_earnings_for_state_unemployment_tax", period
+        )
+        wa_ss_capped_wages = person(
+            "employer_total_wa_payroll_tax_social_security_capped_wages",
+            period,
         )
 
         ca = (
@@ -33,13 +44,13 @@ class employer_total_additional_state_payroll_tax(Variable):
         co_p = parameters(period).gov.states.co.tax.payroll.famli
         co = where(
             headcount >= co_p.employer_headcount_threshold,
-            co_p.employer_rate * ss_taxable,
+            co_p.employer_rate * state_ss_capped_wages,
             0,
         )
 
         dc = (
             parameters(period).gov.states.dc.tax.payroll.paid_leave.employer_rate
-            * gross_wages
+            * state_gross_wages
         )
 
         de_p = parameters(period).gov.states.de.tax.payroll.paid_leave
@@ -59,21 +70,23 @@ class employer_total_additional_state_payroll_tax(Variable):
         ma_p = parameters(period).gov.states.ma.tax.payroll.paid_leave
         ma = where(
             headcount >= ma_p.employer_headcount_threshold,
-            ma_p.medical_rate * (1 - ma_p.medical_employee_share) * ss_taxable,
+            ma_p.medical_rate
+            * (1 - ma_p.medical_employee_share)
+            * state_ss_capped_wages,
             0,
         )
 
         me_p = parameters(period).gov.states.me.tax.payroll.paid_leave
         me = where(
             headcount >= me_p.employer_headcount_threshold,
-            me_p.employer_rate * ss_taxable,
+            me_p.employer_rate * state_ss_capped_wages,
             0,
         )
 
         or_p = parameters(period).gov.states["or"].tax.payroll.paid_leave
         or_tax = where(
             headcount >= or_p.employer_headcount_threshold,
-            or_p.employer_rate * ss_taxable,
+            or_p.employer_rate * state_ss_capped_wages,
             0,
         )
 
@@ -86,13 +99,13 @@ class employer_total_additional_state_payroll_tax(Variable):
 
         vt = (
             parameters(period).gov.states.vt.tax.payroll.child_care.employer_rate
-            * gross_wages
+            * income_tax_wages
         )
 
         wa_p = parameters(period).gov.states.wa.tax.payroll.paid_leave
         wa = where(
             headcount >= wa_p.employer_headcount_threshold,
-            wa_p.total_rate * wa_p.employer_share * ss_taxable,
+            wa_p.total_rate * wa_p.employer_share * wa_ss_capped_wages,
             0,
         )
 

--- a/policyengine_us/variables/gov/states/tax/payroll/state_payroll_tax_gross_wages.py
+++ b/policyengine_us/variables/gov/states/tax/payroll/state_payroll_tax_gross_wages.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class state_payroll_tax_gross_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "state payroll tax gross wages"
+    documentation = (
+        "Gross employment wages used by state payroll taxes and contributions "
+        "that include federal pre-tax payroll deductions in their wage base."
+    )
+    definition_period = YEAR
+    unit = USD
+
+    def formula(person, period, parameters):
+        return max_(0, person("employment_income", period))

--- a/policyengine_us/variables/gov/states/tax/payroll/state_payroll_tax_social_security_capped_wages.py
+++ b/policyengine_us/variables/gov/states/tax/payroll/state_payroll_tax_social_security_capped_wages.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class state_payroll_tax_social_security_capped_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "state payroll tax Social Security capped wages"
+    documentation = (
+        "Gross employment wages capped at the Social Security contribution and "
+        "benefit base for state payroll taxes that use that cap but do not "
+        "exclude federal FICA pre-tax payroll deductions."
+    )
+    definition_period = YEAR
+    unit = USD
+    reference = "https://www.ssa.gov/oact/cola/cbb.html"
+
+    def formula(person, period, parameters):
+        return min_(
+            person("state_payroll_tax_gross_wages", period),
+            parameters(period).gov.irs.payroll.social_security.cap,
+        )

--- a/policyengine_us/variables/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.py
+++ b/policyengine_us/variables/gov/states/tax/payroll/unemployment/taxable_earnings_for_state_unemployment_tax.py
@@ -21,11 +21,21 @@ class taxable_earnings_for_state_unemployment_tax(Variable):
         )
         state_code = person.household("state_code_str", period)
         payroll_tax_gross_wages = person("payroll_tax_gross_wages", period)
+        gross_state_payroll_wages = person("state_payroll_tax_gross_wages", period)
+        income_tax_wages = person("irs_employment_income", period)
         return min_(
-            where(
-                state_code == "CA",
-                person("ca_payroll_tax_gross_wages", period),
-                payroll_tax_gross_wages,
+            select(
+                [
+                    state_code == "CA",
+                    (state_code == "MA") | (state_code == "NJ"),
+                    state_code == "RI",
+                ],
+                [
+                    person("ca_payroll_tax_gross_wages", period),
+                    gross_state_payroll_wages,
+                    income_tax_wages,
+                ],
+                default=payroll_tax_gross_wages,
             ),
             wage_base,
         )

--- a/policyengine_us/variables/gov/states/vt/tax/payroll/child_care/vt_employee_child_care_contribution.py
+++ b/policyengine_us/variables/gov/states/vt/tax/payroll/child_care/vt_employee_child_care_contribution.py
@@ -15,4 +15,4 @@ class vt_employee_child_care_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.vt.tax.payroll.child_care.employee_rate
-        return rate * person("payroll_tax_gross_wages", period)
+        return rate * person("irs_employment_income", period)

--- a/policyengine_us/variables/gov/states/vt/tax/payroll/child_care/vt_employer_child_care_contribution.py
+++ b/policyengine_us/variables/gov/states/vt/tax/payroll/child_care/vt_employer_child_care_contribution.py
@@ -15,4 +15,4 @@ class vt_employer_child_care_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.vt.tax.payroll.child_care.employer_rate
-        return rate * person("payroll_tax_gross_wages", period)
+        return rate * person("irs_employment_income", period)

--- a/policyengine_us/variables/gov/states/wa/tax/payroll/long_term_care/wa_employee_long_term_care_contribution.py
+++ b/policyengine_us/variables/gov/states/wa/tax/payroll/long_term_care/wa_employee_long_term_care_contribution.py
@@ -12,4 +12,4 @@ class wa_employee_long_term_care_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.wa.tax.payroll.long_term_care.employee_rate
-        return rate * person("payroll_tax_gross_wages", period)
+        return rate * person("wa_payroll_tax_gross_wages", period)

--- a/policyengine_us/variables/gov/states/wa/tax/payroll/paid_leave/wa_employee_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/wa/tax/payroll/paid_leave/wa_employee_paid_leave_contribution.py
@@ -14,5 +14,5 @@ class wa_employee_paid_leave_contribution(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.wa.tax.payroll.paid_leave
-        taxable_wages = person("taxable_earnings_for_social_security", period)
+        taxable_wages = person("wa_payroll_tax_social_security_capped_wages", period)
         return p.total_rate * (1 - p.employer_share) * taxable_wages

--- a/policyengine_us/variables/gov/states/wa/tax/payroll/paid_leave/wa_employer_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/wa/tax/payroll/paid_leave/wa_employer_paid_leave_contribution.py
@@ -15,5 +15,5 @@ class wa_employer_paid_leave_contribution(Variable):
     def formula(person, period, parameters):
         p = parameters(period).gov.states.wa.tax.payroll.paid_leave
         liable = person("employer_headcount", period) >= p.employer_headcount_threshold
-        taxable_wages = person("taxable_earnings_for_social_security", period)
+        taxable_wages = person("wa_payroll_tax_social_security_capped_wages", period)
         return where(liable, p.total_rate * p.employer_share * taxable_wages, 0)

--- a/policyengine_us/variables/gov/states/wa/tax/payroll/wa_payroll_tax_gross_wages.py
+++ b/policyengine_us/variables/gov/states/wa/tax/payroll/wa_payroll_tax_gross_wages.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class wa_payroll_tax_gross_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Washington payroll tax gross wages"
+    documentation = (
+        "Gross wages for Washington paid leave and WA Cares premiums, excluding tips."
+    )
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.WA
+    reference = "https://paidleave.wa.gov/employer-roles-responsibilities/"
+
+    def formula(person, period, parameters):
+        return max_(
+            0,
+            person("employment_income", period) - person("tip_income", period),
+        )

--- a/policyengine_us/variables/gov/states/wa/tax/payroll/wa_payroll_tax_social_security_capped_wages.py
+++ b/policyengine_us/variables/gov/states/wa/tax/payroll/wa_payroll_tax_social_security_capped_wages.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class wa_payroll_tax_social_security_capped_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Washington payroll tax Social Security capped wages"
+    documentation = (
+        "Washington paid leave gross wages, excluding tips, capped at the "
+        "Social Security contribution and benefit base."
+    )
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.WA
+    reference = "https://paidleave.wa.gov/employer-roles-responsibilities/"
+
+    def formula(person, period, parameters):
+        return min_(
+            person("wa_payroll_tax_gross_wages", period),
+            parameters(period).gov.irs.payroll.social_security.cap,
+        )

--- a/policyengine_us/variables/input/employer_payroll.py
+++ b/policyengine_us/variables/input/employer_payroll.py
@@ -67,6 +67,86 @@ class employer_total_taxable_earnings_for_social_security(Variable):
     default_value = 0
 
 
+class employer_total_state_payroll_tax_gross_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer total state payroll tax gross wages"
+    documentation = (
+        "Aggregate employer gross wages for state payroll taxes that include "
+        "federal pre-tax payroll deductions in their wage base."
+    )
+    unit = USD
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("employer_total_payroll_tax_gross_wages", period)
+
+
+class employer_total_state_payroll_tax_social_security_capped_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer total state payroll tax Social Security capped wages"
+    documentation = (
+        "Aggregate employer gross wages, capped per employee at the Social "
+        "Security contribution and benefit base, for state payroll taxes that "
+        "use that cap but do not exclude federal FICA pre-tax payroll "
+        "deductions."
+    )
+    unit = USD
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("employer_total_taxable_earnings_for_social_security", period)
+
+
+class employer_total_income_tax_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer total income tax wages"
+    documentation = (
+        "Aggregate employer wages under the federal income tax withholding "
+        "base for employer-only payroll tax calculations."
+    )
+    unit = USD
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("employer_total_payroll_tax_gross_wages", period)
+
+
+class employer_total_wa_payroll_tax_gross_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer total Washington payroll tax gross wages"
+    documentation = (
+        "Aggregate employer Washington paid leave and WA Cares gross wages, "
+        "excluding tips."
+    )
+    unit = USD
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("employer_total_state_payroll_tax_gross_wages", period)
+
+
+class employer_total_wa_payroll_tax_social_security_capped_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Employer total Washington payroll tax Social Security capped wages"
+    documentation = (
+        "Aggregate employer Washington paid leave gross wages, excluding tips, "
+        "capped per employee at the Social Security contribution and benefit "
+        "base."
+    )
+    unit = USD
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person(
+            "employer_total_state_payroll_tax_social_security_capped_wages", period
+        )
+
+
 class employer_total_taxable_earnings_for_federal_unemployment_tax(Variable):
     value_type = float
     entity = Person


### PR DESCRIPTION
## Summary
- Adds shared state payroll wage-base variables for gross wages that include federal pre-tax deductions and Social Security-capped gross wages.
- Updates CO, DC, MA, ME, NJ, NY, OR, VT, WA, and selected state unemployment wage bases to match program-specific treatment of 401(k), HSA, cafeteria-plan, health-premium, and tip amounts.
- Keeps CT paid leave and DE paid leave on FICA-style Social Security taxable wages, keeps FUTA unchanged, and adds aggregate employer wage-base inputs so `employer_total_additional_state_payroll_tax` can follow the same state-specific bases.

Fixes #8379.
Builds on #8378, which handled the narrow CA HSA payroll contribution addback.

## Local microsimulation
Dataset: `hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5`, period 2026.

Compared with current `upstream/main`:
- `employee_payroll_tax`: -$13.778M (-0.001354%)
- `employee_state_payroll_tax`: -$13.778M (-0.034044%)
- `employer_additional_state_payroll_tax`: -$2.765M (-0.052349%)
- `employer_payroll_tax`: -$2.765M (-0.000266%)
- `employer_state_payroll_tax`: -$2.765M (-0.004234%)
- `employer_state_unemployment_tax`: +$0.000M (+0.000000%)
- `income_tax`: +$0.000M (+0.000000%)
- total payroll tax (`employee_payroll_tax + employer_payroll_tax`): -$16.543M (-0.000805%)

The enhanced CPS has traditional 401(k) deductions but no HSA/payroll health premium amounts in this run, so the aggregate effect is driven by the states moved to income-tax wage bases.

## Tests
- `uv run pytest policyengine_us/tests/core/test_payroll_contributions.py`
- `uv run python -m policyengine_core.scripts.policyengine_command test -c policyengine_us policyengine_us/tests/policy/baseline/gov/irs/payroll policyengine_us/tests/policy/baseline/gov/states/ca/tax/payroll policyengine_us/tests/policy/baseline/gov/states/tax/payroll`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `git diff --check`

## Review
Ran the requested `$cycle` loop. The first review found the aggregate employer-total path still used old bases; this PR now fixes that. The second read-only review reported no actionable findings.
