### PR TITLE
Fix Oklahoma child credit federal CTC match

### DIFF
--- a/changelog.d/fixed/8239.md
+++ b/changelog.d/fixed/8239.md
@@ -1,0 +1,1 @@
+Fixed Oklahoma's Child Care/Child Tax Credit to include federal non-refundable Child Tax Credit amounts used against federal income tax.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/tax_unit_itemizes.yaml
@@ -177,4 +177,4 @@
   output:
     ok_itemized_deductions: 0
     tax_unit_itemizes: false
-    ok_income_tax: 3_483
+    ok_income_tax: 3_410.03

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/credits/eitc/ok_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/credits/eitc/ok_eitc.yaml
@@ -108,8 +108,10 @@
   output:
     # Federal EITC for 1 child at $20k income ~ $3,480
     # OK EITC = $3,480 * 5% = $174
+    # OK CTC = 5% of $1,700 refundable federal CTC.
+    ok_child_care_child_tax_credit: 85
     ok_eitc: 174
-    ok_income_tax: -239.7
+    ok_income_tax: -224.8
 
 - name: OK EITC - 2025 - full year resident
   period: 2025

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/integration.yaml
@@ -69,9 +69,10 @@
   output:
     ctc_value: 0
     ctc: 4_000
-    # Only match 5% of the actual federal CTC
-    ok_child_care_child_tax_credit: 0
-    ok_income_tax: 110
+    ok_federal_ctc: 93.26
+    # Only match 5% of the actual federal CTC allowed.
+    ok_child_care_child_tax_credit: 4.66
+    ok_income_tax: 106
 
 # 2025 Comprehensive Integration Tests
 

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_child_care_child_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_child_care_child_tax_credit.yaml
@@ -12,7 +12,7 @@
     adjusted_gross_income: 40_000
     ok_agi: 20_000
     cdcc_potential: 2_000
-    ctc_value: 3_000
+    ok_federal_ctc: 3_000
     state_code: OK
   output:
     # 5% CTC: $3,000 * 0.05 = $150
@@ -30,7 +30,7 @@
     adjusted_gross_income: 50_000
     ok_agi: 50_000
     cdcc_potential: 500
-    ctc_value: 4_000
+    ok_federal_ctc: 4_000
     state_code: OK
   output:
     # 5% CTC: $4,000 * 0.05 = $200
@@ -45,7 +45,7 @@
     adjusted_gross_income: 60_000
     ok_agi: 60_000
     cdcc_potential: 3_000
-    ctc_value: 2_000
+    ok_federal_ctc: 2_000
     state_code: OK
   output:
     # 5% CTC: $2,000 * 0.05 = $100
@@ -59,7 +59,7 @@
     adjusted_gross_income: 120_000
     ok_agi: 120_000
     cdcc_potential: 2_000
-    ctc_value: 4_000
+    ok_federal_ctc: 4_000
     state_code: OK
   output:
     # AGI $120,000 > $100,000 limit = no credit
@@ -71,7 +71,7 @@
     adjusted_gross_income: 100_000
     ok_agi: 100_000
     cdcc_potential: 1_500
-    ctc_value: 3_000
+    ok_federal_ctc: 3_000
     state_code: OK
   output:
     # AGI exactly at $100,000 limit = eligible
@@ -86,7 +86,7 @@
     adjusted_gross_income: 45_000
     ok_agi: 45_000
     cdcc_potential: 0
-    ctc_value: 0
+    ok_federal_ctc: 0
     state_code: OK
   output:
     ok_child_care_child_tax_credit: 0
@@ -97,7 +97,7 @@
     adjusted_gross_income: 80_000
     ok_agi: 40_000
     cdcc_potential: 2_000
-    ctc_value: 4_000
+    ok_federal_ctc: 4_000
     state_code: OK
   output:
     # 5% CTC: $4,000 * 0.05 = $200
@@ -106,3 +106,46 @@
     # Part-year ratio: 40,000 / 80,000 = 0.5
     # Final credit: $400 * 0.5 = $200
     ok_child_care_child_tax_credit: 200
+
+- name: OK CTC includes federal non-refundable CTC used against unearned-income tax
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      head:
+        age: 40
+        taxable_interest_income: 79_445
+        real_estate_taxes: 30_000
+        deductible_mortgage_interest: 20_000
+        is_tax_unit_head: true
+      child1:
+        age: 11
+        is_tax_unit_dependent: true
+      child2:
+        age: 2
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, child1, child2]
+    marital_units:
+      marital_unit:
+        members: [head]
+      child1_marital_unit:
+        members: [child1]
+      child2_marital_unit:
+        members: [child2]
+    families:
+      family:
+        members: [head, child1, child2]
+    spm_units:
+      spm_unit:
+        members: [head, child1, child2]
+    households:
+      household:
+        members: [head, child1, child2]
+        state_code: OK
+  output:
+    ctc_value: 0
+    ok_federal_ctc: 2_799
+    ok_child_care_child_tax_credit: 140
+    taxsim_ok_child_tax_credit_component: 140

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
@@ -27,7 +27,7 @@ class ok_child_care_child_tax_credit(Variable):
     Calculation steps:
     1. Check AGI eligibility (federal AGI <= $100,000)
     2. Calculate OK CDCC: federal_cdcc_potential * 20%
-    3. Calculate OK CTC: federal_ctc_value * 5%
+    3. Calculate OK CTC: federal CTC allowed * 5%
     4. Take the greater of OK CDCC or OK CTC
     5. Prorate by (OK AGI / Federal AGI)
 
@@ -59,8 +59,8 @@ class ok_child_care_child_tax_credit(Variable):
         # Step 2: Calculate OK CDCC amount (20% of federal potential)
         us_cdcc = tax_unit("cdcc_potential", period)
         ok_cdcc = us_cdcc * p.child.cdcc_fraction
-        # Step 3: Calculate OK CTC amount (5% of federal CTC)
-        us_ctc = tax_unit("ctc_value", period)
+        # Step 3: Calculate OK CTC amount (5% of federal CTC allowed)
+        us_ctc = tax_unit("ok_federal_ctc", period)
         ok_ctc = us_ctc * p.child.ctc_fraction
         # Step 4: Compute proration ratio (OK AGI / Federal AGI)
         ok_agi = tax_unit("ok_agi", period)

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_federal_ctc.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_federal_ctc.py
@@ -1,0 +1,47 @@
+from policyengine_us.model_api import *
+
+
+class ok_federal_ctc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Federal Child Tax Credit allowed for Oklahoma child credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.OK
+    reference = (
+        # 2025 Form 511 packet, pages 11 and 25.
+        "https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/current/511-Pkt.pdf#page=11",
+    )
+    documentation = (
+        "Federal Child Tax Credit allowed for Oklahoma's Child Care/Child "
+        "Tax Credit, including both non-refundable CTC actually used against "
+        "federal income tax and refundable additional CTC."
+    )
+
+    def formula(tax_unit, period, parameters):
+        non_refundable_credits = parameters(period).gov.irs.credits.non_refundable
+        ctc_index = non_refundable_credits.index("non_refundable_ctc")
+        credits_before_ctc = non_refundable_credits[:ctc_index]
+        preceding_credits = add(tax_unit, period, credits_before_ctc)
+
+        non_refundable_ctc = tax_unit("non_refundable_ctc", period)
+        total_non_refundable_credits = tax_unit(
+            "income_tax_non_refundable_credits", period
+        )
+        capped_non_refundable_credits = tax_unit(
+            "income_tax_capped_non_refundable_credits", period
+        )
+        income_tax_cap_binds = (
+            capped_non_refundable_credits < total_non_refundable_credits
+        )
+        applied_non_refundable_ctc = min_(
+            non_refundable_ctc,
+            max_(0, capped_non_refundable_credits - preceding_credits),
+        )
+        applied_non_refundable_ctc = where(
+            income_tax_cap_binds,
+            applied_non_refundable_ctc,
+            non_refundable_ctc,
+        )
+        refundable_ctc = tax_unit("refundable_ctc", period)
+        return applied_non_refundable_ctc + refundable_ctc

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/taxsim_ok_child_tax_credit_component.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/taxsim_ok_child_tax_credit_component.py
@@ -15,7 +15,7 @@ class taxsim_ok_child_tax_credit_component(Variable):
         p = parameters(period).gov.states.ok.tax.income.credits.child
         us_cdcc = tax_unit("cdcc_potential", period)
         ok_cdcc = us_cdcc * p.cdcc_fraction
-        us_ctc = tax_unit("ctc_value", period)
+        us_ctc = tax_unit("ok_federal_ctc", period)
         ok_ctc = us_ctc * p.ctc_fraction
         ctc_larger_than_cdcc = ok_ctc > ok_cdcc
         combined = tax_unit("ok_child_care_child_tax_credit", period)


### PR DESCRIPTION
Fixes #8239.

## Summary
- add an Oklahoma-specific federal CTC helper that includes non-refundable CTC actually used against federal income tax plus refundable CTC
- use that helper in both the Oklahoma Child Care/Child Tax Credit and the TAXSIM CTC component
- add a regression for unearned-income tax with no earned-income CTC phase-in and update affected Oklahoma integration expectations

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ok/tax/income -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_child_care_child_tax_credit.yaml -c policyengine_us
- uv run ruff check policyengine_us/variables/gov/states/ok/tax/income/credits/ok_federal_ctc.py policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py policyengine_us/variables/gov/states/ok/tax/income/credits/taxsim_ok_child_tax_credit_component.py
- git diff --check