### PR TITLE
Fix MN and PA employee payroll wage bases

### DIFF
--- a/policyengine_us/tests/core/test_payroll_contributions.py
+++ b/policyengine_us/tests/core/test_payroll_contributions.py
@@ -632,6 +632,14 @@ def test_small_employer_thresholds_zero_employer_paid_leave_share(
             id="ME",
         ),
         pytest.param(
+            "MN",
+            {
+                "mn_paid_leave_taxable_wages": 7_000,
+                "mn_employee_paid_leave_contribution": 30.8,
+            },
+            id="MN",
+        ),
+        pytest.param(
             "NJ",
             {
                 "nj_temporary_disability_insurance_taxable_wages": 7_000,
@@ -661,6 +669,14 @@ def test_small_employer_thresholds_zero_employer_paid_leave_share(
                 "or_employer_paid_leave_contribution": 28,
             },
             id="OR",
+        ),
+        pytest.param(
+            "PA",
+            {
+                "pa_employee_unemployment_compensation_contribution": 4.9,
+                "pa_employee_state_payroll_tax": 4.9,
+            },
+            id="PA",
         ),
     ],
 )

--- a/policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_paid_leave_taxable_wages.py
+++ b/policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_paid_leave_taxable_wages.py
@@ -17,4 +17,4 @@ class mn_paid_leave_taxable_wages(Variable):
     def formula(person, period, parameters):
         social_security_cap = parameters(period).gov.irs.payroll.social_security.cap
         taxable_wage_base = 1_000 * np.floor(social_security_cap / 1_000 + 0.5)
-        return min_(person("state_payroll_tax_gross_wages", period), taxable_wage_base)
+        return min_(max_(0, person("employment_income", period)), taxable_wage_base)

--- a/policyengine_us/variables/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.py
+++ b/policyengine_us/variables/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.py
@@ -12,4 +12,4 @@ class pa_employee_unemployment_compensation_contribution(Variable):
 
     def formula(person, period, parameters):
         rate = parameters(period).gov.states.pa.tax.payroll.unemployment.employee_rate
-        return rate * person("state_payroll_tax_gross_wages", period)
+        return rate * max_(0, person("employment_income", period))


### PR DESCRIPTION
## Summary
- update Minnesota Paid Leave taxable wages to use nonnegative employment income after the shared state payroll wage-base helper was removed
- update Pennsylvania employee UC withholding to use nonnegative gross employment income
- add MN/PA regressions covering pre-tax deduction treatment in state payroll gross wage bases

## Tests
- `uv run pytest policyengine_us/tests/core/test_payroll_contributions.py -q`
- `uv run ruff check policyengine_us/variables/gov/states/mn/tax/payroll/paid_leave/mn_paid_leave_taxable_wages.py policyengine_us/variables/gov/states/pa/tax/payroll/unemployment/pa_employee_unemployment_compensation_contribution.py policyengine_us/tests/core/test_payroll_contributions.py`
- `git diff --check`

## Review
- `/cycle` read-only review found PA should use gross employment income instead of FICA wages; fixed
- second `/cycle` review found no actionable findings