### PR TITLE
Fix Michigan homestead property tax credit income limit

### DIFF
--- a/changelog.d/fixed/8241.md
+++ b/changelog.d/fixed/8241.md
@@ -1,0 +1,1 @@
+Fix Michigan homestead property tax credit eligibility for filers above the total household resources limit.

--- a/policyengine_us/parameters/gov/states/mi/tax/income/credits/homestead_property_tax/household_resources_limit.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/credits/homestead_property_tax/household_resources_limit.yaml
@@ -1,0 +1,27 @@
+description: Michigan limits total household resources to this amount under the homestead property tax credit.
+metadata:
+  unit: currency-USD
+  period: year
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 100
+  label: Michigan homestead property tax credit household resources limit
+  reference:
+    - title: Michigan Income Tax Act 206.520 - (8)
+      href: https://www.legislature.mi.gov/Laws/MCL?objectName=mcl-206-520
+    - title: 2024 MI-1040CR Tax Form, Line 33
+      href: https://www.michigan.gov/taxes/-/media/Project/Websites/taxes/Forms/IIT/TY2024/MI-1040CR.pdf#page=2
+    - title: 2025 MI-1040CR Tax Form, Line 33
+      href: https://www.michigan.gov/taxes/-/media/Project/Websites/taxes/Forms/IIT/TY2025/MI-1040CR.pdf#page=2
+    - title: 2025 MI-1040 Instructions, MI-1040CR Table B
+      href: https://www.michigan.gov/taxes/-/media/Project/Websites/taxes/Forms/IIT/TY2025/MI-1040-Book.pdf#page=33
+values:
+  2016-01-01: 50_000
+  2018-01-01: 60_000
+  2021-01-01: 60_600
+  2022-01-01: 63_000
+  2023-01-01: 67_300
+  2024-01-01: 69_700
+  2025-01-01: 71_500

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/credits/homestead_property_tax/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/credits/homestead_property_tax/integration.yaml
@@ -50,8 +50,8 @@
   output:
     mi_homestead_property_tax_credit_countable_property_tax: 2_100
     mi_homestead_property_tax_credit_household_resource_exemption: 80.8
-    mi_homestead_property_tax_credit_eligible: true
-    mi_allowable_homestead_property_tax_credit: 48.48
+    mi_homestead_property_tax_credit_eligible: false
+    mi_allowable_homestead_property_tax_credit: 0
     mi_homestead_property_tax_credit_pre_alternate_senior_amount: 0
     mi_homestead_property_tax_credit: 0
 
@@ -401,3 +401,44 @@
     mi_homestead_property_tax_credit_eligible: true
     mi_allowable_homestead_property_tax_credit: 1_900
     mi_homestead_property_tax_credit: 1_900
+
+- name: 2025 household resources above line 33 limit, ineligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+        taxable_pension_income: 29_092
+        taxable_interest_income: 14_196
+        social_security: 30_000
+        real_estate_taxes: 30_000
+        deductible_mortgage_interest: 20_000
+        rent: 62_436
+      person2:
+        age: 11
+      person3:
+        age: 2
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MI
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+      marital_unit3:
+        members: [person3]
+    families:
+      family:
+        members: [person1, person2, person3]
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+  output:
+    mi_household_resources: 73_288
+    mi_homestead_property_tax_credit_eligible: false
+    mi_homestead_property_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/credits/homestead_property_tax/mi_homestead_property_tax_credit_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/credits/homestead_property_tax/mi_homestead_property_tax_credit_eligible.yaml
@@ -104,3 +104,27 @@
   output:
     # Half of limit: $82,700 < $165,400 = eligible
     mi_homestead_property_tax_credit_eligible: true
+
+- name: Case 7, 2025 household resources at limit.
+  period: 2025
+  input:
+    mi_household_resources: 71_500
+    state_code: MI
+  output:
+    mi_homestead_property_tax_credit_eligible: true
+
+- name: Case 8, 2025 household resources above limit.
+  period: 2025
+  input:
+    mi_household_resources: 71_501
+    state_code: MI
+  output:
+    mi_homestead_property_tax_credit_eligible: false
+
+- name: Case 9, 2024 household resources above limit.
+  period: 2024
+  input:
+    mi_household_resources: 69_701
+    state_code: MI
+  output:
+    mi_homestead_property_tax_credit_eligible: false

--- a/policyengine_us/variables/gov/states/mi/tax/income/credits/homestead_property_tax/mi_homestead_property_tax_credit_eligible.py
+++ b/policyengine_us/variables/gov/states/mi/tax/income/credits/homestead_property_tax/mi_homestead_property_tax_credit_eligible.py
@@ -15,7 +15,10 @@ class mi_homestead_property_tax_credit_eligible(Variable):
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.mi.tax.income.credits.homestead_property_tax
-        # Line 38 & 39 & 41
-        return (
+        property_value_eligible = (
             add(tax_unit, period, ["assessed_property_value"]) <= p.property_value_limit
         )
+        household_resources_eligible = (
+            tax_unit("mi_household_resources", period) <= p.household_resources_limit
+        )
+        return property_value_eligible & household_resources_eligible


### PR DESCRIPTION
Fixes #8241.

## Summary
- add the MI-1040CR household resources eligibility limit for the Michigan homestead property tax credit
- apply the limit in `mi_homestead_property_tax_credit_eligible` so above-limit senior renter cases do not receive the alternate credit
- add 2024/2025 boundary tests and a 2025 integration reproduction case

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/credits/homestead_property_tax -c policyengine_us`
- `uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_system_import.py -q`
- `uv run ruff check policyengine_us/variables/gov/states/mi/tax/income/credits/homestead_property_tax/mi_homestead_property_tax_credit_eligible.py`