### PR TITLE
Fix NM modified gross income retirement distributions

### DIFF
--- a/changelog.d/fixed/8395.md
+++ b/changelog.d/fixed/8395.md
@@ -1,0 +1,1 @@
+Fixed New Mexico modified gross income to include retirement account distributions.

--- a/policyengine_us/parameters/gov/states/nm/tax/income/modified_gross_income.yaml
+++ b/policyengine_us/parameters/gov/states/nm/tax/income/modified_gross_income.yaml
@@ -11,6 +11,7 @@ values:
     - child_support_received
     - rental_income
     - pension_income
+    - retirement_distributions
     - unemployment_compensation
     - irs_employment_income
     - self_employment_income

--- a/policyengine_us/tests/core/test_run_selective_tests.py
+++ b/policyengine_us/tests/core/test_run_selective_tests.py
@@ -29,6 +29,29 @@ def test_runner_unit_test_is_not_treated_as_infrastructure():
     )
 
 
+def test_yaml_only_changes_do_not_request_python_coverage():
+    assert (
+        SelectiveTestRunner.get_changed_python_coverage_patterns(
+            {
+                "policyengine_us/parameters/gov/states/nm/tax/income/modified_gross_income.yaml",
+                "policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_modified_gross_income.yaml",
+            }
+        )
+        == []
+    )
+
+
+def test_changed_tests_are_not_coverage_targets():
+    assert SelectiveTestRunner.get_changed_python_coverage_patterns(
+        {
+            "policyengine_us/tests/core/test_run_selective_tests.py",
+            "policyengine_us/variables/gov/states/nm/tax/income/nm_modified_gross_income.py",
+        }
+    ) == [
+        "policyengine_us/variables/gov/states/nm/tax/income/nm_modified_gross_income.py"
+    ]
+
+
 def test_limit_test_paths_prefers_directly_changed_tests_for_broad_changes():
     runner = SelectiveTestRunner()
     runner.max_test_targets = 1

--- a/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_modified_gross_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_modified_gross_income.yaml
@@ -66,6 +66,24 @@
     # dividends: max(5000, 0) = 5000
     nm_modified_gross_income: 105_000
 
+- name: NM modified gross income includes retirement distributions for rebate eligibility
+  period: 2026
+  input:
+    state_code: NM
+    age: 72
+    social_security_retirement: 13_632
+    taxable_ira_distributions: 42_000
+    self_employment_income: 144
+    taxable_interest_income: 1
+    real_estate_taxes: 1_250
+    filing_status: SINGLE
+  output:
+    nm_modified_gross_income: 55_777
+    nm_property_tax_rebate_eligible: false
+    nm_low_income_comprehensive_tax_rebate: 0
+    nm_property_tax_rebate: 0
+    state_refundable_credits: 0
+
 - name: NM zero income
   period: 2024
   input:

--- a/policyengine_us/tests/run_selective_tests.py
+++ b/policyengine_us/tests/run_selective_tests.py
@@ -338,6 +338,14 @@ class SelectiveTestRunner:
                 )
         return total
 
+    @staticmethod
+    def get_changed_python_coverage_patterns(changed_files: Set[str]) -> List[str]:
+        return [
+            file
+            for file in changed_files
+            if file.endswith(".py") and "/tests/" not in file
+        ]
+
     def limit_test_paths(
         self, test_paths: Set[str], changed_files: Set[str]
     ) -> Set[str]:
@@ -397,6 +405,23 @@ class SelectiveTestRunner:
 
         # Construct pytest command
         if with_coverage:
+            # Only track coverage for the specific files that changed in the PR
+            include_patterns = []
+            if changed_files:
+                # Only include Python files that were actually changed (excluding test directories)
+                changed_py_files = self.get_changed_python_coverage_patterns(
+                    changed_files
+                )
+                if changed_py_files:
+                    include_patterns = changed_py_files
+                else:
+                    print(
+                        "No changed Python source files; running tests without "
+                        "coverage."
+                    )
+                    with_coverage = False
+
+        if with_coverage:
             # Use coverage to run the tests
             # First check if coverage is importable
             try:
@@ -408,16 +433,7 @@ class SelectiveTestRunner:
                 print("Please ensure coverage is installed: pip install coverage")
                 return 1
 
-            # Only track coverage for the specific files that changed in the PR
-            include_patterns = []
-            if changed_files:
-                # Only include Python files that were actually changed (excluding test directories)
-                changed_py_files = [
-                    f for f in changed_files if f.endswith(".py") and "/tests/" not in f
-                ]
-                if changed_py_files:
-                    include_patterns = changed_py_files
-            else:
+            if not changed_files:
                 # Fallback to directory-based patterns if no changed files provided
                 for test_path in test_paths:
                     base_test_path = test_path
@@ -441,6 +457,7 @@ class SelectiveTestRunner:
                             "policyengine_us/parameters/contrib/*.py"
                         )
 
+        if with_coverage:
             pytest_args = [
                 sys.executable,
                 "-m",


### PR DESCRIPTION
## Summary
- include retirement account distributions in New Mexico modified gross income
- add a senior-filer regression covering IRA distributions and downstream rebate/refundable-credit eligibility
- avoid uploading full-repo Codecov reports for YAML-only selective-test runs
- add a changelog fragment

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_modified_gross_income.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/nm/tax/income -c policyengine_us`
- `uv run pytest policyengine_us/tests/core/test_run_selective_tests.py`
- `uv run python policyengine_us/tests/run_selective_tests.py --files policyengine_us/tests/policy/baseline/gov/states/nm/tax/income/nm_modified_gross_income.yaml --coverage`
- `uv run ruff format --check policyengine_us/tests/run_selective_tests.py policyengine_us/tests/core/test_run_selective_tests.py`
- `uv run ruff check policyengine_us/tests/run_selective_tests.py policyengine_us/tests/core/test_run_selective_tests.py`
- `git diff --check`

Closes #8395