### PR TITLE
Add regression tests for Roth 401(k)/403(b) exclusion from pre-tax contributions

### DIFF
--- a/changelog.d/lock-in-roth-pretax-exclusion.fixed.md
+++ b/changelog.d/lock-in-roth-pretax-exclusion.fixed.md
@@ -1,0 +1,1 @@
+Add regression tests asserting Roth 401(k) and 403(b) contributions do not reduce taxable wages, and document the exclusion in the pre-tax contributions parameter.

--- a/policyengine_us/parameters/gov/irs/gross_income/pre_tax_contributions.yaml
+++ b/policyengine_us/parameters/gov/irs/gross_income/pre_tax_contributions.yaml
@@ -1,8 +1,9 @@
 description: The US subtracts these payroll deductions from wages and salaries when determining the taxable amount.
 values:
   2010-01-01:
-    # Assumes all are pre-tax.
-    # Roth 401(k)/403(b) contributions are post-tax and intentionally excluded.
+    # Only the traditional (pre-tax) variants reduce taxable wages.
+    # Roth 401(k)/403(b) contributions are designated Roth contributions
+    # under IRC §402A and are includible in gross income.
     - capped_traditional_401k_contributions
     - capped_traditional_403b_contributions
     # Only explicit pre-tax payroll health premiums reduce taxable wages.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/roth_contributions_not_pre_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/roth_contributions_not_pre_tax.yaml
@@ -1,0 +1,32 @@
+- name: Roth 401(k) contributions do not reduce IRS employment income.
+  period: 2025
+  input:
+    employment_income: 100_000
+    roth_401k_contributions: 20_000
+  output:
+    pre_tax_contributions: 0
+    irs_employment_income: 100_000
+
+- name: Roth 403(b) contributions do not reduce IRS employment income.
+  period: 2025
+  input:
+    employment_income: 100_000
+    roth_403b_contributions: 15_000
+  output:
+    pre_tax_contributions: 0
+    irs_employment_income: 100_000
+
+- name: Mixed traditional and Roth contributions reduce wages only by the traditional amount.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    employment_income: 100_000
+    traditional_401k_contributions: 10_000
+    roth_401k_contributions: 10_000
+    traditional_403b_contributions: 5_000
+    roth_403b_contributions: 5_000
+  output:
+    capped_traditional_401k_contributions: 7_833.33
+    capped_traditional_403b_contributions: 3_916.67
+    pre_tax_contributions: 11_750
+    irs_employment_income: 88_250


### PR DESCRIPTION
## Summary

- Verified that the `gov.irs.gross_income.pre_tax_contributions` parameter already correctly excludes Roth 401(k) and Roth 403(b) contributions. The variables `roth_401k_contributions` and `roth_403b_contributions` are not in the list, so they do not reduce `irs_employment_income`.
- However, **no regression test** asserts this. A future edit could silently add Roth to the list and break AGI calculations.
- This PR adds three YAML test cases under `irs_gross_income/roth_contributions_not_pre_tax.yaml`:
  1. Roth 401(k) alone does not reduce wages.
  2. Roth 403(b) alone does not reduce wages.
  3. Mixed traditional + Roth — only the traditional amounts reduce wages.
- Also adds a clarifying comment to `pre_tax_contributions.yaml` explaining why Roth variants are excluded (IRC §402A designated Roth contributions are includible in gross income).

Fixes #8387.

## Test plan

- [x] `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/roth_contributions_not_pre_tax.yaml -c policyengine_us` — 3/3 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)