### PR TITLE
[codex] Notify Slack for partner test changes

### DIFF
--- a/.github/workflows/partner-api-impact-notice.yaml
+++ b/.github/workflows/partner-api-impact-notice.yaml
@@ -61,11 +61,18 @@ jobs:
             exit 0
           fi
 
-          file_list=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d; s/^/- /')
+          file_count=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d' | wc -l | tr -d ' ')
+          file_list=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d' | head -20 | sed 's/^/- /')
+
+          if [ "${file_count}" -gt 20 ]; then
+            file_list="${file_list}
+- ...and $((file_count - 20)) more. See the PR file diff for the full list."
+          fi
 
           payload=$(
             jq -n \
               --arg author "${PR_AUTHOR}" \
+              --arg count "${file_count}" \
               --arg files "${file_list}" \
               --arg number "${PR_NUMBER}" \
               --arg title "${PR_TITLE}" \
@@ -75,7 +82,8 @@ jobs:
                   ":warning: Partner API contract tests changed\n" +
                   "PR: <" + $url + "|#" + $number + " " + $title + ">\n" +
                   "Author: " + $author + "\n" +
-                  "Changed files:\n" + $files + "\n\n" +
+                  "Changed partner files: " + $count + "\n" +
+                  "Showing first 20:\n" + $files + "\n\n" +
                   "Please review whether this changes partner-facing API behavior before merge."
                 )
               }'

--- a/.github/workflows/partner-api-impact-notice.yaml
+++ b/.github/workflows/partner-api-impact-notice.yaml
@@ -1,0 +1,88 @@
+name: Partner API impact notice
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "policyengine_us/tests/policy/baseline/partners/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify-slack:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find changed partner tests
+        id: partner_files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          files=$(
+            gh api --paginate \
+              "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[].filename' \
+              | grep '^policyengine_us/tests/policy/baseline/partners/' \
+              || true
+          )
+
+          {
+            echo "files<<EOF"
+            echo "${files}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [ -n "${files}" ]; then
+            echo "any_changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "any_changed=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Notify Slack
+        if: steps.partner_files.outputs.any_changed == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PARTNER_WEBHOOK_URL }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          CHANGED_FILES: ${{ steps.partner_files.outputs.files }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "::notice::SLACK_PARTNER_WEBHOOK_URL is not configured; skipping Slack notification."
+            exit 0
+          fi
+
+          file_list=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d; s/^/- /')
+
+          payload=$(
+            jq -n \
+              --arg author "${PR_AUTHOR}" \
+              --arg files "${file_list}" \
+              --arg number "${PR_NUMBER}" \
+              --arg title "${PR_TITLE}" \
+              --arg url "${PR_URL}" \
+              '{
+                text: (
+                  ":warning: Partner API contract tests changed\n" +
+                  "PR: <" + $url + "|#" + $number + " " + $title + ">\n" +
+                  "Author: " + $author + "\n" +
+                  "Changed files:\n" + $files + "\n\n" +
+                  "Please review whether this changes partner-facing API behavior before merge."
+                )
+              }'
+          )
+
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Content-type: application/json" \
+            --data "${payload}" \
+            "${SLACK_WEBHOOK_URL}"

--- a/changelog.d/partner-api-impact-slack-notice.added.md
+++ b/changelog.d/partner-api-impact-slack-notice.added.md
@@ -1,0 +1,1 @@
+Added Slack notices for partner API contract test changes.


### PR DESCRIPTION
## Summary
- add a `pull_request_target` workflow for partner API impact notices
- detect changed files under `policyengine_us/tests/policy/baseline/partners/**` with the GitHub API
- post PR metadata and changed partner files to Slack via `SLACK_PARTNER_WEBHOOK_URL`
- show the total partner-file count and cap the displayed file list at the first 20 files

## Why this PR is needed
Partner API contract tests are intended to surface partner-facing behavior changes. The existing CI verifies that those tests pass, but it does not notify the team when partner contract files themselves are changed.

This workflow sends an automatic Slack notice when a PR changes partner test files, without requiring contributors to add labels or use the GitHub UI.

The workflow uses `pull_request_target` so repository secrets are available for fork PRs, but it does not check out or execute pull request code. It only reads changed file names through the GitHub API before posting the Slack message.

Closes #8519.

## Validation
- `git diff --check HEAD~1 HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/partner-api-impact-notice.yaml"); puts "yaml ok"'`

Note: the workflow itself will start applying after this PR is merged, because `pull_request_target` workflows run from the base branch.