### PR TITLE
Fix Social Security benefit aging uprater

### DIFF
--- a/changelog.d/fixed/8336.md
+++ b/changelog.d/fixed/8336.md
@@ -1,0 +1,1 @@
+Fix long-run Social Security benefit aging to use gross Social Security benefits instead of taxable Social Security income.

--- a/policyengine_us/parameters/calibration/gov/irs/soi/social_security.yaml
+++ b/policyengine_us/parameters/calibration/gov/irs/soi/social_security.yaml
@@ -5,7 +5,7 @@ values:
 metadata:
   unit: currency-USD
   label: SOI social security
-  uprating: calibration.gov.cbo.income_by_source.taxable_social_security
+  uprating: calibration.gov.cbo.social_security
   reference:
     - title: IRS SOI Tax Stats - Individual Statistical Tables by Size of Adjusted Gross Income
       href: https://www.irs.gov/statistics/soi-tax-stats-individual-statistical-tables-by-size-of-adjusted-gross-income

--- a/policyengine_us/parameters/uprating_extensions.py
+++ b/policyengine_us/parameters/uprating_extensions.py
@@ -366,6 +366,16 @@ def set_all_uprating_parameters(parameters: ParameterNode) -> ParameterNode:
         period_day=1,
     )
 
+    # Gross Social Security benefit inputs should age with gross Social
+    # Security benefits, not taxable Social Security income.
+    extend_parameter_values(
+        parameters.calibration.gov.cbo.social_security,
+        last_projected_year=2036,
+        end_year=END_YEAR,
+        period_month=1,
+        period_day=1,
+    )
+
     # CBO income-by-source aggregates are used directly and as anchors for
     # SOI-based income upraters. Extending them in the baseline path keeps
     # long-run nominal data aging independent of scenario-specific reforms.

--- a/policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py
+++ b/policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py
@@ -1,5 +1,7 @@
 """Test unified uprating extensions through 2100."""
 
+import pytest
+
 from policyengine_us.system import system
 from policyengine_us.parameters.uprating_extensions import (
     LONG_RUN_CBO_INCOME_BY_SOURCE_PARAMETERS,
@@ -70,6 +72,50 @@ def test_cbo_income_by_source_anchors_extend_to_2100():
             assert value > 0, f"{parameter_name} should stay positive"
         for previous, current in zip(values, values[1:]):
             assert current != previous, f"{parameter_name} should extend after 2036"
+
+
+def test_gross_social_security_benefits_extend_to_2100():
+    """Gross Social Security benefits should not flatten after the budget window."""
+    social_security = PARAMETERS.calibration.gov.cbo.social_security
+
+    assert social_security("2037-01-01") > social_security("2036-01-01")
+    assert social_security("2100-01-01") > social_security("2036-01-01")
+
+
+def test_soi_social_security_uses_gross_benefit_uprater():
+    """Social Security benefit inputs should age with gross benefits."""
+    soi_social_security = PARAMETERS.calibration.gov.irs.soi.social_security
+    gross_social_security = PARAMETERS.calibration.gov.cbo.social_security
+
+    assert (
+        soi_social_security.metadata["uprating"]
+        == "calibration.gov.cbo.social_security"
+    )
+
+    for year in [2037, 2050, 2075, 2100]:
+        previous_year = year - 1
+        soi_growth = soi_social_security(f"{year}-01-01") / soi_social_security(
+            f"{previous_year}-01-01"
+        )
+        gross_growth = gross_social_security(f"{year}-01-01") / gross_social_security(
+            f"{previous_year}-01-01"
+        )
+
+        assert soi_growth == pytest.approx(gross_growth)
+
+
+def test_social_security_benefit_inputs_use_gross_benefit_uprater():
+    """Reported Social Security benefit inputs should share the gross-benefit path."""
+    for variable_name in [
+        "social_security_retirement",
+        "social_security_disability",
+        "social_security_survivors",
+        "social_security_dependents",
+    ]:
+        assert (
+            system.variables[variable_name].uprating
+            == "calibration.gov.irs.soi.social_security"
+        )
 
 
 def test_cms_moop_per_capita_extends_to_2100():


### PR DESCRIPTION
## Summary
- age reported Social Security benefit inputs with gross CBO Social Security benefits instead of taxable Social Security income
- extend gross CBO Social Security benefits through 2100 in the shared long-run uprating path
- add regression coverage that the gross benefit anchor and SOI Social Security uprater keep growing after 2036 and share the same growth path

Fixes #8336.

## Tests
- uv run pytest policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py -q
- uv run pytest policyengine_us/tests/test_parameter_files.py -q
- uv run pytest policyengine_us/tests/policy/contrib/ssa/test_trustees_core_thresholds.py -q
- uv run ruff check policyengine_us/parameters/uprating_extensions.py policyengine_us/tests/policy/baseline/parameters/test_uprating_extensions.py