### PR TITLE
Cite Massachusetts Senior Circuit Breaker income guidance

### DIFF
--- a/changelog.d/fixed/1030.md
+++ b/changelog.d/fixed/1030.md
@@ -1,0 +1,1 @@
+Added the Mass.gov guidance reference for Massachusetts Senior Circuit Breaker income sources.

--- a/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/income/disallowed_deductions.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/income/disallowed_deductions.yaml
@@ -14,5 +14,7 @@ metadata:
   unit: list
   label: Massachusetts Senior Circuit Breaker income disallowed deductions
   reference:
+    - title: Mass.gov, Massachusetts Senior Circuit Breaker Tax Credit, Calculate your total income
+      href: https://www.mass.gov/info-details/massachusetts-senior-circuit-breaker-tax-credit#calculate-your-total-income-
     - title: Mass. General Laws c.62 § 6(k)
       href: https://www.mass.gov/info-details/mass-general-laws-c62-ss-6


### PR DESCRIPTION
## Summary
- add the Mass.gov Senior Circuit Breaker total-income guidance reference to the income source parameter
- add a changelog fragment for #1030

Closes #1030.

## Tests
- uv run python -m pytest policyengine_us/tests/test_build_metadata.py
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/senior_circuit_breaker/ma_scb_total_income.yaml policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/senior_circuit_breaker/ma_senior_circuit_breaker.yaml -c policyengine_us
- git diff --check