### PR TITLE
Model Mississippi Working Disabled Medicaid buy-in pathway

### DIFF
--- a/changelog.d/added/8441.md
+++ b/changelog.d/added/8441.md
@@ -1,0 +1,1 @@
+Added the Mississippi Working Disabled Medicaid buy-in pathway.

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/README.md
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/README.md
@@ -1,0 +1,6 @@
+# Mississippi Working Disabled (WD)
+
+Mississippi's Working Disabled program is a Medicaid Buy-In pathway for disabled workers.
+It uses an individual/couple budget, separate earned and unearned income tests, a higher
+resource limit than SSI, and a premium for countable earnings above 150% of the federal
+poverty level.

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/exclusions/earned/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/exclusions/earned/amount.yaml
@@ -1,0 +1,13 @@
+description: Mississippi excludes this amount from countable earned income under the Working Disabled program.
+values:
+  1999-07-01: 65
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Mississippi Working Disabled earned income exclusion
+  reference:
+    - title: Mississippi Division of Medicaid Administrative Code Part 104, Income
+      href: https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=23
+    - title: Mississippi Division of Medicaid Administrative Code Part 104, Income
+      href: https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=24

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/exclusions/earned/remainder_disregard.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/exclusions/earned/remainder_disregard.yaml
@@ -1,0 +1,11 @@
+description: Mississippi excludes this share of remaining earned income under the Working Disabled program.
+values:
+  1999-07-01: 0.5
+
+metadata:
+  unit: /1
+  period: month
+  label: Mississippi Working Disabled earned income remainder exclusion
+  reference:
+    - title: Mississippi Division of Medicaid Administrative Code Part 104, Income
+      href: https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=24

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/exclusions/general.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/exclusions/general.yaml
@@ -1,0 +1,13 @@
+description: Mississippi excludes this amount from countable unearned income under the Working Disabled program.
+values:
+  1999-07-01: 50
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Mississippi Working Disabled general income exclusion
+  reference:
+    - title: Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, Working Disabled
+      href: https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32
+    - title: Mississippi Division of Medicaid Administrative Code Part 104, Income
+      href: https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=23

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/limit/earned.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/limit/earned.yaml
@@ -1,0 +1,13 @@
+description: Mississippi limits countable earned income to this share of the federal poverty level under the Working Disabled program.
+values:
+  1999-07-01: 2.5
+
+metadata:
+  unit: /1
+  period: month
+  label: Mississippi Working Disabled earned income limit
+  reference:
+    - title: Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, Working Disabled
+      href: https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32
+    - title: Mississippi Division of Medicaid, Working Disabled
+      href: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/limit/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/limit/unearned.yaml
@@ -1,0 +1,13 @@
+description: Mississippi limits countable unearned income to this share of the federal poverty level under the Working Disabled program.
+values:
+  1999-07-01: 1.35
+
+metadata:
+  unit: /1
+  period: month
+  label: Mississippi Working Disabled unearned income limit
+  reference:
+    - title: Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, Working Disabled
+      href: https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32
+    - title: Mississippi Division of Medicaid, Working Disabled
+      href: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/sources/earned.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/sources/earned.yaml
@@ -1,0 +1,14 @@
+description: Mississippi counts these income sources as earned income under the Working Disabled program.
+values:
+  1999-07-01:
+    - employment_income
+    - self_employment_income
+    - sstb_self_employment_income
+
+metadata:
+  unit: list
+  period: year
+  label: Mississippi Working Disabled earned income sources
+  reference:
+    - title: Mississippi Division of Medicaid Administrative Code Part 104, Income
+      href: https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=20

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/income/sources/unearned.yaml
@@ -1,0 +1,28 @@
+description: Mississippi counts these income sources as unearned income under the Working Disabled program.
+values:
+  1999-07-01:
+    - pension_income
+    - social_security
+    - disability_benefits
+    - veterans_benefits
+    - survivor_benefits
+    - workers_compensation
+    - unemployment_compensation
+    - retirement_distributions
+    - gi_cash_assistance
+    - alimony_income
+    - child_support_received
+    - financial_assistance
+    - dividend_income
+    - interest_income
+    - rental_income
+
+metadata:
+  unit: list
+  period: year
+  label: Mississippi Working Disabled unearned income sources
+  reference:
+    - title: Mississippi Division of Medicaid Administrative Code Part 104, Income
+      href: https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=8
+    - title: Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, Working Disabled
+      href: https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/resources/limit/couple.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/resources/limit/couple.yaml
@@ -1,0 +1,13 @@
+description: Mississippi limits couple resources to this amount under the Working Disabled program.
+values:
+  1999-07-01: 26_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: Mississippi Working Disabled couple resource limit
+  reference:
+    - title: Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, Working Disabled
+      href: https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=31
+    - title: Mississippi Division of Medicaid, Working Disabled
+      href: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/resources/limit/individual.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/resources/limit/individual.yaml
@@ -1,0 +1,13 @@
+description: Mississippi limits individual resources to this amount under the Working Disabled program.
+values:
+  1999-07-01: 24_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: Mississippi Working Disabled individual resource limit
+  reference:
+    - title: Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, Working Disabled
+      href: https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=31
+    - title: Mississippi Division of Medicaid, Working Disabled
+      href: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/work/monthly_hours.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/eligibility/work/monthly_hours.yaml
@@ -1,0 +1,13 @@
+description: Mississippi limits monthly paid work to this threshold under the Working Disabled program.
+values:
+  1999-07-01: 40
+
+metadata:
+  unit: hour
+  period: month
+  label: Mississippi Working Disabled monthly work hours
+  reference:
+    - title: Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, Working Disabled
+      href: https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=30
+    - title: Mississippi Division of Medicaid, Working Disabled
+      href: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/premium/fpl_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/premium/fpl_threshold.yaml
@@ -1,0 +1,13 @@
+description: Mississippi sets the premium threshold to this share of the federal poverty level under the Working Disabled program.
+values:
+  1999-07-01: 1.5
+
+metadata:
+  unit: /1
+  period: month
+  label: Mississippi Working Disabled premium FPL threshold
+  reference:
+    - title: Mississippi Division of Medicaid, Appendix A-5 Sliding Scale for Working Disabled Premiums
+      href: https://medicaid.ms.gov/wp-content/uploads/2026/03/Appendix-A-5-WD-Premiums-for-March-2026.pdf#page=3
+    - title: Mississippi Division of Medicaid, Working Disabled
+      href: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/

--- a/policyengine_us/parameters/gov/states/ms/dom/wd/premium/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ms/dom/wd/premium/rate.yaml
@@ -1,0 +1,13 @@
+description: Mississippi sets the premium to this share of countable earned income under the Working Disabled program.
+values:
+  1999-07-01: 0.05
+
+metadata:
+  unit: /1
+  period: month
+  label: Mississippi Working Disabled premium rate
+  reference:
+    - title: Mississippi Division of Medicaid, Appendix A-5 Sliding Scale for Working Disabled Premiums
+      href: https://medicaid.ms.gov/wp-content/uploads/2026/03/Appendix-A-5-WD-Premiums-for-March-2026.pdf#page=3
+    - title: Mississippi Division of Medicaid, Working Disabled
+      href: https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -1050,6 +1050,17 @@ programs:
     parameter_prefix: gov.states.il.hfs.hbwd
     notes: Medicaid buy-in program for workers with disabilities
 
+  - id: ms_wd
+    name: Mississippi WD
+    full_name: Mississippi Working Disabled
+    category: Healthcare
+    agency: State
+    status: complete
+    coverage: MS
+    variable: ms_wd_eligible
+    parameter_prefix: gov.states.ms.dom.wd
+    notes: Medicaid buy-in program for workers with disabilities
+
   - id: il_ihwap
     name: Illinois IHWAP
     full_name: Illinois Home Weatherization Assistance Program

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.yaml
@@ -11,3 +11,16 @@
     ca_wdp_eligible: false
   output:
     is_working_disabled_buy_in_for_medicaid: false
+
+- name: Case 3, Mississippi WD qualifies as working disabled Buy-In.
+  period: 2026
+  input:
+    state_code: MS
+    age: 40
+    is_disabled: true
+    monthly_hours_worked: 40
+    employment_income: 49_380
+    ssi_countable_resources: 23_000
+    is_medicaid_immigration_status_eligible: true
+  output:
+    is_working_disabled_buy_in_for_medicaid: true

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.yaml
@@ -31,3 +31,14 @@
     social_security_disability: 0
   output:
     ms_wd_disability_eligible: false
+
+- name: Case 5, broad disability flag alone does not satisfy the SSA disability screen.
+  period: 2026-01
+  input:
+    state_code: MS
+    is_disabled: true
+    meets_ssi_disability_criteria: false
+    is_blind: false
+    social_security_disability: 0
+  output:
+    ms_wd_disability_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.yaml
@@ -1,0 +1,33 @@
+- name: Case 1, disabled person meets the disability test.
+  period: 2026-01
+  input:
+    state_code: MS
+    is_disabled: true
+  output:
+    ms_wd_disability_eligible: true
+
+- name: Case 2, blind person meets the disability test.
+  period: 2026-01
+  input:
+    state_code: MS
+    is_blind: true
+  output:
+    ms_wd_disability_eligible: true
+
+- name: Case 3, person receiving Social Security disability meets the disability test.
+  period: 2026-01
+  input:
+    state_code: MS
+    social_security_disability: 12_000
+  output:
+    ms_wd_disability_eligible: true
+
+- name: Case 4, person without modeled disability indicators fails the disability test.
+  period: 2026-01
+  input:
+    state_code: MS
+    is_disabled: false
+    is_blind: false
+    social_security_disability: 0
+  output:
+    ms_wd_disability_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_earned_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_earned_income_eligible.yaml
@@ -1,0 +1,36 @@
+- name: Case 1, individual at the earned income threshold qualifies.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_countable_earned_income: 3_325
+  output:
+    # 2026 monthly FPL: $1,330; 250% = $3,325.
+    ms_wd_earned_income_eligible: true
+
+- name: Case 2, individual just above the earned income threshold is ineligible.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_countable_earned_income: 3_325.01
+  output:
+    ms_wd_earned_income_eligible: false
+
+- name: Case 3, couple at the earned income threshold qualifies.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        ms_wd_countable_earned_income: 4_508.33
+      person2:
+        ms_wd_countable_earned_income: 4_508.33
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+  output:
+    # 2026 couple monthly FPL: $1,803.33; 250% = $4,508.33.
+    ms_wd_earned_income_eligible: [true, true]

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_eligible.yaml
@@ -1,0 +1,35 @@
+- name: Case 1, all eligibility components pass.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_work_eligible: true
+    ms_wd_disability_eligible: true
+    ms_wd_income_eligible: true
+    ms_wd_resource_eligible: true
+    is_medicaid_immigration_status_eligible: true
+  output:
+    ms_wd_eligible: true
+
+- name: Case 2, immigration ineligibility fails WD eligibility.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_work_eligible: true
+    ms_wd_disability_eligible: true
+    ms_wd_income_eligible: true
+    ms_wd_resource_eligible: true
+    is_medicaid_immigration_status_eligible: false
+  output:
+    ms_wd_eligible: false
+
+- name: Case 3, failing work test fails WD eligibility.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_work_eligible: false
+    ms_wd_disability_eligible: true
+    ms_wd_income_eligible: true
+    ms_wd_resource_eligible: true
+    is_medicaid_immigration_status_eligible: true
+  output:
+    ms_wd_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_income_eligible.yaml
@@ -1,0 +1,26 @@
+- name: Case 1, both earned and unearned tests pass.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_earned_income_eligible: true
+    ms_wd_unearned_income_eligible: true
+  output:
+    ms_wd_income_eligible: true
+
+- name: Case 2, failing earned income fails overall income.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_earned_income_eligible: false
+    ms_wd_unearned_income_eligible: true
+  output:
+    ms_wd_income_eligible: false
+
+- name: Case 3, failing unearned income fails overall income.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_earned_income_eligible: true
+    ms_wd_unearned_income_eligible: false
+  output:
+    ms_wd_income_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_resource_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_resource_eligible.yaml
@@ -1,0 +1,51 @@
+- name: Case 1, individual at the resource limit qualifies.
+  period: 2026-01
+  input:
+    state_code: MS
+    ssi_countable_resources: 24_000
+  output:
+    ms_wd_resource_eligible: true
+
+- name: Case 2, individual above the resource limit is ineligible.
+  period: 2026-01
+  input:
+    state_code: MS
+    ssi_countable_resources: 24_001
+  output:
+    ms_wd_resource_eligible: false
+
+- name: Case 3, couple at the resource limit qualifies.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        ssi_countable_resources: 20_000
+      person2:
+        ssi_countable_resources: 6_000
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+  output:
+    ms_wd_resource_eligible: [true, true]
+
+- name: Case 4, couple above the resource limit is ineligible.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        ssi_countable_resources: 20_000
+      person2:
+        ssi_countable_resources: 6_001
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+  output:
+    ms_wd_resource_eligible: [false, false]

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_unearned_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_unearned_income_eligible.yaml
@@ -1,0 +1,16 @@
+- name: Case 1, individual at the unearned income threshold qualifies.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_countable_unearned_income: 1_795.50
+  output:
+    # 2026 monthly FPL: $1,330; 135% = $1,795.50.
+    ms_wd_unearned_income_eligible: true
+
+- name: Case 2, individual just above the unearned income threshold is ineligible.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_countable_unearned_income: 1_795.51
+  output:
+    ms_wd_unearned_income_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_work_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility/ms_wd_work_eligible.yaml
@@ -1,0 +1,15 @@
+- name: Case 1, forty monthly hours meets the work test.
+  period: 2026-01
+  input:
+    state_code: MS
+    monthly_hours_worked: 40
+  output:
+    ms_wd_work_eligible: true
+
+- name: Case 2, thirty-nine monthly hours fails the work test.
+  period: 2026-01
+  input:
+    state_code: MS
+    monthly_hours_worked: 39
+  output:
+    ms_wd_work_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/income/ms_wd_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/income/ms_wd_countable_earned_income.yaml
@@ -1,0 +1,48 @@
+- name: Case 1, no unearned income leaves the general exclusion for earnings.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_gross_earned_income: 4_115
+    ms_wd_gross_unearned_income: 0
+  output:
+    # ($4,115 - $50 general - $65 earned) * 50% = $2,000.
+    ms_wd_countable_earned_income: 2_000
+
+- name: Case 2, unearned income uses the general exclusion before earnings.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_gross_earned_income: 4_065
+    ms_wd_gross_unearned_income: 100
+  output:
+    # ($4,065 - $65 earned) * 50% = $2,000.
+    ms_wd_countable_earned_income: 2_000
+
+- name: Case 3, low earned income floors at zero after exclusions.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_gross_earned_income: 60
+    ms_wd_gross_unearned_income: 0
+  output:
+    ms_wd_countable_earned_income: 0
+
+- name: Case 4, partial unearned income leaves part of the general exclusion for earnings.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_gross_earned_income: 115
+    ms_wd_gross_unearned_income: 30
+  output:
+    # Remaining general exclusion is $20, then ($115 - $20 - $65) * 50% = $15.
+    ms_wd_countable_earned_income: 15
+
+- name: Case 5, negative unearned income does not increase the general exclusion.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_gross_earned_income: 200
+    ms_wd_gross_unearned_income: -100
+  output:
+    # ($200 - $50 general exclusion - $65 earned exclusion) * 50% = $42.50.
+    ms_wd_countable_earned_income: 42.50

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/income/ms_wd_countable_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/income/ms_wd_countable_unearned_income.yaml
@@ -1,0 +1,15 @@
+- name: Case 1, unearned income excludes the first fifty dollars.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_gross_unearned_income: 100
+  output:
+    ms_wd_countable_unearned_income: 50
+
+- name: Case 2, unearned income below the general exclusion floors at zero.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_gross_unearned_income: 25
+  output:
+    ms_wd_countable_unearned_income: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/integration.yaml
@@ -1,0 +1,131 @@
+- name: Case 1, single disabled worker qualifies and pays a premium.
+  period: 2026-01
+  input:
+    state_code: MS
+    age: 40
+    is_disabled: true
+    monthly_hours_worked: 40
+    employment_income: 49_380
+    ssi_countable_resources: 23_000
+    is_medicaid_immigration_status_eligible: true
+  output:
+    # Monthly earnings: $4,115.
+    # Countable earnings: ($4,115 - $50 - $65) * 50% = $2,000.
+    ms_wd_gross_earned_income: 4_115
+    ms_wd_countable_earned_income: 2_000
+    ms_wd_earned_income_eligible: true
+    ms_wd_unearned_income_eligible: true
+    ms_wd_resource_eligible: true
+    ms_wd_eligible: true
+    ms_wd_premium: 100
+
+- name: Case 2, disabled worker below forty monthly hours is ineligible.
+  period: 2026-01
+  input:
+    state_code: MS
+    age: 40
+    is_disabled: true
+    monthly_hours_worked: 39
+    employment_income: 36_000
+    ssi_countable_resources: 1_000
+    is_medicaid_immigration_status_eligible: true
+  output:
+    ms_wd_work_eligible: false
+    ms_wd_eligible: false
+
+- name: Case 3, disabled worker above the individual resource limit is ineligible.
+  period: 2026-01
+  input:
+    state_code: MS
+    age: 40
+    is_disabled: true
+    monthly_hours_worked: 40
+    employment_income: 36_000
+    ssi_countable_resources: 24_001
+    is_medicaid_immigration_status_eligible: true
+  output:
+    ms_wd_resource_eligible: false
+    ms_wd_eligible: false
+
+- name: Case 4, earned income just above two hundred fifty percent FPL is ineligible.
+  period: 2026-01
+  input:
+    state_code: MS
+    age: 40
+    is_disabled: true
+    monthly_hours_worked: 40
+    employment_income: 81_192
+    ssi_countable_resources: 1_000
+    is_medicaid_immigration_status_eligible: true
+  output:
+    # Monthly earnings: $6,766; countable earnings: ($6,766 - $115) * 50% = $3,325.50.
+    ms_wd_countable_earned_income: 3_325.50
+    ms_wd_earned_income_eligible: false
+    ms_wd_eligible: false
+
+- name: Case 5, unearned income just above one hundred thirty-five percent FPL is ineligible.
+  period: 2026-01
+  input:
+    state_code: MS
+    age: 40
+    is_disabled: true
+    monthly_hours_worked: 40
+    employment_income: 12_000
+    social_security: 22_152
+    ssi_countable_resources: 1_000
+    is_medicaid_immigration_status_eligible: true
+  output:
+    # Monthly unearned income: $1,846; countable unearned income: $1,796.
+    ms_wd_countable_unearned_income: 1_796
+    ms_wd_unearned_income_eligible: false
+    ms_wd_eligible: false
+
+- name: Case 6, married worker budgets an ineligible spouse and qualifies under couple limits.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 45
+        is_disabled: true
+        monthly_hours_worked: 40
+        employment_income: 48_000
+        ssi_countable_resources: 20_000
+        is_medicaid_immigration_status_eligible: true
+      person2:
+        age: 43
+        social_security: 1_200
+        ssi_countable_resources: 5_000
+        is_medicaid_immigration_status_eligible: true
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+  output:
+    # Spouse's $100/month unearned income uses the general exclusion.
+    # Countable earnings: ($4,000 - $65) * 50% = $1,967.50.
+    ms_wd_countable_earned_income: [1_967.50, 1_967.50]
+    ms_wd_countable_unearned_income: [50, 50]
+    ms_wd_income_eligible: [true, true]
+    ms_wd_resource_eligible: [true, true]
+    ms_wd_eligible: [true, false]
+    ms_wd_premium: [0, 0]
+
+- name: Case 7, negative earned income is floored before income eligibility.
+  period: 2026-01
+  input:
+    state_code: MS
+    age: 40
+    is_disabled: true
+    monthly_hours_worked: 40
+    employment_income: -1_200
+    ssi_countable_resources: 1_000
+    is_medicaid_immigration_status_eligible: true
+  output:
+    ms_wd_gross_earned_income: -100
+    ms_wd_countable_earned_income: 0
+    ms_wd_income_eligible: true
+    ms_wd_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/ms_wd_fpg.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/ms_wd_fpg.yaml
@@ -1,0 +1,25 @@
+- name: Case 1, single person uses individual monthly FPL.
+  period: 2026-01
+  input:
+    state_code: MS
+  output:
+    ms_wd_fpg: 1_330
+
+- name: Case 2, married couple uses couple monthly FPL.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+      person2:
+        age: 38
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+  output:
+    ms_wd_fpg: [1_803.33, 1_803.33]

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/ms_wd_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/ms_wd_premium.yaml
@@ -1,0 +1,49 @@
+- name: Case 1, countable earned income at the premium threshold owes no premium.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_eligible: true
+    ms_wd_countable_earned_income: 1_995
+  output:
+    # 2026 monthly FPL: $1,330; 150% = $1,995.
+    ms_wd_premium: 0
+
+- name: Case 2, countable earned income above the threshold pays five percent rounded down.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_eligible: true
+    ms_wd_countable_earned_income: 2_000
+  output:
+    # floor($2,000 * 5%) = $100.
+    ms_wd_premium: 100
+
+- name: Case 3, ineligible person owes no premium.
+  period: 2026-01
+  input:
+    state_code: MS
+    ms_wd_eligible: false
+    ms_wd_countable_earned_income: 2_000
+  output:
+    ms_wd_premium: 0
+
+- name: Case 4, eligible couple splits one marital-unit premium across eligible spouses.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        ms_wd_eligible: true
+        ms_wd_countable_earned_income: 3_000
+      person2:
+        ms_wd_eligible: true
+        ms_wd_countable_earned_income: 3_000
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MS
+  output:
+    # floor($3,000 * 5%) = $150 total; $75 assigned to each eligible spouse.
+    ms_wd_premium: [75, 75]

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.py
@@ -8,16 +8,18 @@ class is_working_disabled_buy_in_for_medicaid(Variable):
     documentation = (
         "Whether this person qualifies for Medicaid through a working disabled "
         "Buy-In pathway. Currently modeled pathways are California's 250% "
-        "Working Disabled Program and Illinois Health Benefits for Workers "
-        "with Disabilities."
+        "Working Disabled Program, Illinois Health Benefits for Workers "
+        "with Disabilities, and Mississippi's Working Disabled program."
     )
     definition_period = YEAR
     reference = (
         "https://www.dhcs.ca.gov/services/working-disabled-program/",
         "https://hfs.illinois.gov/medicalprograms/hbwd.html",
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
     )
 
     def formula(person, period, parameters):
         ca_wdp_eligible = person("ca_wdp_eligible", period)
         il_hbwd_eligible = person("il_hbwd_eligible", period.first_month)
-        return ca_wdp_eligible | il_hbwd_eligible
+        ms_wd_eligible = person("ms_wd_eligible", period.first_month)
+        return ca_wdp_eligible | il_hbwd_eligible | ms_wd_eligible

--- a/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium.py
@@ -10,6 +10,7 @@ class medicaid_working_disabled_buy_in_premium(Variable):
     reference = (
         "https://www.dhcs.ca.gov/services/working-disabled-program/",
         "https://hfs.illinois.gov/medicalprograms/hbwd/premiums.html",
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
     )
 
     def formula(tax_unit, period, parameters):

--- a/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium_person.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium_person.py
@@ -10,9 +10,11 @@ class medicaid_working_disabled_buy_in_premium_person(Variable):
     reference = (
         "https://www.dhcs.ca.gov/services/working-disabled-program/",
         "https://hfs.illinois.gov/medicalprograms/hbwd/premiums.html",
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
     )
 
     adds = [
         "ca_wdp_premium",
         "il_hbwd_premium",
+        "ms_wd_premium",
     ]

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.py
@@ -13,7 +13,9 @@ class ms_wd_disability_eligible(Variable):
     defined_for = StateCode.MS
 
     def formula(person, period, parameters):
-        is_disabled = person("is_disabled", period.this_year)
+        meets_ssi_disability_criteria = person(
+            "meets_ssi_disability_criteria", period.this_year
+        )
         is_blind = person("is_blind", period.this_year)
         receives_ssdi = person("social_security_disability", period) > 0
-        return is_disabled | is_blind | receives_ssdi
+        return meets_ssi_disability_criteria | is_blind | receives_ssdi

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_disability_eligible.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_disability_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Mississippi Working Disabled disability eligible"
+    definition_period = MONTH
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=31",
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
+    )
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        is_disabled = person("is_disabled", period.this_year)
+        is_blind = person("is_blind", period.this_year)
+        receives_ssdi = person("social_security_disability", period) > 0
+        return is_disabled | is_blind | receives_ssdi

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_earned_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_earned_income_eligible.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_earned_income_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Mississippi Working Disabled earned income eligible"
+    definition_period = MONTH
+    reference = "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32"
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.wd.eligibility.income
+        countable_earned_income = person("ms_wd_countable_earned_income", period)
+        return countable_earned_income <= person("ms_wd_fpg", period) * p.limit.earned

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_eligible.py
@@ -1,0 +1,33 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Mississippi Working Disabled eligible"
+    definition_period = MONTH
+    documentation = (
+        "Eligibility for Mississippi's Working Disabled Medicaid Buy-In "
+        "pathway. The model covers paid work of at least 40 monthly hours, "
+        "disability without an SGA screen, marital-unit earned and unearned "
+        "income tests, the higher WD resource limit, and Medicaid immigration "
+        "status. Premium billing, retroactive-month processes, child "
+        "allocations, and specialized income/resource exclusions lacking "
+        "PolicyEngine inputs are not modeled."
+    )
+    reference = (
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
+        "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=30",
+        "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=31",
+        "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32",
+    )
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        return (
+            person("ms_wd_work_eligible", period)
+            & person("ms_wd_disability_eligible", period)
+            & person("ms_wd_income_eligible", period)
+            & person("ms_wd_resource_eligible", period)
+            & person("is_medicaid_immigration_status_eligible", period.this_year)
+        )

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_income_eligible.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_income_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Mississippi Working Disabled income eligible"
+    definition_period = MONTH
+    reference = "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32"
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        return person("ms_wd_earned_income_eligible", period) & person(
+            "ms_wd_unearned_income_eligible", period
+        )

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_resource_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_resource_eligible.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_resource_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Mississippi Working Disabled resource eligible"
+    definition_period = MONTH
+    documentation = (
+        "Uses modeled SSI countable resources with Mississippi's higher WD "
+        "individual and couple limits. Mississippi-specific second-vehicle, "
+        "personal-property, life-insurance, and income-producing property "
+        "exemptions are not separately modeled."
+    )
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=31",
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
+    )
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.wd.eligibility.resources.limit
+        countable_resources = person.marital_unit.sum(
+            person("ssi_countable_resources", period.this_year)
+        )
+        resource_limit = where(
+            person.marital_unit.nb_persons() == 2,
+            p.couple,
+            p.individual,
+        )
+        return countable_resources <= resource_limit

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_unearned_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_unearned_income_eligible.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_unearned_income_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Mississippi Working Disabled unearned income eligible"
+    definition_period = MONTH
+    reference = "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32"
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.wd.eligibility.income
+        countable_unearned_income = person("ms_wd_countable_unearned_income", period)
+        return (
+            countable_unearned_income <= person("ms_wd_fpg", period) * p.limit.unearned
+        )

--- a/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_work_eligible.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/eligibility/ms_wd_work_eligible.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_work_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Mississippi Working Disabled work eligible"
+    definition_period = MONTH
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=30",
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
+    )
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.wd.eligibility.work
+        return person("monthly_hours_worked", period.this_year) >= p.monthly_hours

--- a/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_countable_earned_income.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_countable_earned_income.py
@@ -1,0 +1,36 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_countable_earned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Mississippi Working Disabled countable earned income"
+    unit = USD
+    definition_period = MONTH
+    documentation = (
+        "Countable earned income for Mississippi's Working Disabled program. "
+        "This applies the remaining general income exclusion, the flat earned "
+        "income exclusion, and the one-half earned-income remainder exclusion. "
+        "Student earned income, impairment-related work expenses, blind work "
+        "expenses, and PASS exclusions are not modeled."
+    )
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32",
+        "https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=23",
+        "https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=24",
+    )
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.wd.eligibility.income.exclusions
+        earned_income = person.marital_unit.sum(
+            person("ms_wd_gross_earned_income", period)
+        )
+        unearned_income = max_(
+            person.marital_unit.sum(person("ms_wd_gross_unearned_income", period)),
+            0,
+        )
+        remaining_general_exclusion = max_(p.general - unearned_income, 0)
+        earned_after_general = max_(earned_income - remaining_general_exclusion, 0)
+        earned_after_flat = max_(earned_after_general - p.earned.amount, 0)
+        return earned_after_flat * (1 - p.earned.remainder_disregard)

--- a/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_countable_unearned_income.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_countable_unearned_income.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_countable_unearned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Mississippi Working Disabled countable unearned income"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32"
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.wd.eligibility.income
+        unearned_income = person.marital_unit.sum(
+            person("ms_wd_gross_unearned_income", period)
+        )
+        return max_(unearned_income - p.exclusions.general, 0)

--- a/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_gross_earned_income.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_gross_earned_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_gross_earned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Mississippi Working Disabled gross earned income"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=20"
+    defined_for = StateCode.MS
+
+    adds = "gov.states.ms.dom.wd.eligibility.income.sources.earned"

--- a/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_gross_unearned_income.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/income/ms_wd_gross_unearned_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_gross_unearned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Mississippi Working Disabled gross unearned income"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=8"
+    defined_for = StateCode.MS
+
+    adds = "gov.states.ms.dom.wd.eligibility.income.sources.unearned"

--- a/policyengine_us/variables/gov/states/ms/dom/wd/ms_wd_fpg.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/ms_wd_fpg.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_fpg(Variable):
+    value_type = float
+    entity = Person
+    label = "Mississippi Working Disabled monthly federal poverty guideline"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32"
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.hhs.fpg
+        state_group = person.household("state_group_str", period)
+        unit_size = person.marital_unit.nb_persons()
+        annual_fpg = (
+            p.first_person[state_group]
+            + (unit_size - 1) * p.additional_person[state_group]
+        )
+        return annual_fpg / MONTHS_IN_YEAR

--- a/policyengine_us/variables/gov/states/ms/dom/wd/ms_wd_premium.py
+++ b/policyengine_us/variables/gov/states/ms/dom/wd/ms_wd_premium.py
@@ -1,0 +1,34 @@
+from policyengine_us.model_api import *
+
+
+class ms_wd_premium(Variable):
+    value_type = float
+    entity = Person
+    label = "Mississippi Working Disabled monthly premium"
+    unit = USD
+    definition_period = MONTH
+    reference = (
+        "https://medicaid.ms.gov/wp-content/uploads/2026/03/Appendix-A-5-WD-Premiums-for-March-2026.pdf#page=1",
+        "https://medicaid.ms.gov/wp-content/uploads/2026/03/Appendix-A-5-WD-Premiums-for-March-2026.pdf#page=3",
+        "https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/",
+    )
+    defined_for = StateCode.MS
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.ms.dom.wd.premium
+        eligible = person("ms_wd_eligible", period)
+        eligible_count = person.marital_unit.sum(eligible)
+        countable_earned_income = person("ms_wd_countable_earned_income", period)
+        premium_applies = (
+            countable_earned_income > person("ms_wd_fpg", period) * p.fpl_threshold
+        )
+        marital_unit_premium = where(
+            premium_applies,
+            np.floor(countable_earned_income * p.rate),
+            0,
+        )
+        return where(
+            eligible & (eligible_count > 0),
+            marital_unit_premium / eligible_count,
+            0,
+        )

--- a/sources/working_references.md
+++ b/sources/working_references.md
@@ -1,0 +1,61 @@
+# Mississippi Working Disabled Medicaid Buy-In References
+
+## Official Program Name
+
+**Federal Program**: Medicaid Buy-In for workers with disabilities
+**State's Official Name**: Working Disabled
+**Abbreviation**: WD
+**Source**: Mississippi Division of Medicaid, Working Disabled page
+**Variable Prefix**: `ms_wd`
+
+## Official Sources
+
+1. Mississippi Division of Medicaid, Working Disabled
+   - https://medicaid.ms.gov/medicaid-coverage/who-qualifies-for-coverage/working-disabled/
+   - Confirms WD is a Buy-In program; 40 hours/month paid work; Social Security disability definition without SGA; 250% FPL earnings limit; 135% FPL unearned income limit; $24,000 individual and $26,000 couple resource limits; premium above 150% FPL equal to 5% of countable earnings.
+
+2. Mississippi Division of Medicaid, Medicaid Eligibility Guide for Persons Working and Disabled
+   - https://www.medicaid.ms.gov/wp-content/uploads/2014/03/Working-Disabled.pdf#page=1
+   - Public guide restating program purpose, 40 hours/month paid work, disability without SGA, separate earned/unearned income tests, and resource exclusions.
+
+3. Mississippi Division of Medicaid, Eligibility Policy and Procedures Manual, Chapter 400, section 400.06 Working Disabled COE-025
+   - https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=30
+   - Establishes July 1, 1999 implementation and work/disability requirements.
+   - https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=31
+   - Establishes $24,000/$26,000 resource limits and SSI-based disability treatment.
+   - https://medicaid.ms.gov/wp-content/uploads/2025/07/Chapter-400-ABD-and-MAGI-Eligibility-Criteria-and-Budgeting.-Revised-July-2025v2.pdf#page=32
+   - Establishes marital-unit earned and unearned income budgeting, 250% FPL earned test, 135% FPL unearned test, $50 unearned exclusion, 150% FPL premium trigger, and 5% premium.
+
+4. Mississippi Division of Medicaid, Administrative Code Part 104 Income
+   - https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=23
+   - Lists the earned-income exclusion order, including remaining general exclusion, $65 earned exclusion, and one-half remainder exclusion.
+   - https://www.medicaid.ms.gov/wp-content/uploads/2014/01/Admin-Code-Part-104.pdf#page=24
+   - Describes the $65 plus one-half earned income exclusion.
+
+5. Mississippi Division of Medicaid, Appendix A-5 Sliding Scale for Working Disabled Premiums, revised March 1, 2026
+   - https://medicaid.ms.gov/wp-content/uploads/2026/03/Appendix-A-5-WD-Premiums-for-March-2026.pdf#page=1
+   - Shows 2026 individual/couple premium table.
+   - https://medicaid.ms.gov/wp-content/uploads/2026/03/Appendix-A-5-WD-Premiums-for-March-2026.pdf#page=3
+   - States premiums apply for countable earned income between 150% and 250% FPL and equal 5% of countable earnings.
+
+## Source Collection Notes
+
+Downloaded PDFs, extracted text, and 300-DPI page renders are stored under `/tmp/ms-working-disabled-medicaid-buy-in-sources/`.
+
+## Main Requirements
+
+- Disabled individual must work at least 40 hours/month in paid activity.
+- Disability follows SSI/Social Security criteria except SGA and current work are ignored.
+- Each spouse applying as WD must be disabled and must meet the work test.
+- Budget unit is the individual or marital unit, including an ineligible spouse.
+- Countable earned income from applicant and spouse must not exceed 250% FPL for individual/couple.
+- Countable unearned income from applicant and spouse, after the $50 general exclusion, must not exceed 135% FPL for individual/couple.
+- Countable resources must not exceed $24,000 for an individual or $26,000 for a couple.
+- Countable earned income above 150% FPL triggers a monthly premium; the premium is 5% of countable earned income.
+
+## Not Modeled
+
+- Regional office application, DDS referral, notices, invoices, retroactive eligibility, and premium payment enforcement.
+- Allocations to ineligible children.
+- Student earned income, impairment-related work expenses, blind work expenses, PASS, and infrequent/irregular income exclusions.
+- Mississippi-specific second-vehicle, income-producing property, personal-property, and life-insurance resource exclusions beyond existing `ssi_countable_resources` inputs.


### PR DESCRIPTION
Fixes #8441

## Summary

This PR models Mississippi's Working Disabled Medicaid Buy-In pathway.

It adds:
- Mississippi WD parameters under `gov.states.ms.dom.wd`
- WD income source lists, exclusions, work hour, resource, income-limit, premium-threshold, and premium-rate parameters
- WD variables for FPG, gross/countable earned and unearned income, work/disability/income/resource eligibility, final eligibility, and monthly premium
- Integration with the shared Medicaid working-disabled Buy-In category and premium aggregation
- Program metadata for `ms_wd`
- Focused YAML tests and a changelog fragment

## Regulatory Authority

Primary sources:
- Mississippi Division of Medicaid, Working Disabled program page
- Mississippi Eligibility Policy and Procedures Manual, Chapter 400, section 400.06 Working Disabled COE-025
- Mississippi Administrative Code Part 104, Income
- Mississippi Appendix A-5 Sliding Scale for Working Disabled Premiums

All PDF references added in model files include page anchors.

## Eligibility Rules Modeled

- Paid work of at least 40 monthly hours
- Disability/blindness/SSDI screen without a substantial gainful activity exclusion
- Countable earned income at or below 250% FPL
- Countable unearned income at or below 135% FPL after the $50 general exclusion
- Resource limit of $24,000 for an individual or $26,000 for a couple
- Medicaid immigration status eligibility

## Income Deductions and Premium

The earned-income calculation applies modeled SSI-style exclusions:
- remaining general exclusion after unearned income
- $65 earned-income exclusion
- one-half remainder exclusion

The premium applies when countable earned income exceeds 150% FPL and equals 5% of countable earned income, rounded down.

## Requirements Coverage

| Requirement | Coverage |
| --- | --- |
| REQ-001 WD pathway | `ms_wd_eligible`, WD parameters, integration tests |
| REQ-002 40 monthly hours | `ms_wd_work_eligible`, `monthly_hours` parameter |
| REQ-003 disability without SGA screen | `ms_wd_disability_eligible` |
| REQ-004 resource limit | `ms_wd_resource_eligible`, individual/couple resource parameters |
| REQ-005 earned income <= 250% FPL | `ms_wd_countable_earned_income`, `ms_wd_earned_income_eligible` |
| REQ-006 unearned income <= 135% FPL | `ms_wd_countable_unearned_income`, `ms_wd_unearned_income_eligible` |
| REQ-007 earned exclusions | `ms_wd_countable_earned_income` |
| REQ-008 shared Buy-In category | `is_working_disabled_buy_in_for_medicaid` |
| REQ-009 premium | `ms_wd_premium`, shared premium aggregation |
| REQ-010 immigration status | `ms_wd_eligible` |

## Not Modeled

- Regional-office application steps, DDS referral mechanics, notices, invoices, retroactive eligibility, and premium payment enforcement
- Allocations to ineligible children
- Student earned income, impairment-related work expenses, blind work expenses, PASS, and infrequent/irregular income exclusions
- Mississippi-specific resource exclusions beyond existing modeled `ssi_countable_resources`

## Validation

- `make format`: passed
- `uv run --frozen policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd -c policyengine_us -v`: 41 passed, 1 warning
- `uv run --frozen policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_working_disabled_buy_in_for_medicaid.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/medicaid_working_disabled_buy_in_premium.yaml -c policyengine_us -v`: 4 passed, 1 warning
- `.venv/bin/ruff format .` and `.venv/bin/ruff check .` after review patch: passed
- `git diff --check`: passed
- New-file PDF reference check for missing `#page=XX`: passed

Known warning: pytest emitted `PytestAssertRewriteWarning` for `anyio`.
