### PR TITLE
Fix NJ and MT state tax edge cases

### DIFF
--- a/changelog.d/fixed/8343.md
+++ b/changelog.d/fixed/8343.md
@@ -1,0 +1,1 @@
+Fixed New Jersey filing-threshold zero-out logic in state income tax variables.

--- a/changelog.d/fixed/8344.md
+++ b/changelog.d/fixed/8344.md
@@ -1,0 +1,1 @@
+Fixed Montana joint capital gains tax threshold application.

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/capital_gains/mt_capital_gains_tax_joint.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/capital_gains/mt_capital_gains_tax_joint.yaml
@@ -74,7 +74,7 @@
     filing_status: JOINT
     state_code: MT
   output:
-    mt_capital_gains_tax_joint: 410
+    mt_capital_gains_tax_joint: 388
 
 - name: No CG tax when net capital gains are negative
   # LTCG=50K but STCG=-80K → net=-30K → no preferential treatment
@@ -100,7 +100,26 @@
     state_code: MT
   output:
     # lesser_of_cg_and_taxable = min(30K, 100K) = 30K
-    # excess_over_taxable = max(100K - 30K, 0) = 70K
-    # excess_over_threshold = max(41K - 70K, 0) = 0
-    # All 30K taxed at higher rate: 30K * 0.041 = 1230
-    mt_capital_gains_tax_joint: 1_230
+    # all 30K is below the 41K remaining threshold: 30K * 0.03 = 900
+    mt_capital_gains_tax_joint: 900
+
+- name: Case 10, ordinary income is not subtracted twice.
+  period: 2025
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        age: 40
+        taxable_interest_income: 25_340.57
+        short_term_capital_gains: 1_717.07
+        long_term_capital_gains: 12_595.03
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MT
+  output:
+    mt_capital_gains_tax_joint: 409

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
@@ -509,5 +509,5 @@
   output:
     mt_taxable_income: 65_800
     mt_regular_income_tax_joint: 1_918
-    mt_capital_gains_tax_joint: 1_025
-    mt_income_tax: 2_943
+    mt_capital_gains_tax_joint: 1_022.8
+    mt_income_tax: 2_940.8

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax.yaml
@@ -13,3 +13,25 @@
     state_refundable_credits: 300
   output:
     state_income_tax: -300
+
+- name: Case 3, New Jersey income tax uses filing-threshold zero-out.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        taxable_interest_income: 9_611.82
+        short_term_capital_gains: 42.93
+        long_term_capital_gains: 314.91
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_income_tax: 0
+    state_income_tax: 0

--- a/policyengine_us/tests/policy/baseline/household/income/household/household_state_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/household/household_state_income_tax.yaml
@@ -20,3 +20,25 @@
     wi_refundable_credits: 200
   output:
     household_state_income_tax: 3_000
+
+- name: Case 3, New Jersey household state income tax uses filing-threshold zero-out.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        taxable_interest_income: 9_611.82
+        short_term_capital_gains: 42.93
+        long_term_capital_gains: 314.91
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_income_tax: 0
+    household_state_income_tax: 0

--- a/policyengine_us/variables/gov/states/mt/tax/income/capital_gains/mt_capital_gains_tax_joint.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/capital_gains/mt_capital_gains_tax_joint.py
@@ -25,12 +25,8 @@ class mt_capital_gains_tax_joint(Variable):
             capital_gains = max_(min_(ltcg, net_cg), 0)
             # Line 3
             lesser_of_cg_and_taxable_income = min_(capital_gains, taxable_income)
-            # Line 4
-            excess_over_taxable_income = max_(
-                taxable_income - lesser_of_cg_and_taxable_income, 0
-            )
             filing_status = tax_unit("filing_status", period)
-            # Line 5
+            # Line 6
             applicable_threshold = tax_unit(
                 "mt_capital_gains_tax_applicable_threshold_joint", period
             )
@@ -68,19 +64,15 @@ class mt_capital_gains_tax_joint(Variable):
                     p.rates.head_of_household.amounts[-1],
                 ],
             )
-            # Line 6
-            excess_over_threshold = max_(
-                applicable_threshold - excess_over_taxable_income, 0
-            )
             # Line 7
             capital_gains_below_threshold = min_(
-                excess_over_threshold, lesser_of_cg_and_taxable_income
+                applicable_threshold, lesser_of_cg_and_taxable_income
             )
             # Line 8
             lower_capital_gains_tax = capital_gains_below_threshold * lower_rate
             # Line 9
             income_above_threshold = max_(
-                lesser_of_cg_and_taxable_income - excess_over_threshold, 0
+                lesser_of_cg_and_taxable_income - applicable_threshold, 0
             )
             # Line 10
             higher_capital_gains_tax = income_above_threshold * higher_rate

--- a/policyengine_us/variables/gov/states/tax/income/state_income_tax.py
+++ b/policyengine_us/variables/gov/states/tax/income/state_income_tax.py
@@ -17,8 +17,14 @@ class state_income_tax(Variable):
         refundable_credits = add(tax_unit, period, ["state_refundable_credits"])
         default_tax = income_tax_before_refundable_credits - refundable_credits
         state_code = tax_unit.household("state_code", period)
-        return where(
-            state_code == StateCode.WI,
-            tax_unit("wi_income_tax", period),
-            default_tax,
+        return select(
+            [
+                state_code == StateCode.WI,
+                state_code == StateCode.NJ,
+            ],
+            [
+                tax_unit("wi_income_tax", period),
+                tax_unit("nj_income_tax", period),
+            ],
+            default=default_tax,
         )

--- a/policyengine_us/variables/household/income/household/household_state_income_tax.py
+++ b/policyengine_us/variables/household/income/household/household_state_income_tax.py
@@ -16,8 +16,14 @@ class household_state_income_tax(Variable):
             ["state_income_tax_before_refundable_credits"],
         ) - add(tax_unit, period, ["state_refundable_credits"])
         state_code = tax_unit.household("state_code", period)
-        return where(
-            state_code == StateCode.WI,
-            tax_unit("wi_income_tax", period),
-            default_tax,
+        return select(
+            [
+                state_code == StateCode.WI,
+                state_code == StateCode.NJ,
+            ],
+            [
+                tax_unit("wi_income_tax", period),
+                tax_unit("nj_income_tax", period),
+            ],
+            default=default_tax,
         )


### PR DESCRIPTION
## Summary
- Route NJ state income tax aggregators through `nj_income_tax` so the filing-threshold zero-out applies to `state_income_tax` and `household_state_income_tax`.
- Use Montana joint capital gains tax remaining threshold directly instead of subtracting ordinary income a second time.
- Add regression coverage for the NJ and MT issue repros and update the affected MT integration expectations.

Closes #8343.
Closes #8344.

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax.yaml policyengine_us/tests/policy/baseline/household/income/household/household_state_income_tax.yaml policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/capital_gains/mt_capital_gains_tax_joint.yaml policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/gov/states/tax/income/state_income_tax.py policyengine_us/variables/household/income/household/household_state_income_tax.py policyengine_us/variables/gov/states/mt/tax/income/capital_gains/mt_capital_gains_tax_joint.py`
- `git diff --check`

## Review
- `/cycle` review found and fixed the missing `household_state_income_tax` NJ mirror.
- `/cycle` review found and fixed stale MT integration expectations.
- Final review pass found no actionable findings.