### PR TITLE
Add Minnesota Paid Leave employee payroll tax

### DIFF
--- a/changelog.d/fixed/8401.md
+++ b/changelog.d/fixed/8401.md
@@ -1,0 +1,1 @@
+Added Minnesota Paid Leave employee contributions to employee payroll taxes.

--- a/policyengine_us/parameters/gov/states/mn/tax/payroll/paid_leave/employee_rate.yaml
+++ b/policyengine_us/parameters/gov/states/mn/tax/payroll/paid_leave/employee_rate.yaml
@@ -1,0 +1,14 @@
+description: Employee-side Minnesota Paid Leave contribution rate.
+values:
+  0000-01-01: 0
+  2026-01-01: 0.0044
+
+metadata:
+  period: year
+  unit: /1
+  label: Minnesota Paid Leave employee rate
+  reference:
+    - title: Minnesota DEED confirms Paid Leave premium rate
+      href: https://mn.gov/deed/newscenter/press-releases/?id=1045-670064
+    - title: Minnesota Statutes Section 268B.14
+      href: https://www.revisor.mn.gov/statutes/cite/268B.14

--- a/policyengine_us/tests/core/test_payroll_contributions.py
+++ b/policyengine_us/tests/core/test_payroll_contributions.py
@@ -301,6 +301,15 @@ def make_employer_total_simulation(
             id="ME",
         ),
         pytest.param(
+            "MN",
+            {
+                "mn_employee_paid_leave_contribution": 440,
+                "mn_employee_state_payroll_tax": 440,
+                "employee_state_payroll_tax": 440,
+            },
+            id="MN",
+        ),
+        pytest.param(
             "NJ",
             {
                 "nj_employee_temporary_disability_insurance_contribution": 190,

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/payroll/paid_leave/mn_employee_paid_leave_contribution.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/payroll/paid_leave/mn_employee_paid_leave_contribution.yaml
@@ -1,0 +1,29 @@
+- name: Minnesota Paid Leave employee contribution is included in employee payroll tax.
+  period: 2026
+  input:
+    employment_income: 8_000
+    state_code: MN
+  output:
+    mn_paid_leave_taxable_wages: 8_000
+    mn_employee_paid_leave_contribution: 35.20
+    mn_employee_state_payroll_tax: 35.20
+    employee_state_payroll_tax: 35.20
+    employee_payroll_tax: 647.20
+
+- name: Minnesota Paid Leave employee contribution is not in effect before 2026.
+  period: 2025
+  input:
+    employment_income: 8_000
+    state_code: MN
+  output:
+    mn_employee_paid_leave_contribution: 0
+    mn_employee_state_payroll_tax: 0
+
+- name: Minnesota Paid Leave taxable wages use the rounded Social Security wage base.
+  period: 2026
+  input:
+    employment_income: 200_000
+    state_code: MN
+  output:
+    mn_paid_leave_taxable_wages: 185_000
+    mn_employee_paid_leave_contribution: 814

--- a/policyengine_us/variables/gov/states/mn/tax/payroll/mn_employee_state_payroll_tax.py
+++ b/policyengine_us/variables/gov/states/mn/tax/payroll/mn_employee_state_payroll_tax.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class mn_employee_state_payroll_tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Minnesota employee state payroll tax"
+    documentation = "Employee-side Minnesota Paid Leave contributions."
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.MN
+    adds = ["mn_employee_paid_leave_contribution"]

--- a/policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_employee_paid_leave_contribution.py
+++ b/policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_employee_paid_leave_contribution.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class mn_employee_paid_leave_contribution(Variable):
+    value_type = float
+    entity = Person
+    label = "Minnesota employee paid leave contribution"
+    documentation = (
+        "Employee-side Minnesota Paid Leave contribution, assuming the employer "
+        "withholds the maximum permitted employee share."
+    )
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.MN
+
+    def formula(person, period, parameters):
+        rate = parameters(period).gov.states.mn.tax.payroll.paid_leave.employee_rate
+        return rate * person("mn_paid_leave_taxable_wages", period)

--- a/policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_paid_leave_taxable_wages.py
+++ b/policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_paid_leave_taxable_wages.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class mn_paid_leave_taxable_wages(Variable):
+    value_type = float
+    entity = Person
+    label = "Minnesota Paid Leave taxable wages"
+    documentation = (
+        "Minnesota Paid Leave covered wages capped at the Social Security "
+        "contribution and benefit base, rounded to the nearest $1,000."
+    )
+    definition_period = YEAR
+    unit = USD
+    defined_for = StateCode.MN
+    reference = "https://www.revisor.mn.gov/statutes/cite/268B.01"
+
+    def formula(person, period, parameters):
+        social_security_cap = parameters(period).gov.irs.payroll.social_security.cap
+        taxable_wage_base = 1_000 * np.floor(social_security_cap / 1_000 + 0.5)
+        return min_(person("state_payroll_tax_gross_wages", period), taxable_wage_base)

--- a/policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py
+++ b/policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py
@@ -7,6 +7,7 @@ EMPLOYEE_STATE_PAYROLL_TAX_COMPONENTS = [
     "de_employee_state_payroll_tax",
     "ma_employee_state_payroll_tax",
     "me_employee_state_payroll_tax",
+    "mn_employee_state_payroll_tax",
     "nj_employee_state_payroll_tax",
     "ny_employee_state_payroll_tax",
     "or_employee_state_payroll_tax",


### PR DESCRIPTION
Fixes #8401.

## Summary
- add Minnesota Paid Leave employee contribution rate starting in 2026
- cap Minnesota Paid Leave taxable wages at the rounded Social Security wage base
- include the contribution in employee state payroll tax and employee payroll tax

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/mn/tax/payroll/paid_leave/mn_employee_paid_leave_contribution.yaml -c policyengine_us`
- `uv run pytest policyengine_us/tests/core/test_payroll_contributions.py -k employee_state_payroll_contributions`
- `uv run ruff format --check policyengine_us/variables/gov/states/mn/tax/payroll/mn_employee_state_payroll_tax.py policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_paid_leave_taxable_wages.py policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_employee_paid_leave_contribution.py policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py policyengine_us/tests/core/test_payroll_contributions.py`
- `uv run ruff check policyengine_us/variables/gov/states/mn/tax/payroll/mn_employee_state_payroll_tax.py policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_paid_leave_taxable_wages.py policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_employee_paid_leave_contribution.py policyengine_us/variables/gov/states/tax/payroll/employee_state_payroll_tax.py policyengine_us/tests/core/test_payroll_contributions.py`
- `git diff --check`

## Review
- `/cycle` read-only review completed with no actionable findings.