### PR TITLE
Enforce IRA contribution limits

### DIFF
--- a/changelog.d/fixed/8388.md
+++ b/changelog.d/fixed/8388.md
@@ -1,0 +1,1 @@
+Enforce the combined traditional and Roth IRA contribution limit.

--- a/policyengine_us/parameters/gov/contrib/crfb/surtax/increased_base/sources.yaml
+++ b/policyengine_us/parameters/gov/contrib/crfb/surtax/increased_base/sources.yaml
@@ -2,7 +2,7 @@ description: Additional income sources for CRFB surtax expanded base beyond IRS 
 values:
   2010-01-01:
     # Retirement contributions (IRA, 401k, 403b)
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - traditional_401k_contributions
     - traditional_403b_contributions
     # HSA contributions (no Archer MSA variable exists)

--- a/policyengine_us/parameters/gov/irs/ald/deductions.yaml
+++ b/policyengine_us/parameters/gov/irs/ald/deductions.yaml
@@ -12,7 +12,7 @@ values:
     - health_savings_account_ald
     - self_employed_health_insurance_ald
     - self_employed_pension_contribution_ald
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - qualified_adoption_assistance_expense
     - us_bonds_for_higher_ed
     - specified_possession_income
@@ -28,7 +28,7 @@ values:
     - health_savings_account_ald
     - self_employed_health_insurance_ald
     - self_employed_pension_contribution_ald
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - qualified_adoption_assistance_expense
     - us_bonds_for_higher_ed
     - specified_possession_income
@@ -43,7 +43,7 @@ values:
     - health_savings_account_ald
     - self_employed_health_insurance_ald
     - self_employed_pension_contribution_ald
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - qualified_adoption_assistance_expense
     - us_bonds_for_higher_ed
     - specified_possession_income
@@ -58,7 +58,7 @@ values:
     - health_savings_account_ald
     - self_employed_health_insurance_ald
     - self_employed_pension_contribution_ald
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - qualified_adoption_assistance_expense
     - us_bonds_for_higher_ed
     - specified_possession_income

--- a/policyengine_us/parameters/gov/irs/credits/retirement_saving/qualified_retirement_savings_contributions.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/retirement_saving/qualified_retirement_savings_contributions.yaml
@@ -1,20 +1,20 @@
 description: The IRA sums the following elements as qualified retirement savings contributions when computing the saver's credit.  
 values:
   2018-01-01:
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - traditional_401k_contributions
     - traditional_403b_contributions
-    - roth_ira_contributions
+    - capped_roth_ira_contributions
     - roth_401k_contributions
     - roth_403b_contributions
     - self_employed_pension_contributions
     - able_contributions_person
 
   2026-01-01:
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - traditional_401k_contributions
     - traditional_403b_contributions
-    - roth_ira_contributions
+    - capped_roth_ira_contributions
     - roth_401k_contributions
     - roth_403b_contributions
     - self_employed_pension_contributions

--- a/policyengine_us/parameters/gov/local/ca/riv/general_relief/income/deductions/sources.yaml
+++ b/policyengine_us/parameters/gov/local/ca/riv/general_relief/income/deductions/sources.yaml
@@ -5,7 +5,7 @@ values:
     - employee_social_security_tax
     - employee_medicare_tax
     - additional_medicare_tax
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/al/tax/income/agi/deductions.yaml
+++ b/policyengine_us/parameters/gov/states/al/tax/income/agi/deductions.yaml
@@ -2,13 +2,13 @@ description: Alabama provides these deductions for the state adjusted gross inco
 values:
   2021-01-01:
   # IRA distributions prior to 1982 are not deductible.
-    - traditional_ira_contributions # Line 1 
+    - capped_traditional_ira_contributions # Line 1
     - alimony_expense # Line 4
     - self_employed_health_insurance_ald # Line 7
     - us_govt_interest
   2023-01-01:
   # IRA distributions prior to 1982 are not deductible.
-    - traditional_ira_contributions # Line 1 
+    - capped_traditional_ira_contributions # Line 1
     - alimony_expense # Line 4
     - self_employed_health_insurance_ald # Line 7
     - us_govt_interest

--- a/policyengine_us/parameters/gov/states/ia/tax/income/income_adjustments/sources.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/income_adjustments/sources.yaml
@@ -1,7 +1,7 @@
 description: Iowa subtracts these sources from gross income.
 values:
   2021-01-01:
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - self_employment_tax_ald_person
     - alimony_expense
     - ia_pension_exclusion

--- a/policyengine_us/parameters/gov/states/ma/tax/income/ald/disallowed.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/ald/disallowed.yaml
@@ -2,18 +2,18 @@ description: Above-the-line deductions disallowed in Massachusetts income tax.
 values:
   2001-01-01:
     - loss_ald # (c)
-    - traditional_ira_contributions # (f)
+    - capped_traditional_ira_contributions # (f)
     - early_withdrawal_penalty # (h)
     - self_employment_tax_ald
   2018-01-01:
     - loss_ald # (c)
-    - traditional_ira_contributions # (f)
+    - capped_traditional_ira_contributions # (f)
     - early_withdrawal_penalty # (h)
     - self_employment_tax_ald
     - alimony_income  # is a US ALD only in 2018 through 2025
   2026-01-01:
     - loss_ald # (c)
-    - traditional_ira_contributions # (f)
+    - capped_traditional_ira_contributions # (f)
     - early_withdrawal_penalty # (h)
     - self_employment_tax_ald
 metadata:

--- a/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/adjustments.yaml
+++ b/policyengine_us/parameters/gov/states/ms/tax/income/adjustments/adjustments.yaml
@@ -1,7 +1,7 @@
 description: Mississippi subtracts these adjustments from federal adjusted gross income when computing state adjusted gross income.
 values:
   2020-01-01:
-    - traditional_ira_contributions # Line 50
+    - capped_traditional_ira_contributions # Line 50
     - ms_self_employment_adjustment # Line 61
     - ms_national_guard_or_reserve_pay_adjustment # Line 55
     - alimony_expense # Line 53

--- a/policyengine_us/parameters/gov/states/ut/tax/property/homeowner_renter_relief/nontaxable_income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/ut/tax/property/homeowner_renter_relief/nontaxable_income/sources.yaml
@@ -10,7 +10,7 @@ values:
     - tax_exempt_retirement_distributions
     - traditional_401k_contributions
     - traditional_403b_contributions
-    - traditional_ira_contributions
+    - capped_traditional_ira_contributions
     - self_employed_pension_contributions
     - veterans_benefits
     - workers_compensation

--- a/policyengine_us/tests/policy/baseline/household/expense/retirement/ira_contribution_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/retirement/ira_contribution_limit.yaml
@@ -76,3 +76,19 @@
         roth_ira_contributions: 3_000
   output:
     savers_credit_qualified_contributions: 7_000
+
+- name: Case 7, Puerto Rico retirement deduction uses capped IRA contributions.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        pr_agi_person: 10_000
+        traditional_ira_contributions: 9_000
+        roth_ira_contributions: 3_000
+    households:
+      household:
+        members: [person1]
+        state_code: PR
+  output:
+    pr_retirement_deduction: 5_000

--- a/policyengine_us/tests/policy/baseline/household/expense/retirement/ira_contribution_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/retirement/ira_contribution_limit.yaml
@@ -1,0 +1,78 @@
+- name: Case 1, IRA contributions below the base limit are unchanged.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        traditional_ira_contributions: 4_000
+        roth_ira_contributions: 2_000
+  output:
+    ira_contribution_limit: 7_000
+    capped_traditional_ira_contributions: 4_000
+    capped_roth_ira_contributions: 2_000
+
+- name: Case 2, IRA contributions above the base limit are capped proportionally.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        traditional_ira_contributions: 9_000
+        roth_ira_contributions: 3_000
+  output:
+    ira_contribution_limit: 7_000
+    capped_traditional_ira_contributions: 5_250
+    capped_roth_ira_contributions: 1_750
+
+- name: Case 3, IRA catch-up contribution raises the combined limit.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 50
+        traditional_ira_contributions: 9_000
+        roth_ira_contributions: 3_000
+  output:
+    ira_contribution_limit: 8_000
+    capped_traditional_ira_contributions: 6_000
+    capped_roth_ira_contributions: 2_000
+
+- name: Case 4, reported IRA variables override legacy inputs.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 45
+        traditional_ira_contributions: 100
+        roth_ira_contributions: 100
+        traditional_ira_contributions_reported: 2_000
+        roth_ira_contributions_reported: 8_000
+  output:
+    capped_traditional_ira_contributions: 1_400
+    capped_roth_ira_contributions: 5_600
+
+- name: Case 5, federal above-the-line deductions use capped traditional IRA contributions.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 100_000
+        traditional_ira_contributions: 12_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    above_the_line_deductions: 7_000
+    adjusted_gross_income: 93_000
+
+- name: Case 6, Saver's Credit qualified contributions use capped IRA contributions.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 40
+        traditional_ira_contributions: 9_000
+        roth_ira_contributions: 3_000
+  output:
+    savers_credit_qualified_contributions: 7_000

--- a/policyengine_us/variables/gov/territories/pr/tax/income/taxable_income/deductions/retirement/pr_retirement_deduction.py
+++ b/policyengine_us/variables/gov/territories/pr/tax/income/taxable_income/deductions/retirement/pr_retirement_deduction.py
@@ -20,6 +20,9 @@ class pr_retirement_deduction(Variable):
         contributions = add(
             person,
             period,
-            ["traditional_ira_contributions", "roth_ira_contributions"],
+            [
+                "capped_traditional_ira_contributions",
+                "capped_roth_ira_contributions",
+            ],
         )
         return min_(max_deduction, contributions)

--- a/policyengine_us/variables/household/expense/retirement/capped_roth_ira_contributions.py
+++ b/policyengine_us/variables/household/expense/retirement/capped_roth_ira_contributions.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class capped_roth_ira_contributions(Variable):
+    value_type = float
+    entity = Person
+    label = "Capped Roth IRA contributions"
+    unit = USD
+    documentation = (
+        "Roth IRA contributions after applying the combined traditional "
+        "and Roth IRA contribution limit."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/26/219#b",
+        "https://www.law.cornell.edu/uscode/text/26/408A#c_2",
+    )
+
+    def formula(person, period, parameters):
+        raw = person("uncapped_roth_ira_contributions", period)
+        total_reported = add(
+            person,
+            period,
+            [
+                "uncapped_traditional_ira_contributions",
+                "uncapped_roth_ira_contributions",
+            ],
+        )
+        scale = min_(
+            person("ira_contribution_limit", period) / max_(total_reported, 1), 1
+        )
+        return raw * scale

--- a/policyengine_us/variables/household/expense/retirement/capped_traditional_ira_contributions.py
+++ b/policyengine_us/variables/household/expense/retirement/capped_traditional_ira_contributions.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class capped_traditional_ira_contributions(Variable):
+    value_type = float
+    entity = Person
+    label = "Capped traditional IRA contributions"
+    unit = USD
+    documentation = (
+        "Traditional IRA contributions after applying the combined "
+        "traditional and Roth IRA contribution limit."
+    )
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/219#b"
+
+    def formula(person, period, parameters):
+        raw = person("uncapped_traditional_ira_contributions", period)
+        total_reported = add(
+            person,
+            period,
+            [
+                "uncapped_traditional_ira_contributions",
+                "uncapped_roth_ira_contributions",
+            ],
+        )
+        scale = min_(
+            person("ira_contribution_limit", period) / max_(total_reported, 1), 1
+        )
+        return raw * scale

--- a/policyengine_us/variables/household/expense/retirement/ira_contribution_limit.py
+++ b/policyengine_us/variables/household/expense/retirement/ira_contribution_limit.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class ira_contribution_limit(Variable):
+    value_type = float
+    entity = Person
+    label = "IRA contribution limit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/26/219#b",
+        "https://www.law.cornell.edu/uscode/text/26/408A#c_2",
+    )
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.irs.gross_income.retirement_contributions
+        age = person("age", period)
+        catch_up_eligible = age >= p.catch_up.age_threshold
+        return p.limit.ira + where(
+            catch_up_eligible,
+            p.catch_up.limit.ira,
+            0,
+        )

--- a/policyengine_us/variables/household/expense/retirement/roth_ira_contributions.py
+++ b/policyengine_us/variables/household/expense/retirement/roth_ira_contributions.py
@@ -6,5 +6,5 @@ class roth_ira_contributions(Variable):
     entity = Person
     label = "Roth IRA contributions"
     unit = USD
-    documentation = "Contributions to Roth Individual Retirement Accounts."
+    documentation = "Reported contributions to Roth Individual Retirement Accounts."
     definition_period = YEAR

--- a/policyengine_us/variables/household/expense/retirement/roth_ira_contributions_reported.py
+++ b/policyengine_us/variables/household/expense/retirement/roth_ira_contributions_reported.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class roth_ira_contributions_reported(Variable):
+    value_type = float
+    entity = Person
+    label = "Reported Roth IRA contributions"
+    unit = USD
+    documentation = "Contributions reported to Roth Individual Retirement Accounts before statutory contribution limits."
+    definition_period = YEAR

--- a/policyengine_us/variables/household/expense/retirement/traditional_ira_contributions.py
+++ b/policyengine_us/variables/household/expense/retirement/traditional_ira_contributions.py
@@ -6,5 +6,7 @@ class traditional_ira_contributions(Variable):
     entity = Person
     label = "Traditional IRA contributions"
     unit = USD
-    documentation = "Contributions to traditional Individual Retirement Accounts."
+    documentation = (
+        "Reported contributions to traditional Individual Retirement Accounts."
+    )
     definition_period = YEAR

--- a/policyengine_us/variables/household/expense/retirement/traditional_ira_contributions_reported.py
+++ b/policyengine_us/variables/household/expense/retirement/traditional_ira_contributions_reported.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class traditional_ira_contributions_reported(Variable):
+    value_type = float
+    entity = Person
+    label = "Reported traditional IRA contributions"
+    unit = USD
+    documentation = "Contributions reported to traditional Individual Retirement Accounts before statutory contribution limits."
+    definition_period = YEAR

--- a/policyengine_us/variables/household/expense/retirement/uncapped_roth_ira_contributions.py
+++ b/policyengine_us/variables/household/expense/retirement/uncapped_roth_ira_contributions.py
@@ -1,0 +1,14 @@
+from policyengine_us.model_api import *
+
+
+class uncapped_roth_ira_contributions(Variable):
+    value_type = float
+    entity = Person
+    label = "Uncapped Roth IRA contributions"
+    unit = USD
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        reported = person("roth_ira_contributions_reported", period)
+        legacy_reported = person("roth_ira_contributions", period)
+        return where(reported > 0, reported, legacy_reported)

--- a/policyengine_us/variables/household/expense/retirement/uncapped_traditional_ira_contributions.py
+++ b/policyengine_us/variables/household/expense/retirement/uncapped_traditional_ira_contributions.py
@@ -1,0 +1,14 @@
+from policyengine_us.model_api import *
+
+
+class uncapped_traditional_ira_contributions(Variable):
+    value_type = float
+    entity = Person
+    label = "Uncapped traditional IRA contributions"
+    unit = USD
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        reported = person("traditional_ira_contributions_reported", period)
+        legacy_reported = person("traditional_ira_contributions", period)
+        return where(reported > 0, reported, legacy_reported)


### PR DESCRIPTION
Fixes #8388.

## Summary
- adds reported, uncapped, capped, and limit variables for traditional/Roth IRA contributions
- applies the combined IRA cap proportionally across traditional and Roth IRA contributions
- routes federal ALD, Saver's Credit, PR retirement deduction, and affected state/source-list consumers through capped IRA variables

## Verification
- `uv run ruff format --check ... && uv run ruff check ...`
- `uv run python -m policyengine_core.scripts.policyengine_command test ... -c policyengine_us` covering IRA, Saver's Credit, PR, CRFB, Riverside, AL, IA, MA, MS, and UT cases: 66 passed
- `uv run pytest policyengine_us/tests/core/test_input_variable_definitions.py policyengine_us/tests/code_health/variable_names.py -q`: 4 passed
- independent read-only review: no actionable findings

## Notes
This enforces the absolute combined IRA contribution cap and catch-up amount. Compensation limits and traditional IRA deductibility phaseouts remain out of scope.
