### PR TITLE
Derive monthly hours worked for Medicaid work requirements

### DIFF
--- a/changelog.d/fixed/7492.md
+++ b/changelog.d/fixed/7492.md
@@ -1,0 +1,1 @@
+Derive monthly hours worked from last-week hours for Medicaid work requirements.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -159,3 +159,20 @@
     medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: false
+
+- name: Case 18, last-week hours above monthly threshold meet the work requirement.
+  period: 2027
+  input:
+    age: 30
+    hours_worked_last_week: 20
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 19, last-week hours below monthly threshold do not meet the work requirement.
+  period: 2027
+  input:
+    age: 30
+    hours_worked_last_week: 18
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: false

--- a/policyengine_us/tests/policy/baseline/household/income/person/monthly_hours_worked.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/monthly_hours_worked.yaml
@@ -1,0 +1,13 @@
+- name: Case 1, monthly hours worked derives from last week's hours.
+  period: 2027
+  absolute_error_margin: 0.001
+  input:
+    hours_worked_last_week: 20
+  output:
+    monthly_hours_worked: 86.667
+
+- name: Case 2, missing last-week hours derive zero monthly hours.
+  period: 2027
+  input: {}
+  output:
+    monthly_hours_worked: 0

--- a/policyengine_us/variables/household/income/person/monthly_hours_worked.py
+++ b/policyengine_us/variables/household/income/person/monthly_hours_worked.py
@@ -7,3 +7,6 @@ class monthly_hours_worked(Variable):
     label = "Average monthly hours worked"
     unit = "hour"
     definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("hours_worked_last_week", period) * WEEKS_IN_YEAR / MONTHS_IN_YEAR


### PR DESCRIPTION
## Summary

Closes #7492.

This fixes the Medicaid work-requirement hours path by deriving `monthly_hours_worked` from the populated `hours_worked_last_week` input when monthly hours are not supplied directly.

- Adds a formula for `monthly_hours_worked`: last-week hours times 52 weeks divided by 12 months.
- Adds direct tests for the monthly-hours derivation, including the zero-hours default.
- Adds Medicaid work-requirement tests showing derived monthly hours can meet or miss the 80-hour monthly threshold.

I used `hours_worked_last_week` rather than `weekly_hours_worked_before_lsr` because the latter defaults to 40 when absent, which would make otherwise unspecified household cases appear to satisfy Medicaid work requirements.

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/income/person/monthly_hours_worked.yaml policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml -c policyengine_us`
  - 19 passed.
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility policyengine_us/tests/policy/baseline/gov/states/ms/dom/wd/eligibility policyengine_us/tests/policy/baseline/gov/states/md/tca policyengine_us/tests/policy/baseline/gov/states/il/dhs/aabd -c policyengine_us`
  - 299 passed.
- `uv run --extra dev ruff format policyengine_us/variables/household/income/person/monthly_hours_worked.py`
- `uv run --extra dev ruff check policyengine_us/variables/household/income/person/monthly_hours_worked.py`
  - All checks passed.
- `uv run pytest policyengine_us/tests/test_parameter_files.py policyengine_us/tests/test_system_import.py -q`
  - 10 passed.
- `git diff --check`
