### PR TITLE
Use WIC pregnancy count in family size

### DIFF
--- a/changelog.d/8186.fixed.md
+++ b/changelog.d/8186.fixed.md
@@ -1,0 +1,1 @@
+Use the number of current pregnancies when increasing WIC family size for pregnant applicants.

--- a/policyengine_us/tests/policy/baseline/gov/usda/wic/wic_fpg.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/wic/wic_fpg.yaml
@@ -49,3 +49,12 @@
     is_pregnant: false
   output:
     wic_fpg: 12_880
+
+- name: Case 7, twin pregnancy increases family size by two.
+  period: 2021-01
+  absolute_error_margin: 0.1
+  input:
+    spm_unit_size: 1
+    current_pregnancies: 2
+  output:
+    wic_fpg: 1_830

--- a/policyengine_us/tests/policy/baseline/gov/usda/wic/wic_income_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/wic/wic_income_limit.yaml
@@ -42,3 +42,16 @@
         state_code: GU
   output:
     wic_income_limit: 39_128
+
+- name: Twin pregnancy increases the WIC income unit by two.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        current_pregnancies: 2
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    wic_income_limit: 49_303

--- a/policyengine_us/variables/gov/usda/wic/wic_fpg.py
+++ b/policyengine_us/variables/gov/usda/wic/wic_fpg.py
@@ -5,19 +5,24 @@ class wic_fpg(Variable):
     value_type = float
     entity = SPMUnit
     definition_period = MONTH
-    documentation = "Federal poverty guideline for WIC, with family size incremented by one for pregnant women"
+    documentation = "Federal poverty guideline for WIC, with family size incremented by the number of embryos or fetuses for pregnant applicants"
     label = "Pregnancy-adjusted poverty line for WIC"
-    reference = "https://www.law.cornell.edu/uscode/text/42/1786#d_2_D"
+    reference = [
+        "https://www.law.cornell.edu/uscode/text/42/1786#d_2_D",
+        "https://www.law.cornell.edu/cfr/text/7/246.7#d_2_vii",
+    ]
     unit = USD
 
     def formula(spm_unit, period, parameters):
-        pregnant = spm_unit.any(spm_unit.members("is_pregnant", period))
+        current_pregnancies = spm_unit.sum(
+            spm_unit.members("current_pregnancies", period.this_year)
+        )
         # The system divides annual variables by 12 automatically when bringing them down to a month.
         # The normal FPG is an annual variable, so the system divides it by 12 by default.
         normal_fpg = spm_unit("spm_unit_fpg", period)
         state_group = spm_unit.household("state_group_str", period)
         additional = parameters(period).gov.hhs.fpg.additional_person[state_group]
-        annual_pregnant_addition = additional * pregnant
+        annual_pregnant_addition = additional * current_pregnancies
         # The additional amount is based on a yearly parameter, so we need to manually divide it by 12.
         monthly_pregnant_addition = annual_pregnant_addition / MONTHS_IN_YEAR
         return normal_fpg + monthly_pregnant_addition

--- a/policyengine_us/variables/gov/usda/wic/wic_income_limit.py
+++ b/policyengine_us/variables/gov/usda/wic/wic_income_limit.py
@@ -10,13 +10,16 @@ class wic_income_limit(Variable):
     documentation = "Annual income limit for WIC direct income eligibility"
     reference = [
         "https://www.law.cornell.edu/uscode/text/42/1786#d_2_A_i",
+        "https://www.law.cornell.edu/cfr/text/7/246.7#d_2_vii",
         "https://www.fns.usda.gov/wic/income-eligibility-guidelines-2025-26",
     ]
 
     def formula(spm_unit, period, parameters):
         spm_unit_size = spm_unit("spm_unit_size", period.this_year)
-        pregnant = spm_unit.any(spm_unit.members("is_pregnant", period))
-        wic_unit_size = spm_unit_size + pregnant
+        current_pregnancies = spm_unit.sum(
+            spm_unit.members("current_pregnancies", period.this_year)
+        )
+        wic_unit_size = spm_unit_size + current_pregnancies
 
         state_group = spm_unit.household("state_group_str", period.this_year)
         wic_state_group = np.where(


### PR DESCRIPTION
## Summary
- use summed `current_pregnancies` instead of a boolean pregnancy flag for WIC family-size adjustments
- preserve the `is_pregnant`-only path because `current_pregnancies` defaults from `is_pregnant`
- add WIC FPG and income-limit regression tests for twin pregnancy

Fixes #8186.

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/usda/wic/wic_fpg.yaml policyengine_us/tests/policy/baseline/gov/usda/wic/wic_income_limit.yaml -c policyengine_us`
- `uv run ruff check policyengine_us/variables/gov/usda/wic/wic_fpg.py policyengine_us/variables/gov/usda/wic/wic_income_limit.py`
- `git diff --check`