### PR TITLE
Make Medicaid cost if enrolled data-backed

### DIFF
--- a/changelog.d/8499.changed.md
+++ b/changelog.d/8499.changed.md
@@ -1,0 +1,1 @@
+- Made Medicaid cost if enrolled data-backed and used Medicaid enrollment, rather than the Medicaid dollar value, for categorical eligibility checks.

--- a/policyengine_us/parameters/gov/ed/pell_grant/efc/simplified/benefits.yaml
+++ b/policyengine_us/parameters/gov/ed/pell_grant/efc/simplified/benefits.yaml
@@ -5,7 +5,7 @@ values:
     - school_meal_net_subsidy
     - tanf
     - wic
-    - medicaid
+    - medicaid_enrolled
     - ssi
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/fcc/lifeline/categorical_eligibility.yaml
+++ b/policyengine_us/parameters/gov/fcc/lifeline/categorical_eligibility.yaml
@@ -1,7 +1,7 @@
 description: Program participation that entitles a non-tribal household to the Lifeline program
 values:
   2016-12-01:
-    - medicaid
+    - medicaid_enrolled
     - snap
     - ssi
     # Also not implemented:

--- a/policyengine_us/parameters/gov/states/ca/calepa/carb/cvrp/increased_rebate/categorical_eligibility.yaml
+++ b/policyengine_us/parameters/gov/states/ca/calepa/carb/cvrp/increased_rebate/categorical_eligibility.yaml
@@ -1,7 +1,7 @@
 description: List of programs that qualify a household for an increased rebate under California's Clean Vehicle Rebate Project.
 values:
   2016-01-01:
-    - medicaid
+    - medicaid_enrolled
     - ssi
     # Also:
     # - tanf # Not yet implemented in California.

--- a/policyengine_us/parameters/gov/states/ca/cpuc/care/eligibility/categorical.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cpuc/care/eligibility/categorical.yaml
@@ -1,7 +1,7 @@
 description: California provides CARE eligibility to households that are enrolled in these programs.
 values:
   2022-06-01:
-    - medicaid
+    - medicaid_enrolled
     - wic
     - snap
     - ssi

--- a/policyengine_us/parameters/gov/states/ma/dot/mbta/income_eligible_reduced_fares/applicable_programs.yaml
+++ b/policyengine_us/parameters/gov/states/ma/dot/mbta/income_eligible_reduced_fares/applicable_programs.yaml
@@ -6,7 +6,7 @@ values:
     - snap
     # Medicaid includes MassHealth CarePlus, MassHealth Family Assistance,
     # MassHealth Limited, and MassHealth Standard
-    - medicaid
+    - medicaid_enrolled
 metadata:
   unit: list
   label: Massachusetts Bay Transportation Authority (MBTA) reduced fare program categorical eligibility applicable programs

--- a/policyengine_us/parameters/gov/states/tx/dart/qualifying_programs.yaml
+++ b/policyengine_us/parameters/gov/states/tx/dart/qualifying_programs.yaml
@@ -2,7 +2,7 @@ description: Dallas Area Rapid Transit (DART) provides the Discount GoPass Progr
 values:
   2024-01-01:
     - chip
-    - medicaid
+    - medicaid_enrolled
     - is_medicare_eligible # medicare
     - wic
     - snap

--- a/policyengine_us/tests/policy/baseline/gov/ed/pell_grant/pell_grant_simplified_formula_applies.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/ed/pell_grant/pell_grant_simplified_formula_applies.yaml
@@ -3,7 +3,7 @@
   input:
     people:
       person:
-        medicaid: 0
+        medicaid_enrolled: false
         ssi: 0
         wic: 0
     tax_unit:
@@ -20,7 +20,7 @@
   input:
     people:
       person:
-        medicaid: 1
+        medicaid_enrolled: true
         ssi: 0
         wic: 0
     tax_unit:
@@ -37,7 +37,7 @@
   input:
     people:
       person:
-        medicaid: 0
+        medicaid_enrolled: false
         ssi: 1
         wic: 0
     tax_unit:
@@ -54,7 +54,7 @@
   input:
     people:
       person:
-        medicaid: 0
+        medicaid_enrolled: false
         ssi: 0
         wic: 1
     tax_unit:
@@ -71,7 +71,7 @@
   input:
     people:
       person:
-        medicaid: 0
+        medicaid_enrolled: false
         ssi: 0
         wic: 0
     tax_unit:
@@ -88,7 +88,7 @@
   input:
     people:
       person:
-        medicaid: 0
+        medicaid_enrolled: false
         ssi: 0
         wic: 0
     tax_unit:
@@ -105,7 +105,7 @@
   input:
     people:
       person:
-        medicaid: 0
+        medicaid_enrolled: false
         ssi: 0
         wic: 0
     tax_unit:
@@ -122,11 +122,11 @@
   input:
     people:
       main:
-        medicaid: 0
+        medicaid_enrolled: false
         ssi: 0
         wic: 0
       other:
-        medicaid: 1
+        medicaid_enrolled: true
         ssi: 0
         wic: 0
     tax_unit:
@@ -143,7 +143,7 @@
   input:
     people:
       person:
-        medicaid: 1
+        medicaid_enrolled: true
         ssi: 1
         wic: 1
     tax_unit:

--- a/policyengine_us/tests/policy/baseline/gov/fcc/acp/is_acp_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/fcc/acp/is_acp_eligible.yaml
@@ -7,7 +7,7 @@
     fdpir: 0
     tanf: 0
     ebb: 0
-    medicaid_cost: 0
+    medicaid_enrolled: false
     pell_grant: 0
     is_on_tribal_land: false
     fcc_fpg_ratio: 2.01

--- a/policyengine_us/tests/policy/baseline/gov/fcc/lifeline/is_lifeline_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/fcc/lifeline/is_lifeline_eligible.yaml
@@ -8,7 +8,7 @@
   input:
     fcc_fpg_ratio: 1.5
     snap: 0
-    medicaid: 0
+    medicaid_enrolled: false
   output:
     is_lifeline_eligible: false
 
@@ -17,7 +17,7 @@
   input:
     fcc_fpg_ratio: 1.5
     snap: 100
-    medicaid: 0
+    medicaid_enrolled: false
   output:
     is_lifeline_eligible: true
 
@@ -48,7 +48,7 @@
   input:
     fcc_fpg_ratio: 1.5
     snap: 0
-    medicaid: 0
+    medicaid_enrolled: false
     state_code: TX
   output:
     is_lifeline_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/fcc/test_vectorization.py
+++ b/policyengine_us/tests/policy/baseline/gov/fcc/test_vectorization.py
@@ -33,7 +33,7 @@ def _parameter_tree():
     gov.fcc.ebb.categorical_eligibility = ["pell_grant"]
     gov.fcc.ebb.prior_enrollment_required = True
     gov.fcc.lifeline = Node()
-    gov.fcc.lifeline.categorical_eligibility = ["medicaid"]
+    gov.fcc.lifeline.categorical_eligibility = ["medicaid_enrolled"]
     gov.fcc.lifeline.tribal_categorical_eligibility = ["fdpir"]
     return _Parameters(gov)
 
@@ -49,7 +49,7 @@ def test_acp_lifeline_categorical_eligibility_is_vectorized(monkeypatch):
     program_values = {
         "lifeline": np.array([0, 0, 0]),
         "wic": np.array([0, 0, 0]),
-        "medicaid": np.array([1, 1, 0]),
+        "medicaid_enrolled": np.array([1, 1, 0]),
         "fdpir": np.array([0, 0, 1]),
     }
 

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.yaml
@@ -1,95 +1,23 @@
-- name: AZ child
-  period: 2023
-  absolute_error_margin: 0.1
+- name: Medicaid cost if enrolled is a data input.
+  period: 2026
   input:
-    households:
-      household:
-        state_code: AZ
-        members: [person]
-    people:
-      person:
-        is_infant_for_medicaid: true
-        is_medicaid_eligible: true
+    medicaid_cost_if_enrolled: 12_000
   output: 
-    medicaid_cost_if_enrolled: 3_564.1
+    medicaid_cost_if_enrolled: 12_000
 
-- name: IA disabled
-  period: 2023
-  absolute_error_margin: 0.1
+- name: Medicaid cost remains zero when not enrolled.
+  period: 2026
   input:
-    households:
-      household:
-        state_code: IA
-        members: [person]
-    people:
-      person:
-        is_optional_senior_or_disabled_for_medicaid: true
-        is_medicaid_eligible: true
-        meets_ssi_disability_criteria: true
+    medicaid_cost_if_enrolled: 12_000
+    is_medicaid_eligible: false
   output: 
-    medicaid_cost_if_enrolled: 24_257.3
+    medicaid_cost: 0
 
-- name: IA aged
-  period: 2023
-  absolute_error_margin: 0.1
+- name: Medicaid cost uses input when enrolled.
+  period: 2026
   input:
-    households:
-      household:
-        state_code: IA
-        members: [person]
-    people:
-      person:
-        age: 65
-        is_ssi_recipient_for_medicaid: true
-        is_medicaid_eligible: true
+    medicaid_cost_if_enrolled: 12_000
+    is_medicaid_eligible: true
+    takes_up_medicaid_if_eligible: true
   output: 
-    medicaid_cost_if_enrolled: 24_257.3
-
-- name: texas ineligible 
-  period: 2023
-  absolute_error_margin: 0.1
-  input:
-    households:
-      household:
-        state_code: TX
-        members: [person]
-    people:
-      person:
-        is_ssi_recipient_for_medicaid: false
-        is_medicaid_eligible: false
-  output: 
-    medicaid_cost_if_enrolled: 0
-
-- name: North Carolina Expansion adult (defaults to national average)
-  period: 2024
-  absolute_error_margin: 0.1
-  input:
-    households:
-      household:
-        state_code: NC
-        members: [person]
-    people:
-      person:
-        is_ssi_recipient_for_medicaid: false
-        is_medicaid_eligible: true
-  output: 
-    medicaid_cost_if_enrolled: 7_054
-
-- name: Multiple people in recent expansion state
-  period: 2024
-  absolute_error_margin: 0.1
-  input:
-    households:
-      household:
-        state_code: WI
-        members: [person1, person2]
-    people:
-      person1:
-        age: 25
-        employment_income: 0
-      person2:
-        age: 2
-  output:
-    # person1 is assigned to PARENT category (mandatory group) before ADULT
-    # (expansion), so uses NON_EXPANSION_ADULT per-capita cost
-    medicaid_cost_if_enrolled: [4_631.1, 2_867.8]
+    medicaid_cost: 12_000

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.yaml
@@ -25,6 +25,7 @@
       person:
         is_optional_senior_or_disabled_for_medicaid: true
         is_medicaid_eligible: true
+        meets_ssi_disability_criteria: true
   output: 
     medicaid_cost_if_enrolled: 24_257.3
 
@@ -38,6 +39,7 @@
         members: [person]
     people:
       person:
+        age: 65
         is_ssi_recipient_for_medicaid: true
         is_medicaid_eligible: true
   output: 

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_federal_share.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_federal_share.yaml
@@ -116,3 +116,15 @@
     medicaid_category: PREGNANT
   output:
     medicaid_federal_share: 0.7422
+
+- name: Disabled expansion adult keeps expansion FMAP despite aged-disabled cost group.
+  period: 2026
+  input:
+    state_code: NC
+    is_medicaid_eligible: true
+    takes_up_medicaid_if_eligible: true
+    medicaid_category: ADULT
+    meets_ssi_disability_criteria: true
+  output:
+    medicaid_group: AGED_DISABLED
+    medicaid_federal_share: 0.9000

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_federal_share.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_federal_share.yaml
@@ -117,7 +117,7 @@
   output:
     medicaid_federal_share: 0.7422
 
-- name: Disabled expansion adult keeps expansion FMAP despite aged-disabled cost group.
+- name: Expansion adult keeps expansion FMAP even when disability criteria are true.
   period: 2026
   input:
     state_code: NC
@@ -126,5 +126,4 @@
     medicaid_category: ADULT
     meets_ssi_disability_criteria: true
   output:
-    medicaid_group: AGED_DISABLED
     medicaid_federal_share: 0.9000

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
@@ -2,6 +2,7 @@
   period: 2026
   input:
     medicaid_category: MEDICALLY_NEEDY
+    meets_ssi_disability_criteria: true
   output:
     medicaid_group: AGED_DISABLED
 
@@ -9,6 +10,7 @@
   period: 2026
   input:
     medicaid_category: WORKING_DISABLED_BUY_IN
+    meets_ssi_disability_criteria: true
   output:
     medicaid_group: AGED_DISABLED
 
@@ -20,3 +22,23 @@
   output:
     medicaid_category: ADULT
     medicaid_group: EXPANSION_ADULT
+
+- name: Case 4, disabled adult enrollee uses aged or disabled cost group.
+  period: 2026
+  input:
+    medicaid_category: ADULT
+    meets_ssi_disability_criteria: true
+  output:
+    medicaid_category: ADULT
+    medicaid_group: AGED_DISABLED
+
+- name: Case 5, disabled adult above SGA still uses aged or disabled cost group.
+  period: 2026
+  input:
+    medicaid_category: ADULT
+    meets_ssi_disability_criteria: true
+    employment_income: 100_000
+  output:
+    ssi_engaged_in_sga: true
+    is_ssi_disabled: false
+    medicaid_group: AGED_DISABLED

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/medicaid_group.yaml
@@ -2,7 +2,6 @@
   period: 2026
   input:
     medicaid_category: MEDICALLY_NEEDY
-    meets_ssi_disability_criteria: true
   output:
     medicaid_group: AGED_DISABLED
 
@@ -10,7 +9,6 @@
   period: 2026
   input:
     medicaid_category: WORKING_DISABLED_BUY_IN
-    meets_ssi_disability_criteria: true
   output:
     medicaid_group: AGED_DISABLED
 
@@ -22,23 +20,3 @@
   output:
     medicaid_category: ADULT
     medicaid_group: EXPANSION_ADULT
-
-- name: Case 4, disabled adult enrollee uses aged or disabled cost group.
-  period: 2026
-  input:
-    medicaid_category: ADULT
-    meets_ssi_disability_criteria: true
-  output:
-    medicaid_category: ADULT
-    medicaid_group: AGED_DISABLED
-
-- name: Case 5, disabled adult above SGA still uses aged or disabled cost group.
-  period: 2026
-  input:
-    medicaid_category: ADULT
-    meets_ssi_disability_criteria: true
-    employment_income: 100_000
-  output:
-    ssi_engaged_in_sga: true
-    is_ssi_disabled: false
-    medicaid_group: AGED_DISABLED

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/medicaid_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/medicaid_enrolled.yaml
@@ -11,6 +11,7 @@
         employment_income: 15_000
         immigration_status: UNDOCUMENTED
         receives_medicaid: true
+        medicaid_cost_if_enrolled: 6_439.11
     tax_units:
       tax_unit:
         members: [person1]

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/calepa/carb/cvrp/is_ca_cvrp_increased_rebate_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/calepa/carb/cvrp/is_ca_cvrp_increased_rebate_eligible.yaml
@@ -2,7 +2,7 @@
   period: 2022
   input:
     school_meal_fpg_ratio: 4
-    medicaid: 0
+    medicaid_enrolled: false
   output:
     is_ca_cvrp_increased_rebate_eligible: true
 
@@ -10,7 +10,7 @@
   period: 2022
   input:
     school_meal_fpg_ratio: 4.01
-    medicaid: 0
+    medicaid_enrolled: false
   output:
     is_ca_cvrp_increased_rebate_eligible: false
 
@@ -18,7 +18,7 @@
   period: 2022
   input:
     school_meal_fpg_ratio: 4.01
-    medicaid: 0
+    medicaid_enrolled: false
     ssi: 1
   output:
     is_ca_cvrp_increased_rebate_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/eligibility/tx_dart_reduced_fare_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/eligibility/tx_dart_reduced_fare_eligible.yaml
@@ -104,7 +104,7 @@
     is_veteran: false
     is_full_time_student: false
     snap: 0
-    medicaid: 0
+    medicaid_enrolled: false
   output:
     tx_dart_reduced_fare_eligible: false
 

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/eligibility/tx_dart_reduced_fare_program_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/eligibility/tx_dart_reduced_fare_program_eligible.yaml
@@ -23,7 +23,7 @@
       person1:
         age: 25
         is_disabled: false
-        medicaid: 1
+        medicaid_enrolled: true
     households:
       household:
         members: [person1]
@@ -132,7 +132,7 @@
       person1:
         age: 30
         employment_income: 12_000
-        medicaid: 1
+        medicaid_enrolled: true
     spm_units:
       spm_unit:
         members: [person1]

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/tx_dart_reduced_fare_benefit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/tx_dart_reduced_fare_benefit.yaml
@@ -59,7 +59,7 @@
     is_veteran: false
     is_full_time_student: false
     snap: 0
-    medicaid: 0
+    medicaid_enrolled: false
     chip: 0
     tanf: 0
     wic: 0
@@ -73,7 +73,7 @@
     state_code: TX
     age: 3
     snap: 0
-    medicaid: 0
+    medicaid_enrolled: false
     chip: 0
     tanf: 0
     wic: 0
@@ -89,28 +89,28 @@
         age: 35
         is_veteran: true
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
       spouse:
         age: 33
         is_veteran: false
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
       child:
         age: 12
         is_veteran: false
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
       senior:
         age: 68
         is_veteran: false
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
     spm_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/dart/tx_dart_benefit_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/dart/tx_dart_benefit_person.yaml
@@ -67,7 +67,7 @@
     is_veteran: false
     is_full_time_student: false
     snap: 0
-    medicaid: 0
+    medicaid_enrolled: false
     chip: 0
     tanf: 0
     wic: 0
@@ -83,28 +83,28 @@
         age: 35
         is_veteran: false
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
       parent2:
         age: 33
         is_veteran: false
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
       toddler:
         age: 2
         is_veteran: false
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
       senior:
         age: 70
         is_veteran: false
         is_medicare_eligible: false
-        medicaid: 0
+        medicaid_enrolled: false
         chip: 0
         wic: 0
     spm_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/uct/lifeline/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/uct/lifeline/integration.yaml
@@ -139,7 +139,7 @@
       person1:
         age: 45
         is_disabled: true
-        medicaid: 1
+        medicaid_enrolled: true
     spm_units:
       spm_unit:
         members: [person1]

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -10,5 +10,6 @@
       person:
         is_infant_for_medicaid: true
         is_medicaid_eligible: true
+        medicaid_cost_if_enrolled: 3_564.1
   output: 
     healthcare_benefit_value: 3_564.1

--- a/policyengine_us/tests/policy/baseline/partners/amplifi/2025.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/amplifi/2025.yaml
@@ -19,12 +19,14 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 1
         immigration_status_str: CITIZEN
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '91367'

--- a/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
@@ -19,12 +19,14 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 1
         immigration_status_str: CITIZEN
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '91367'
@@ -163,6 +165,7 @@
         is_pregnant: false
         ca_calworks_child_care_time_category: MONTHLY
         receives_medicaid: false
+        medicaid_cost_if_enrolled: 6439.11
       member1:
         age: 2
         ca_calworks_child_care_full_time: true
@@ -170,6 +173,7 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 4
         ca_calworks_child_care_full_time: true
@@ -177,6 +181,7 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '90019'
@@ -313,6 +318,7 @@
         is_pregnant: false
         ca_calworks_child_care_time_category: MONTHLY
         receives_medicaid: false
+        medicaid_cost_if_enrolled: 4367.51
       member1:
         age: 3
         ca_calworks_child_care_full_time: true
@@ -320,6 +326,7 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 6
         ca_calworks_child_care_full_time: true
@@ -327,6 +334,7 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '90019'

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ca.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 2001
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/co.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/federal.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -177,6 +179,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 2000
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id004
@@ -285,6 +288,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id006
@@ -339,6 +343,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id007

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/il.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 2001
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -123,6 +125,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id003

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/la.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ma.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -123,6 +124,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id003

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/nc.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/wa.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/composition/cash_health/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/composition/cash_health/federal.yaml
@@ -69,6 +69,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -213,6 +214,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -293,6 +295,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -305,6 +308,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id005
@@ -411,6 +415,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -423,6 +428,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id006

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ca.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -147,6 +149,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -251,6 +254,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/co.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/il.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -147,6 +149,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -251,6 +254,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/la.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -147,6 +149,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -251,6 +254,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ma.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/nc.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -147,6 +149,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -251,6 +254,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/wa.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -147,6 +149,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -251,6 +254,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ca.yaml
@@ -39,6 +39,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -143,6 +144,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/co.yaml
@@ -143,6 +143,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/il.yaml
@@ -39,6 +39,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -143,6 +144,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -247,6 +249,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/la.yaml
@@ -143,6 +143,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ma.yaml
@@ -143,6 +143,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/nc.yaml
@@ -143,6 +143,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/wa.yaml
@@ -143,6 +143,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ca.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -39,6 +41,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -119,6 +122,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/co.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -39,6 +41,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -119,6 +122,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/federal.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -81,6 +83,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 0
         is_tax_unit_head: false
@@ -93,6 +96,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id002
@@ -173,6 +177,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -185,6 +190,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 1
         is_tax_unit_head: false
@@ -197,6 +203,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -277,6 +284,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -289,6 +297,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 5
         is_tax_unit_head: false
@@ -301,6 +310,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -381,6 +391,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -393,6 +404,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 6
         is_tax_unit_head: false
@@ -405,6 +417,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id005
@@ -485,6 +498,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -497,6 +511,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 18
         is_tax_unit_head: false
@@ -509,6 +524,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id006
@@ -589,6 +605,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -601,6 +618,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/il.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -39,6 +41,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -119,6 +122,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/la.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -39,6 +41,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -119,6 +122,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ma.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -39,6 +41,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
     households:
       household:
         members: &id001
@@ -119,6 +122,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/nc.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -39,6 +41,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -119,6 +122,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/tx.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/wa.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -27,6 +28,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -39,6 +41,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -119,6 +122,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/msp/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/msp/federal.yaml
@@ -15,6 +15,7 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id001
@@ -69,6 +70,7 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -123,6 +125,7 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id003
@@ -177,6 +180,7 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id004
@@ -231,6 +235,7 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
+        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id005

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ca.yaml
@@ -52,6 +52,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -68,6 +69,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -264,6 +266,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -280,6 +283,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -459,6 +463,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -473,6 +478,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -622,6 +628,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -635,6 +642,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -648,6 +656,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -661,6 +670,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -836,6 +846,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -849,6 +860,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -997,6 +1009,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -1009,6 +1022,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -1021,6 +1035,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1033,6 +1048,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1214,6 +1230,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1229,6 +1246,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1410,6 +1428,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1424,6 +1443,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1575,6 +1595,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -1588,6 +1609,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -1601,6 +1623,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1614,6 +1637,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1799,6 +1823,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1815,6 +1840,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1965,6 +1991,7 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -1977,6 +2004,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -1989,6 +2017,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2001,6 +2030,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2185,6 +2215,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2200,6 +2231,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2354,6 +2386,7 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -2367,6 +2400,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -2380,6 +2414,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2393,6 +2428,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2573,6 +2609,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2587,6 +2624,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2771,6 +2809,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2787,6 +2826,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2936,6 +2976,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -2949,6 +2990,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -2961,6 +3003,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2973,6 +3016,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3156,6 +3200,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3171,6 +3216,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3320,6 +3366,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -3333,6 +3380,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -3346,6 +3394,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3359,6 +3408,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3510,6 +3560,7 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -3523,6 +3574,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -3536,6 +3588,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3549,6 +3602,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3730,6 +3784,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3745,6 +3800,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3925,6 +3981,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3939,6 +3996,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4091,6 +4149,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -4105,6 +4164,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -4119,6 +4179,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4133,6 +4194,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4284,6 +4346,7 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -4297,6 +4360,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -4310,6 +4374,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4323,6 +4388,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4499,6 +4565,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4512,6 +4579,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4693,6 +4761,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4708,6 +4777,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4889,6 +4959,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4904,6 +4975,7 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -5055,6 +5127,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -5068,6 +5141,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -5081,6 +5155,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -5094,6 +5169,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -5245,6 +5321,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -5258,6 +5335,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -5271,6 +5349,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -5284,6 +5363,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -5434,6 +5514,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -5446,6 +5527,7 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -5458,6 +5540,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -5470,6 +5553,7 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
@@ -75,6 +75,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -95,6 +96,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -280,6 +282,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -300,6 +303,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -479,6 +483,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -500,6 +505,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -768,6 +774,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -789,6 +796,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -965,6 +973,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -986,6 +995,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
@@ -97,6 +97,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -122,6 +123,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -361,6 +363,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -388,6 +391,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -608,6 +612,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -634,6 +639,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -858,6 +864,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -883,6 +890,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1110,6 +1118,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1136,6 +1145,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1366,6 +1376,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1393,6 +1404,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1612,6 +1624,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1638,6 +1651,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
@@ -84,6 +84,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -105,6 +106,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -331,6 +333,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -352,6 +355,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -569,6 +573,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -590,6 +595,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -808,6 +814,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -830,6 +837,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1049,6 +1057,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1071,6 +1080,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
@@ -75,6 +75,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -95,6 +96,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -263,6 +265,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -283,6 +286,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -445,6 +449,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -466,6 +471,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -629,6 +635,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -650,6 +657,7 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -808,6 +816,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -829,6 +838,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
@@ -90,6 +90,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -114,6 +115,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -350,6 +352,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -374,6 +377,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -850,6 +854,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -873,6 +878,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1101,6 +1107,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1124,6 +1131,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1356,6 +1364,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1380,6 +1389,7 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
+        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001

--- a/policyengine_us/tests/policy/baseline/partners/my_friend_ben/2025.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/my_friend_ben/2025.yaml
@@ -29,6 +29,7 @@
         other_medical_expenses: 0
         is_snap_ineligible_student: true
         is_full_time_college_student: true
+        medicaid_cost_if_enrolled: 4580.0
     households:
       household:
         members:

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_cost_if_enrolled.py
@@ -1,32 +1,9 @@
 from policyengine_us.model_api import *
-from policyengine_us.variables.gov.hhs.medicaid.costs.medicaid_group import (
-    MedicaidGroup,
-)
-from policyengine_us.variables.gov.hhs.medicaid.costs.per_capita_cost_helpers import (
-    calculate_per_capita_cost,
-)
 
 
 class medicaid_cost_if_enrolled(Variable):
     value_type = float
     entity = Person
-    label = "Per capita Medicaid cost by eligibility group & state"
+    label = "Medicaid cost if enrolled"
     unit = USD
     definition_period = YEAR
-    defined_for = "is_medicaid_eligible"
-
-    def formula(person, period, parameters):
-        group = person("medicaid_group", period)
-        return calculate_per_capita_cost(
-            person,
-            period,
-            parameters,
-            group,
-            MedicaidGroup,
-            groups=[
-                MedicaidGroup.AGED_DISABLED,
-                MedicaidGroup.CHILD,
-                MedicaidGroup.EXPANSION_ADULT,
-                MedicaidGroup.NON_EXPANSION_ADULT,
-            ],
-        )

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_federal_share.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_federal_share.py
@@ -1,7 +1,4 @@
 from policyengine_us.model_api import *
-from policyengine_us.variables.gov.hhs.medicaid.costs.medicaid_group import (
-    MedicaidGroup,
-)
 
 
 class medicaid_federal_share(Variable):
@@ -23,14 +20,13 @@ class medicaid_federal_share(Variable):
         p = parameters(period).gov.hhs.medicaid.cost_share
         state = person.household("state_code", period)
         regular_fmap = p.fmap[state]
-        group = person("medicaid_group", period)
+        category = person("medicaid_category", period)
+        categories = category.possible_values
         return select(
             [
-                group == MedicaidGroup.EXPANSION_ADULT,
-                group == MedicaidGroup.AGED_DISABLED,
-                group == MedicaidGroup.CHILD,
-                group == MedicaidGroup.NON_EXPANSION_ADULT,
+                category == categories.ADULT,
+                category != categories.NONE,
             ],
-            [p.expansion_fmap, regular_fmap, regular_fmap, regular_fmap],
+            [p.expansion_fmap, regular_fmap],
             default=0,
         )

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
@@ -10,9 +10,14 @@ class MedicaidGroup(Enum):
 
 
 class medicaid_group(Variable):
-    """Maps fine-grained Medicaid categories to broader spending groups
+    """Maps Medicaid enrollees to broader spending/risk groups.
+
+    Medicaid legal eligibility pathways can change under reforms even when
+    enrollee traits do not. This variable is therefore based first on stable
+    cost/risk traits, not only on the selected legal Medicaid category.
+
     Precedence order (highest → lowest):
-    1. Disabled / SSI / medically-needy / Buy-In → AGED_DISABLED
+    1. Aged, blind, disabled, or Medicare-enrolled → AGED_DISABLED
     2. Pregnant                       → NON_EXPANSION_ADULT
     3. Parent                         → NON_EXPANSION_ADULT
     4. Young adult (19-20)            → NON_EXPANSION_ADULT
@@ -33,16 +38,12 @@ class medicaid_group(Variable):
         cat = person("medicaid_category", period)
         cats = cat.possible_values
 
-        # Follow the selected Medicaid category for newly modeled optional
-        # pathways so they do not override mandatory category precedence.
-        # Preserve existing raw SSI and optional aged/disabled cost grouping.
-        disabled = (
-            (cat == cats.SSI_RECIPIENT)
-            | (cat == cats.SENIOR_OR_DISABLED)
-            | (cat == cats.MEDICALLY_NEEDY)
-            | (cat == cats.WORKING_DISABLED_BUY_IN)
-            | person("is_ssi_recipient_for_medicaid", period)
-            | person("is_optional_senior_or_disabled_for_medicaid", period)
+        aged_disabled = (
+            person("is_ssi_aged", period)
+            | person("is_blind", period)
+            | person("is_disabled", period)
+            | person("meets_ssi_disability_criteria", period)
+            | person("medicare_enrolled", period)
         )
 
         # Pregnant OR Parent OR Young adult (19–20) → NON_EXPANSION_ADULT
@@ -73,7 +74,7 @@ class medicaid_group(Variable):
         return select(
             [
                 ~eligible,
-                disabled | il_hbi_senior,
+                aged_disabled | il_hbi_senior,
                 non_expansion_adult,
                 expansion_adult | il_hbi_adult,
                 child | il_hbi_child,

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/medicaid_group.py
@@ -10,14 +10,9 @@ class MedicaidGroup(Enum):
 
 
 class medicaid_group(Variable):
-    """Maps Medicaid enrollees to broader spending/risk groups.
-
-    Medicaid legal eligibility pathways can change under reforms even when
-    enrollee traits do not. This variable is therefore based first on stable
-    cost/risk traits, not only on the selected legal Medicaid category.
-
+    """Maps fine-grained Medicaid categories to broader spending groups
     Precedence order (highest → lowest):
-    1. Aged, blind, disabled, or Medicare-enrolled → AGED_DISABLED
+    1. Disabled / SSI / medically-needy / Buy-In → AGED_DISABLED
     2. Pregnant                       → NON_EXPANSION_ADULT
     3. Parent                         → NON_EXPANSION_ADULT
     4. Young adult (19-20)            → NON_EXPANSION_ADULT
@@ -38,12 +33,16 @@ class medicaid_group(Variable):
         cat = person("medicaid_category", period)
         cats = cat.possible_values
 
-        aged_disabled = (
-            person("is_ssi_aged", period)
-            | person("is_blind", period)
-            | person("is_disabled", period)
-            | person("meets_ssi_disability_criteria", period)
-            | person("medicare_enrolled", period)
+        # Follow the selected Medicaid category for newly modeled optional
+        # pathways so they do not override mandatory category precedence.
+        # Preserve existing raw SSI and optional aged/disabled cost grouping.
+        disabled = (
+            (cat == cats.SSI_RECIPIENT)
+            | (cat == cats.SENIOR_OR_DISABLED)
+            | (cat == cats.MEDICALLY_NEEDY)
+            | (cat == cats.WORKING_DISABLED_BUY_IN)
+            | person("is_ssi_recipient_for_medicaid", period)
+            | person("is_optional_senior_or_disabled_for_medicaid", period)
         )
 
         # Pregnant OR Parent OR Young adult (19–20) → NON_EXPANSION_ADULT
@@ -74,7 +73,7 @@ class medicaid_group(Variable):
         return select(
             [
                 ~eligible,
-                aged_disabled | il_hbi_senior,
+                disabled | il_hbi_senior,
                 non_expansion_adult,
                 expansion_adult | il_hbi_adult,
                 child | il_hbi_child,

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/per_capita_cost_helpers.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/per_capita_cost_helpers.py
@@ -2,7 +2,6 @@
 
 This module provides shared logic for calculating per capita costs that is
 used by:
-- medicaid_cost_if_enrolled (for federal Medicaid)
 - or_healthier_oregon_cost_if_enrolled (for Oregon Healthier Oregon)
 - wa_apple_health_cost_if_enrolled (for Washington Apple Health)
 - Other state Medicaid-like programs


### PR DESCRIPTION
## Summary
- remove the PolicyEngine-US formula for `medicaid_cost_if_enrolled` so datasets provide the conditional Medicaid cost
- keep `medicaid_cost` zero for non-enrollees and using the data input for enrollees
- compute Medicaid federal share from the legal Medicaid category, so expansion FMAP does not depend on any cost allocation group

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs -c policyengine_us`

Note: I also started the broader `policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/hhs --mode per-subdir`; it reached the Medicare subdirectory with no failure output but did not produce progress, so I stopped it and kept the targeted Medicaid suite as the local gate.
