### PR TITLE
Add MSP fiscal accounting

### DIFF
--- a/changelog.d/fixed/8496.md
+++ b/changelog.d/fixed/8496.md
@@ -1,0 +1,1 @@
+Add explicit Medicare Savings Program fiscal accounting for MSP-only beneficiaries.

--- a/policyengine_us/parameters/gov/hhs/medicare/savings_programs/qi/federal_share.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicare/savings_programs/qi/federal_share.yaml
@@ -1,0 +1,11 @@
+description: The Department of Health and Human Services provides this federal share for Qualifying Individual assistance under the Medicare Savings Programs.
+values:
+  1998-01-01: 1
+
+metadata:
+  unit: /1
+  period: year
+  label: QI federal share
+  reference:
+    - title: 42 U.S.C. 1396u-3(d) - Qualifying Individual applicable FMAP
+      href: https://www.law.cornell.edu/uscode/text/42/1396u-3#d

--- a/policyengine_us/parameters/gov/hhs/medicare/savings_programs/qmb/cost_sharing_rate.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicare/savings_programs/qmb/cost_sharing_rate.yaml
@@ -1,0 +1,13 @@
+description: The Department of Health and Human Services uses this share to approximate Qualified Medicare Beneficiary cost sharing under the Medicare Savings Programs.
+values:
+  1989-01-01: 0.2
+
+metadata:
+  unit: /1
+  period: year
+  label: QMB cost-sharing approximation rate
+  reference:
+    - title: 42 U.S.C. 1396d(p)(3) - Medicare cost-sharing definition
+      href: https://www.law.cornell.edu/uscode/text/42/1396d#p_3
+    - title: Medicare.gov - Medicare Part B costs
+      href: https://www.medicare.gov/basics/costs/medicare-costs

--- a/policyengine_us/parameters/gov/household/federal_benefit_cost.yaml
+++ b/policyengine_us/parameters/gov/household/federal_benefit_cost.yaml
@@ -3,6 +3,7 @@ values:
   2015-01-01:
     - medicaid_federal_cost
     - chip_federal_cost
+    - msp_federal_cost
 metadata:
   unit: list
   label: Federal benefit cost sources

--- a/policyengine_us/parameters/gov/household/household_health_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_health_benefits.yaml
@@ -2,6 +2,7 @@ description: The government counts these sources as household benefits.
 values:
   2022-01-01:
     - medicaid
+    - msp_cost
     - chip
     - premium_tax_credit
 

--- a/policyengine_us/parameters/gov/household/state_benefit_cost.yaml
+++ b/policyengine_us/parameters/gov/household/state_benefit_cost.yaml
@@ -3,6 +3,7 @@ values:
   2015-01-01:
     - medicaid_state_cost
     - chip_state_cost
+    - msp_state_cost
 metadata:
   unit: list
   label: State benefit cost sources

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/msp_cost.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/msp_cost.yaml
@@ -1,0 +1,57 @@
+- name: Case 1, QMB MSP-only beneficiary receives premium and cost-sharing value.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: false
+    msp_category: QMB
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    # Part B premium: $202.90 * 12 = $2,434.80.
+    # QMB cost sharing: $14,500 * 20% = $2,900.
+    msp_cost: 5_334.8
+
+- name: Case 2, SLMB MSP-only beneficiary receives Part B premium value.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: false
+    msp_category: SLMB
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    msp_cost: 2_434.8
+
+- name: Case 3, QI MSP-only beneficiary receives Part B premium value.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: false
+    msp_category: QI
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    msp_cost: 2_434.8
+
+- name: Case 4, full Medicaid enrollee does not double count MSP cost.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: true
+    msp_category: QMB
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    msp_cost: 0

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/msp_federal_and_state_cost.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/msp_federal_and_state_cost.yaml
@@ -1,0 +1,45 @@
+- name: Case 1, QMB cost uses the regular federal Medicaid share.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: false
+    msp_category: QMB
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    # CA regular FMAP is 50%; total MSP cost is $5,334.80.
+    msp_federal_cost: 2_667.4
+    msp_state_cost: 2_667.4
+
+- name: Case 2, QI cost is federally financed within allocation.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: false
+    msp_category: QI
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    msp_federal_cost: 2_434.8
+    msp_state_cost: 0
+
+- name: Case 3, full Medicaid enrollee has no separate MSP federal or state cost.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: true
+    msp_category: QMB
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    msp_federal_cost: 0
+    msp_state_cost: 0

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/qmb_cost_sharing.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/qmb_cost_sharing.yaml
@@ -1,0 +1,16 @@
+- name: Case 1, QMB cost sharing uses the monthly Medicare cost approximation.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    msp_category: QMB
+  output:
+    # $14,500 annual Medicare per-capita cost / 12 * 20%.
+    qmb_cost_sharing: 241.67
+
+- name: Case 2, non-QMB MSP categories do not receive QMB cost sharing.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    msp_category: SLMB
+  output:
+    qmb_cost_sharing: 0

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -13,3 +13,12 @@
         medicaid_cost_if_enrolled: 3_564.1
   output: 
     healthcare_benefit_value: 3_564.1
+
+- name: Case 2, MSP limited-benefit cost is a healthcare benefit value.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    medicaid_cost: 0
+    msp_cost: 2_434.8
+  output:
+    healthcare_benefit_value: 2_434.8

--- a/policyengine_us/tests/policy/baseline/household/household_health_benefits.yaml
+++ b/policyengine_us/tests/policy/baseline/household/household_health_benefits.yaml
@@ -19,3 +19,15 @@
   output:
     household_health_benefits: 1_500
     household_benefits: 1_500
+
+- name: flag on includes MSP limited-benefit cost
+  period: 2026
+  input:
+    gov.simulation.include_health_benefits_in_net_income: true
+    premium_tax_credit: 1_000
+    medicaid: 500
+    msp_cost: 2_434.8
+    snap: 0
+  output:
+    household_health_benefits: 3_934.8
+    household_benefits: 3_934.8

--- a/policyengine_us/tests/policy/baseline/household/income/person/federal_and_state_benefit_cost.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/federal_and_state_benefit_cost.yaml
@@ -56,3 +56,18 @@
   output:
     federal_benefit_cost: [9_000, 2_600]
     state_benefit_cost: [1_000, 1_400]
+
+- name: Case 5, QI Medicare Savings Program cost flows to federal benefit cost.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: false
+    msp_category: QI
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    federal_benefit_cost: 2_434.8
+    state_benefit_cost: 0

--- a/policyengine_us/tests/policy/baseline/household/income/person/federal_and_state_benefit_cost.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/federal_and_state_benefit_cost.yaml
@@ -71,3 +71,18 @@
   output:
     federal_benefit_cost: 2_434.8
     state_benefit_cost: 0
+
+- name: Case 6, QMB Medicare Savings Program cost flows to federal and state benefit cost.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: CA
+    age: 67
+    is_medicare_eligible: true
+    medicaid_enrolled: false
+    msp_category: QMB
+    base_part_a_premium: 0
+    base_part_b_premium: 2_434.8
+  output:
+    federal_benefit_cost: 2_667.4
+    state_benefit_cost: 2_667.4

--- a/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_benefit_value.py
+++ b/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_benefit_value.py
@@ -23,7 +23,7 @@ class msp_benefit_value(Variable):
         part_b_premium = person("base_part_b_premium", period)
 
         # Benefit depends on category:
-        # QMB: Part A + Part B premiums (plus deductibles/copays, not modeled)
+        # QMB: Part A + Part B premiums. Cost-sharing is tracked separately.
         # SLMB: Part B premium only
         # QI: Part B premium only
         is_qmb = category == MSPCategory.QMB

--- a/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_cost.py
+++ b/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_cost.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class msp_cost(Variable):
+    value_type = float
+    entity = Person
+    unit = USD
+    label = "Medicare Savings Program cost"
+    definition_period = YEAR
+    reference = (
+        "https://www.medicare.gov/basics/costs/help/medicare-savings-programs",
+        "https://www.law.cornell.edu/uscode/text/42/1396a#a_10_E",
+        "https://www.law.cornell.edu/uscode/text/42/1396d#p_3",
+    )
+    documentation = (
+        "Annual limited-benefit Medicare Savings Program cost for MSP-only "
+        "beneficiaries. This is zero for full Medicaid enrollees to avoid "
+        "double counting the same person as both a limited-benefit MSP "
+        "beneficiary and a full-benefit Medicaid enrollee."
+    )
+
+    def formula(person, period, parameters):
+        monthly_cost = 0
+        for month in period.get_subperiods(MONTH):
+            monthly_cost += person("msp_benefit_value", month) + person(
+                "qmb_cost_sharing", month
+            )
+        return where(person("medicaid_enrolled", period), 0, monthly_cost)

--- a/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_federal_cost.py
+++ b/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_federal_cost.py
@@ -1,0 +1,50 @@
+from policyengine_us.model_api import *
+from policyengine_us.variables.gov.hhs.medicare.savings_programs.category.msp_category import (
+    MSPCategory,
+)
+
+
+class msp_federal_cost(Variable):
+    value_type = float
+    entity = Person
+    unit = USD
+    label = "Medicare Savings Program federal cost"
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/42/1396b",
+        "https://www.law.cornell.edu/uscode/text/42/1396d#b",
+        "https://www.law.cornell.edu/uscode/text/42/1396u-3#d",
+    )
+    documentation = (
+        "Federal share of limited-benefit Medicare Savings Program cost. "
+        "QMB and SLMB use the state's regular FMAP; QI uses the 100% federal "
+        "share within the state allocation."
+    )
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.hhs
+        state = person.household("state_code", period)
+        regular_fmap = p.medicaid.cost_share.fmap[state]
+
+        federal_cost = 0
+        for month in period.get_subperiods(MONTH):
+            category = person("msp_category", month)
+            monthly_cost = person("msp_benefit_value", month) + person(
+                "qmb_cost_sharing", month
+            )
+            federal_share = select(
+                [
+                    category == MSPCategory.QMB,
+                    category == MSPCategory.SLMB,
+                    category == MSPCategory.QI,
+                ],
+                [
+                    regular_fmap,
+                    regular_fmap,
+                    p.medicare.savings_programs.qi.federal_share,
+                ],
+                default=0,
+            )
+            federal_cost += monthly_cost * federal_share
+
+        return where(person("medicaid_enrolled", period), 0, federal_cost)

--- a/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_state_cost.py
+++ b/policyengine_us/variables/gov/hhs/medicare/savings_programs/msp_state_cost.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class msp_state_cost(Variable):
+    value_type = float
+    entity = Person
+    unit = USD
+    label = "Medicare Savings Program state cost"
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/42/1396b",
+        "https://www.law.cornell.edu/uscode/text/42/1396d#b",
+        "https://www.law.cornell.edu/uscode/text/42/1396u-3#d",
+    )
+    documentation = "State share of limited-benefit Medicare Savings Program cost."
+
+    def formula(person, period, parameters):
+        return max_(
+            person("msp_cost", period) - person("msp_federal_cost", period),
+            0,
+        )

--- a/policyengine_us/variables/gov/hhs/medicare/savings_programs/qmb_cost_sharing.py
+++ b/policyengine_us/variables/gov/hhs/medicare/savings_programs/qmb_cost_sharing.py
@@ -1,0 +1,35 @@
+from policyengine_us.model_api import *
+from policyengine_us.variables.gov.hhs.medicare.savings_programs.category.msp_category import (
+    MSPCategory,
+)
+
+
+class qmb_cost_sharing(Variable):
+    value_type = float
+    entity = Person
+    unit = USD
+    label = "Qualified Medicare Beneficiary cost-sharing value"
+    definition_period = MONTH
+    reference = (
+        "https://www.medicare.gov/basics/costs/help/medicare-savings-programs",
+        "https://www.law.cornell.edu/uscode/text/42/1396d#p_3",
+    )
+    documentation = (
+        "First-pass monthly value of QMB coverage for Medicare deductibles, "
+        "coinsurance, and copayments. The model lacks beneficiary-level "
+        "Medicare claims, so this approximates cost sharing as a parameterized "
+        "share of average Medicare per-capita spending."
+    )
+
+    def formula(person, period, parameters):
+        category = person("msp_category", period)
+        p = parameters(period).gov.hhs.medicare.savings_programs
+        monthly_medicare_cost = (
+            parameters(period).calibration.gov.hhs.medicare.per_capita_cost
+            / MONTHS_IN_YEAR
+        )
+        return (
+            (category == MSPCategory.QMB)
+            * monthly_medicare_cost
+            * p.qmb.cost_sharing_rate
+        )

--- a/policyengine_us/variables/household/healthcare_benefit_value.py
+++ b/policyengine_us/variables/household/healthcare_benefit_value.py
@@ -9,6 +9,7 @@ class healthcare_benefit_value(Variable):
     unit = USD
     adds = [
         "medicaid_cost",
+        "msp_cost",
         "per_capita_chip",
         "assigned_aca_ptc",
         "co_omnisalud",


### PR DESCRIPTION
Fixes PolicyEngine/policyengine-us#8496.

## Summary

- Adds explicit annual MSP fiscal accounting with `msp_cost`, `msp_federal_cost`, and `msp_state_cost`.
- Adds `qmb_cost_sharing`, a first-pass QMB cost-sharing value using a parameterized 20% share of average Medicare per-capita spending.
- Adds QMB and QI parameters for cost-sharing approximation and QI federal financing.
- Includes `msp_cost` in household health benefits and healthcare benefit value so baseline MSP/QMB support nets against full Medicaid cost in reform comparisons.
- Avoids double-counting by setting separate MSP cost to zero for full Medicaid enrollees.

## Source and Policy Review

Reviewed again on 2026-05-25 before opening this draft.

- Medicare.gov's 2026 Medicare Savings Programs page says QMB pays Part A premiums when needed, Part B premiums, deductibles, coinsurance, and copayments; SLMB and QI pay Part B premiums.
- Medicare.gov and CMS's CY 2026 Part B update support the 2026 standard Part B premium of $202.90 per month and general 20% Part B coinsurance.
- 42 U.S.C. 1396a(a)(10)(E) requires Medicaid assistance for Medicare cost sharing for QMBs and Part B premium assistance for SLMB/QI groups.
- 42 U.S.C. 1396d(p)(3) defines Medicare cost sharing to include premiums, deductibles, coinsurance, and the Part B 80%-to-100% payment gap.
- 42 U.S.C. 1396u-3(d) sets QI financing at 100% federal within the state allocation and 0% above allocation.

## Scope Notes

- QMB cost sharing is approximated because the household model does not have Medicare claims, service-specific cost sharing, provider assignment, or benefit-period detail.
- QI allocation exhaustion is not modeled; the new QI parameter represents the within-allocation federal share.

## Tests

- `make format`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/qmb_cost_sharing.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/msp_cost.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicare/savings_programs/msp_federal_and_state_cost.yaml -c policyengine_us`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/household/household_health_benefits.yaml policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml -c policyengine_us`
