### PR TITLE
Fix Connecticut EITC bonus eligibility

### DIFF
--- a/changelog.d/ct-eitc-bonus-eligibility.md
+++ b/changelog.d/ct-eitc-bonus-eligibility.md
@@ -1,0 +1,1 @@
+- Fixed the Connecticut EITC qualifying child bonus to require Connecticut EITC eligibility.

--- a/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/eitc/ct_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/eitc/ct_eitc.yaml
@@ -90,3 +90,38 @@
   output:
     ct_eitc: 2_250
     # 5,000 * 0.4 + 250 = 2,000 + 250 = 2,250 (bonus is flat $250)
+
+- name: Case 11, 2025 federal EITC with child but no CT EITC.
+  period: 2025
+  input:
+    gov.states.ct.tax.income.credits.eitc.match: 0
+    state_code: CT
+    eitc: 2_000
+    eitc_child_count: 1
+  output:
+    ct_eitc: 0
+    # The qualifying child bonus requires CT EITC eligibility, not only federal EITC eligibility.
+
+- name: Case 12, computed EITC with child but no CT EITC.
+  period: 2025
+  input:
+    gov.states.ct.tax.income.credits.eitc.match: 0
+    people:
+      parent:
+        age: 30
+        employment_income: 20_000
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: CT
+  output:
+    eitc: 4_328
+    eitc_child_count: 1
+    ct_eitc: 0
+    # Regression test: federal EITC and a qualifying child are computed from
+    # household inputs, but the CT bonus should not survive a zero CT match.

--- a/policyengine_us/variables/gov/states/ct/tax/income/credits/eitc/ct_eitc.py
+++ b/policyengine_us/variables/gov/states/ct/tax/income/credits/eitc/ct_eitc.py
@@ -19,7 +19,7 @@ class ct_eitc(Variable):
         base_credit = federal_eitc * p.match
         # Bonus amount for taxpayers eligible for CT EITC with at least one qualifying child (effective 2025)
         if p.qualifying_child_bonus.in_effect:
-            eitc_eligible = federal_eitc > 0
+            eitc_eligible = base_credit > 0
             has_qualifying_child = tax_unit("eitc_child_count", period) > 0
             bonus = (
                 eitc_eligible * has_qualifying_child * p.qualifying_child_bonus.amount


### PR DESCRIPTION
## Summary
- require positive Connecticut EITC, not just federal EITC, before adding the qualifying child bonus
- add direct and household-style regression cases with the CT EITC match set to zero
- add a changelog entry

Fixes #7468.

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ct/tax/income/credits/eitc/ct_eitc.yaml`
- `uv run ruff check policyengine_us/variables/gov/states/ct/tax/income/credits/eitc/ct_eitc.py`
- `git diff --check`