### PR TITLE
Fix OK STC capital gains gross income

### DIFF
--- a/changelog.d/fixed/6975.md
+++ b/changelog.d/fixed/6975.md
@@ -1,0 +1,1 @@
+Fixed Oklahoma sales tax relief credit gross income to net capital gains before applying the positive-only rule.

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_gross_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_gross_income.yaml
@@ -15,3 +15,15 @@
     state_code: OK
   output:
     ok_gross_income: 100_000
+
+- name: OK gross income nets capital gains before applying positive-only rule
+  period: 2024
+  input:
+    short_term_capital_gains: -12_311
+    long_term_capital_gains: 18_713
+    dividend_income: 6_096
+    interest_income: 1_551
+    social_security: 24_517
+    state_code: OK
+  output:
+    ok_gross_income: 38_566

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_stc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_stc.yaml
@@ -146,3 +146,36 @@
     # Exactly at $20,000 limit = eligible
     # 1 exemption * $40 = $40
     ok_stc: 40
+
+- name: OK STC - 2024 - capital losses offset capital gains
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 70
+        short_term_capital_gains: -6_155.5
+        long_term_capital_gains: 9_356.39
+        dividend_income: 3_048.11
+        interest_income: 775.49
+        social_security: 12_258.43
+        is_tax_unit_head: true
+      person2:
+        age: 58
+        short_term_capital_gains: -6_155.5
+        long_term_capital_gains: 9_356.39
+        dividend_income: 3_048.11
+        interest_income: 775.49
+        social_security: 12_258.43
+        is_tax_unit_spouse: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: OK
+  output:
+    # Net capital gains are $6,401.78, putting gross income below the
+    # elderly $50,000 limit and restoring the $40-per-person credit.
+    ok_gross_income: 38_565.84
+    ok_stc: 80

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_gross_income.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_gross_income.py
@@ -16,8 +16,14 @@ class ok_gross_income(Variable):
     def formula(tax_unit, period, parameters):
         # compute comprehensive gross income for all people in tax unit
         p = parameters(period).gov.states.ok.tax.income
-        income = 0
+        capital_gain_sources = [
+            "short_term_capital_gains",
+            "long_term_capital_gains",
+        ]
+        income = max_(0, add(tax_unit, period, capital_gain_sources))
         for source in p.credits.gross_income_sources:
+            if source in capital_gain_sources:
+                continue
             # gross income includes only positive amounts (i.e., no losses)
             income += max_(0, add(tax_unit, period, [source]))
         return income


### PR DESCRIPTION
## Summary
- Net Oklahoma STC gross-income short- and long-term capital gains before applying the positive-only rule
- Add gross-income and sales tax relief credit regressions for the capital-loss offset case
- Add changelog fragment

Closes #6975.

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_gross_income.yaml policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_stc.yaml -c policyengine_us
- uv run ruff check policyengine_us/variables/gov/states/ok/tax/income/credits/ok_gross_income.py
- git diff --check

## Review
- /cycle subagent review: no actionable findings