### PR TITLE
Update Alaska PFD amounts

### DIFF
--- a/changelog.d/fixed/6035.md
+++ b/changelog.d/fixed/6035.md
@@ -1,0 +1,1 @@
+Update Alaska Permanent Fund Dividend and energy relief amounts for 2025 and 2026.

--- a/policyengine_us/parameters/gov/states/ak/dor/energy_relief.yaml
+++ b/policyengine_us/parameters/gov/states/ak/dor/energy_relief.yaml
@@ -4,6 +4,8 @@ values:
   2022-01-01: 662
   2023-01-01: 0
   2024-01-01: 298.17
+  2025-01-01: 0
+  2026-01-01: 200
 
 metadata:
   label: Alaska energy relief
@@ -15,4 +17,5 @@ metadata:
       href: https://pfd.alaska.gov/payments/tax-information
     - title: Department of Revenue Announces 2024 Permanent Fund Dividend Amount and Energy Relief
       href: https://dor.alaska.gov/department-of-revenue/news-detail/2024/09/19/department-of-revenue-announces-2024-permanent-fund-dividend-amount-and-energy-relief
-
+    - title: Budget heads to governor with $1,200 PFD attached
+      href: https://www.alaskasnewssource.com/2026/05/21/budget-heads-governor-with-1200-pfd-attached/

--- a/policyengine_us/parameters/gov/states/ak/dor/permanent_fund_dividend.yaml
+++ b/policyengine_us/parameters/gov/states/ak/dor/permanent_fund_dividend.yaml
@@ -3,6 +3,8 @@ values:
   2022-01-01: 2_622
   2023-01-01: 1_312
   2024-01-01: 1_403.83
+  2025-01-01: 1_000
+  2026-01-01: 1_000
 
 metadata:
   label: Alaska taxable permanent fund dividend
@@ -14,3 +16,5 @@ metadata:
       href: https://pfd.alaska.gov/payments/tax-information
     - title: Department of Revenue Announces 2024 Permanent Fund Dividend Amount and Energy Relief
       href: https://dor.alaska.gov/department-of-revenue/news-detail/2024/09/19/department-of-revenue-announces-2024-permanent-fund-dividend-amount-and-energy-relief
+    - title: Budget heads to governor with $1,200 PFD attached
+      href: https://www.alaskasnewssource.com/2026/05/21/budget-heads-governor-with-1200-pfd-attached/

--- a/policyengine_us/tests/policy/baseline/gov/states/ak/dor/ak_energy_relief.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ak/dor/ak_energy_relief.yaml
@@ -1,0 +1,28 @@
+- name: Case 1, 2024 Alaska energy relief.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    state_code: AK
+  output:
+    ak_energy_relief: 298.17
+
+- name: Case 2, 2025 Alaska energy relief.
+  period: 2025
+  input:
+    state_code: AK
+  output:
+    ak_energy_relief: 0
+
+- name: Case 3, 2026 Alaska energy relief.
+  period: 2026
+  input:
+    state_code: AK
+  output:
+    ak_energy_relief: 200
+
+- name: Case 4, Alaska energy relief is zero outside Alaska.
+  period: 2026
+  input:
+    state_code: WA
+  output:
+    ak_energy_relief: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ak/dor/ak_permanent_fund_dividend.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ak/dor/ak_permanent_fund_dividend.yaml
@@ -1,0 +1,28 @@
+- name: Case 1, 2024 Alaska Permanent Fund Dividend excludes energy relief.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    state_code: AK
+  output:
+    ak_permanent_fund_dividend: 1_403.83
+
+- name: Case 2, 2025 Alaska Permanent Fund Dividend.
+  period: 2025
+  input:
+    state_code: AK
+  output:
+    ak_permanent_fund_dividend: 1_000
+
+- name: Case 3, 2026 Alaska Permanent Fund Dividend.
+  period: 2026
+  input:
+    state_code: AK
+  output:
+    ak_permanent_fund_dividend: 1_000
+
+- name: Case 4, Alaska Permanent Fund Dividend is zero outside Alaska.
+  period: 2026
+  input:
+    state_code: WA
+  output:
+    ak_permanent_fund_dividend: 0


### PR DESCRIPTION
Fixes #6035.

## Summary
- add 2025 Alaska Permanent Fund Dividend amount of $1,000
- set 2025 Alaska energy relief to $0 so the 2024 energy relief amount does not carry forward
- add 2026 Alaska Permanent Fund Dividend amount of $1,000 and energy relief amount of $200 from the operating budget sent to the governor
- add focused tests for `ak_permanent_fund_dividend` and `ak_energy_relief`

## Notes
- The 2025 value is on the Alaska PFD tax information page.
- The 2026 values are based on reporting that the budget headed to the governor with a $1,000 PFD and $200 energy relief rebate attached; the official PFD tax page has not yet posted a 2026 tax amount.
- Checked `policyengine-taxsim`: it references `ak_energy_relief` and `ak_permanent_fund_dividend` only to zero them in its runner, so this PR keeps those variable names unchanged.

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ak/dor/ak_permanent_fund_dividend.yaml policyengine_us/tests/policy/baseline/gov/states/ak/dor/ak_energy_relief.yaml -c policyengine_us`
- `uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_system_import.py -q`
- `uv run pytest policyengine_us/tests/test_build_metadata.py -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run python policyengine_us/tests/run_selective_tests.py --uncommitted --verbose`
