### PR TITLE
Update SOI long-term capital gains target to 2023

### DIFF
--- a/policyengine_us/parameters/calibration/gov/irs/soi/long_term_capital_gains.yaml
+++ b/policyengine_us/parameters/calibration/gov/irs/soi/long_term_capital_gains.yaml
@@ -1,11 +1,12 @@
 description: Total long-term capital gains.
 values:
-  2015-01-01: 713_598_090_000
-  2020-01-01: 1_137_020_477_000
+  2015-01-01: 733_313_255_000
+  2020-01-01: 1_063_500_316_000
+  2023-01-01: 971_279_947_000
 metadata:
   unit: currency-USD
   label: SOI long-term capital gains
   uprating: calibration.gov.cbo.income_by_source.net_capital_gain
   reference:
-    - title: IRS SOI Tax Stats - Individual Statistical Tables by Size of Adjusted Gross Income
-      href: https://www.irs.gov/statistics/soi-tax-stats-individual-statistical-tables-by-size-of-adjusted-gross-income
+    - title: IRS SOI Tax Stats - Publication 1304 Table 1.4A
+      href: https://www.irs.gov/statistics/soi-tax-stats-individual-income-tax-returns-complete-report-publication-1304-basic-tables-part-1

--- a/policyengine_us/tests/test_parameter_files.py
+++ b/policyengine_us/tests/test_parameter_files.py
@@ -5,6 +5,14 @@ import yaml
 
 
 PARAMETERS_DIR = Path(__file__).resolve().parents[1] / "parameters"
+SOI_LONG_TERM_CAPITAL_GAINS_PATH = (
+    PARAMETERS_DIR / "calibration/gov/irs/soi/long_term_capital_gains.yaml"
+)
+SOI_LONG_TERM_CAPITAL_GAINS_ANCHORS = {
+    date(2015, 1, 1): 733_313_255_000,
+    date(2020, 1, 1): 1_063_500_316_000,
+    date(2023, 1, 1): 971_279_947_000,
+}
 PARAMETER_SCHEMA_KEYS = {
     "brackets",
     "description",
@@ -126,3 +134,16 @@ def test_enum_breakdown_parameters_do_not_have_single_member_tables():
         errors.extend(_enum_breakdown_parameter_errors(path, data))
 
     assert errors == []
+
+
+def test_soi_long_term_capital_gains_uses_latest_publication_1304_anchor():
+    parameter = yaml.safe_load(SOI_LONG_TERM_CAPITAL_GAINS_PATH.read_text())
+    values = parameter["values"]
+
+    for period, value in SOI_LONG_TERM_CAPITAL_GAINS_ANCHORS.items():
+        assert values[period] == value
+
+    assert max(values) >= date(2023, 1, 1)
+    assert parameter["metadata"]["reference"][0]["href"].endswith(
+        "publication-1304-basic-tables-part-1"
+    )


### PR DESCRIPTION
## Summary
- Update the SOI long-term capital gains calibration parameter to IRS Publication 1304 Table 1.4A net long-term capital gain amounts for 2015, 2020, and 2023.
- Point the reference at the current IRS Publication 1304 Basic Tables Part 1 page, which lists 2023 Table 1.4A.
- Add a parameter regression test that pins the source-cell anchors and requires the 2023 anchor.

## Notes
- The prior 2015 and 2020 anchors matched Schedule D taxable net gain, not the Table 1.4A net long-term capital gain column used for PUF P23250-style LTCG.
- New CBO-uprated target values are about .278T for 2024 and .686T for 2026.

## Tests
- env -u UV_FROZEN uv run pytest policyengine_us/tests/test_parameter_files.py -q
- env -u UV_FROZEN uv run pytest policyengine_us/tests/test_system_import.py policyengine_us/tests/test_parameter_files.py -q
- env -u UV_FROZEN uv run ruff check policyengine_us/tests/test_parameter_files.py
- env -u UV_FROZEN uv run ruff format --check policyengine_us/tests/test_parameter_files.py
- git diff --check