### PR TITLE
Add Pennsylvania employee UC payroll tax

### DIFF
--- a/changelog.d/fixed/8406.md
+++ b/changelog.d/fixed/8406.md
@@ -1,0 +1,1 @@
+Added Pennsylvania employee unemployment compensation withholding to employee payroll taxes.

--- a/policyengine_us/parameters/gov/states/pa/tax/payroll/unemployment/employee_rate.yaml
+++ b/policyengine_us/parameters/gov/states/pa/tax/payroll/unemployment/employee_rate.yaml
@@ -1,0 +1,17 @@
+description: Employee-side unemployment compensation contribution rate for Pennsylvania.
+values:
+  2015-01-01: 0.0007
+  2018-01-01: 0.0006
+  2023-01-01: 0.0007
+
+metadata:
+  period: year
+  unit: /1
+  label: Pennsylvania employee unemployment compensation rate
+  reference:
+    - title: Pennsylvania DLI Contribution Rate Chart, UC-749 Rev. 08-21
+      href: https://www.pa.gov/content/dam/copapwp-pagov/en/dli/documents/uc/employer/uc-tax-rates/uc-749-rev-08-21.pdf
+    - title: Pennsylvania DLI Calculating Contributions, Penalties, and Interest
+      href: https://www.pa.gov/agencies/dli/resources/for-employers-and-educators/how-to-file/uc-tax/calculating-contributions--penalties-and-interest
+    - title: Pennsylvania DLI Employee Withholding
+      href: https://www.pa.gov/agencies/dli/resources/for-employers-and-educators/how-to-file/uc-tax/employee-withholding

--- a/policyengine_us/tests/core/test_payroll_contributions.py
+++ b/policyengine_us/tests/core/test_payroll_contributions.py
@@ -331,6 +331,15 @@ def make_employer_total_simulation(
             id="OR",
         ),
         pytest.param(
+            "PA",
+            {
+                "pa_employee_unemployment_compensation_contribution": 70,
+                "pa_employee_state_payroll_tax": 70,
+                "employee_state_payroll_tax": 70,
+            },
+            id="PA",
+        ),
+        pytest.param(
             "RI",
             {
                 "ri_employee_temporary_disability_insurance_contribution": 1_100,

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.yaml
@@ -1,0 +1,19 @@
+- name: Pennsylvania employee unemployment compensation contribution is included in employee payroll tax.
+  period: 2026
+  input:
+    employment_income: 27_000
+    state_code: PA
+  output:
+    pa_employee_unemployment_compensation_contribution: 18.90
+    pa_employee_state_payroll_tax: 18.90
+    employee_state_payroll_tax: 18.90
+    employee_payroll_tax: 2_084.40
+
+- name: Pennsylvania employee unemployment compensation contribution uses the 2018-2022 rate.
+  period: 2022
+  input:
+    employment_income: 27_000
+    state_code: PA
+  output:
+    pa_employee_unemployment_compensation_contribution: 16.20
+    pa_employee_state_payroll_tax: 16.20

--- a/policyengine_us/variables/gov/states/pa/tax/payroll/pa_employee_state_payroll_tax.py
+++ b/policyengine_us/variables/gov/states/pa/tax/payroll/pa_employee_state_payroll_tax.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class pa_employee_state_payroll_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Pennsylvania employee state payroll tax"
+    documentation = (
+        "Employee-side Pennsylvania payroll-funded contributions, including "
+        "unemployment compensation withholding."
+    )
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.PA
+    adds = ["pa_employee_unemployment_compensation_contribution"]

--- a/policyengine_us/variables/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.py
+++ b/policyengine_us/variables/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class pa_employee_unemployment_compensation_contribution(Variable):
+    value_type = float
+    entity = Person
+    label = "Pennsylvania employee unemployment compensation contribution"
+    documentation = "Employee-side Pennsylvania unemployment compensation withholding."
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.PA
+
+    def formula(person, period, parameters):
+        rate = parameters(period).gov.states.pa.tax.payroll.unemployment.employee_rate
+        return rate * person("state_payroll_tax_gross_wages", period)

--- a/policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py
+++ b/policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py
@@ -10,6 +10,7 @@ EMPLOYEE_STATE_PAYROLL_TAX_COMPONENTS = [
     "nj_employee_state_payroll_tax",
     "ny_employee_state_payroll_tax",
     "or_employee_state_payroll_tax",
+    "pa_employee_state_payroll_tax",
     "ri_employee_state_payroll_tax",
     "vt_employee_state_payroll_tax",
     "wa_employee_state_payroll_tax",


### PR DESCRIPTION
Fixes #8406.

## Summary
- add Pennsylvania employee UC withholding rates and contribution variable
- include PA in employee state payroll tax and employee payroll tax
- add 2026 and 2022 regression coverage

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.yaml -c policyengine_us`
- `uv run pytest policyengine_us/tests/core/test_payroll_contributions.py -k employee_state_payroll_contributions`
- `uv run ruff format --check policyengine_us/variables/gov/states/pa/tax/payroll/pa_employee_state_payroll_tax.py policyengine_us/variables/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.py policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py policyengine_us/tests/core/test_payroll_contributions.py`
- `uv run ruff check policyengine_us/variables/gov/states/pa/tax/payroll/pa_employee_state_payroll_tax.py policyengine_us/variables/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.py policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py policyengine_us/tests/core/test_payroll_contributions.py`
- `git diff --check`

## Review
- `/cycle` review completed with no actionable findings remaining.