### PR TITLE
Model Healthier Mississippi Waiver Medicaid eligibility

### DIFF
--- a/changelog.d/added/8442.md
+++ b/changelog.d/added/8442.md
@@ -1,0 +1,1 @@
+Added Mississippi Healthier Mississippi Waiver Medicaid eligibility.

--- a/policyengine_us/parameters/gov/states/ms/dom/hmw/enrollment/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/hmw/enrollment/cap.yaml
@@ -1,0 +1,15 @@
+description: Mississippi limits enrollment to this number of people under the Healthier Mississippi Waiver program.
+values:
+  2000-01-01: 0
+  2006-01-01: 6_000
+metadata:
+  unit: person
+  period: year
+  label: Mississippi Healthier Mississippi Waiver enrollment cap
+  reference:
+    - title: Centers for Medicare & Medicaid Services, Healthier Mississippi Extension
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9
+    - title: Mississippi Division of Medicaid, Healthier Mississippi Waiver Fact Sheet
+      href: https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1
+    - title: Mississippi Division of Medicaid, Healthier Mississippi Waiver Full Public Notice
+      href: https://medicaid.ms.gov/wp-content/uploads/2022/07/Healthier-Mississippi-Waiver-Full-Public-Notice-Website.pdf#page=3

--- a/policyengine_us/parameters/gov/states/ms/dom/hmw/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/hmw/in_effect.yaml
@@ -1,0 +1,13 @@
+description: Mississippi determines whether the Healthier Mississippi Waiver program is active.
+values:
+  2000-01-01: false
+  2006-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: Mississippi Healthier Mississippi Waiver in effect
+  reference:
+    - title: Mississippi Division of Medicaid, Healthier Mississippi Waiver Fact Sheet
+      href: https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1
+    - title: Centers for Medicare & Medicaid Services, Healthier Mississippi Extension
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=3

--- a/policyengine_us/parameters/gov/states/ms/dom/hmw/income/limit/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/hmw/income/limit/rate.yaml
@@ -1,0 +1,15 @@
+description: Mississippi limits income to this share of the federal poverty level under the Healthier Mississippi Waiver program.
+values:
+  2000-01-01: 0
+  2006-01-01: 1.35
+metadata:
+  unit: /1
+  period: year
+  label: Mississippi Healthier Mississippi Waiver income limit
+  reference:
+    - title: Centers for Medicare & Medicaid Services, Healthier Mississippi Extension
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9
+    - title: Mississippi Division of Medicaid, Healthier Mississippi Waiver Fact Sheet
+      href: https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=2
+    - title: Mississippi Division of Medicaid, Member Coverage Descriptions Job Aid
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5

--- a/policyengine_us/parameters/gov/states/ms/dom/hmw/resources/limit/couple.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/hmw/resources/limit/couple.yaml
@@ -1,0 +1,15 @@
+description: Mississippi limits resources to this amount under the Healthier Mississippi Waiver program.
+values:
+  2000-01-01: 0
+  2006-01-01: 6_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Mississippi Healthier Mississippi Waiver couple resource limit
+  reference:
+    - title: Centers for Medicare & Medicaid Services, Healthier Mississippi Extension
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9
+    - title: Mississippi Division of Medicaid, Healthier Mississippi Waiver Fact Sheet
+      href: https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1
+    - title: Mississippi Division of Medicaid, Member Coverage Descriptions Job Aid
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5

--- a/policyengine_us/parameters/gov/states/ms/dom/hmw/resources/limit/individual.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/hmw/resources/limit/individual.yaml
@@ -1,0 +1,15 @@
+description: Mississippi limits resources to this amount under the Healthier Mississippi Waiver program.
+values:
+  2000-01-01: 0
+  2006-01-01: 4_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Mississippi Healthier Mississippi Waiver individual resource limit
+  reference:
+    - title: Centers for Medicare & Medicaid Services, Healthier Mississippi Extension
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9
+    - title: Mississippi Division of Medicaid, Healthier Mississippi Waiver Fact Sheet
+      href: https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1
+    - title: Mississippi Division of Medicaid, Member Coverage Descriptions Job Aid
+      href: https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_demographic_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_demographic_eligible.yaml
@@ -1,0 +1,29 @@
+- name: Case 1, aged blind or disabled person passes demographic rules.
+  period: 2026
+  input:
+    state_code: MS
+    is_ssi_aged_blind_disabled: true
+    is_pregnant: false
+    is_in_medicaid_facility: false
+  output:
+    ms_hmw_demographic_eligible: true
+
+- name: Case 2, pregnant person fails demographic rules.
+  period: 2026
+  input:
+    state_code: MS
+    is_ssi_aged_blind_disabled: true
+    is_pregnant: true
+    is_in_medicaid_facility: false
+  output:
+    ms_hmw_demographic_eligible: false
+
+- name: Case 3, person in Medicaid facility fails demographic rules.
+  period: 2026
+  input:
+    state_code: MS
+    is_ssi_aged_blind_disabled: true
+    is_pregnant: false
+    is_in_medicaid_facility: true
+  output:
+    ms_hmw_demographic_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_eligible.yaml
@@ -1,0 +1,35 @@
+- name: Case 1, all eligibility components pass.
+  period: 2026
+  input:
+    state_code: MS
+    ms_hmw_demographic_eligible: true
+    ms_hmw_non_medicare_eligible: true
+    ms_hmw_income_eligible: true
+    ms_hmw_resource_eligible: true
+    ms_hmw_other_coverage_ineligible: true
+  output:
+    ms_hmw_eligible: true
+
+- name: Case 2, ineligible before waiver start date.
+  period: 2005
+  input:
+    state_code: MS
+    ms_hmw_demographic_eligible: true
+    ms_hmw_non_medicare_eligible: true
+    ms_hmw_income_eligible: true
+    ms_hmw_resource_eligible: true
+    ms_hmw_other_coverage_ineligible: true
+  output:
+    ms_hmw_eligible: false
+
+- name: Case 3, one failed eligibility component fails.
+  period: 2026
+  input:
+    state_code: MS
+    ms_hmw_demographic_eligible: true
+    ms_hmw_non_medicare_eligible: false
+    ms_hmw_income_eligible: true
+    ms_hmw_resource_eligible: true
+    ms_hmw_other_coverage_ineligible: true
+  output:
+    ms_hmw_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.yaml
@@ -1,0 +1,36 @@
+- name: Case 1, countable income at 135 percent of poverty passes.
+  period: 2026
+  input:
+    state_code: MS
+    medicaid_optional_senior_or_disabled_countable_income: 13_500
+    tax_unit_fpg: 10_000
+  output:
+    ms_hmw_income_eligible: true
+
+- name: Case 2, countable income over 135 percent of poverty fails.
+  period: 2026
+  input:
+    state_code: MS
+    medicaid_optional_senior_or_disabled_countable_income: 13_501
+    tax_unit_fpg: 10_000
+  output:
+    ms_hmw_income_eligible: false
+
+- name: Case 3, joint tax unit income at 135 percent of poverty passes.
+  period: 2026
+  input:
+    people:
+      person1:
+        medicaid_optional_senior_or_disabled_countable_income: 6_750
+      person2:
+        medicaid_optional_senior_or_disabled_countable_income: 6_750
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_fpg: 10_000
+  output:
+    ms_hmw_income_eligible: [true, true]

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.yaml
@@ -2,8 +2,7 @@
   period: 2026
   input:
     state_code: MS
-    medicaid_optional_senior_or_disabled_countable_income: 13_500
-    tax_unit_fpg: 10_000
+    medicaid_optional_senior_or_disabled_countable_income: 21_546
   output:
     ms_hmw_income_eligible: true
 
@@ -11,26 +10,79 @@
   period: 2026
   input:
     state_code: MS
-    medicaid_optional_senior_or_disabled_countable_income: 13_501
-    tax_unit_fpg: 10_000
+    medicaid_optional_senior_or_disabled_countable_income: 21_547
   output:
     ms_hmw_income_eligible: false
 
-- name: Case 3, joint tax unit income at 135 percent of poverty passes.
+- name: Case 3, couple income at 135 percent of poverty passes.
   period: 2026
   input:
     people:
       person1:
-        medicaid_optional_senior_or_disabled_countable_income: 6_750
+        age: 67
+        medicaid_optional_senior_or_disabled_countable_income: 14_607
       person2:
-        medicaid_optional_senior_or_disabled_countable_income: 6_750
+        age: 66
+        medicaid_optional_senior_or_disabled_countable_income: 14_607
     households:
       household:
         members: [person1, person2]
         state_code: MS
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
     tax_units:
       tax_unit:
         members: [person1, person2]
-        tax_unit_fpg: 10_000
+  output:
+    ms_hmw_income_eligible: [true, true]
+
+- name: Case 4, dependent does not increase the income limit.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 67
+        medicaid_optional_senior_or_disabled_countable_income: 21_547
+      person2:
+        age: 10
+        medicaid_optional_senior_or_disabled_countable_income: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    ms_hmw_income_eligible: [false, true]
+
+- name: Case 5, spouse in a separate tax unit counts toward the couple income limit.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 67
+        medicaid_optional_senior_or_disabled_countable_income: 22_000
+      person2:
+        age: 66
+        medicaid_optional_senior_or_disabled_countable_income: 7_214
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit1:
+        members: [person1]
+      tax_unit2:
+        members: [person2]
   output:
     ms_hmw_income_eligible: [true, true]

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.yaml
@@ -1,0 +1,15 @@
+- name: Case 1, person not enrolled in Medicare passes Medicare exclusion.
+  period: 2026
+  input:
+    state_code: MS
+    medicare_enrolled: false
+  output:
+    ms_hmw_non_medicare_eligible: true
+
+- name: Case 2, person enrolled in Medicare fails Medicare exclusion.
+  period: 2026
+  input:
+    state_code: MS
+    medicare_enrolled: true
+  output:
+    ms_hmw_non_medicare_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.yaml
@@ -1,15 +1,15 @@
-- name: Case 1, person not enrolled in Medicare passes Medicare exclusion.
+- name: Case 1, person not eligible for Medicare passes Medicare exclusion.
   period: 2026
   input:
     state_code: MS
-    medicare_enrolled: false
+    is_medicare_eligible: false
   output:
     ms_hmw_non_medicare_eligible: true
 
-- name: Case 2, person enrolled in Medicare fails Medicare exclusion.
+- name: Case 2, person eligible for Medicare fails Medicare exclusion.
   period: 2026
   input:
     state_code: MS
-    medicare_enrolled: true
+    is_medicare_eligible: true
   output:
     ms_hmw_non_medicare_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_other_coverage_ineligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_other_coverage_ineligible.yaml
@@ -1,0 +1,58 @@
+- name: Case 1, person with no other Medicaid or CHIP category passes.
+  period: 2026
+  input:
+    state_code: MS
+    is_ssi_recipient_for_medicaid: false
+    is_infant_for_medicaid: false
+    is_young_child_for_medicaid: false
+    is_older_child_for_medicaid: false
+    is_pregnant_for_medicaid: false
+    is_parent_for_medicaid: false
+    is_young_adult_for_medicaid: false
+    is_adult_for_medicaid: false
+    is_optional_senior_or_disabled_for_medicaid: false
+    is_medically_needy_for_medicaid: false
+    is_working_disabled_buy_in_for_medicaid: false
+    age: 45
+  output:
+    ms_hmw_other_coverage_ineligible: true
+
+- name: Case 2, person otherwise eligible for optional senior or disabled Medicaid fails.
+  period: 2026
+  input:
+    state_code: MS
+    is_ssi_recipient_for_medicaid: false
+    is_infant_for_medicaid: false
+    is_young_child_for_medicaid: false
+    is_older_child_for_medicaid: false
+    is_pregnant_for_medicaid: false
+    is_parent_for_medicaid: false
+    is_young_adult_for_medicaid: false
+    is_adult_for_medicaid: false
+    is_optional_senior_or_disabled_for_medicaid: true
+    is_medically_needy_for_medicaid: false
+    is_working_disabled_buy_in_for_medicaid: false
+    age: 45
+  output:
+    ms_hmw_other_coverage_ineligible: false
+
+- name: Case 3, person otherwise eligible for CHIP fails.
+  period: 2026
+  input:
+    state_code: MS
+    age: 10
+    medicaid_income_level: 1
+    has_esi: false
+    is_ssi_recipient_for_medicaid: false
+    is_infant_for_medicaid: false
+    is_young_child_for_medicaid: false
+    is_older_child_for_medicaid: false
+    is_pregnant_for_medicaid: false
+    is_parent_for_medicaid: false
+    is_young_adult_for_medicaid: false
+    is_adult_for_medicaid: false
+    is_optional_senior_or_disabled_for_medicaid: false
+    is_medically_needy_for_medicaid: false
+    is_working_disabled_buy_in_for_medicaid: false
+  output:
+    ms_hmw_other_coverage_ineligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.yaml
@@ -1,0 +1,53 @@
+- name: Case 1, individual resources below limit pass.
+  period: 2026
+  input:
+    state_code: MS
+    ssi_countable_resources: 3_999
+  output:
+    ms_hmw_resource_eligible: true
+
+- name: Case 2, individual resources at limit fail.
+  period: 2026
+  input:
+    state_code: MS
+    ssi_countable_resources: 4_000
+  output:
+    ms_hmw_resource_eligible: false
+
+- name: Case 3, joint tax unit resources below couple limit pass.
+  period: 2026
+  input:
+    people:
+      person1:
+        ssi_countable_resources: 2_999
+      person2:
+        ssi_countable_resources: 2_999
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+  output:
+    ms_hmw_resource_eligible: [true, true]
+
+- name: Case 4, joint tax unit resources at couple limit fail.
+  period: 2026
+  input:
+    people:
+      person1:
+        ssi_countable_resources: 3_000
+      person2:
+        ssi_countable_resources: 3_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+  output:
+    ms_hmw_resource_eligible: [false, false]

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.yaml
@@ -14,40 +14,98 @@
   output:
     ms_hmw_resource_eligible: false
 
-- name: Case 3, joint tax unit resources below couple limit pass.
+- name: Case 3, couple resources below couple limit pass.
   period: 2026
   input:
     people:
       person1:
+        age: 67
         ssi_countable_resources: 2_999
       person2:
+        age: 66
         ssi_countable_resources: 2_999
     households:
       household:
         members: [person1, person2]
         state_code: MS
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
     tax_units:
       tax_unit:
         members: [person1, person2]
-        tax_unit_is_joint: true
   output:
     ms_hmw_resource_eligible: [true, true]
 
-- name: Case 4, joint tax unit resources at couple limit fail.
+- name: Case 4, couple resources at couple limit fail.
   period: 2026
   input:
     people:
       person1:
+        age: 67
         ssi_countable_resources: 3_000
       person2:
+        age: 66
         ssi_countable_resources: 3_000
     households:
       household:
         members: [person1, person2]
         state_code: MS
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
     tax_units:
       tax_unit:
         members: [person1, person2]
-        tax_unit_is_joint: true
   output:
     ms_hmw_resource_eligible: [false, false]
+
+- name: Case 5, dependent resources do not count toward the applicant resource limit.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 67
+        ssi_countable_resources: 3_500
+      person2:
+        age: 10
+        ssi_countable_resources: 1_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+    marital_units:
+      marital_unit1:
+        members: [person1]
+      marital_unit2:
+        members: [person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    ms_hmw_resource_eligible: [true, true]
+
+- name: Case 6, spouse in a separate tax unit counts toward the couple resource limit.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 67
+        ssi_countable_resources: 4_500
+      person2:
+        age: 66
+        ssi_countable_resources: 1_499
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit1:
+        members: [person1]
+      tax_unit2:
+        members: [person2]
+  output:
+    ms_hmw_resource_eligible: [true, true]

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/integration.yaml
@@ -1,0 +1,102 @@
+- name: Case 1, disabled non-Medicare adult above standard ABD resource limit qualifies through HMW.
+  period: 2026
+  input:
+    age: 45
+    state_code: MS
+    is_ssi_disabled: true
+    is_pregnant: false
+    is_in_medicaid_facility: false
+    medicaid_optional_senior_or_disabled_countable_income: 13_500
+    tax_unit_fpg: 10_000
+    ssi_countable_resources: 3_999
+  output:
+    ms_hmw_eligible: true
+    medicaid_category: HEALTHIER_MISSISSIPPI_WAIVER
+    is_medicaid_eligible: true
+    medicaid_group: AGED_DISABLED
+
+- name: Case 2, individual at the resource limit does not qualify through HMW.
+  period: 2026
+  input:
+    age: 45
+    state_code: MS
+    is_ssi_disabled: true
+    is_pregnant: false
+    is_in_medicaid_facility: false
+    medicaid_optional_senior_or_disabled_countable_income: 13_500
+    tax_unit_fpg: 10_000
+    ssi_countable_resources: 4_000
+  output:
+    ms_hmw_eligible: false
+
+- name: Case 3, income above 135 percent of poverty does not qualify through HMW.
+  period: 2026
+  input:
+    age: 45
+    state_code: MS
+    is_ssi_disabled: true
+    is_pregnant: false
+    is_in_medicaid_facility: false
+    medicaid_optional_senior_or_disabled_countable_income: 13_501
+    tax_unit_fpg: 10_000
+    ssi_countable_resources: 3_999
+  output:
+    ms_hmw_eligible: false
+
+- name: Case 4, Medicare enrollee does not qualify through HMW.
+  period: 2026
+  input:
+    age: 67
+    state_code: MS
+    takes_up_medicare_if_eligible: true
+    is_ssi_disabled: true
+    is_pregnant: false
+    is_in_medicaid_facility: false
+    medicaid_optional_senior_or_disabled_countable_income: 13_500
+    tax_unit_fpg: 10_000
+    ssi_countable_resources: 3_999
+  output:
+    ms_hmw_eligible: false
+
+- name: Case 5, non-Medicare senior can qualify through HMW.
+  period: 2026
+  input:
+    age: 67
+    state_code: MS
+    takes_up_medicare_if_eligible: false
+    is_pregnant: false
+    is_in_medicaid_facility: false
+    medicaid_optional_senior_or_disabled_countable_income: 13_500
+    tax_unit_fpg: 10_000
+    ssi_countable_resources: 3_999
+  output:
+    ms_hmw_eligible: true
+
+- name: Case 6, pregnant disabled adult does not qualify through HMW.
+  period: 2026
+  input:
+    age: 45
+    state_code: MS
+    is_ssi_disabled: true
+    is_pregnant: true
+    is_in_medicaid_facility: false
+    medicaid_optional_senior_or_disabled_countable_income: 13_500
+    tax_unit_fpg: 10_000
+    ssi_countable_resources: 3_999
+  output:
+    ms_hmw_eligible: false
+
+- name: Case 7, person eligible under standard optional ABD Medicaid does not use HMW.
+  period: 2026
+  input:
+    age: 45
+    state_code: MS
+    is_ssi_disabled: true
+    is_pregnant: false
+    is_in_medicaid_facility: false
+    medicaid_optional_senior_or_disabled_countable_income: 5_000
+    tax_unit_fpg: 10_000
+    ssi_countable_resources: 1_500
+  output:
+    ms_hmw_eligible: false
+    ms_hmw_other_coverage_ineligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/integration.yaml
@@ -6,8 +6,7 @@
     is_ssi_disabled: true
     is_pregnant: false
     is_in_medicaid_facility: false
-    medicaid_optional_senior_or_disabled_countable_income: 13_500
-    tax_unit_fpg: 10_000
+    medicaid_optional_senior_or_disabled_countable_income: 21_546
     ssi_countable_resources: 3_999
   output:
     ms_hmw_eligible: true
@@ -23,8 +22,7 @@
     is_ssi_disabled: true
     is_pregnant: false
     is_in_medicaid_facility: false
-    medicaid_optional_senior_or_disabled_countable_income: 13_500
-    tax_unit_fpg: 10_000
+    medicaid_optional_senior_or_disabled_countable_income: 21_546
     ssi_countable_resources: 4_000
   output:
     ms_hmw_eligible: false
@@ -37,8 +35,7 @@
     is_ssi_disabled: true
     is_pregnant: false
     is_in_medicaid_facility: false
-    medicaid_optional_senior_or_disabled_countable_income: 13_501
-    tax_unit_fpg: 10_000
+    medicaid_optional_senior_or_disabled_countable_income: 21_547
     ssi_countable_resources: 3_999
   output:
     ms_hmw_eligible: false
@@ -52,7 +49,6 @@
     is_pregnant: false
     is_in_medicaid_facility: false
     medicaid_optional_senior_or_disabled_countable_income: 13_500
-    tax_unit_fpg: 10_000
     ssi_countable_resources: 3_999
   output:
     ms_hmw_eligible: false
@@ -66,7 +62,6 @@
     is_pregnant: false
     is_in_medicaid_facility: false
     medicaid_optional_senior_or_disabled_countable_income: 13_500
-    tax_unit_fpg: 10_000
     ssi_countable_resources: 3_999
   output:
     ms_hmw_eligible: false
@@ -80,7 +75,6 @@
     is_pregnant: true
     is_in_medicaid_facility: false
     medicaid_optional_senior_or_disabled_countable_income: 13_500
-    tax_unit_fpg: 10_000
     ssi_countable_resources: 3_999
   output:
     ms_hmw_eligible: false
@@ -94,7 +88,6 @@
     is_pregnant: false
     is_in_medicaid_facility: false
     medicaid_optional_senior_or_disabled_countable_income: 5_000
-    tax_unit_fpg: 10_000
     ssi_countable_resources: 1_500
   output:
     ms_hmw_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw/integration.yaml
@@ -43,12 +43,11 @@
   output:
     ms_hmw_eligible: false
 
-- name: Case 4, Medicare enrollee does not qualify through HMW.
+- name: Case 4, Medicare-eligible person does not qualify through HMW.
   period: 2026
   input:
     age: 67
     state_code: MS
-    takes_up_medicare_if_eligible: true
     is_ssi_disabled: true
     is_pregnant: false
     is_in_medicaid_facility: false
@@ -58,7 +57,7 @@
   output:
     ms_hmw_eligible: false
 
-- name: Case 5, non-Medicare senior can qualify through HMW.
+- name: Case 5, Medicare-eligible senior still fails HMW when not enrolled.
   period: 2026
   input:
     age: 67
@@ -70,7 +69,7 @@
     tax_unit_fpg: 10_000
     ssi_countable_resources: 3_999
   output:
-    ms_hmw_eligible: true
+    ms_hmw_eligible: false
 
 - name: Case 6, pregnant disabled adult does not qualify through HMW.
   period: 2026

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
@@ -41,6 +41,7 @@ class medicaid_group(Variable):
             | (cat == cats.SENIOR_OR_DISABLED)
             | (cat == cats.MEDICALLY_NEEDY)
             | (cat == cats.WORKING_DISABLED_BUY_IN)
+            | (cat == cats.HEALTHIER_MISSISSIPPI_WAIVER)
             | person("is_ssi_recipient_for_medicaid", period)
             | person("is_optional_senior_or_disabled_for_medicaid", period)
         )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
@@ -14,6 +14,7 @@ class MedicaidCategory(Enum):
     NONE = "None"
     MEDICALLY_NEEDY = "Medically needy"
     WORKING_DISABLED_BUY_IN = "Working disabled Buy-In"
+    HEALTHIER_MISSISSIPPI_WAIVER = "Healthier Mississippi Waiver"
 
 
 class medicaid_category(Variable):
@@ -74,6 +75,9 @@ class medicaid_category(Variable):
             for name, category in variable_to_category.items()
             if name in categories
         }
+        variable_to_category["ms_hmw_eligible"] = (
+            MedicaidCategory.HEALTHIER_MISSISSIPPI_WAIVER
+        )
 
         return select(
             [person(variable, period) for variable in variable_to_category.keys()],

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_demographic_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_demographic_eligible.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class ms_hmw_demographic_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Meets the Healthier Mississippi Waiver demographic eligibility rules"
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9",
+        "https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1",
+    )
+
+    def formula(person, period, parameters):
+        return (
+            person("is_ssi_aged_blind_disabled", period)
+            & ~person("is_pregnant", period)
+            & ~person("is_in_medicaid_facility", period.first_month)
+        )

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_eligible.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class ms_hmw_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for the Healthier Mississippi Waiver"
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9",
+        "https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1",
+        "https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5",
+    )
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.hmw
+        return (
+            p.in_effect
+            & person("ms_hmw_demographic_eligible", period)
+            & person("ms_hmw_non_medicare_eligible", period)
+            & person("ms_hmw_income_eligible", period)
+            & person("ms_hmw_resource_eligible", period)
+            & person("ms_hmw_other_coverage_ineligible", period)
+        )

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class ms_hmw_income_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Meets the Healthier Mississippi Waiver income eligibility rules"
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9",
+        "https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=2",
+        "https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5",
+    )
+
+    def formula(person, period, parameters):
+        personal_income = person(
+            "medicaid_optional_senior_or_disabled_countable_income", period
+        )
+        tax_unit = person.tax_unit
+        p = parameters(period).gov.states.ms.dom.hmw.income.limit
+        return tax_unit.sum(personal_income) <= p.rate * tax_unit(
+            "tax_unit_fpg", period
+        )

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_income_eligible.py
@@ -17,8 +17,13 @@ class ms_hmw_income_eligible(Variable):
         personal_income = person(
             "medicaid_optional_senior_or_disabled_countable_income", period
         )
-        tax_unit = person.tax_unit
-        p = parameters(period).gov.states.ms.dom.hmw.income.limit
-        return tax_unit.sum(personal_income) <= p.rate * tax_unit(
-            "tax_unit_fpg", period
+        marital_unit = person.marital_unit
+        couple = marital_unit.nb_persons() == 2
+        income = where(couple, marital_unit.sum(personal_income), personal_income)
+        state_group = person.household("state_group_str", period)
+        fpg = parameters(period).gov.hhs.fpg
+        unit_fpg = fpg.first_person[state_group] + (
+            couple * fpg.additional_person[state_group]
         )
+        p = parameters(period).gov.states.ms.dom.hmw.income.limit
+        return income <= p.rate * unit_fpg

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class ms_hmw_non_medicare_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Meets the Healthier Mississippi Waiver Medicare exclusion"
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9",
+        "https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5",
+        "https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1",
+    )
+
+    def formula(person, period, parameters):
+        return ~person("medicare_enrolled", period)

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_non_medicare_eligible.py
@@ -5,6 +5,11 @@ class ms_hmw_non_medicare_eligible(Variable):
     value_type = bool
     entity = Person
     label = "Meets the Healthier Mississippi Waiver Medicare exclusion"
+    documentation = (
+        "The Healthier Mississippi Waiver excludes people eligible for "
+        "Medicare. Use Medicare eligibility rather than Medicare enrollment "
+        "so Medicaid eligibility does not depend on modeled Medicare take-up."
+    )
     definition_period = YEAR
     defined_for = StateCode.MS
     reference = (
@@ -14,4 +19,4 @@ class ms_hmw_non_medicare_eligible(Variable):
     )
 
     def formula(person, period, parameters):
-        return ~person("medicare_enrolled", period)
+        return ~person("is_medicare_eligible", period)

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_other_coverage_ineligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_other_coverage_ineligible.py
@@ -1,0 +1,44 @@
+from policyengine_us.model_api import *
+
+
+class ms_hmw_other_coverage_ineligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Not otherwise eligible for Medicaid or CHIP under the Healthier Mississippi Waiver"
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9",
+        "https://medicaid.ms.gov/wp-content/uploads/2022/07/Healthier-Mississippi-Waiver-Full-Public-Notice-Website.pdf#page=2",
+    )
+
+    def formula(person, period, parameters):
+        other_coverage_categories = [
+            "is_ssi_recipient_for_medicaid",
+            "is_infant_for_medicaid",
+            "is_young_child_for_medicaid",
+            "is_older_child_for_medicaid",
+            "is_pregnant_for_medicaid",
+            "is_parent_for_medicaid",
+            "is_young_adult_for_medicaid",
+            "is_adult_for_medicaid",
+            "is_optional_senior_or_disabled_for_medicaid",
+            "is_medically_needy_for_medicaid",
+            "is_working_disabled_buy_in_for_medicaid",
+        ]
+        state_code = person.household("state_code", period)
+        age = person("age", period)
+        p = parameters(period).gov.hhs.chip.child
+        income_limit = p.income_limit[state_code]
+        istatus = person("immigration_status", period)
+        undocumented = istatus == istatus.possible_values.UNDOCUMENTED
+        potentially_chip_child_eligible = (
+            (age < p.max_age)
+            & (income_limit > 0)
+            & ~undocumented
+            & (person("medicaid_income_level", period) <= income_limit)
+            & ~person("has_esi", period)
+        )
+        return (add(person, period, other_coverage_categories) == 0) & (
+            ~potentially_chip_child_eligible
+        )

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class ms_hmw_resource_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Meets the Healthier Mississippi Waiver resource eligibility rules"
+    definition_period = YEAR
+    defined_for = StateCode.MS
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=9",
+        "https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1",
+        "https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5",
+    )
+
+    def formula(person, period, parameters):
+        tax_unit = person.tax_unit
+        resources = tax_unit.sum(person("ssi_countable_resources", period))
+        is_joint = tax_unit("tax_unit_is_joint", period)
+        p = parameters(period).gov.states.ms.dom.hmw.resources.limit
+        return resources < where(is_joint, p.couple, p.individual)

--- a/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/hmw/eligibility/ms_hmw_resource_eligible.py
@@ -14,8 +14,13 @@ class ms_hmw_resource_eligible(Variable):
     )
 
     def formula(person, period, parameters):
-        tax_unit = person.tax_unit
-        resources = tax_unit.sum(person("ssi_countable_resources", period))
-        is_joint = tax_unit("tax_unit_is_joint", period)
+        personal_resources = person("ssi_countable_resources", period)
+        marital_unit = person.marital_unit
+        couple = marital_unit.nb_persons() == 2
+        resources = where(
+            couple,
+            marital_unit.sum(personal_resources),
+            personal_resources,
+        )
         p = parameters(period).gov.states.ms.dom.hmw.resources.limit
-        return resources < where(is_joint, p.couple, p.individual)
+        return resources < where(couple, p.couple, p.individual)

--- a/sources/working_references.md
+++ b/sources/working_references.md
@@ -104,7 +104,7 @@ Downloaded PDFs, extracted text, and 300-DPI page renders are stored under `/tmp
 ## Requirement Notes
 
 - Eligibility group: aged, blind, or disabled individuals. The CMS STCs use "aged, blind, or disabled"; the state page/fact sheet emphasizes age 65+ or disability. Reuse `is_ssi_aged_blind_disabled`.
-- Medicare exclusion: sources use no Medicare / not Medicare eligible / not covered by or entitled to Medicare. PolicyEngine's `is_medicare_eligible` treats all age-65+ people as eligible, which would erase the aged-without-Medicare pathway. Use `medicare_enrolled` as the operational no-Medicare proxy and document this model choice.
+- Medicare exclusion: sources use no Medicare / not Medicare eligible / not covered by or entitled to Medicare. Use `is_medicare_eligible` rather than Medicare take-up so HMW eligibility does not change when modeled Medicare enrollment changes. This may understate eligibility for rare age-65+ people who are not actually entitled to Medicare until PolicyEngine has a narrower Medicare entitlement input.
 - Pregnancy exclusion: state page and fact sheet say pregnant people cannot qualify. Use `is_pregnant`.
 - Long-term care institution exclusion: CMS STCs exclude inpatients in long-term care institutions. Use `is_in_medicaid_facility` as available proxy.
 - Income: at or below 135% FPL for the individual/couple, using SSI-based methodology and state-plan exclusions. Reuse `medicaid_optional_senior_or_disabled_countable_income` and the applicant's `marital_unit` so spouses in separate tax units are still counted and dependents do not expand the limit.

--- a/sources/working_references.md
+++ b/sources/working_references.md
@@ -59,3 +59,55 @@ Downloaded PDFs, extracted text, and 300-DPI page renders are stored under `/tmp
 - Allocations to ineligible children.
 - Student earned income, impairment-related work expenses, blind work expenses, PASS, and infrequent/irregular income exclusions.
 - Mississippi-specific second-vehicle, income-producing property, personal-property, and life-insurance resource exclusions beyond existing `ssi_countable_resources` inputs.
+
+# Healthier Mississippi Waiver Working References
+
+## Official Program Name
+
+**Federal Program**: Medicaid section 1115 demonstration
+**State's Official Name**: Healthier Mississippi Waiver
+**Abbreviation**: HMW
+**Source**: Mississippi Division of Medicaid, Healthier Mississippi Waiver page
+**Variable Prefix**: `ms_hmw`
+
+## Official Sources
+
+1. Mississippi Division of Medicaid, Healthier Mississippi Waiver page.
+   - URL: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/healthier-mississippi-waiver/
+   - Key points: enrollment began January 1, 2006; cap is 6,000; eligibility includes age 65 or older or disabled under SSI rules, no Medicare, not pregnant; income no more than 135% FPL; resources below $4,000 individual / $6,000 couple; excluded benefits include long-term care, swing bed, and maternity/newborn care.
+
+2. Mississippi Division of Medicaid, Healthier Mississippi Waiver Fact Sheet 2026.
+   - URL: https://medicaid.ms.gov/wp-content/uploads/2026/02/HMW-Fact-Sheet-2026.pdf#page=1
+   - Relevant pages:
+     - #page=1: enrollment start date, cap, Medicare exclusion, age/disability/pregnancy rules, 135% FPL rule, resource exclusions and countable resources.
+     - #page=2: 2026 monthly income examples, couple income rule, covered service exclusions, application instructions.
+
+3. Centers for Medicare & Medicaid Services / Mississippi Division of Medicaid, Healthier Mississippi Extension, approved September 24, 2024.
+   - URL: https://medicaid.ms.gov/wp-content/uploads/2024/09/Healthier-Mississippi-Extension.pdf#page=1
+   - Relevant pages:
+     - #page=1: expenditure authority for aged, blind, or disabled individuals at or below 135% FPL, not Medicare-eligible, and not otherwise Medicaid state plan eligible.
+     - #page=3: demonstration history and extension through September 30, 2029 with no programmatic changes.
+     - #page=9: eligibility rule, SSI-based income methodology, $4,000/$6,000 resource limits, enrollment cap, and benefit exclusions.
+
+4. Mississippi Division of Medicaid, Member Coverage Descriptions Job Aid, April 3, 2024.
+   - URL: https://medicaid.ms.gov/wp-content/uploads/2024/04/20240403_MES_Gainwell_PRP-101_Member-Coverage-Description-Job_Aid_v0.1.pdf#page=5
+   - Relevant pages:
+     - #page=5: COE 045, "PLAD Healthier MS Waiver - no Medicare"; income up to 135% of poverty; aged or disabled; not eligible for Medicare; $4,000/$6,000 resource test; benefit exclusions.
+
+5. Mississippi Division of Medicaid, Healthier Mississippi Waiver Full Public Notice, July 19, 2022.
+   - URL: https://medicaid.ms.gov/wp-content/uploads/2022/07/Healthier-Mississippi-Waiver-Full-Public-Notice-Website.pdf#page=1
+   - Relevant pages:
+     - #page=1: renewal requested no changes; HMW operated since 2006.
+     - #page=2: statewide operation, over 65 or SSI disability, no Medicare, income below 135% FPL, resources under $4,000/$6,000, not otherwise eligible for Medicaid/CHIP/other waiver, MAGI note, and benefit exclusions.
+     - #page=3: enrollment cap and waiting list process.
+
+## Requirement Notes
+
+- Eligibility group: aged, blind, or disabled individuals. The CMS STCs use "aged, blind, or disabled"; the state page/fact sheet emphasizes age 65+ or disability. Reuse `is_ssi_aged_blind_disabled`.
+- Medicare exclusion: sources use no Medicare / not Medicare eligible / not covered by or entitled to Medicare. PolicyEngine's `is_medicare_eligible` treats all age-65+ people as eligible, which would erase the aged-without-Medicare pathway. Use `medicare_enrolled` as the operational no-Medicare proxy and document this model choice.
+- Pregnancy exclusion: state page and fact sheet say pregnant people cannot qualify. Use `is_pregnant`.
+- Long-term care institution exclusion: CMS STCs exclude inpatients in long-term care institutions. Use `is_in_medicaid_facility` as available proxy.
+- Income: at or below 135% FPL for the individual/couple, using SSI-based methodology and state-plan exclusions. Reuse `medicaid_optional_senior_or_disabled_countable_income` and the applicant's `marital_unit` so spouses in separate tax units are still counted and dependents do not expand the limit.
+- Resources: below $4,000 individual / $6,000 couple. Reuse `ssi_countable_resources` and the applicant's `marital_unit` to match the individual/couple HMW standard.
+- Not otherwise eligible: HMW is for people not otherwise eligible for Medicaid state plan, CHIP, or other waiver. Explicitly check existing Medicaid category variables; use a non-circular CHIP child proxy because PolicyEngine's `is_chip_eligible` depends on `is_medicaid_eligible`.
+- Enrollment cap: cap is 6,000; allocation/waiting list is not mechanically simulated because PolicyEngine does not have a deterministic slot assignment or current HMW enrollment variable.


### PR DESCRIPTION
## Summary

Fixes PolicyEngine/policyengine-us#8442 by modeling Mississippi's Healthier Mississippi Waiver (HMW) Medicaid eligibility pathway.

## Regulatory authority

- Mississippi Division of Medicaid HMW page and 2026 fact sheet.
- CMS Healthier Mississippi Extension approved September 24, 2024, extending the section 1115 demonstration through September 30, 2029.
- Mississippi member coverage job aid COE 045, "PLAD Healthier MS Waiver - no Medicare."

## Eligibility modeled

- Mississippi resident, via `defined_for = StateCode.MS`.
- Aged, blind, or disabled, using existing SSI categorical status.
- Not enrolled in Medicare. This uses `medicare_enrolled` as the operational proxy so age-65+ people not actually enrolled in Medicare can still qualify.
- Not pregnant.
- Not in a Medicaid facility / long-term care proxy.
- Countable income at or below 135% FPL, reusing optional ABD Medicaid countable income.
- Countable resources below $4,000 individual / $6,000 couple, reusing SSI countable resources.
- Not otherwise eligible for modeled Medicaid categories or CHIP. CHIP is checked with a non-circular child proxy because `is_chip_eligible` depends on `is_medicaid_eligible`.

## Requirements coverage

| Requirement | Coverage |
|---|---|
| Active since 2006 | `gov.states.ms.dom.hmw.in_effect`, `ms_hmw_eligible.yaml` |
| Aged/blind/disabled | `ms_hmw_demographic_eligible` |
| No Medicare | `ms_hmw_non_medicare_eligible` |
| Pregnancy and facility exclusions | `ms_hmw_demographic_eligible` |
| Income <= 135% FPL | `ms_hmw_income_eligible` |
| Resources < $4,000/$6,000 | `ms_hmw_resource_eligible` |
| Not otherwise Medicaid/CHIP eligible | `ms_hmw_other_coverage_ineligible` |
| Medicaid category/cost group | `medicaid_category`, `medicaid_group` |

## Not modeled

- The 6,000-person enrollment cap and waiting-list allocation are documented as a parameter but do not gate eligibility.
- HMW service-package exclusions are documented but not separately costed because PolicyEngine's Medicaid cost model does not split services by waiver package.

## Tests

- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ms/dom/hmw -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_category.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml -c policyengine_us`
- `make format`
