### PR TITLE
Cite Pennsylvania income tax rate code

### DIFF
--- a/changelog.d/fixed/1272.md
+++ b/changelog.d/fixed/1272.md
@@ -1,0 +1,1 @@
+Added a codified Tax Reform Code reference for the Pennsylvania income tax rate.

--- a/policyengine_us/parameters/gov/states/pa/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/pa/tax/income/rate.yaml
@@ -6,6 +6,8 @@ metadata:
   period: year
   label: PA income tax rate
   reference:
+    - title: Tax Reform Code of 1971, Article III, Section 302
+      href: https://www.legis.state.pa.us/WU01/LI/LI/US/PDF/1971/0/0002..PDF#page=118
     - title: The General Assembly of Pennsylvania House Bill No. 200, Section 302 (3), page 50, line 27
       href: https://www.legis.state.pa.us/CFDOCS/Legis/PN/Public/btCheck.cfm?txtType=PDF&sessYr=2003&sessInd=0&billBody=H&billTyp=B&billNbr=0200&pn=3160#page=50
     - title: PA Form PA-40 Instructions, page 1


### PR DESCRIPTION
## Summary
- add the codified Tax Reform Code Article III Section 302 reference for Pennsylvania's 3.07% income tax rate
- add a changelog fragment for #1272

Closes #1272.

## Tests
- uv run python -m pytest policyengine_us/tests/test_build_metadata.py
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax.yaml policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/forgiveness/pa_income_tax_before_forgiveness.yaml -c policyengine_us
- git diff --check