### PR TITLE
Limit DC property tax credit to DC

### DIFF
--- a/changelog.d/fixed/dc-ptc-state-gate.md
+++ b/changelog.d/fixed/dc-ptc-state-gate.md
@@ -1,0 +1,1 @@
+Fixed the DC property tax credit applying outside DC.

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_ptc.yaml
@@ -270,3 +270,25 @@
   output:
     dc_ptc: 0  # No credit when there's no rent or property taxes paid
     dc_income_tax: 0
+
+- name: dc_ptc is zero outside DC.
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 40
+        employment_income: 50_000
+        real_estate_taxes: 3_150
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    dc_ptc: 0
+    taxsim_state_property_tax_credit: 0
+    state_property_tax_credit: 0

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_ptc.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/dc_ptc.py
@@ -8,10 +8,10 @@ class dc_ptc(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=49"
-        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=47"
+        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/52926_D-40_12.21.21_Final_Rev011122.pdf#page=49",
+        "https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/2022_D-40_Booklet_Final_blk_01_23_23_Ordc.pdf#page=47",
     )
-    defined_for = "takes_up_dc_ptc"
+    defined_for = StateCode.DC
 
     def formula(tax_unit, period, parameters):
         rent = add(tax_unit, period, ["rent"])
@@ -33,4 +33,4 @@ class dc_ptc(Variable):
             p_dc.ptc.fraction_nonelderly.calc(positive_agi, right=True),
         )
         uncapped_ptc = max_(0, ptax - ptax_offset)
-        return min_(p_dc.ptc.max, uncapped_ptc)
+        return min_(p_dc.ptc.max, uncapped_ptc) * tax_unit("takes_up_dc_ptc", period)


### PR DESCRIPTION
Fixes a state-gating bug where the DC property tax credit could contribute to state property tax credit aggregates outside DC because the take-up flag defaulted true.

Changes:
- Gate `dc_ptc` directly to DC.
- Keep the take-up toggle within the DC formula.
- Add a non-DC regression case verifying `dc_ptc`, `taxsim_state_property_tax_credit`, and `state_property_tax_credit` are zero.
- Split the concatenated reference URLs.

Checks:
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_ptc.yaml policyengine_us/tests/policy/baseline/gov/states/dc/tax/property/senior_disabled_property_tax_relief/dc_senior_disabled_property_tax_relief.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/gov/states/dc/tax/income/credits/dc_ptc.py`
- `git diff --check upstream/main...HEAD`
- `uv run python -m coverage run --branch --include policyengine_us/variables/gov/states/dc/tax/income/credits/dc_ptc.py -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_ptc.yaml policyengine_us/tests/policy/baseline/gov/states/dc/tax/property/senior_disabled_property_tax_relief/dc_senior_disabled_property_tax_relief.yaml -c policyengine_us && uv run python -m coverage report --fail-under=0 --skip-covered --skip-empty`
