### PR TITLE
Limit auto loan deduction to qualified vehicle interest

### DIFF
--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/auto_loan_interest_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/auto_loan_interest_deduction.yaml
@@ -3,7 +3,7 @@
   input:
     irs_gross_income: 220_000
     filing_status: JOINT
-    auto_loan_interest: 20_000
+    qualified_passenger_vehicle_loan_interest: 20_000
     standard_deduction: 0
     tax_unit_itemizes: false
   output:
@@ -16,7 +16,7 @@
   input:
     irs_gross_income: 220_000
     filing_status: JOINT
-    auto_loan_interest: 20_000
+    qualified_passenger_vehicle_loan_interest: 20_000
     standard_deduction: 0
     tax_unit_itemizes: true
     salt_deduction: 10_000
@@ -24,3 +24,15 @@
     auto_loan_interest_deduction: 6_000
     adjusted_gross_income: 220_000
     taxable_income_deductions: 16_000
+
+- name: Generic auto loan interest is not deductible without qualified interest
+  period: 2026
+  input:
+    irs_gross_income: 220_000
+    filing_status: JOINT
+    auto_loan_interest: 20_000
+    standard_deduction: 0
+    tax_unit_itemizes: false
+  output:
+    auto_loan_interest_deduction: 0
+    taxable_income_deductions: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.yaml
@@ -29,7 +29,7 @@
       household:
         members: [person1]
         state_code: ID
-        auto_loan_interest: 10_000
+        qualified_passenger_vehicle_loan_interest: 10_000
   output:
     tip_income_deduction: 10_000
     overtime_income_deduction: 10_000

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/deductions/obbba_conformity/in_auto_loan_interest_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/deductions/obbba_conformity/in_auto_loan_interest_deduction.yaml
@@ -2,7 +2,7 @@
   period: 2026
   input:
     state_code: IN
-    auto_loan_interest: 2_000
+    qualified_passenger_vehicle_loan_interest: 2_000
     employment_income: 50_000
   output:
     in_auto_loan_interest_deduction: 2_000
@@ -20,7 +20,7 @@
   period: 2025
   input:
     state_code: IN
-    auto_loan_interest: 2_000
+    qualified_passenger_vehicle_loan_interest: 2_000
     employment_income: 50_000
   output:
     in_auto_loan_interest_deduction: 2_000
@@ -28,10 +28,10 @@
 
 - name: Indiana auto loan interest deduction in in_deductions in 2026
   period: 2026
-  absolute_error_margin: 1
+  absolute_error_margin: 0.01
   input:
     state_code: IN
-    auto_loan_interest: 2_000
+    qualified_passenger_vehicle_loan_interest: 2_000
     employment_income: 50_000
   output:
     in_auto_loan_interest_deduction: 2_000
@@ -41,8 +41,18 @@
   period: 2027
   input:
     state_code: IN
-    auto_loan_interest: 2_000
+    qualified_passenger_vehicle_loan_interest: 2_000
     employment_income: 50_000
   output:
     in_auto_loan_interest_deduction: 2_000
+    in_deductions: 0
+
+- name: Indiana generic auto loan interest is not deductible without qualified interest
+  period: 2026
+  input:
+    state_code: IN
+    auto_loan_interest: 2_000
+    employment_income: 50_000
+  output:
+    in_auto_loan_interest_deduction: 0
     in_deductions: 0

--- a/policyengine_us/variables/gov/irs/income/taxable_income/deductions/auto_loan_interest/auto_loan_interest_deduction.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/deductions/auto_loan_interest/auto_loan_interest_deduction.py
@@ -7,10 +7,18 @@ class auto_loan_interest_deduction(Variable):
     label = "Auto loan interest deduction"
     unit = USD
     definition_period = YEAR
-    reference = "https://www.congress.gov/bill/119th-congress/house-bill/1/text"
+    reference = (
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+        "https://www.irs.gov/taxtopics/tc505",
+        "https://www.irs.gov/pub/irs-pdf/p6126.pdf",
+    )
 
     def formula(tax_unit, period, parameters):
-        auto_loan_interest = add(tax_unit, period, ["auto_loan_interest"])
+        auto_loan_interest = add(
+            tax_unit,
+            period,
+            ["qualified_passenger_vehicle_loan_interest"],
+        )
         p = parameters(period).gov.irs.deductions.auto_loan_interest
         capped_interest = min_(auto_loan_interest, p.cap)
         # Get filing status.

--- a/policyengine_us/variables/household/expense/vehicle/qualified_passenger_vehicle_loan_interest.py
+++ b/policyengine_us/variables/household/expense/vehicle/qualified_passenger_vehicle_loan_interest.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class qualified_passenger_vehicle_loan_interest(Variable):
+    value_type = float
+    entity = Household
+    label = "qualified passenger vehicle loan interest"
+    unit = USD
+    documentation = (
+        "Interest on loans that meet the federal qualified passenger "
+        "vehicle loan interest requirements, including qualifying vehicle "
+        "and loan requirements."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.irs.gov/taxtopics/tc505",
+        "https://www.irs.gov/pub/irs-pdf/p6126.pdf",
+        "https://www.irs.gov/irb/2026-05_IRB",
+    )
+    uprating = "gov.bls.cpi.cpi_u"


### PR DESCRIPTION
Fixes #8402.

## Summary
- add a qualified passenger vehicle loan interest input
- base the federal auto loan interest deduction on that qualified input instead of generic auto loan interest
- update federal, Indiana, and Idaho tests to cover qualified-interest behavior and generic-interest non-deductibility

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/auto_loan_interest_deduction.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/in/tax/income/deductions/obbba_conformity/in_auto_loan_interest_deduction.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/id/tax/income/deductions/id_qualified_business_income_and_federal_schedule_1a_deductions.yaml -c policyengine_us`
- `uv run pytest policyengine_us/tests/core/test_input_variable_definitions.py policyengine_us/tests/code_health/variable_names.py -q`
- `uv run ruff check policyengine_us/variables/gov/irs/income/taxable_income/deductions/auto_loan_interest/auto_loan_interest_deduction.py policyengine_us/variables/household/expense/vehicle/qualified_passenger_vehicle_loan_interest.py`
- `git diff --check`

## Review
- `/cycle` read-only review: no actionable findings