### PR TITLE
Model Medicaid CE 1115 comparable adults

### DIFF
--- a/changelog.d/added/8271.md
+++ b/changelog.d/added/8271.md
@@ -1,0 +1,1 @@
+Added section 1115 minimum essential coverage adults to Medicaid work requirement applicability.

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/covered.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/covered.yaml
@@ -12,6 +12,7 @@ values:
     - is_optional_senior_or_disabled_for_medicaid
     - is_medically_needy_for_medicaid
     - is_working_disabled_buy_in_for_medicaid
+    - is_medicaid_1115_mec_adult
 metadata:
   unit: list
   label: "Medicaid categories"

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_category.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_category.yaml
@@ -44,3 +44,19 @@
     is_optional_senior_or_disabled_asset_eligible: true
   output:
     medicaid_category: SSI_RECIPIENT
+
+- name: Case 6, section 1115 MEC adult category.
+  period: 2027
+  input:
+    is_adult_for_medicaid: false
+    is_medicaid_1115_mec_adult: true
+  output:
+    medicaid_category: SECTION_1115_MEC_ADULT
+
+- name: Case 7, adult group takes priority over section 1115 MEC adult.
+  period: 2027
+  input:
+    is_adult_for_medicaid: true
+    is_medicaid_1115_mec_adult: true
+  output:
+    medicaid_category: ADULT

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml
@@ -290,3 +290,27 @@
     state_code: AR
   output:
     is_medicaid_eligible: true
+
+- name: Case 15, section 1115 MEC adult is ineligible when work requirements apply and are unmet.
+  period: 2027
+  input:
+    is_adult_for_medicaid: false
+    is_medicaid_1115_mec_adult: true
+    immigration_status: CITIZEN
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_category: SECTION_1115_MEC_ADULT
+    is_medicaid_work_requirement_applicable_adult: true
+    is_medicaid_eligible: false
+
+- name: Case 16, section 1115 MEC adult remains eligible when meeting the income safe harbor.
+  period: 2027
+  input:
+    is_adult_for_medicaid: false
+    is_medicaid_1115_mec_adult: true
+    immigration_status: CITIZEN
+    employment_income: 6_960
+  output:
+    medicaid_category: SECTION_1115_MEC_ADULT
+    is_medicaid_work_requirement_applicable_adult: true
+    is_medicaid_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_work_requirement_applicable_adult.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_work_requirement_applicable_adult.yaml
@@ -1,0 +1,48 @@
+- name: Case 1, ACA adult group is subject to Medicaid work requirements.
+  period: 2027
+  input:
+    medicaid_category: ADULT
+  output:
+    is_medicaid_work_requirement_applicable_adult: true
+
+- name: Case 2, section 1115 MEC adult is subject to Medicaid work requirements.
+  period: 2027
+  input:
+    medicaid_category: SECTION_1115_MEC_ADULT
+  output:
+    is_medicaid_work_requirement_applicable_adult: true
+
+- name: Case 3, parent category is not subject to Medicaid work requirements.
+  period: 2027
+  input:
+    medicaid_category: PARENT
+  output:
+    is_medicaid_work_requirement_applicable_adult: false
+
+- name: Case 4, child category is not subject to Medicaid work requirements.
+  period: 2027
+  input:
+    medicaid_category: OLDER_CHILD
+  output:
+    is_medicaid_work_requirement_applicable_adult: false
+
+- name: Case 5, pregnant category is not subject to Medicaid work requirements.
+  period: 2027
+  input:
+    medicaid_category: PREGNANT
+  output:
+    is_medicaid_work_requirement_applicable_adult: false
+
+- name: Case 6, SSI recipient category is not subject to Medicaid work requirements.
+  period: 2027
+  input:
+    medicaid_category: SSI_RECIPIENT
+  output:
+    is_medicaid_work_requirement_applicable_adult: false
+
+- name: Case 7, senior or disabled category is not subject to Medicaid work requirements.
+  period: 2027
+  input:
+    medicaid_category: SENIOR_OR_DISABLED
+  output:
+    is_medicaid_work_requirement_applicable_adult: false

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_medicaid_1115_mec_adult.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_medicaid_1115_mec_adult.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class is_medicaid_1115_mec_adult(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible under a Medicaid section 1115 MEC adult demonstration"
+    definition_period = YEAR
+    reference = (
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf",
+    )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py
@@ -14,6 +14,7 @@ class MedicaidCategory(Enum):
     NONE = "None"
     MEDICALLY_NEEDY = "Medically needy"
     WORKING_DISABLED_BUY_IN = "Working disabled Buy-In"
+    SECTION_1115_MEC_ADULT = "Section 1115 MEC adult"
     HEALTHIER_MISSISSIPPI_WAIVER = "Healthier Mississippi Waiver"
 
 
@@ -65,6 +66,9 @@ class medicaid_category(Variable):
             is_medically_needy_for_medicaid=MedicaidCategory.MEDICALLY_NEEDY,
             # 9. Medicaid Buy-In pathways for working disabled people.
             is_working_disabled_buy_in_for_medicaid=MedicaidCategory.WORKING_DISABLED_BUY_IN,
+            # 10. Adult-like section 1115 demonstration coverage that
+            #     provides minimum essential coverage.
+            is_medicaid_1115_mec_adult=MedicaidCategory.SECTION_1115_MEC_ADULT,
         )
 
         # Ensure parametric reforms to the list of categories prevent those

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py
@@ -14,7 +14,6 @@ class is_medicaid_eligible(Variable):
     def formula(person, period, parameters):
         category = person("medicaid_category", period)
         categorically_eligible = category != category.possible_values.NONE
-        adult_group = category == category.possible_values.ADULT
         immigration_status_eligible = person(
             "is_medicaid_immigration_status_eligible", period
         )
@@ -28,7 +27,12 @@ class is_medicaid_eligible(Variable):
             work_requirement_eligible = person(
                 "medicaid_work_requirement_eligible", period
             )
-            federal_work_requirement_eligible = ~adult_group | work_requirement_eligible
+            work_requirement_applicable = person(
+                "is_medicaid_work_requirement_applicable_adult", period
+            )
+            federal_work_requirement_eligible = (
+                ~work_requirement_applicable | work_requirement_eligible
+            )
 
         ar_p = parameters(period).gov.states.ar.dhs.medicaid.work_requirements
         ar_work_requirement_eligible = True

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_work_requirement_applicable_adult.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_work_requirement_applicable_adult.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class is_medicaid_work_requirement_applicable_adult(Variable):
+    value_type = bool
+    entity = Person
+    label = "Adult subject to Medicaid work requirements"
+    definition_period = YEAR
+    reference = (
+        "https://www.congress.gov/bill/119th-congress/house-bill/1/text",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf",
+    )
+
+    def formula(person, period, parameters):
+        category = person("medicaid_category", period)
+        return (category == category.possible_values.ADULT) | (
+            category == category.possible_values.SECTION_1115_MEC_ADULT
+        )


### PR DESCRIPTION
## Summary

Closes #8271.

This scopes Medicaid community engagement/work-requirement applicability through a dedicated variable instead of checking only the ACA adult category inline.

- Adds `is_medicaid_1115_mec_adult` as an explicit person-level input for section 1115 demonstration adults receiving minimum essential coverage and not otherwise eligible under the Medicaid state plan.
- Adds `SECTION_1115_MEC_ADULT` to `medicaid_category` and includes it in covered Medicaid categories.
- Adds `is_medicaid_work_requirement_applicable_adult`, covering ACA adult group and section 1115 MEC adult categories.
- Updates `is_medicaid_eligible` so work requirements apply to both applicable adult groups while parents, children, pregnant people, SSI recipients, and senior/disabled categories remain outside the applicability variable.

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_work_requirement_applicable_adult.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_category.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/is_medicaid_eligible.yaml -c policyengine_us`
  - 41 passed.
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility -c policyengine_us`
  - 174 passed.
- `uv run --extra dev ruff format policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_medicaid_1115_mec_adult.py policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_work_requirement_applicable_adult.py policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py`
- `uv run --extra dev ruff check policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/is_medicaid_1115_mec_adult.py policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_work_requirement_applicable_adult.py policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_category.py policyengine_us/variables/gov/hhs/medicaid/eligibility/is_medicaid_eligible.py`
  - All checks passed.
- `uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_system_import.py -q`
  - 10 passed.
- `git diff --check`
