### PR TITLE
Update Michigan Tier 3 Social Security offset

### DIFF
--- a/policyengine_us/parameters/gov/states/mi/tax/income/deductions/standard/tier_three/taxable_social_security_offset_applies.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/deductions/standard/tier_three/taxable_social_security_offset_applies.yaml
@@ -1,0 +1,16 @@
+description: Michigan requires filers to reduce the tier three standard deduction by taxable Social Security benefits included in adjusted gross income.
+values:
+  2017-01-01: true
+  2026-01-01: false
+  2029-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: Michigan tier three standard deduction taxable Social Security offset applies
+  reference:
+    - title: Michigan Legal Code Section 206.30 - (9)(e)
+      href: http://legislature.mi.gov/doc.aspx?mcl-206-30
+    - title: Social Security Taxation Changes in Public Act 24 of 2025
+      href: https://www.michigan.gov/treasury/reference/taxpayer-notices/2025/11/17/social-security-taxation-changes-in-public-act-24-of-2025
+    - title: Revenue Administrative Bulletin 2026-1
+      href: https://www.michigan.gov/taxes/rep-legal/rab/2026-revenue-administrative-bulletins/revenue-administrative-bulletin-2026-1

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/deductions/standard/tier_three/mi_standard_deduction_tier_three.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/deductions/standard/tier_three/mi_standard_deduction_tier_three.yaml
@@ -73,3 +73,87 @@
       state_code: MI
   output: # 20000 - 1000 - (500 > 100) - 2000 < 20000
     mi_standard_deduction_tier_three: 20_000
+
+- name: 2025 tier 3 standard deduction is reduced by taxable Social Security
+  period: 2025
+  input:
+    people:
+      person1:
+        taxable_social_security: 9_260
+        military_service_income: 0
+        is_tax_unit_head_or_spouse: true
+    tax_units:
+      tax_unit:
+        mi_standard_deduction_tier_three_eligible: true
+        mi_personal_exemptions: 5_950
+        mi_expanded_retirement_benefits_deduction: 0
+        members: [person1]
+        filing_status: SINGLE
+    household:
+      members: [person1]
+      state_code: MI
+  output:
+    mi_standard_deduction_tier_three: 4_790
+
+- name: 2026 PA 24 removes the taxable Social Security reduction
+  period: 2026
+  input:
+    people:
+      person1:
+        taxable_social_security: 9_260
+        military_service_income: 0
+        is_tax_unit_head_or_spouse: true
+    tax_units:
+      tax_unit:
+        mi_standard_deduction_tier_three_eligible: true
+        mi_personal_exemptions: 5_950
+        mi_expanded_retirement_benefits_deduction: 0
+        members: [person1]
+        filing_status: SINGLE
+    household:
+      members: [person1]
+      state_code: MI
+  output:
+    mi_standard_deduction_tier_three: 14_050
+
+- name: 2026 PA 24 does not remove the military service income reduction
+  period: 2026
+  input:
+    people:
+      person1:
+        taxable_social_security: 9_260
+        military_service_income: 500
+        is_tax_unit_head_or_spouse: true
+    tax_units:
+      tax_unit:
+        mi_standard_deduction_tier_three_eligible: true
+        mi_personal_exemptions: 5_950
+        mi_expanded_retirement_benefits_deduction: 0
+        members: [person1]
+        filing_status: SINGLE
+    household:
+      members: [person1]
+      state_code: MI
+  output:
+    mi_standard_deduction_tier_three: 13_550
+
+- name: 2029 tier 3 standard deduction is again reduced by taxable Social Security
+  period: 2029
+  input:
+    people:
+      person1:
+        taxable_social_security: 9_260
+        military_service_income: 0
+        is_tax_unit_head_or_spouse: true
+    tax_units:
+      tax_unit:
+        mi_standard_deduction_tier_three_eligible: true
+        mi_personal_exemptions: 5_950
+        mi_expanded_retirement_benefits_deduction: 0
+        members: [person1]
+        filing_status: SINGLE
+    household:
+      members: [person1]
+      state_code: MI
+  output:
+    mi_standard_deduction_tier_three: 4_790

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/integration.yaml
@@ -175,3 +175,27 @@
     mi_household_resources: 0
     mi_home_heating_credit: 410
     mi_income_tax: -410
+
+- name: 2026 single senior with Social Security can claim the full tier 3 residual standard deduction under PA 24
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 69
+        employment_income: 30_000
+        social_security_retirement: 19_200
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MI
+  output:
+    adjusted_gross_income: 39_260
+    taxable_social_security: 9_260
+    mi_personal_exemptions: 5_950
+    mi_standard_deduction_tier_three: 14_050
+    mi_taxable_income: 10_000
+    mi_income_tax_before_refundable_credits: 425

--- a/policyengine_us/variables/gov/states/mi/tax/income/deductions/standard/tier_three/mi_standard_deduction_tier_three.py
+++ b/policyengine_us/variables/gov/states/mi/tax/income/deductions/standard/tier_three/mi_standard_deduction_tier_three.py
@@ -10,6 +10,8 @@ class mi_standard_deduction_tier_three(Variable):
     reference = (
         "http://legislature.mi.gov/doc.aspx?mcl-206-30",  # (9)(e)
         "https://www.michigan.gov/taxes/iit/retirement-and-pension-benefits/michigan-standard-deduction",
+        "https://www.michigan.gov/treasury/reference/taxpayer-notices/2025/11/17/social-security-taxation-changes-in-public-act-24-of-2025",
+        "https://www.michigan.gov/taxes/rep-legal/rab/2026-revenue-administrative-bulletins/revenue-administrative-bulletin-2026-1",
         "https://www.michigan.gov/taxes/-/media/Project/Websites/taxes/Forms/2022/2022-IIT-Forms/BOOK_MI-1040.pdf#page=16",
     )
     defined_for = "mi_standard_deduction_tier_three_eligible"
@@ -33,7 +35,10 @@ class mi_standard_deduction_tier_three(Variable):
         # Line 3: enter military service income or taxable social security
         taxable_ss = person("taxable_social_security", period)
         military_service_income = person("military_service_income", period)
-        larger_ss_or_military_pay = max_(taxable_ss, military_service_income)
+        taxable_ss_offset = (
+            taxable_ss * p.standard.tier_three.taxable_social_security_offset_applies
+        )
+        larger_ss_or_military_pay = max_(taxable_ss_offset, military_service_income)
         # Line 4 are personal (and stillborn) exemptions
         mi_personal_exemptions = tax_unit("mi_personal_exemptions", period)
         # Line 5: add lines 2 through 4


### PR DESCRIPTION
Fixes #8403.

## Summary
- add a Michigan Tier 3 standard deduction parameter for when taxable Social Security offsets the residual deduction
- turn that offset off for tax years 2026 through 2028 under PA 24, while preserving personal exemption and military income reductions
- add direct 2025/2026/2029 tests plus the PolicyBench-style 2026 Michigan senior scenario

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/deductions/standard/tier_three/mi_standard_deduction_tier_three.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/integration.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/mi/tax/income -c policyengine_us
- uv run ruff check policyengine_us/variables/gov/states/mi/tax/income/deductions/standard/tier_three/mi_standard_deduction_tier_three.py
- git diff --check

## Review
- /cycle read-only review pass found the new parameter file was unstaged; fixed by staging/committing it
- follow-up read-only review found no actionable issues