### PR TITLE
Add Minnesota Homestead Credit Refund

### DIFF
--- a/changelog.d/added/8397.md
+++ b/changelog.d/added/8397.md
@@ -1,0 +1,1 @@
+Added the Minnesota homeowner Homestead Credit Refund.

--- a/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
@@ -122,6 +122,7 @@ values:
     - ma_senior_circuit_breaker
     - me_property_tax_fairness_credit
     - mi_homestead_property_tax_credit
+    - mn_homestead_credit_refund
     - mn_renters_credit
     - mo_property_tax_credit
     - mt_elderly_homeowner_or_renter_credit
@@ -144,6 +145,7 @@ values:
     - ma_senior_circuit_breaker
     - me_property_tax_fairness_credit
     - mi_homestead_property_tax_credit
+    - mn_homestead_credit_refund
     - mn_renters_credit
     - mo_property_tax_credit
     - mt_elderly_homeowner_or_renter_credit
@@ -169,6 +171,7 @@ values:
     - ma_senior_circuit_breaker
     - me_property_tax_fairness_credit
     - mi_homestead_property_tax_credit
+    - mn_homestead_credit_refund
     - mn_renters_credit
     - mo_property_tax_credit
     - mt_elderly_homeowner_or_renter_credit

--- a/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/max_refund.yaml
+++ b/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/max_refund.yaml
@@ -1,0 +1,172 @@
+description: Minnesota limits the Homestead Credit Refund to this amount by household income.
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: currency-USD
+  period: year
+  label: Minnesota Homestead Credit Refund maximum amount
+  reference:
+    - title: 2024 Form M1PR Instructions, Refund Worksheet
+      href: https://www.taxformfinder.org/forms/2024/2024-minnesota-form-m1pr-instructions.pdf#page=23
+    - title: 2025 Form M1PR Instructions, Refund Worksheet
+      href: https://www.taxformfinder.org/forms/2025/2025-minnesota-form-m1pr-instructions.pdf#page=23
+
+brackets:
+  - threshold:
+      2024-01-01: 0
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 2_140
+        2025-01-01: 2_190
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 4_260
+        2025-01-01: 4_360
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 6_450
+        2025-01-01: 6_600
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 8_610
+        2025-01-01: 8_810
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 10_740
+        2025-01-01: 10_990
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 15_040
+        2025-01-01: 15_380
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 17_170
+        2025-01-01: 17_560
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 19_340
+        2025-01-01: 19_780
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 21_480
+        2025-01-01: 21_970
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 23_610
+        2025-01-01: 24_150
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 30_080
+        2025-01-01: 30_770
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 36_530
+        2025-01-01: 37_370
+    amount:
+      2024-01-01: 3_410
+      2025-01-01: 3_480
+  - threshold:
+      values:
+        2024-01-01: 51_550
+        2025-01-01: 52_720
+    amount:
+      2024-01-01: 2_760
+      2025-01-01: 2_820
+  - threshold:
+      values:
+        2024-01-01: 75_170
+        2025-01-01: 76_880
+    amount:
+      2024-01-01: 2_420
+      2025-01-01: 2_470
+  - threshold:
+      values:
+        2024-01-01: 85_910
+        2025-01-01: 87_860
+    amount:
+      2024-01-01: 2_000
+      2025-01-01: 2_040
+  - threshold:
+      values:
+        2024-01-01: 96_650
+        2025-01-01: 98_850
+    amount:
+      2024-01-01: 1_790
+      2025-01-01: 1_830
+  - threshold:
+      values:
+        2024-01-01: 107_390
+        2025-01-01: 109_840
+    amount:
+      2024-01-01: 1_560
+      2025-01-01: 1_600
+  - threshold:
+      values:
+        2024-01-01: 118_130
+        2025-01-01: 120_820
+    amount:
+      2024-01-01: 1_320
+      2025-01-01: 1_350
+  - threshold:
+      values:
+        2024-01-01: 124_580
+        2025-01-01: 127_420
+    amount:
+      2024-01-01: 1_100
+      2025-01-01: 1_130
+  - threshold:
+      values:
+        2024-01-01: 128_910
+        2025-01-01: 131_840
+    amount:
+      2024-01-01: 900
+      2025-01-01: 920
+  - threshold:
+      values:
+        2024-01-01: 134_110
+        2025-01-01: 137_160
+    amount:
+      2024-01-01: 670
+      2025-01-01: 680
+  - threshold:
+      values:
+        2024-01-01: 139_320
+        2025-01-01: 142_490
+    amount:
+      2024-01-01: 0

--- a/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/percent_of_income.yaml
+++ b/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/percent_of_income.yaml
@@ -1,0 +1,150 @@
+description: Minnesota sets the household-income percentage by household income under the Homestead Credit Refund program.
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: /1
+  period: year
+  label: Minnesota Homestead Credit Refund percent of income
+  reference:
+    - title: 2024 Form M1PR Instructions, Refund Worksheet
+      href: https://www.taxformfinder.org/forms/2024/2024-minnesota-form-m1pr-instructions.pdf#page=23
+    - title: 2025 Form M1PR Instructions, Refund Worksheet
+      href: https://www.taxformfinder.org/forms/2025/2025-minnesota-form-m1pr-instructions.pdf#page=23
+
+brackets:
+  - threshold:
+      2024-01-01: 0
+    amount:
+      2024-01-01: 0.01
+  - threshold:
+      values:
+        2024-01-01: 2_140
+        2025-01-01: 2_190
+    amount:
+      2024-01-01: 0.011
+  - threshold:
+      values:
+        2024-01-01: 4_260
+        2025-01-01: 4_360
+    amount:
+      2024-01-01: 0.012
+  - threshold:
+      values:
+        2024-01-01: 6_450
+        2025-01-01: 6_600
+    amount:
+      2024-01-01: 0.013
+  - threshold:
+      values:
+        2024-01-01: 8_610
+        2025-01-01: 8_810
+    amount:
+      2024-01-01: 0.014
+  - threshold:
+      values:
+        2024-01-01: 10_740
+        2025-01-01: 10_990
+    amount:
+      2024-01-01: 0.015
+  - threshold:
+      values:
+        2024-01-01: 15_040
+        2025-01-01: 15_380
+    amount:
+      2024-01-01: 0.016
+  - threshold:
+      values:
+        2024-01-01: 17_170
+        2025-01-01: 17_560
+    amount:
+      2024-01-01: 0.017
+  - threshold:
+      values:
+        2024-01-01: 19_340
+        2025-01-01: 19_780
+    amount:
+      2024-01-01: 0.018
+  - threshold:
+      values:
+        2024-01-01: 21_480
+        2025-01-01: 21_970
+    amount:
+      2024-01-01: 0.019
+  - threshold:
+      values:
+        2024-01-01: 23_610
+        2025-01-01: 24_150
+    amount:
+      2024-01-01: 0.02
+  - threshold:
+      values:
+        2024-01-01: 30_080
+        2025-01-01: 30_770
+    amount:
+      2024-01-01: 0.02
+  - threshold:
+      values:
+        2024-01-01: 36_530
+        2025-01-01: 37_370
+    amount:
+      2024-01-01: 0.02
+  - threshold:
+      values:
+        2024-01-01: 51_550
+        2025-01-01: 52_720
+    amount:
+      2024-01-01: 0.02
+  - threshold:
+      values:
+        2024-01-01: 75_170
+        2025-01-01: 76_880
+    amount:
+      2024-01-01: 0.02
+  - threshold:
+      values:
+        2024-01-01: 85_910
+        2025-01-01: 87_860
+    amount:
+      2024-01-01: 0.021
+  - threshold:
+      values:
+        2024-01-01: 96_650
+        2025-01-01: 98_850
+    amount:
+      2024-01-01: 0.022
+  - threshold:
+      values:
+        2024-01-01: 107_390
+        2025-01-01: 109_840
+    amount:
+      2024-01-01: 0.023
+  - threshold:
+      values:
+        2024-01-01: 118_130
+        2025-01-01: 120_820
+    amount:
+      2024-01-01: 0.024
+  - threshold:
+      values:
+        2024-01-01: 124_580
+        2025-01-01: 127_420
+    amount:
+      2024-01-01: 0.025
+  - threshold:
+      values:
+        2024-01-01: 128_910
+        2025-01-01: 131_840
+    amount:
+      2024-01-01: 0.025
+  - threshold:
+      values:
+        2024-01-01: 134_110
+        2025-01-01: 137_160
+    amount:
+      2024-01-01: 0.025
+  - threshold:
+      values:
+        2024-01-01: 139_320
+        2025-01-01: 142_490
+    amount:
+      2024-01-01: 0

--- a/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/refund_rate.yaml
+++ b/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/refund_rate.yaml
@@ -1,0 +1,150 @@
+description: Minnesota provides this share of excess property tax under the Homestead Credit Refund program.
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: /1
+  period: year
+  label: Minnesota Homestead Credit Refund refund rate
+  reference:
+    - title: 2024 Form M1PR Instructions, Refund Worksheet
+      href: https://www.taxformfinder.org/forms/2024/2024-minnesota-form-m1pr-instructions.pdf#page=23
+    - title: 2025 Form M1PR Instructions, Refund Worksheet
+      href: https://www.taxformfinder.org/forms/2025/2025-minnesota-form-m1pr-instructions.pdf#page=23
+
+brackets:
+  - threshold:
+      2024-01-01: 0
+    amount:
+      2024-01-01: 0.88
+  - threshold:
+      values:
+        2024-01-01: 2_140
+        2025-01-01: 2_190
+    amount:
+      2024-01-01: 0.88
+  - threshold:
+      values:
+        2024-01-01: 4_260
+        2025-01-01: 4_360
+    amount:
+      2024-01-01: 0.88
+  - threshold:
+      values:
+        2024-01-01: 6_450
+        2025-01-01: 6_600
+    amount:
+      2024-01-01: 0.83
+  - threshold:
+      values:
+        2024-01-01: 8_610
+        2025-01-01: 8_810
+    amount:
+      2024-01-01: 0.83
+  - threshold:
+      values:
+        2024-01-01: 10_740
+        2025-01-01: 10_990
+    amount:
+      2024-01-01: 0.83
+  - threshold:
+      values:
+        2024-01-01: 15_040
+        2025-01-01: 15_380
+    amount:
+      2024-01-01: 0.83
+  - threshold:
+      values:
+        2024-01-01: 17_170
+        2025-01-01: 17_560
+    amount:
+      2024-01-01: 0.83
+  - threshold:
+      values:
+        2024-01-01: 19_340
+        2025-01-01: 19_780
+    amount:
+      2024-01-01: 0.83
+  - threshold:
+      values:
+        2024-01-01: 21_480
+        2025-01-01: 21_970
+    amount:
+      2024-01-01: 0.78
+  - threshold:
+      values:
+        2024-01-01: 23_610
+        2025-01-01: 24_150
+    amount:
+      2024-01-01: 0.78
+  - threshold:
+      values:
+        2024-01-01: 30_080
+        2025-01-01: 30_770
+    amount:
+      2024-01-01: 0.73
+  - threshold:
+      values:
+        2024-01-01: 36_530
+        2025-01-01: 37_370
+    amount:
+      2024-01-01: 0.68
+  - threshold:
+      values:
+        2024-01-01: 51_550
+        2025-01-01: 52_720
+    amount:
+      2024-01-01: 0.68
+  - threshold:
+      values:
+        2024-01-01: 75_170
+        2025-01-01: 76_880
+    amount:
+      2024-01-01: 0.63
+  - threshold:
+      values:
+        2024-01-01: 85_910
+        2025-01-01: 87_860
+    amount:
+      2024-01-01: 0.63
+  - threshold:
+      values:
+        2024-01-01: 96_650
+        2025-01-01: 98_850
+    amount:
+      2024-01-01: 0.63
+  - threshold:
+      values:
+        2024-01-01: 107_390
+        2025-01-01: 109_840
+    amount:
+      2024-01-01: 0.63
+  - threshold:
+      values:
+        2024-01-01: 118_130
+        2025-01-01: 120_820
+    amount:
+      2024-01-01: 0.58
+  - threshold:
+      values:
+        2024-01-01: 124_580
+        2025-01-01: 127_420
+    amount:
+      2024-01-01: 0.58
+  - threshold:
+      values:
+        2024-01-01: 128_910
+        2025-01-01: 131_840
+    amount:
+      2024-01-01: 0.53
+  - threshold:
+      values:
+        2024-01-01: 134_110
+        2025-01-01: 137_160
+    amount:
+      2024-01-01: 0.53
+  - threshold:
+      values:
+        2024-01-01: 139_320
+        2025-01-01: 142_490
+    amount:
+      2024-01-01: 0

--- a/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/retirement_subtraction/limit.yaml
+++ b/policyengine_us/parameters/gov/states/mn/tax/property/homestead_credit_refund/retirement_subtraction/limit.yaml
@@ -1,0 +1,28 @@
+description: Minnesota limits the retirement account subtraction to this amount under the Homestead Credit Refund program.
+metadata:
+  unit: currency-USD
+  period: year
+  label: Minnesota Homestead Credit Refund retirement account subtraction limit
+  breakdown:
+    - filing_status
+  reference:
+    - title: 2024 Form M1PR Instructions, Line 10
+      href: https://www.taxformfinder.org/forms/2024/2024-minnesota-form-m1pr-instructions.pdf#page=9
+    - title: 2025 Form M1PR Instructions, Line 10
+      href: https://www.taxformfinder.org/forms/2025/2025-minnesota-form-m1pr-instructions.pdf#page=9
+
+JOINT:
+  values:
+    2024-01-01: 14_000
+HEAD_OF_HOUSEHOLD:
+  values:
+    2024-01-01: 7_000
+SURVIVING_SPOUSE:
+  values:
+    2024-01-01: 7_000
+SINGLE:
+  values:
+    2024-01-01: 7_000
+SEPARATE:
+  values:
+    2024-01-01: 7_000

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund.yaml
@@ -1,0 +1,133 @@
+- name: Case 1, standard homeowner refund.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        real_estate_taxes: 3_150
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 50_000
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    mn_homestead_credit_refund_eligible: true
+    mn_homestead_credit_refund_household_income: 50_000
+    mn_homestead_credit_refund: 1_462
+
+- name: Case 2, nontaxable Social Security is included in household income.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 67
+        social_security: 17_996
+        taxable_social_security: 10_000
+        real_estate_taxes: 3_150
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 65_636.60
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    mn_homestead_credit_refund_household_income: 68_432.60
+    mn_homestead_credit_refund: 1_211
+
+- name: Case 3, age, dependent, and retirement contribution subtractions reduce household income.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 66
+        employment_income: 60_000
+        traditional_401k_contributions: 10_000
+        is_tax_unit_head: true
+      person2:
+        is_tax_unit_dependent: true
+      person3:
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        filing_status: SINGLE
+        adjusted_gross_income: 50_000
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MN
+  output:
+    mn_homestead_credit_refund_household_income: 33_760
+
+- name: Case 4, self-employed pension contributions are added back before the retirement subtraction.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        self_employment_income: 50_000
+        self_employed_pension_contributions: 10_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+        adjusted_gross_income: 40_000
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    mn_homestead_credit_refund_household_income: 43_000
+
+- name: Case 5, claimed dependent homeowner is ineligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        real_estate_taxes: 3_150
+        is_tax_unit_head: true
+        claimed_as_dependent_on_another_return: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 10_000
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    mn_homestead_credit_refund_eligible: false
+    mn_homestead_credit_refund: 0
+
+- name: Case 6, income above the homeowner limit is ineligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        real_estate_taxes: 10_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 142_490
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    mn_homestead_credit_refund_eligible: false
+    mn_homestead_credit_refund: 0

--- a/policyengine_us/variables/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund.py
+++ b/policyengine_us/variables/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class mn_homestead_credit_refund(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Minnesota Homestead Credit Refund"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.revisor.mn.gov/statutes/cite/290A.04",
+        "https://www.taxformfinder.org/forms/2024/2024-minnesota-form-m1pr-instructions.pdf#page=23",
+        "https://www.taxformfinder.org/forms/2025/2025-minnesota-form-m1pr-instructions.pdf#page=23",
+    )
+    defined_for = "mn_homestead_credit_refund_eligible"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.mn.tax.property.homestead_credit_refund
+        household_income = max_(
+            0, tax_unit("mn_homestead_credit_refund_household_income", period)
+        )
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+        excess_property_tax = max_(
+            0,
+            property_tax
+            - household_income * p.percent_of_income.calc(household_income),
+        )
+        refund = excess_property_tax * p.refund_rate.calc(household_income)
+        return round_(min_(refund, p.max_refund.calc(household_income)))

--- a/policyengine_us/variables/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund_eligible.py
+++ b/policyengine_us/variables/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund_eligible.py
@@ -1,0 +1,37 @@
+from policyengine_us.model_api import *
+
+
+class mn_homestead_credit_refund_eligible(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Eligible for the Minnesota Homestead Credit Refund"
+    definition_period = YEAR
+    reference = (
+        "https://www.taxformfinder.org/forms/2024/2024-minnesota-form-m1pr-instructions.pdf#page=2",
+        "https://www.taxformfinder.org/forms/2025/2025-minnesota-form-m1pr-instructions.pdf#page=2",
+    )
+    defined_for = StateCode.MN
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.mn.tax.property.homestead_credit_refund
+        household_income = tax_unit(
+            "mn_homestead_credit_refund_household_income", period
+        )
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+
+        claimants = tax_unit.members("is_tax_unit_head_or_spouse", period)
+        claimant_is_tax_unit_dependent = tax_unit.any(
+            claimants & tax_unit.members("is_tax_unit_dependent", period)
+        )
+        claimant_is_dependent_elsewhere = tax_unit(
+            "head_is_dependent_elsewhere", period
+        ) | tax_unit("spouse_is_dependent_elsewhere", period)
+        claimant_is_dependent = (
+            claimant_is_tax_unit_dependent | claimant_is_dependent_elsewhere
+        )
+
+        return (
+            (property_tax > 0)
+            & ~claimant_is_dependent
+            & (p.max_refund.calc(household_income) > 0)
+        )

--- a/policyengine_us/variables/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund_household_income.py
+++ b/policyengine_us/variables/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund_household_income.py
@@ -1,0 +1,100 @@
+from policyengine_us.model_api import *
+
+
+class mn_homestead_credit_refund_household_income(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Minnesota Homestead Credit Refund household income"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "Approximates Form M1PR lines 1 through 13 using modeled adjusted gross "
+        "income, nontaxable Social Security, retirement add-backs and "
+        "contributions, and age/disability and dependent subtractions. "
+        "Co-occupant income and other nontaxable additions or subtractions "
+        "are not separately modeled."
+    )
+    reference = (
+        "https://www.taxformfinder.org/forms/2024/2024-minnesota-form-m1pr-instructions.pdf#page=7",
+        "https://www.taxformfinder.org/forms/2025/2025-minnesota-form-m1pr-instructions.pdf#page=7",
+    )
+    defined_for = StateCode.MN
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.mn
+        income_p = p.tax.income
+        refund_p = p.tax.property.homestead_credit_refund
+
+        filing_status = tax_unit("filing_status", period)
+        separate = filing_status == filing_status.possible_values.SEPARATE
+        gross_income = tax_unit("adjusted_gross_income", period) + (
+            tax_unit("spouse_separate_adjusted_gross_income", period) * separate
+        )
+
+        people = tax_unit.members
+        is_dependent = people("is_tax_unit_dependent", period) | people(
+            "claimed_as_dependent_on_another_return", period
+        )
+        social_security = people("social_security", period)
+        taxable_social_security = people("taxable_social_security", period)
+        nontaxable_social_security = tax_unit.sum(
+            max_(0, social_security - taxable_social_security) * ~is_dependent
+        )
+
+        retirement_contributions = add(
+            tax_unit,
+            period,
+            [
+                "traditional_401k_contributions",
+                "roth_401k_contributions",
+                "traditional_403b_contributions",
+                "roth_403b_contributions",
+                "traditional_ira_contributions",
+                "roth_ira_contributions",
+                "self_employed_pension_contributions",
+            ],
+        )
+        retirement_additions = add(
+            tax_unit,
+            period,
+            [
+                "traditional_401k_contributions",
+                "traditional_403b_contributions",
+                "traditional_ira_contributions",
+                "self_employed_pension_contributions",
+            ],
+        )
+        compensation = add(
+            tax_unit, period, ["employment_income", "self_employment_income"]
+        )
+        retirement_subtraction = min_(
+            retirement_contributions,
+            min_(compensation, refund_p.retirement_subtraction.limit[filing_status]),
+        )
+
+        claimant = people("is_tax_unit_head_or_spouse", period)
+        minimum_age = income_p.credits.renters.age_threshold
+        is_age_eligible = people("age", period) >= minimum_age
+        is_disabled = people("is_permanently_and_totally_disabled", period)
+        age_or_disability_subtraction = (
+            tax_unit.any(claimant & ~is_dependent & (is_age_eligible | is_disabled))
+            * income_p.exemptions.amount
+        )
+
+        dependent_count = tax_unit("tax_unit_dependents", period)
+        dependent_subtraction_multiplier = (
+            income_p.credits.renters.dependent_subtraction_multiplier.calc(
+                dependent_count
+            )
+        )
+        dependent_subtraction = (
+            income_p.exemptions.amount * dependent_subtraction_multiplier
+        )
+
+        additions = nontaxable_social_security + retirement_additions
+        subtractions = (
+            age_or_disability_subtraction
+            + dependent_subtraction
+            + retirement_subtraction
+        )
+        return max_(0, gross_income + additions - subtractions)


### PR DESCRIPTION
Fixes #8397.

## Summary
- add Minnesota's homeowner Homestead Credit Refund as a property tax credit/circuit-breaker variable
- parameterize the 2024 and 2025 M1PR refund worksheet percent-of-income, refund-rate, and maximum-refund schedules
- include the credit in `gov.states.household.state_property_tax_credits` so it flows into `taxsim_state_property_tax_credit` / `state_property_tax_credit`
- model M1PR household income using modeled AGI, nontaxable Social Security, retirement contributions, and age/disability/dependent subtractions

## Notes
- This covers the regular homeowner Homestead Credit Refund. The separate special property tax refund is not modeled because it requires prior-year homestead property tax and same-owner January 2 information.
- Co-occupant income and miscellaneous nontaxable additions/subtractions on Form M1PR are documented as not separately modeled.

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/mn/tax/property/homestead_credit_refund/mn_homestead_credit_refund.yaml -c policyengine_us`
- `uv run ruff check $(git diff upstream/main...HEAD --name-only | rg '\.py$')`
- `git diff --check upstream/main...HEAD`
- `uv run coverage erase && git diff upstream/main...HEAD --name-only | xargs uv run python policyengine_us/tests/run_selective_tests.py --coverage --files && uv run coverage report --fail-under=0 --skip-covered --skip-empty`
