### PR TITLE
Add NM, SC, and WV 529 plan deductions

### DIFF
--- a/changelog.d/added/7548.md
+++ b/changelog.d/added/7548.md
@@ -1,0 +1,1 @@
+Add explicit New Mexico, South Carolina, and West Virginia 529 plan contribution deductions.

--- a/policyengine_us/parameters/gov/states/nm/tax/income/other_deductions_and_exemptions.yaml
+++ b/policyengine_us/parameters/gov/states/nm/tax/income/other_deductions_and_exemptions.yaml
@@ -2,7 +2,7 @@ description: New Mexico other deduction and exemptions elements.
 values:
   2021-01-01:
     - us_govt_interest
-    - investment_in_529_plan
+    - nm_529_plan_deduction
     - military_service_income
 metadata:
   unit: list
@@ -19,4 +19,4 @@ metadata:
     - title: New Mexico Income Tax Act, Chapter 7 - Taxation, 3.3.1.12. INCOME FROM OBLIGATIONS OF GOVERNMENTS
       href: https://casetext.com/regulation/new-mexico-administrative-code/title-3-taxation/chapter-3-personal-income-taxes/part-1-general-provisions/section-33112-income-from-obligations-of-governments
     - title: New Mexico Income Tax Act, Chapter 7 - Taxation, 7-2-32. Deduction; payments into education trust fund.
-      hef: https://nmonesource.com/nmos/nmsa/en/item/4340/index.do#!fragment/zoupio-_Toc141270056/BQCwhgziBcwMYgK4DsDWszIQewE4BUBTADwBdoAvbRABwEtsBaAfX2zgEYAWDgJgHYADIICsANgCUAGmTZShCAEVEhXAE9oAck1SIhMLgTLVG7bv2GQAZTykAQhoBKAUQAyzgGoBBAHIBhZylSMAAjaFJ2CQkgA
+      href: https://nmonesource.com/nmos/nmsa/en/item/4340/index.do#!fragment/zoupio-_Toc141270056/BQCwhgziBcwMYgK4DsDWszIQewE4BUBTADwBdoAvbRABwEtsBaAfX2zgEYAWDgJgHYADIICsANgCUAGmTZShCAEVEhXAE9oAck1SIhMLgTLVG7bv2GQAZTykAQhoBKAUQAyzgGoBBAHIBhZylSMAAjaFJ2CQkgA

--- a/policyengine_us/parameters/gov/states/sc/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/sc/tax/income/subtractions/subtractions.yaml
@@ -4,7 +4,7 @@ values:
     - salt_refund_income
     - disability_benefits #include tax disability benefits
     - sc_net_capital_gain_deduction
-    - investment_in_529_plan
+    - sc_529_plan_deduction
     - us_govt_interest
     - taxable_social_security
     - sc_military_deduction
@@ -25,7 +25,7 @@ values:
     - salt_refund_income
     - disability_benefits
     - sc_net_capital_gain_deduction
-    - investment_in_529_plan
+    - sc_529_plan_deduction
     - us_govt_interest
     - taxable_social_security
     - sc_military_deduction

--- a/policyengine_us/parameters/gov/states/wv/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/wv/tax/income/subtractions/subtractions.yaml
@@ -7,7 +7,7 @@ values:
     - wv_social_security_benefits_subtraction # Line 32
     - military_service_income # Line 34
     - salt_refund_income # Line 36
-    - investment_in_529_plan
+    - wv_529_plan_deduction
     - wv_senior_citizen_disability_deduction # Line 47
     - wv_low_income_earned_income_exclusion
 

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/deductions/nm_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/deductions/nm_529_plan_deduction.yaml
@@ -1,0 +1,37 @@
+- name: New Mexico deducts full 529 contributions
+  period: 2024
+  input:
+    state_code: NM
+    investment_in_529_plan_indv: 5_000
+  output:
+    nm_529_plan_deduction: 5_000
+    nm_other_deductions_and_exemptions: 5_000
+
+- name: New Mexico sums 529 contributions across joint filers
+  period: 2024
+  input:
+    people:
+      person1:
+        investment_in_529_plan_indv: 7_000
+      person2:
+        investment_in_529_plan_indv: 3_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NM
+  output:
+    nm_529_plan_deduction: 10_000
+    nm_other_deductions_and_exemptions: 10_000
+
+- name: New Mexico 529 deduction is zero without contributions
+  period: 2024
+  input:
+    state_code: NM
+    investment_in_529_plan_indv: 0
+  output:
+    nm_529_plan_deduction: 0
+    nm_other_deductions_and_exemptions: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/subtractions/sc_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/subtractions/sc_529_plan_deduction.yaml
@@ -1,0 +1,37 @@
+- name: South Carolina deducts full 529 contributions
+  period: 2024
+  input:
+    state_code: SC
+    investment_in_529_plan_indv: 5_000
+  output:
+    sc_529_plan_deduction: 5_000
+    sc_subtractions: 5_000
+
+- name: South Carolina sums 529 contributions across joint filers
+  period: 2024
+  input:
+    people:
+      person1:
+        investment_in_529_plan_indv: 7_000
+      person2:
+        investment_in_529_plan_indv: 3_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: SC
+  output:
+    sc_529_plan_deduction: 10_000
+    sc_subtractions: 10_000
+
+- name: South Carolina 529 deduction is zero without contributions
+  period: 2024
+  input:
+    state_code: SC
+    investment_in_529_plan_indv: 0
+  output:
+    sc_529_plan_deduction: 0
+    sc_subtractions: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/subtractions/wv_529_plan_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/subtractions/wv_529_plan_deduction.yaml
@@ -1,0 +1,37 @@
+- name: West Virginia deducts full 529 contributions
+  period: 2024
+  input:
+    state_code: WV
+    investment_in_529_plan_indv: 5_000
+  output:
+    wv_529_plan_deduction: 5_000
+    wv_subtractions: 5_000
+
+- name: West Virginia sums 529 contributions across joint filers
+  period: 2024
+  input:
+    people:
+      person1:
+        investment_in_529_plan_indv: 7_000
+      person2:
+        investment_in_529_plan_indv: 3_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: WV
+  output:
+    wv_529_plan_deduction: 10_000
+    wv_subtractions: 10_000
+
+- name: West Virginia 529 deduction is zero without contributions
+  period: 2024
+  input:
+    state_code: WV
+    investment_in_529_plan_indv: 0
+  output:
+    wv_529_plan_deduction: 0
+    wv_subtractions: 0

--- a/policyengine_us/variables/gov/states/nm/tax/income/deductions/nm_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/nm/tax/income/deductions/nm_529_plan_deduction.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class nm_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "New Mexico 529 plan contribution deduction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://hed.nm.gov/financial-aid/new-mexico-529-college-savings-plan",
+        "https://nmonesource.com/nmos/nmsa/en/item/4340/index.do",
+    )
+    defined_for = StateCode.NM
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit("investment_in_529_plan", period)

--- a/policyengine_us/variables/gov/states/sc/tax/income/subtractions/sc_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/sc/tax/income/subtractions/sc_529_plan_deduction.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class sc_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "South Carolina 529 plan contribution deduction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.scstatehouse.gov/code/t59c002.php",
+        "https://treasurer.sc.gov/about-us/newsroom/529-updates-in-one-big-beautiful-bill-give-south-carolina-families-even-more-flexibility-for-educational-savings/",
+    )
+    defined_for = StateCode.SC
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit("investment_in_529_plan", period)

--- a/policyengine_us/variables/gov/states/wv/tax/income/subtractions/wv_529_plan_deduction.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/subtractions/wv_529_plan_deduction.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class wv_529_plan_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "West Virginia 529 plan contribution deduction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.smart529.com/learn/features-and-benefits.html",
+        "https://code.wvlegislature.gov/11-21-12/",
+    )
+    defined_for = StateCode.WV
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit("investment_in_529_plan", period)


### PR DESCRIPTION
## Summary
- add explicit 529 plan contribution deduction variables for New Mexico, South Carolina, and West Virginia
- route each state subtraction list through the state-specific variable instead of the raw generic input
- add baseline tests for positive, joint-filer, and zero-contribution cases

Closes #7548.
Closes #7561.
Closes #7570.

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/deductions/nm_529_plan_deduction.yaml policyengine_us/tests/policy/baseline/gov/states/sc/tax/income/subtractions/sc_529_plan_deduction.yaml policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/subtractions/wv_529_plan_deduction.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/nm/tax/income policyengine_us/tests/policy/baseline/gov/states/sc/tax/income policyengine_us/tests/policy/baseline/gov/states/wv/tax/income -c policyengine_us
- uv run ruff check policyengine_us/variables/gov/states/nm/tax/income/deductions/nm_529_plan_deduction.py policyengine_us/variables/gov/states/sc/tax/income/subtractions/sc_529_plan_deduction.py policyengine_us/variables/gov/states/wv/tax/income/subtractions/wv_529_plan_deduction.py
- git diff --check