### PR TITLE
Add vectorized sum code-health test

### DIFF
--- a/changelog.d/fixed/7321.md
+++ b/changelog.d/fixed/7321.md
@@ -1,0 +1,1 @@
+Add a code-health test for non-vectorized built-in sum calls over entity variables.

--- a/policyengine_us/tests/code_health/test_no_builtin_sum_over_entity_calls.py
+++ b/policyengine_us/tests/code_health/test_no_builtin_sum_over_entity_calls.py
@@ -1,0 +1,47 @@
+import ast
+
+from policyengine_us.model_api import REPO
+
+
+VARIABLES_ROOT = REPO / "variables"
+ENTITY_NAMES = {
+    "person",
+    "marital_unit",
+    "tax_unit",
+    "family",
+    "spm_unit",
+    "household",
+}
+
+
+def is_builtin_sum_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "sum"
+    )
+
+
+def contains_direct_entity_call(node: ast.AST) -> bool:
+    return any(
+        isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id in ENTITY_NAMES
+        for child in ast.walk(node)
+    )
+
+
+def test_builtin_sum_does_not_wrap_entity_variable_calls():
+    violations = []
+
+    for file_name in sorted(VARIABLES_ROOT.glob("**/*.py")):
+        tree = ast.parse(file_name.read_text(), filename=str(file_name))
+        for node in ast.walk(tree):
+            if is_builtin_sum_call(node) and contains_direct_entity_call(node):
+                violations.append(f"{file_name.relative_to(REPO)}:{node.lineno}")
+
+    assert not violations, (
+        "Use add(entity, period, sources) or precompute arrays before "
+        "calling built-in sum(); direct entity variable calls inside sum() "
+        "can break vectorization. Violations:\n" + "\n".join(violations)
+    )

--- a/policyengine_us/tests/policy/baseline/gov/states/ak/dpa/ccap/income/ak_ccap_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ak/dpa/ccap/income/ak_ccap_countable_earned_income.yaml
@@ -78,3 +78,28 @@
         state_code: AK
   output:
     ak_ccap_countable_earned_income: 0
+
+- name: Case 5, multiple adult earned income sources are counted.
+  period: 2022-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 24_000
+      person2:
+        age: 28
+        self_employment_income: 12_000
+      minor:
+        age: 16
+        employment_income: 6_000
+    spm_units:
+      spm_unit:
+        members: [person1, person2, minor]
+    households:
+      household:
+        members: [person1, person2, minor]
+        state_code: AK
+  output:
+    # (24_000 + 12_000) / 12 = 3_000/month (minor excluded)
+    ak_ccap_countable_earned_income: 3_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_countable_income.yaml
@@ -286,3 +286,25 @@
     # Earnings-only exclusion per 17b-749-05(b)(2)(E); unearned income
     # of minors is counted under 17b-749-05(b)(1)(A).
     ct_c4k_countable_income: 2_500
+
+- name: Case 13, multiple adult earned income sources are counted.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+        self_employment_income: 6_000
+      child:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: CT
+  output:
+    # (24,000 + 6,000) / 12 = 2,500
+    ct_c4k_countable_income: 2_500

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/payment/il_aabd_utility_allowance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/payment/il_aabd_utility_allowance.yaml
@@ -40,3 +40,12 @@
     state_code: [IL, IL]
   output:
     il_aabd_utility_allowance: [3.8, 12]
+
+- name: No utility expenses returns zero allowance.
+  period: 2022-01
+  input:
+    spm_unit_size: 1
+    county_str: COOK_COUNTY_IL
+    state_code: IL
+  output:
+    il_aabd_utility_allowance: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.yaml
@@ -221,3 +221,25 @@
     # applicant/co-applicant-only rule; an adult family member's
     # earnings still contribute to household countable income.
     nj_ccap_countable_income: 3_500
+
+- name: Case 10, adult self-employment income counts.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+        self_employment_income: 12_000
+      child:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: NJ
+  output:
+    # (24,000 + 12,000) / 12 = 3,000
+    nj_ccap_countable_income: 3_000

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_countable_income.yaml
@@ -189,3 +189,25 @@
     # Only earnings (wages/self-employment) of children <18 are excluded;
     # unearned income (e.g. social_security) of minors is still countable.
     va_ccsp_countable_income: 2_500
+
+- name: Case 9, adult self-employment income counts.
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+        employment_income: 24_000
+        self_employment_income: 12_000
+      child:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: VA
+  output:
+    # (24,000 + 12,000) / 12 = 3,000
+    va_ccsp_countable_income: 3_000

--- a/policyengine_us/tests/policy/baseline/household/expense/utilities/count_distinct_utility_expenses.yaml
+++ b/policyengine_us/tests/policy/baseline/household/expense/utilities/count_distinct_utility_expenses.yaml
@@ -1,0 +1,25 @@
+- name: Counts utility expense categories with positive expenses.
+  period: 2024
+  input:
+    heating_cooling_expense: 600
+    pre_subsidy_electricity_expense: 1_200
+    gas_expense: 0
+    phone_expense: 360
+    trash_expense: 0
+    water_expense: 240
+    sewage_expense: 180
+  output:
+    count_distinct_utility_expenses: 5
+
+- name: Returns zero with no utility expenses.
+  period: 2024
+  input:
+    heating_cooling_expense: 0
+    pre_subsidy_electricity_expense: 0
+    gas_expense: 0
+    phone_expense: 0
+    trash_expense: 0
+    water_expense: 0
+    sewage_expense: 0
+  output:
+    count_distinct_utility_expenses: 0

--- a/policyengine_us/variables/gov/states/ak/dpa/ccap/income/ak_ccap_countable_earned_income.py
+++ b/policyengine_us/variables/gov/states/ak/dpa/ccap/income/ak_ccap_countable_earned_income.py
@@ -26,7 +26,5 @@ class ak_ccap_countable_earned_income(Variable):
         adult_age = parameters(period).gov.states.ak.dpa.ccap.age_threshold.adult
         person = spm_unit.members
         is_adult = person("age", period.this_year) >= adult_age
-        earned_per_person = sum(
-            person(source, period) for source in p_income.earned_sources
-        )
+        earned_per_person = add(person, period, p_income.earned_sources)
         return spm_unit.sum(earned_per_person * is_adult)

--- a/policyengine_us/variables/gov/states/ct/oec/c4k/ct_c4k_countable_income.py
+++ b/policyengine_us/variables/gov/states/ct/oec/c4k/ct_c4k_countable_income.py
@@ -27,7 +27,7 @@ class ct_c4k_countable_income(Variable):
         is_adult = person("age", period.this_year) >= 18
         is_parent = person("is_tax_unit_head_or_spouse", period.this_year)
         earnings_counted = is_adult | is_parent
-        earned_per_person = sum(person(source, period) for source in p.earned_sources)
+        earned_per_person = add(person, period, p.earned_sources)
         earned_income = spm_unit.sum(earned_per_person * earnings_counted)
         unearned_income = add(spm_unit, period, p.unearned_sources)
         deductions = add(spm_unit, period, p.deductions)

--- a/policyengine_us/variables/gov/states/il/dhs/aabd/payment/utility/il_utility_allowance.py
+++ b/policyengine_us/variables/gov/states/il/dhs/aabd/payment/utility/il_utility_allowance.py
@@ -18,17 +18,18 @@ class il_aabd_utility_allowance(Variable):
         capped_size = clip(size, 1, 19)
         area = spm_unit.household("il_aabd_area", period)
         # Households may have more than one applicable utility allowance type
-        total_allowance = sum(
-            [
+        allowances = []
+        for expense in p.utility.utility_types:
+            expense_amount = spm_unit(expense, period)
+            allowances.append(
                 where(
-                    spm_unit(expense, period) > 0,
+                    expense_amount > 0,
                     min_(
-                        spm_unit(expense, period),
+                        expense_amount,
                         p.utility[expense.replace("_expense", "")][area][capped_size],
                     ),
                     0,
                 )
-                for expense in p.utility.utility_types
-            ]
-        )
+            )
+        total_allowance = sum(allowances)
         return total_allowance

--- a/policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py
+++ b/policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py
@@ -26,7 +26,7 @@ class nj_ccap_countable_income(Variable):
         # `age` is YEAR-defined; use period.this_year inside this
         # monthly formula to get the annual value instead of age/12.
         is_adult = person("age", period.this_year) >= 18
-        earned_per_person = sum(person(source, period) for source in p.earned_sources)
+        earned_per_person = add(person, period, p.earned_sources)
         adult_earned_income = spm_unit.sum(earned_per_person * is_adult)
         unearned_income = add(spm_unit, period, p.unearned_sources)
         return adult_earned_income + unearned_income

--- a/policyengine_us/variables/gov/states/va/dss/ccsp/income/va_ccsp_countable_income.py
+++ b/policyengine_us/variables/gov/states/va/dss/ccsp/income/va_ccsp_countable_income.py
@@ -23,7 +23,7 @@ class va_ccsp_countable_income(Variable):
         # `age` is a YEAR-defined variable; use period.this_year so the
         # monthly formula picks up the annual age rather than age/12.
         is_adult = person("age", period.this_year) >= 18
-        earned_per_person = sum(person(source, period) for source in p.earned_sources)
+        earned_per_person = add(person, period, p.earned_sources)
         adult_earned_income = spm_unit.sum(earned_per_person * is_adult)
         unearned_income = add(spm_unit, period, p.unearned_sources)
         deductions = add(spm_unit, period, p.subtracts)

--- a/policyengine_us/variables/household/expense/utilities/count_distinct_utility_expenses.py
+++ b/policyengine_us/variables/household/expense/utilities/count_distinct_utility_expenses.py
@@ -20,6 +20,7 @@ class count_distinct_utility_expenses(Variable):
             "water",
             "sewage",
         ]
-        return sum(
-            [spm_unit(variable + "_expense", period) > 0 for variable in UTILITIES]
-        )
+        has_expense = [
+            spm_unit(variable + "_expense", period) > 0 for variable in UTILITIES
+        ]
+        return sum(has_expense)


### PR DESCRIPTION
Fixes #7321.

## Summary
- add an AST-based code-health test that rejects built-in `sum()` wrapping direct entity variable calls under `policyengine_us/variables`
- replace existing `sum(person(...))` income-source patterns with `add(person, period, sources)`
- precompute entity-call arrays before built-in `sum()` where the sum is intentionally over arrays

## Tests
- `uv run pytest policyengine_us/tests/code_health/test_no_builtin_sum_over_entity_calls.py -q`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ak/dpa/ccap/income/ak_ccap_countable_earned_income.yaml policyengine_us/tests/policy/baseline/gov/states/ct/oec/c4k/ct_c4k_countable_income.yaml policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd/payment/il_aabd_utility_allowance.yaml policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.yaml policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_countable_income.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/tests/code_health/test_no_builtin_sum_over_entity_calls.py policyengine_us/variables/gov/states/ct/oec/c4k/ct_c4k_countable_income.py policyengine_us/variables/gov/states/va/dss/ccsp/income/va_ccsp_countable_income.py policyengine_us/variables/household/expense/utilities/count_distinct_utility_expenses.py policyengine_us/variables/gov/states/ak/dpa/ccap/income/ak_ccap_countable_earned_income.py policyengine_us/variables/gov/states/il/dhs/aabd/payment/utility/il_utility_allowance.py policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py`
- `uv run ruff format --check policyengine_us/tests/code_health/test_no_builtin_sum_over_entity_calls.py policyengine_us/variables/gov/states/ct/oec/c4k/ct_c4k_countable_income.py policyengine_us/variables/gov/states/va/dss/ccsp/income/va_ccsp_countable_income.py policyengine_us/variables/household/expense/utilities/count_distinct_utility_expenses.py policyengine_us/variables/gov/states/ak/dpa/ccap/income/ak_ccap_countable_earned_income.py policyengine_us/variables/gov/states/il/dhs/aabd/payment/utility/il_utility_allowance.py policyengine_us/variables/gov/states/nj/njdhs/ccap/nj_ccap_countable_income.py`
- `git diff --check`