### PR TITLE
Test Roth contributions do not reduce wages

### DIFF
--- a/policyengine_us/parameters/gov/irs/gross_income/pre_tax_contributions.yaml
+++ b/policyengine_us/parameters/gov/irs/gross_income/pre_tax_contributions.yaml
@@ -2,6 +2,7 @@ description: The US subtracts these payroll deductions from wages and salaries w
 values:
   2010-01-01:
     # Assumes all are pre-tax.
+    # Roth 401(k)/403(b) contributions are post-tax and intentionally excluded.
     - traditional_401k_contributions
     - traditional_403b_contributions
     # Only explicit pre-tax payroll health premiums reduce taxable wages.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/irs_employment_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/irs_employment_income.yaml
@@ -43,3 +43,13 @@
   output:
     pre_tax_contributions: 18
     irs_employment_income: 82
+
+- name: Roth 401k and 403b contributions do not reduce IRS employment income.
+  period: 2024
+  input:
+    employment_income: 100
+    roth_401k_contributions: 10
+    roth_403b_contributions: 5
+  output:
+    pre_tax_contributions: 0
+    irs_employment_income: 100


### PR DESCRIPTION
Fixes #8387.

## Summary
- add a regression case ensuring Roth 401(k)/403(b) contributions do not reduce `irs_employment_income`
- clarify that Roth 401(k)/403(b) contributions are intentionally excluded from pre-tax payroll deductions

## Tests
- uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/irs_employment_income.yaml -c policyengine_us
- git diff --check

## Review
- /cycle read-only review found no actionable issues