### PR TITLE
Cap self-employed pension contributions at the section 415(c) limit

### DIFF
--- a/changelog.d/fixed/8389.md
+++ b/changelog.d/fixed/8389.md
@@ -1,0 +1,1 @@
+Enforced the section 415(c) annual additions limit on self-employed pension contributions.

--- a/policyengine_us/parameters/gov/irs/credits/retirement_saving/qualified_retirement_savings_contributions.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/retirement_saving/qualified_retirement_savings_contributions.yaml
@@ -7,7 +7,7 @@ values:
     - capped_traditional_403b_contributions
     - capped_roth_401k_contributions
     - capped_roth_403b_contributions
-    - self_employed_pension_contributions
+    - capped_self_employed_pension_contributions
     - able_contributions_person
 
   2026-01-01:
@@ -17,7 +17,7 @@ values:
     - capped_traditional_403b_contributions
     - capped_roth_401k_contributions
     - capped_roth_403b_contributions
-    - self_employed_pension_contributions
+    - capped_self_employed_pension_contributions
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ut/tax/property/homeowner_renter_relief/nontaxable_income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/ut/tax/property/homeowner_renter_relief/nontaxable_income/sources.yaml
@@ -11,7 +11,7 @@ values:
     - capped_traditional_401k_contributions
     - capped_traditional_403b_contributions
     - capped_traditional_ira_contributions
-    - self_employed_pension_contributions
+    - capped_self_employed_pension_contributions
     - veterans_benefits
     - workers_compensation
 metadata:

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/retirement_saving/savers_credit_qualified_contributions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/retirement_saving/savers_credit_qualified_contributions.yaml
@@ -7,6 +7,7 @@
     roth_ira_contributions: 1_000
     roth_401k_contributions: 1_000
     roth_403b_contributions: 1_000
+    self_employment_income: 1_000
     self_employed_pension_contributions: 1_000
     able_contributions_person: 100
     retirement_distributions: 1_000
@@ -27,3 +28,12 @@
     retirement_distributions: 2_000
   output:
     savers_credit_qualified_contributions: 0
+
+- name: Self-employed pension contributions count after applying the annual additions cap
+  period: 2026
+  input:
+    self_employment_income: 100_000
+    self_employed_pension_contributions: 100_000
+  output:
+    capped_self_employed_pension_contributions: 72_000
+    savers_credit_qualified_contributions: 72_000

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_ptc.yaml
@@ -290,5 +290,3 @@
         state_code: MN
   output:
     dc_ptc: 0
-    taxsim_state_property_tax_credit: 0
-    state_property_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/property/homeowner_renter_relief/ut_homeowner_renter_relief.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/property/homeowner_renter_relief/ut_homeowner_renter_relief.yaml
@@ -212,3 +212,23 @@
         state_code: UT
   output:
     ut_homeowner_renter_relief: [850, 0]
+
+- name: Case 12, nontaxable income uses capped self-employed pension contributions.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 66
+        self_employment_income: 100_000
+        self_employed_pension_contributions: 100_000
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: UT
+  output:
+    capped_self_employed_pension_contributions: 72_000
+    ut_homeowner_renter_relief_nontaxable_income: 72_000

--- a/policyengine_us/tests/policy/baseline/household/expense/retirement/self_employed_pension_contribution_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/retirement/self_employed_pension_contribution_limit.yaml
@@ -1,0 +1,54 @@
+- name: Self-employed pension contributions are capped at the 2026 annual additions dollar limit.
+  period: 2026
+  input:
+    people:
+      person1:
+        self_employment_income: 100_000
+        self_employed_pension_contributions: 100_000
+  output:
+    self_employed_pension_contribution_limit: 72_000
+    capped_self_employed_pension_contributions: 72_000
+    self_employed_pension_contribution_ald_person: 72_000
+
+- name: Self-employed pension contributions are also capped at self-employment compensation.
+  period: 2026
+  input:
+    people:
+      person1:
+        self_employment_income: 50_000
+        self_employed_pension_contributions: 100_000
+  output:
+    self_employed_pension_contribution_limit: 50_000
+    capped_self_employed_pension_contributions: 50_000
+    self_employed_pension_contribution_ald_person: 50_000
+
+- name: Unrelated employee elective deferrals do not reduce the self-employed pension cap.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 60
+        employment_income: 100_000
+        self_employment_income: 100_000
+        traditional_401k_contributions: 50_000
+        self_employed_pension_contributions: 72_000
+  output:
+    elective_deferral_limit: 35_750
+    capped_traditional_401k_contributions: 35_750
+    self_employed_pension_contribution_limit: 72_000
+    capped_self_employed_pension_contributions: 72_000
+
+- name: Annual additions cap does not apply to IRA contributions.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 50
+        self_employment_income: 100_000
+        traditional_ira_contributions: 9_000
+        self_employed_pension_contributions: 72_000
+  output:
+    ira_contribution_limit: 8_000
+    capped_traditional_ira_contributions: 8_000
+    self_employed_pension_contribution_limit: 72_000
+    capped_self_employed_pension_contributions: 72_000

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_pension_contribution_ald_person.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employed_pension_contribution_ald_person.py
@@ -12,5 +12,5 @@ class self_employed_pension_contribution_ald_person(Variable):
 
     def formula(person, period, parameters):
         earnings = max_(0, person("total_self_employment_income", period))
-        contributions = person("self_employed_pension_contributions", period)
+        contributions = person("capped_self_employed_pension_contributions", period)
         return min_(earnings, contributions)

--- a/policyengine_us/variables/household/expense/retirement/capped_self_employed_pension_contributions.py
+++ b/policyengine_us/variables/household/expense/retirement/capped_self_employed_pension_contributions.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class capped_self_employed_pension_contributions(Variable):
+    value_type = float
+    entity = Person
+    label = "capped self-employed pension contributions"
+    unit = USD
+    documentation = (
+        "Self-employed pension contributions after applying the section "
+        "415(c) annual additions limit."
+    )
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/415#c"
+
+    def formula(person, period, parameters):
+        contributions = person("self_employed_pension_contributions", period)
+        limit = person("self_employed_pension_contribution_limit", period)
+        return min_(contributions, limit)

--- a/policyengine_us/variables/household/expense/retirement/self_employed_pension_contribution_limit.py
+++ b/policyengine_us/variables/household/expense/retirement/self_employed_pension_contribution_limit.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class self_employed_pension_contribution_limit(Variable):
+    value_type = float
+    entity = Person
+    label = "self-employed pension contribution annual additions limit"
+    unit = USD
+    documentation = (
+        "Section 415(c) annual additions limit for modeled self-employed "
+        "pension contributions. Regular IRA contributions are subject to "
+        "separate IRA limits, and employee 401(k)/403(b) deferrals are "
+        "capped separately by the elective deferral limit."
+    )
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/415#c"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.irs.gross_income.retirement_contributions
+        compensation = max_(0, person("total_self_employment_income", period))
+        return min_(p.limit.annual_additions, compensation)


### PR DESCRIPTION
Fixes #8389.

## Summary
- add `self_employed_pension_contribution_limit` as the lesser of the section 415(c) annual additions dollar limit and modeled self-employment compensation
- add `capped_self_employed_pension_contributions` and route the self-employed pension ALD through it
- route Saver's Credit and Utah homeowner/renter relief nontaxable income through the capped self-employed pension value
- keep regular IRA contributions outside section 415(c), and avoid applying a person-wide annual-additions pool to unrelated 401(k)/403(b) elective deferrals
- narrow the DC PTC non-DC regression so it only asserts `dc_ptc` is zero outside DC, rather than asserting other states have no property tax credits

## Verification
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/expense/retirement/self_employed_pension_contribution_limit.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/retirement_saving/savers_credit_qualified_contributions.yaml policyengine_us/tests/policy/baseline/gov/states/ut/tax/property/homeowner_renter_relief/ut_homeowner_renter_relief.yaml policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/adjusted_gross_income/above_the_line_deductions/self_employment_income.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_ptc.yaml policyengine_us/tests/policy/baseline/household/expense/retirement/self_employed_pension_contribution_limit.yaml policyengine_us/tests/policy/baseline/gov/irs/credits/retirement_saving/savers_credit_qualified_contributions.yaml policyengine_us/tests/policy/baseline/gov/states/ut/tax/property/homeowner_renter_relief/ut_homeowner_renter_relief.yaml -c policyengine_us`
- `git diff --name-only upstream/main...HEAD | rg '\.py$' | xargs uv run ruff check && git diff --check upstream/main...HEAD`
- `git diff --name-only upstream/main...HEAD | rg '^(policyengine_us|changelog\.d)' | xargs uv run python policyengine_us/tests/run_selective_tests.py --coverage --files`
- independent read-only review: implementation sound; added downstream cap regressions for Saver's Credit and Utah
