### PR TITLE
[codex] Validate changelog fragment paths

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,13 +22,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Check for changelog fragment
+        with:
+          fetch-depth: 2
+      - name: Check changed changelog fragments
+        shell: bash
         run: |
-          FRAGMENTS=$(find changelog.d -type f ! -name '.gitkeep' | wc -l)
-          if [ "$FRAGMENTS" -eq 0 ]; then
-            echo "::error::No changelog fragment found in changelog.d/"
-            echo "Add one with: echo 'Description.' > changelog.d/\$(git branch --show-current).<type>.md"
-            echo "Types: added, changed, fixed, removed, breaking"
+          set -euo pipefail
+
+          valid_count=0
+          invalid=0
+
+          while IFS= read -r fragment; do
+            if [ "$fragment" = "changelog.d/.gitkeep" ]; then
+              continue
+            fi
+
+            if [[ "$fragment" =~ ^changelog\.d/[^/]+\.(breaking|added|changed|fixed|removed)\.md$ ]]; then
+              valid_count=$((valid_count + 1))
+            else
+              echo "::error file=${fragment}::Invalid changelog fragment path. Use changelog.d/<name>.<type>.md, where <type> is one of: breaking, added, changed, fixed, removed."
+              invalid=1
+            fi
+          done < <(
+            git diff --name-only --diff-filter=ACMR \
+              HEAD^1 \
+              HEAD \
+              -- changelog.d
+          )
+
+          if [ "$invalid" -ne 0 ]; then
+            exit 1
+          fi
+
+          if [ "$valid_count" -eq 0 ]; then
+            echo "::error::No valid changelog fragment found. Add one like: changelog.d/${{ github.head_ref }}.fixed.md"
             exit 1
           fi
   BundleMetadataContract:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,19 @@ echo "Description of change." > changelog.d/<branch-name>.<type>.md
 ```
 Types: `added` (minor bump), `changed` (patch), `fixed` (patch), `removed` (minor), `breaking` (major)
 
+The fragment must be a top-level file in `changelog.d/`. Do not create type subdirectories.
+
+Correct:
+```text
+changelog.d/medicaid-ce-exclusions.added.md
+```
+
+Incorrect:
+```text
+changelog.d/added/medicaid-ce-exclusions.md
+changelog.d/medicaid-ce-exclusions.md
+```
+
 **DO NOT** edit `CHANGELOG.md` directly or use `changelog_entry.yaml` (deprecated).
 
 ## Project Requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Four types of files usually change together:
 
 Conventions:
 
+- Changelog fragments must be top-level files like `changelog.d/my-change.fixed.md`; do not use `changelog.d/fixed/my-change.md` or omit the type suffix.
 - Write YAML tests **first** (TDD). They fail until the variable formula is in place.
 - Use `where(...)`, `max_(...)`, `min_(...)` inside formulas — never Python `if` / `max` / `min`. Vectorisation requires numpy.
 - Match the variable file name to the class name (e.g. `my_tax_credit.py` defines `class my_tax_credit(Variable)`).

--- a/changelog.d/added/ci-validation-demo.md
+++ b/changelog.d/added/ci-validation-demo.md
@@ -1,1 +1,0 @@
-Demonstrate the changelog fragment path validation failure.

--- a/changelog.d/added/ci-validation-demo.md
+++ b/changelog.d/added/ci-validation-demo.md
@@ -1,0 +1,1 @@
+Demonstrate the changelog fragment path validation failure.

--- a/changelog.d/validate-changelog-fragment-paths.fixed.md
+++ b/changelog.d/validate-changelog-fragment-paths.fixed.md
@@ -1,0 +1,1 @@
+Validate changed changelog fragment paths in pull request CI.


### PR DESCRIPTION
## Summary
- tighten pull request CI so it validates only changelog fragments changed by the PR
- reject malformed future fragments such as `changelog.d/added/foo.md` or `changelog.d/foo.md`
- document the required top-level `changelog.d/<name>.<type>.md` format in agent and contributor guidance

## Why this PR is needed
Recent Codex-assisted PRs created changelog fragments in paths that look reasonable to humans but are not recognized by Towncrier, such as `changelog.d/added/medicaid-ce-exclusions.md`. The existing PR check only counted files anywhere under `changelog.d`, so those malformed fragments passed CI. Later, the release workflow still bumped the package version but Towncrier did not consume the bad fragments, producing releases that said `No significant changes`.

This PR prevents the same failure mode for future PRs without rewriting or blocking on the existing malformed backlog. The check only inspects changelog files changed in the PR, so legacy files do not make unrelated PRs fail.

## Validation
- `git diff --check`
- simulated the changed-fragment validation against this commit under bash
- confirmed the regex rejects `changelog.d/added/bad.md` and accepts `changelog.d/good.fixed.md`
