### PR TITLE
Update Louisiana 2026 standard deduction

### DIFF
--- a/policyengine_us/parameters/gov/states/la/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/la/tax/income/deductions/standard/amount.yaml
@@ -10,18 +10,29 @@ metadata:
   reference:
     - title: Louisiana Revised Statutes, RS 47:294 - Standard deduction
       href: https://www.legis.la.gov/legis/Law.aspx?d=101761
+    - title: Louisiana Register, February 20, 2026, Income Tax Withholding Tables notice
+      href: https://bese.louisiana.gov/docs/default-source/rulemaking-docket/feb-louisiana-register.pdf#page=127
+    - title: Consumer Price Index News Release - 2025 M12 Results
+      href: https://www.bls.gov/news.release/archives/cpi_01132026.htm
     - title: 2025 Louisiana Resident Income Tax Return Instructions, Line 8
       href: https://dam.ldr.la.gov/taxforms/IT540i%20WEB(2025)D11.pdf#page=3
 
 SINGLE:
   2025-01-01: 12_500
+  # 2026 amount applies the December-to-December 2025 CPI-U increase:
+  # 12,500 * (324.054 / 315.605), rounded to the nearest dollar.
+  2026-01-01: 12_835
 SURVIVING_SPOUSE:
   2025-01-01: 25_000
+  2026-01-01: 25_670
 SEPARATE:
   2025-01-01: 12_500
+  2026-01-01: 12_835
 # The legal code defines the HoH and Joint amounts as 200% of the 
 # Single amount.
 HEAD_OF_HOUSEHOLD:
   2025-01-01: 25_000
+  2026-01-01: 25_670
 JOINT:
   2025-01-01: 25_000
+  2026-01-01: 25_670

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/deductions/la_standard_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/deductions/la_standard_deduction.yaml
@@ -14,3 +14,18 @@
   output:
     la_standard_deduction: 25_000
 
+- name: 2026 single filer uses prior-calendar-year CPI-U adjustment
+  period: 2026
+  input:
+    state_code: LA
+    filing_status: SINGLE
+  output:
+    la_standard_deduction: 12_835
+
+- name: 2026 head of household filer gets twice the single amount
+  period: 2026
+  input:
+    state_code: LA
+    filing_status: HEAD_OF_HOUSEHOLD
+  output:
+    la_standard_deduction: 25_670

--- a/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/tax/income/integration.yaml
@@ -215,3 +215,17 @@
         state_fips: 22
   output:
     la_income_tax: 476
+
+- name: 2026 single filer standard deduction uses prior-calendar-year CPI-U adjustment
+  period: 2026
+  input:
+    state_code: LA
+    filing_status: SINGLE
+    la_agi: 40_000
+    tax_unit_itemizes: false
+    la_federal_tax_deduction: 0
+    la_non_refundable_credits: 0
+  output:
+    la_standard_deduction: 12_835
+    la_taxable_income: 27_165
+    la_income_tax_before_refundable_credits: 814.95


### PR DESCRIPTION
Fixes #8404.

## Summary
- pin Louisiana 2026 standard deduction amounts using the prior-calendar-year CPI-U adjustment
- set single/separate to $12,835 and joint/head of household/surviving spouse to $25,670
- add direct standard-deduction tests and the PolicyBench-style $40k LA AGI integration case

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/la/tax/income/deductions/la_standard_deduction.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/la/tax/income/integration.yaml -c policyengine_us
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/la/tax/income -c policyengine_us
- git diff --check

## Review
- /cycle read-only review found the Louisiana Register PDF anchor used the printed page number; fixed to the PDF page anchor
- follow-up focused tests passed after that metadata fix