### PR TITLE
Harden contrib reform tests against CPI updates

### DIFF
--- a/changelog.d/fixed/7391.md
+++ b/changelog.d/fixed/7391.md
@@ -1,0 +1,1 @@
+Make future-year contrib reform tests robust to CPI forecast updates.

--- a/policyengine_us/tests/policy/contrib/additional_tax_bracket/additional_tax_bracket_reform.yaml
+++ b/policyengine_us/tests/policy/contrib/additional_tax_bracket/additional_tax_bracket_reform.yaml
@@ -4,6 +4,12 @@
   reforms: policyengine_us.reforms.additional_tax_bracket.additional_tax_bracket_reform.additional_tax_bracket
   input:
     gov.contrib.additional_tax_bracket.in_effect: true
+    gov.contrib.additional_tax_bracket.bracket.thresholds.1.JOINT: 24_800
+    gov.contrib.additional_tax_bracket.bracket.thresholds.2.JOINT: 100_700
+    gov.contrib.additional_tax_bracket.bracket.thresholds.3.JOINT: 203_250
+    gov.contrib.additional_tax_bracket.bracket.thresholds.4.JOINT: 309_700
+    gov.contrib.additional_tax_bracket.bracket.thresholds.5.JOINT: 553_050
+    gov.contrib.additional_tax_bracket.bracket.thresholds.6.JOINT: 624_700
     gov.contrib.additional_tax_bracket.bracket.thresholds.7.JOINT: 800_000
     gov.contrib.additional_tax_bracket.bracket.rates.8: 0.42
     taxable_income: 1_000_000
@@ -17,6 +23,12 @@
   absolute_error_margin: 1
   input:
     gov.contrib.additional_tax_bracket.in_effect: false
+    gov.irs.income.bracket.thresholds.1.JOINT: 25_450
+    gov.irs.income.bracket.thresholds.2.JOINT: 103_450
+    gov.irs.income.bracket.thresholds.3.JOINT: 216_950
+    gov.irs.income.bracket.thresholds.4.JOINT: 414_200
+    gov.irs.income.bracket.thresholds.5.JOINT: 525_950
+    gov.irs.income.bracket.thresholds.6.JOINT: 788_950
     gov.contrib.additional_tax_bracket.bracket.thresholds.7.JOINT: 800_000
     gov.contrib.additional_tax_bracket.bracket.rates.8: 0.42
     taxable_income: 1_000_000
@@ -31,6 +43,12 @@
   reforms: policyengine_us.reforms.additional_tax_bracket.additional_tax_bracket_reform.additional_tax_bracket
   input:
     gov.contrib.additional_tax_bracket.in_effect: true
+    gov.contrib.additional_tax_bracket.bracket.thresholds.1.JOINT: 24_800
+    gov.contrib.additional_tax_bracket.bracket.thresholds.2.JOINT: 100_700
+    gov.contrib.additional_tax_bracket.bracket.thresholds.3.JOINT: 203_250
+    gov.contrib.additional_tax_bracket.bracket.thresholds.4.JOINT: 309_700
+    gov.contrib.additional_tax_bracket.bracket.thresholds.5.JOINT: 553_050
+    gov.contrib.additional_tax_bracket.bracket.thresholds.6.JOINT: 624_700
     gov.contrib.additional_tax_bracket.bracket.thresholds.7.JOINT: 800_000
     gov.contrib.additional_tax_bracket.bracket.rates.8: 0.42
     taxable_income: 600_000
@@ -44,6 +62,12 @@
   absolute_error_margin: 1
   input:
     gov.contrib.additional_tax_bracket.in_effect: false
+    gov.irs.income.bracket.thresholds.1.JOINT: 25_450
+    gov.irs.income.bracket.thresholds.2.JOINT: 103_450
+    gov.irs.income.bracket.thresholds.3.JOINT: 216_950
+    gov.irs.income.bracket.thresholds.4.JOINT: 414_200
+    gov.irs.income.bracket.thresholds.5.JOINT: 525_950
+    gov.irs.income.bracket.thresholds.6.JOINT: 788_950
     gov.contrib.additional_tax_bracket.bracket.thresholds.7.JOINT: 800_000
     gov.contrib.additional_tax_bracket.bracket.rates.8: 0.42
     taxable_income: 600_000

--- a/policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml
+++ b/policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml
@@ -34,6 +34,8 @@
   reforms: policyengine_us.reforms.crfb.senior_deduction_extension.senior_deduction_extension
   input:
     gov.contrib.crfb.senior_deduction_extension.applies: true
+    gov.irs.deductions.standard.amount.JOINT: 34_450
+    gov.irs.deductions.standard.aged_or_blind.amount.JOINT: 1_750
     people:
       senior1:
         age: 67
@@ -53,7 +55,7 @@
   output:
     additional_senior_deduction: 12_000
     # Total deductions when not itemizing should include:
-    # standard_deduction: 39_000 (joint filing in 2029, includes additional standard deduction for seniors)
+    # standard_deduction: 37_950 (34_450 basic + 1_750 * 2 aged deduction)
     # qualified_business_income_deduction: 5_000
     # additional_senior_deduction: 12_000 (from extension)
     taxable_income_deductions_if_not_itemizing: 54_950
@@ -90,6 +92,8 @@
   reforms: policyengine_us.reforms.crfb.senior_deduction_extension.senior_deduction_extension
   input:
     gov.contrib.crfb.senior_deduction_extension.applies: true
+    gov.irs.deductions.standard.amount.SINGLE: 19_350
+    gov.irs.deductions.standard.aged_or_blind.amount.SINGLE: 2_450
     people:
       senior:
         age: 70
@@ -107,8 +111,8 @@
   output:
     additional_senior_deduction: 6_000
     # Total deductions should include:
-    # basic_standard_deduction: 19_900 (single filing in 2035)
-    # additional_standard_deduction: 2_500 (single senior aged deduction in 2035)
+    # basic_standard_deduction: 19_350
+    # additional_standard_deduction: 2_450
     # qualified_business_income_deduction: 2_000
     # additional_senior_deduction: 6_000 (from extension)
     taxable_income_deductions_if_not_itemizing: 29_800


### PR DESCRIPTION
Fixes #7391.

## Summary
- pin future-year standard deduction parameters in the senior deduction extension tests
- pin CPI-sensitive federal bracket thresholds in the additional tax bracket contrib tests
- keep the tests focused on reform behavior rather than CBO/IRS forecast updates

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/crfb/senior_deduction_extension.yaml policyengine_us/tests/policy/contrib/additional_tax_bracket/additional_tax_bracket_reform.yaml -c policyengine_us`
- `git diff --check`