### PR TITLE
Add TAXSIM total FICA output

### DIFF
--- a/changelog.d/added/8294.md
+++ b/changelog.d/added/8294.md
@@ -1,0 +1,1 @@
+Added a TAXSIM-compatible total FICA output variable.

--- a/policyengine_us/tests/policy/contrib/taxsim/outputs/taxsim_outputs.yaml
+++ b/policyengine_us/tests/policy/contrib/taxsim/outputs/taxsim_outputs.yaml
@@ -409,3 +409,24 @@
         tax_unit_id: 12345
   output:
     taxsim_taxsimid: 12345
+
+- name: Total FICA - TAXSIM fica output
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 100_000
+        is_tax_unit_head: true
+    households:
+      household:
+        members: [head]
+        state_code: TX
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+  output:
+    taxsim_tfica: 7_650
+    taxsim_fica: 15_300

--- a/policyengine_us/variables/contrib/taxsim/taxsim_fica.py
+++ b/policyengine_us/variables/contrib/taxsim/taxsim_fica.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class taxsim_fica(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Total FICA: employer and employee OASDI/HI taxes plus SECA"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://taxsim.nber.org/taxsim35/"
+
+    adds = [
+        "employee_social_security_tax",
+        "employee_medicare_tax",
+        "additional_medicare_tax",
+        "employer_social_security_tax",
+        "employer_medicare_tax",
+        "self_employment_tax",
+    ]


### PR DESCRIPTION
## Summary

- Adds `taxsim_fica` for TAXSIM-compatible total FICA output.
- Uses explicit federal OASDI/HI employee and employer components plus SECA, rather than broad payroll-tax aggregates that include unemployment or state payroll taxes.
- Adds coverage in the TAXSIM outputs YAML and a changelog entry.

Closes #8294.

## Tests

- `uv run policyengine-core test policyengine_us/tests/policy/contrib/taxsim/outputs/taxsim_outputs.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/contrib/taxsim/taxsim_fica.py`
- `git diff --check`