### PR TITLE
Add capital gains basis input variables

### DIFF
--- a/policyengine_us/tests/test_system_import.py
+++ b/policyengine_us/tests/test_system_import.py
@@ -82,3 +82,14 @@ def test_computed_default_uprated_variables_have_microdata_overrides():
             missing_overrides.append(name)
 
     assert missing_overrides == []
+
+
+def test_capital_gains_indexation_inputs_have_expected_uprating():
+    from policyengine_us.system import CountryTaxBenefitSystem
+
+    system = CountryTaxBenefitSystem()
+    assert (
+        system.variables["long_term_capital_gains_basis"].uprating
+        == "calibration.gov.irs.soi.long_term_capital_gains"
+    )
+    assert system.variables["long_term_capital_gains_years_held"].uprating is None

--- a/policyengine_us/tests/variables/household/income/person/capital_gains/long_term_capital_gains_basis.yaml
+++ b/policyengine_us/tests/variables/household/income/person/capital_gains/long_term_capital_gains_basis.yaml
@@ -1,0 +1,18 @@
+- name: Long-term capital gains basis is a person-level input
+  period: 2026
+  input:
+    people:
+      person1:
+        long_term_capital_gains_basis: 80_000
+      person2:
+        long_term_capital_gains_basis: 20_000
+  output:
+    long_term_capital_gains_basis: [80_000, 20_000]
+
+- name: Long-term capital gains basis defaults to zero
+  period: 2026
+  input:
+    people:
+      person1: {}
+  output:
+    long_term_capital_gains_basis: [0]

--- a/policyengine_us/tests/variables/household/income/person/capital_gains/long_term_capital_gains_years_held.yaml
+++ b/policyengine_us/tests/variables/household/income/person/capital_gains/long_term_capital_gains_years_held.yaml
@@ -1,0 +1,18 @@
+- name: Long-term capital gains years held is a person-level input
+  period: 2026
+  input:
+    people:
+      person1:
+        long_term_capital_gains_years_held: 8.5
+      person2:
+        long_term_capital_gains_years_held: 21.25
+  output:
+    long_term_capital_gains_years_held: [8.5, 21.25]
+
+- name: Long-term capital gains years held defaults to zero
+  period: 2026
+  input:
+    people:
+      person1: {}
+  output:
+    long_term_capital_gains_years_held: [0]

--- a/policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_basis.py
+++ b/policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_basis.py
@@ -11,3 +11,4 @@ class long_term_capital_gains_basis(Variable):
         "stored for capital-gains basis indexation analysis."
     )
     definition_period = YEAR
+    uprating = "calibration.gov.irs.soi.long_term_capital_gains"

--- a/policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_basis.py
+++ b/policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_basis.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class long_term_capital_gains_basis(Variable):
+    value_type = float
+    entity = Person
+    label = "long-term capital gains basis"
+    unit = USD
+    documentation = (
+        "Cost basis associated with realized long-term capital gains, "
+        "stored for capital-gains basis indexation analysis."
+    )
+    definition_period = YEAR

--- a/policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_years_held.py
+++ b/policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_years_held.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class long_term_capital_gains_years_held(Variable):
+    value_type = float
+    entity = Person
+    label = "long-term capital gains years held"
+    unit = "year"
+    documentation = (
+        "Representative holding period, in years, associated with realized "
+        "long-term capital gains for capital-gains basis indexation analysis."
+    )
+    definition_period = YEAR


### PR DESCRIPTION
## Summary
- Add person-level long-term capital gains basis and years-held input variables.
- Add focused YAML tests covering supplied values and zero defaults.

## Tests
- uv run --python 3.13 ruff check policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_basis.py policyengine_us/variables/household/income/person/capital_gains/long_term_capital_gains_years_held.py
- uv run --python 3.13 python policyengine_us/tests/test_batched.py policyengine_us/tests/variables/household/income/person/capital_gains --batches 1
- uv run --python 3.13 pytest policyengine_us/tests/core/test_input_variable_definitions.py -q