### PR TITLE
Split Pennsylvania refundable credits

### DIFF
--- a/changelog.d/fixed/8405.md
+++ b/changelog.d/fixed/8405.md
@@ -1,0 +1,1 @@
+Split Pennsylvania refundable credits from state income tax before refundable credits.

--- a/policyengine_us/parameters/gov/household/household_refundable_credits.yaml
+++ b/policyengine_us/parameters/gov/household/household_refundable_credits.yaml
@@ -37,7 +37,7 @@ values:
     - oh_refundable_credits  # Ohio.
     - ok_refundable_credits  # Oklahoma.
     - or_refundable_credits  # Oregon.
-    # Skip PA which has no refundable credits.
+    - pa_refundable_tax_credits  # Pennsylvania.
     - ri_refundable_credits  # Rhode Island.
     - sc_refundable_credits  # South Carolina.
     - wa_refundable_credits  # Washington.

--- a/policyengine_us/parameters/gov/household/household_refundable_state_credits.yaml
+++ b/policyengine_us/parameters/gov/household/household_refundable_state_credits.yaml
@@ -36,7 +36,7 @@ values:
     - oh_refundable_credits  # Ohio.
     - ok_refundable_credits  # Oklahoma.
     - or_refundable_credits  # Oregon.
-    # Skip PA which has no refundable credits.
+    - pa_refundable_tax_credits  # Pennsylvania.
     - ri_refundable_credits  # Rhode Island.
     - sc_refundable_credits  # South Carolina.
     - wa_refundable_credits  # Washington.

--- a/policyengine_us/parameters/gov/states/household/state_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_income_tax_before_refundable_credits.yaml
@@ -36,7 +36,7 @@ values:
     - oh_income_tax_before_refundable_credits
     - or_income_tax_before_refundable_credits
     - ok_income_tax_before_refundable_credits
-    - pa_income_tax
+    - pa_income_tax_before_refundable_credits
     - ri_income_tax_before_refundable_credits
     - sc_income_tax_before_refundable_credits
     - wa_income_tax_before_refundable_credits

--- a/policyengine_us/parameters/gov/states/household/state_refundable_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_refundable_credits.yaml
@@ -36,7 +36,7 @@ values:
     - oh_refundable_credits  # Ohio.
     - ok_refundable_credits  # Oklahoma.
     - or_refundable_credits  # Oregon.
-    # Skip PA which has no refundable credits.
+    - pa_refundable_tax_credits  # Pennsylvania.
     - ri_refundable_credits  # Rhode Island.
     - sc_refundable_credits  # South Carolina.
     - wa_refundable_credits  # Washington.

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.yaml
@@ -1,0 +1,18 @@
+- name: Pennsylvania refundable credits are split from pre-refundable state income tax aggregates.
+  period: 2026
+  input:
+    state_code: PA
+    pa_income_tax_after_forgiveness: 1_730
+    pa_use_tax: 23
+    pa_refundable_tax_credits: 411
+  output:
+    pa_income_tax_before_refundable_credits: 1_753
+    pa_income_tax: 1_342
+    state_income_tax_before_refundable_credits: 1_753
+    state_refundable_credits: 411
+    state_income_tax: 1_342
+    household_state_tax_before_refundable_credits: 1_753
+    household_refundable_state_tax_credits: 411
+    household_tax_before_refundable_credits: 1_753
+    household_refundable_tax_credits: 411
+    household_tax: 1_342

--- a/policyengine_us/tests/policy/baseline/household/income/household/household_state_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/household/household_state_income_tax.yaml
@@ -3,7 +3,7 @@
   input:
     co_income_tax_before_refundable_credits: 3_000
     ne_income_tax_before_refundable_credits: 2_000
-    pa_income_tax: 100
+    pa_income_tax_before_refundable_credits: 100
     hi_refundable_credits: 300
     ok_refundable_credits: 500
     ut_refundable_credits: 400

--- a/policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class pa_income_tax_before_refundable_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Pennsylvania income tax before refundable credits"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.PA
+
+    adds = ["pa_income_tax_after_forgiveness", "pa_use_tax"]


### PR DESCRIPTION
Fixes #8405.

## Summary
- add `pa_income_tax_before_refundable_credits` before PA refundable credits
- include PA refundable credits in state and household refundable-credit aggregates
- update PA and household aggregate regression coverage

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/household/income/household/household_state_income_tax.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/household/income/household/household_net_income.yaml -c policyengine_us`
- `uv run ruff format --check policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.py`
- `uv run ruff check policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.py`
- `git diff --check`

## Review
- `/cycle` review found household aggregate gaps; fixed and follow-up review returned no actionable findings.