### PR TITLE
Deprecate legacy Marketplace coverage input

### DIFF
--- a/changelog.d/fixed/8187.md
+++ b/changelog.d/fixed/8187.md
@@ -1,0 +1,1 @@
+Deprecated the legacy `has_marketplace_health_coverage` input and added ACA PTC regression coverage for reported Marketplace coverage flags.

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml
@@ -391,3 +391,25 @@
         aca_magi_fraction: 2.50
   output:
      is_aca_ptc_eligible: [true, true, true, true, false]
+
+- name: Case 8, legacy and reported Marketplace coverage flags do not gate eligibility.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        has_marketplace_health_coverage: false
+        has_marketplace_health_coverage_at_interview: false
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+        filing_status: SINGLE
+  output:
+    pays_aca_premium: [true]
+    is_aca_ptc_eligible: [true]

--- a/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml
@@ -142,3 +142,30 @@
     tax_unit_is_filer: true
   output:
     aca_ptc: 200
+
+- name: ACA PTC is available when legacy and reported Marketplace coverage flags are false.
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        has_marketplace_health_coverage: false
+        has_marketplace_health_coverage_at_interview: false
+        is_medicaid_eligible: false
+        is_chip_eligible: false
+        is_basic_health_program_eligible: false
+        is_aca_eshi_eligible: false
+        is_medicare_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 25_000
+        aca_magi_fraction: 2.50
+        slcsp: 1_200
+        aca_required_contribution_percentage: 0.04
+        tax_unit_is_filer: true
+        filing_status: SINGLE
+  output:
+    is_aca_ptc_eligible: [true]
+    aca_ptc: 200

--- a/policyengine_us/variables/household/expense/health/has_marketplace_health_coverage.py
+++ b/policyengine_us/variables/household/expense/health/has_marketplace_health_coverage.py
@@ -4,12 +4,13 @@ from policyengine_us.model_api import *
 class has_marketplace_health_coverage(Variable):
     value_type = bool
     entity = Person
-    label = "Person has modeled Marketplace health coverage"
+    label = "Deprecated legacy modeled Marketplace health coverage input"
     definition_period = YEAR
     default_value = True
     documentation = """
-    Legacy modeled Marketplace coverage status.
+    Deprecated legacy modeled Marketplace coverage status.
 
-    Use has_marketplace_health_coverage_at_interview for reported current
-    Marketplace coverage from survey data.
+    Use has_marketplace_health_coverage_at_interview for reported Marketplace
+    coverage from survey data, and takes_up_aca_if_eligible for modeled ACA
+    Marketplace take-up. ACA PTC eligibility does not depend on this variable.
     """


### PR DESCRIPTION
## Summary

- mark `has_marketplace_health_coverage` as a deprecated legacy modeled Marketplace coverage input
- document the explicit replacements for reported coverage and modeled ACA take-up
- add regression tests showing legacy/reported Marketplace coverage flags do not gate ACA PTC eligibility or amount

Fixes #8187.

## Tests

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/eligibility/is_aca_ptc_eligible.yaml policyengine_us/tests/policy/baseline/gov/aca/ptc/aca_ptc.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/household/expense/health/has_marketplace_health_coverage.py`
- `git diff --check`