### PR TITLE
Add modeled Medicaid variables

### DIFF
--- a/changelog.d/restore-medicaid-cost-fallback.fixed.md
+++ b/changelog.d/restore-medicaid-cost-fallback.fixed.md
@@ -1,0 +1,1 @@
+Add parallel modeled Medicaid cost variables for API partner household calculations.

--- a/changelog.d/restore-medicaid-cost-fallback.fixed.md
+++ b/changelog.d/restore-medicaid-cost-fallback.fixed.md
@@ -1,1 +1,1 @@
-Add parallel modeled Medicaid cost variables for API partner household calculations.
+Add parallel modeled Medicaid variables for API partner household calculations.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/modeled_medicaid_cost.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/modeled_medicaid_cost.yaml
@@ -1,0 +1,20 @@
+- name: Case 1, modeled Medicaid cost is zero when not enrolled.
+  period: 2026
+  input:
+    state_code: NC
+    is_medicaid_eligible: true
+    takes_up_medicaid_if_eligible: false
+    medicaid_category: ADULT
+  output:
+    modeled_medicaid_cost: 0
+
+- name: Case 2, modeled Medicaid cost uses the per-capita estimate when enrolled.
+  period: 2026
+  absolute_error_margin: 0.1
+  input:
+    state_code: NC
+    is_medicaid_eligible: true
+    takes_up_medicaid_if_eligible: true
+    medicaid_category: ADULT
+  output:
+    modeled_medicaid_cost: 7_054

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/modeled_medicaid_cost_if_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs/modeled_medicaid_cost_if_enrolled.yaml
@@ -1,0 +1,18 @@
+- name: Case 1, expansion adult uses per-capita Medicaid estimate.
+  period: 2026
+  absolute_error_margin: 0.1
+  input:
+    state_code: NC
+    is_medicaid_eligible: true
+    medicaid_category: ADULT
+  output:
+    modeled_medicaid_cost_if_enrolled: 7_054
+
+- name: Case 2, ineligible person has no estimated Medicaid cost.
+  period: 2026
+  input:
+    state_code: TX
+    is_medicaid_eligible: false
+    medicaid_category: NONE
+  output:
+    modeled_medicaid_cost_if_enrolled: 0

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/modeled_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/modeled_medicaid.yaml
@@ -1,0 +1,20 @@
+- name: Case 1, modeled Medicaid is zero when not enrolled.
+  period: 2026
+  input:
+    state_code: NC
+    is_medicaid_eligible: true
+    takes_up_medicaid_if_eligible: false
+    medicaid_category: ADULT
+  output:
+    modeled_medicaid: 0
+
+- name: Case 2, modeled Medicaid uses the modeled cost when enrolled.
+  period: 2026
+  absolute_error_margin: 0.1
+  input:
+    state_code: NC
+    is_medicaid_eligible: true
+    takes_up_medicaid_if_eligible: true
+    medicaid_category: ADULT
+  output:
+    modeled_medicaid: 7_054

--- a/policyengine_us/tests/policy/baseline/partners/amplifi/2025.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/amplifi/2025.yaml
@@ -19,14 +19,12 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 1
         immigration_status_str: CITIZEN
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '91367'
@@ -69,7 +67,7 @@
   output:
     people:
       you:
-        medicaid: 0.0
+        modeled_medicaid_cost: 0.0
         is_medicaid_eligible: false
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -79,7 +77,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 711.43
         is_aca_ptc_eligible: false
@@ -89,7 +87,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 711.27
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/amplifi/2025.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/amplifi/2025.yaml
@@ -67,7 +67,7 @@
   output:
     people:
       you:
-        modeled_medicaid_cost: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -77,7 +77,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 711.43
         is_aca_ptc_eligible: false
@@ -87,7 +87,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 711.27
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
@@ -67,7 +67,7 @@
   output:
     people:
       you:
-        modeled_medicaid_cost: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -77,7 +77,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -87,7 +87,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 722.99
         is_aca_ptc_eligible: false
@@ -217,7 +217,7 @@
   output:
     people:
       you:
-        modeled_medicaid_cost: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -227,7 +227,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -237,7 +237,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -368,7 +368,7 @@
   output:
     people:
       you:
-        modeled_medicaid_cost: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -378,7 +378,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -388,7 +388,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        modeled_medicaid_cost: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         wic: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
@@ -19,14 +19,12 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 1
         immigration_status_str: CITIZEN
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '91367'
@@ -69,7 +67,7 @@
   output:
     people:
       you:
-        medicaid: 0.0
+        modeled_medicaid_cost: 0.0
         is_medicaid_eligible: false
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -79,7 +77,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -89,7 +87,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 722.99
         is_aca_ptc_eligible: false
@@ -165,7 +163,6 @@
         is_pregnant: false
         ca_calworks_child_care_time_category: MONTHLY
         receives_medicaid: false
-        medicaid_cost_if_enrolled: 6439.11
       member1:
         age: 2
         ca_calworks_child_care_full_time: true
@@ -173,7 +170,6 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 4
         ca_calworks_child_care_full_time: true
@@ -181,7 +177,6 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '90019'
@@ -222,7 +217,7 @@
   output:
     people:
       you:
-        medicaid: 6439.11
+        modeled_medicaid_cost: 6439.11
         is_medicaid_eligible: true
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -232,7 +227,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -242,7 +237,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -318,7 +313,6 @@
         is_pregnant: false
         ca_calworks_child_care_time_category: MONTHLY
         receives_medicaid: false
-        medicaid_cost_if_enrolled: 4367.51
       member1:
         age: 3
         ca_calworks_child_care_full_time: true
@@ -326,7 +320,6 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       member2:
         age: 6
         ca_calworks_child_care_full_time: true
@@ -334,7 +327,6 @@
         is_aca_eshi_eligible: false
         is_disabled: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         zip_code: '90019'
@@ -376,7 +368,7 @@
   output:
     people:
       you:
-        medicaid: 4367.51
+        modeled_medicaid_cost: 4367.51
         is_medicaid_eligible: true
         wic: 0.0
         is_aca_ptc_eligible: false
@@ -386,7 +378,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member1:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 723.15
         is_aca_ptc_eligible: false
@@ -396,7 +388,7 @@
         ca_state_supplement_eligible_person: false
         ca_ala_general_assistance_eligible_person: false
       member2:
-        medicaid: 3258.31
+        modeled_medicaid_cost: 3258.31
         is_medicaid_eligible: true
         wic: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ca.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 2001
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -154,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/co.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -99,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -153,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/federal.yaml
@@ -16,7 +16,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id001
@@ -46,7 +45,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -71,7 +70,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -101,7 +99,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -155,7 +153,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -180,7 +178,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 2000
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id004
@@ -210,7 +207,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -264,7 +261,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -289,7 +286,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id006
@@ -319,7 +315,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -344,7 +340,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id007
@@ -374,7 +369,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -428,7 +423,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/il.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 2001
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -125,7 +123,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id003
@@ -155,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/la.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -99,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -153,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/ma.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -99,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -124,7 +123,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id003
@@ -154,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/nc.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -99,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -153,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/tx.yaml
@@ -44,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -98,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -152,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/cash/ssi/wa.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -99,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -153,7 +152,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/composition/cash_health/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/composition/cash_health/federal.yaml
@@ -44,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -69,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -99,7 +98,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -167,7 +166,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -177,7 +176,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -214,7 +213,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -248,7 +246,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -258,7 +256,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -295,7 +293,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -308,7 +305,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id005
@@ -346,7 +342,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -356,7 +352,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -366,7 +362,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -415,7 +411,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -428,7 +423,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id006
@@ -468,7 +462,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -478,7 +472,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -488,7 +482,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -498,7 +492,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ca.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -149,7 +147,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -185,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -195,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -205,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -254,7 +251,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -290,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -300,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -310,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/co.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -184,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -194,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -204,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -288,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -298,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -308,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/federal.yaml
@@ -44,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -98,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -152,7 +152,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +206,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -290,7 +290,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -300,7 +300,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -310,7 +310,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -394,7 +394,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -404,7 +404,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -414,7 +414,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/il.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -149,7 +147,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -185,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -195,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -205,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -254,7 +251,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -290,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -300,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -310,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/la.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -149,7 +147,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -185,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -195,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -205,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -254,7 +251,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -290,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -300,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -310,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/ma.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -184,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -194,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -204,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -288,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -298,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -308,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/nc.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -149,7 +147,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -185,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -195,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -205,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -254,7 +251,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -290,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -300,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -310,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/tx.yaml
@@ -44,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -98,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -182,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -192,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -202,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -286,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -296,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -306,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/aca_ptc/wa.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -149,7 +147,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -185,7 +182,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -195,7 +192,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -205,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -254,7 +251,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -290,7 +286,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -300,7 +296,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -310,7 +306,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ca.yaml
@@ -39,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -75,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -85,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -95,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -144,7 +143,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -180,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -190,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -200,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -284,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -294,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -304,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/co.yaml
@@ -74,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -84,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -94,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -143,7 +143,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -179,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -189,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -199,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -283,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -293,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -303,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/federal.yaml
@@ -74,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -84,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -94,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -178,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -188,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -198,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -282,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -292,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -302,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -386,7 +386,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -396,7 +396,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -406,7 +406,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/il.yaml
@@ -39,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -75,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -85,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -95,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -144,7 +143,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -180,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -190,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -200,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -249,7 +247,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -285,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -295,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -305,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/la.yaml
@@ -74,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -84,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -94,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -143,7 +143,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -179,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -189,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -199,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -283,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -293,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -303,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/ma.yaml
@@ -74,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -84,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -94,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -143,7 +143,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
     households:
       household:
         members: &id002
@@ -179,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -189,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -199,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -283,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -293,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -303,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/nc.yaml
@@ -74,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -84,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -94,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -143,7 +143,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -179,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -189,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -199,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -283,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -293,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -303,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/tx.yaml
@@ -74,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -84,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -94,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -178,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -188,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -198,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -282,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -292,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -302,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/chip/wa.yaml
@@ -74,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -84,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -94,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -143,7 +143,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -179,7 +178,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -189,7 +188,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -199,7 +198,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -283,7 +282,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -293,7 +292,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -303,7 +302,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ca.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -41,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -77,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -87,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -97,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -122,7 +119,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/co.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -41,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -77,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -87,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -97,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -122,7 +119,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/federal.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -83,7 +81,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 0
         is_tax_unit_head: false
@@ -96,7 +93,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id002
@@ -132,7 +128,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -142,7 +138,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -177,7 +173,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -190,7 +185,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 1
         is_tax_unit_head: false
@@ -203,7 +197,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id003
@@ -239,7 +232,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -249,7 +242,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -259,7 +252,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -284,7 +277,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -297,7 +289,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 5
         is_tax_unit_head: false
@@ -310,7 +301,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id004
@@ -346,7 +336,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -356,7 +346,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -366,7 +356,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -391,7 +381,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -404,7 +393,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 6
         is_tax_unit_head: false
@@ -417,7 +405,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id005
@@ -453,7 +440,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -463,7 +450,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -473,7 +460,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -498,7 +485,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -511,7 +497,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 18
         is_tax_unit_head: false
@@ -524,7 +509,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id006
@@ -560,7 +544,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -570,7 +554,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -580,7 +564,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -605,7 +589,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -618,7 +601,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -666,7 +648,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -676,7 +658,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -686,7 +668,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -740,7 +722,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -794,7 +776,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/il.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -41,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -77,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -87,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -97,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -122,7 +119,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/la.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -41,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -77,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -87,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -97,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -122,7 +119,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/ma.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -41,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
     households:
       household:
         members: &id001
@@ -77,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -87,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -97,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -122,7 +119,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/nc.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -41,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -77,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -87,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -97,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -122,7 +119,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/tx.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -76,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -86,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -96,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -150,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true
@@ -204,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/medicaid/wa.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -28,7 +27,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 19
         is_tax_unit_head: false
@@ -41,7 +39,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id001
@@ -77,7 +74,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -87,7 +84,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -97,7 +94,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -122,7 +119,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 6439.11
     households:
       household:
         members: &id002
@@ -152,7 +148,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 6439.11
+        modeled_medicaid: 6439.11
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -206,7 +202,7 @@
         is_ssi_aged: false
         msp: 0.0
         msp_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         is_medicaid_eligible: false
         chip: 0.0
         is_aca_ptc_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/msp/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/healthcare/msp/federal.yaml
@@ -15,7 +15,6 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id001
@@ -45,7 +44,7 @@
         is_ssi_aged: true
         msp: 9214.8
         msp_eligible: true
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -70,7 +69,6 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id002
@@ -100,7 +98,7 @@
         is_ssi_aged: true
         msp: 9214.8
         msp_eligible: true
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -125,7 +123,6 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id003
@@ -155,7 +152,7 @@
         is_ssi_aged: true
         msp: 9214.8
         msp_eligible: true
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -180,7 +177,6 @@
         is_medicare_eligible: true
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id004
@@ -210,7 +206,7 @@
         is_ssi_aged: true
         msp: 9214.8
         msp_eligible: true
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false
@@ -235,7 +231,6 @@
         is_medicare_eligible: false
         ssi_countable_resources: 0
         is_aca_eshi_eligible: false
-        medicaid_cost_if_enrolled: 22373.06
     households:
       household:
         members: &id005
@@ -265,7 +260,7 @@
         is_ssi_aged: true
         msp: 0.0
         msp_eligible: false
-        medicaid: 22373.06
+        modeled_medicaid: 22373.06
         is_medicaid_eligible: true
         chip: 0.0
         is_aca_ptc_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ca.yaml
@@ -52,7 +52,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -69,7 +68,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -171,7 +169,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -181,7 +179,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -191,7 +189,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -201,7 +199,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -266,7 +264,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -283,7 +280,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -375,7 +371,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -385,7 +381,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -395,7 +391,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -405,7 +401,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -463,7 +459,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -478,7 +473,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -569,7 +563,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -579,7 +573,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -589,7 +583,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -599,7 +593,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -628,7 +622,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -642,7 +635,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -656,7 +648,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -670,7 +661,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -761,7 +751,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -771,7 +761,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -781,7 +771,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -791,7 +781,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -846,7 +836,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -860,7 +849,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -951,7 +939,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -961,7 +949,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -971,7 +959,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -981,7 +969,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -1009,7 +997,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -1022,7 +1009,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -1035,7 +1021,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1048,7 +1033,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1139,7 +1123,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -1149,7 +1133,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -1159,7 +1143,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -1169,7 +1153,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -1230,7 +1214,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1246,7 +1229,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1340,7 +1322,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -1350,7 +1332,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -1360,7 +1342,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -1370,7 +1352,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -1428,7 +1410,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1443,7 +1424,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1536,7 +1516,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -1546,7 +1526,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -1556,7 +1536,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -1566,7 +1546,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -1595,7 +1575,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -1609,7 +1588,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -1623,7 +1601,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1637,7 +1614,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1729,7 +1705,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -1739,7 +1715,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -1749,7 +1725,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -1759,7 +1735,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -1823,7 +1799,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1840,7 +1815,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1932,7 +1906,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -1942,7 +1916,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -1952,7 +1926,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -1962,7 +1936,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -1991,7 +1965,6 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -2004,7 +1977,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -2017,7 +1989,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2030,7 +2001,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2121,7 +2091,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -2131,7 +2101,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -2141,7 +2111,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -2151,7 +2121,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -2215,7 +2185,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2231,7 +2200,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2326,7 +2294,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -2336,7 +2304,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -2346,7 +2314,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -2356,7 +2324,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -2386,7 +2354,6 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -2400,7 +2367,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -2414,7 +2380,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2428,7 +2393,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2521,7 +2485,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -2531,7 +2495,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -2541,7 +2505,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -2551,7 +2515,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -2609,7 +2573,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2624,7 +2587,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2715,7 +2677,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -2725,7 +2687,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -2735,7 +2697,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -2745,7 +2707,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -2809,7 +2771,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -2826,7 +2787,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -2917,7 +2877,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -2927,7 +2887,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -2937,7 +2897,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -2947,7 +2907,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -2976,7 +2936,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -2990,7 +2949,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -3003,7 +2961,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3016,7 +2973,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3109,7 +3065,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -3119,7 +3075,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -3129,7 +3085,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -3139,7 +3095,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -3200,7 +3156,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3216,7 +3171,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3307,7 +3261,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -3317,7 +3271,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -3327,7 +3281,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -3337,7 +3291,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -3366,7 +3320,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -3380,7 +3333,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -3394,7 +3346,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3408,7 +3359,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3499,7 +3449,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -3509,7 +3459,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -3519,7 +3469,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -3529,7 +3479,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -3560,7 +3510,6 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -3574,7 +3523,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -3588,7 +3536,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3602,7 +3549,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3693,7 +3639,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -3703,7 +3649,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -3713,7 +3659,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -3723,7 +3669,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -3784,7 +3730,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3800,7 +3745,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -3893,7 +3837,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -3903,7 +3847,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -3913,7 +3857,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -3923,7 +3867,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -3981,7 +3925,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -3996,7 +3939,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4089,7 +4031,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -4099,7 +4041,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -4109,7 +4051,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -4119,7 +4061,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -4149,7 +4091,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -4164,7 +4105,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -4179,7 +4119,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4194,7 +4133,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4285,7 +4223,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -4295,7 +4233,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -4305,7 +4243,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -4315,7 +4253,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -4346,7 +4284,6 @@
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
         ca_riv_general_relief_meets_work_requirements: false
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -4360,7 +4297,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -4374,7 +4310,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4388,7 +4323,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4480,7 +4414,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -4490,7 +4424,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -4500,7 +4434,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -4510,7 +4444,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -4565,7 +4499,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4579,7 +4512,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4670,7 +4602,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -4680,7 +4612,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -4690,7 +4622,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -4700,7 +4632,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -4761,7 +4693,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4777,7 +4708,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -4868,7 +4798,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -4878,7 +4808,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -4888,7 +4818,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -4898,7 +4828,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -4959,7 +4889,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -4975,7 +4904,6 @@
         other_medical_expenses: 0
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -5068,7 +4996,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -5078,7 +5006,7 @@
         is_medicaid_eligible: false
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         ssi: 0.0
         wic: 0.0
       child1:
@@ -5088,7 +5016,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -5098,7 +5026,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -5127,7 +5055,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -5141,7 +5068,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -5155,7 +5081,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -5169,7 +5094,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -5262,7 +5186,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -5272,7 +5196,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -5282,7 +5206,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -5292,7 +5216,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -5321,7 +5245,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -5335,7 +5258,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -5349,7 +5271,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -5363,7 +5284,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -5456,7 +5376,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -5466,7 +5386,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -5476,7 +5396,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -5486,7 +5406,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:
@@ -5514,7 +5434,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -5527,7 +5446,6 @@
         health_insurance_premiums: 0
         receives_medicaid: false
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 4367.51
       child1:
         age: 8
         is_tax_unit_head: false
@@ -5540,7 +5458,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -5553,7 +5470,6 @@
         receives_medicaid: false
         health_insurance_premiums: 0
         ca_calworks_child_care_time_category: MONTHLY
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -5645,7 +5561,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       spouse:
@@ -5655,7 +5571,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 4367.51
+        modeled_medicaid: 4367.51
         ssi: 0.0
         wic: 0.0
       child1:
@@ -5665,7 +5581,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 0.0
       child2:
@@ -5675,7 +5591,7 @@
         is_medicaid_eligible: true
         is_ssi_aged: false
         is_ssi_eligible: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         ssi: 0.0
         wic: 723.15
     households:

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
@@ -75,7 +75,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -96,7 +95,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -151,7 +149,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -163,7 +161,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -175,7 +173,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -187,7 +185,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -282,7 +280,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -303,7 +300,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -350,7 +346,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -362,7 +358,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -374,7 +370,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -386,7 +382,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -483,7 +479,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -505,7 +500,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -552,7 +546,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -564,7 +558,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -576,7 +570,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -588,7 +582,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -774,7 +768,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -796,7 +789,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -843,7 +835,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         wic: 0.0
         wic_category: 5
@@ -854,7 +846,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         wic: 0.0
         wic_category: 5
@@ -865,7 +857,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         wic: 0.0
         wic_category: 5
@@ -876,7 +868,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         wic: 723.15
         wic_category: 4
@@ -973,7 +965,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -995,7 +986,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1042,7 +1032,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -1054,7 +1044,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -1066,7 +1056,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -1078,7 +1068,7 @@
         co_state_supplement: 0.0
         commodity_supplemental_food_program: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
@@ -97,7 +97,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -123,7 +122,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -191,7 +189,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -208,7 +206,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -225,7 +223,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -242,7 +240,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -363,7 +361,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -391,7 +388,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -450,7 +446,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -465,7 +461,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -480,7 +476,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -495,7 +491,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -612,7 +608,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -639,7 +634,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -699,7 +693,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -716,7 +710,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -733,7 +727,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -750,7 +744,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -864,7 +858,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -890,7 +883,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -950,7 +942,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -967,7 +959,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -984,7 +976,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -1001,7 +993,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -1118,7 +1110,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1145,7 +1136,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1205,7 +1195,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1222,7 +1212,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1239,7 +1229,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -1256,7 +1246,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -1376,7 +1366,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1404,7 +1393,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1463,7 +1451,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1478,7 +1466,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1493,7 +1481,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -1508,7 +1496,7 @@
         il_hbwd_person: 0.0
         il_mpe_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -1624,7 +1612,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1651,7 +1638,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1711,7 +1697,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1727,7 +1713,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1743,7 +1729,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -1759,7 +1745,7 @@
         il_mpe_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
@@ -84,7 +84,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -106,7 +105,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -180,7 +178,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -197,7 +195,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -214,7 +212,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -231,7 +229,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -333,7 +331,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -355,7 +352,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -422,7 +418,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -439,7 +435,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -456,7 +452,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -473,7 +469,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -573,7 +569,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -595,7 +590,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -661,7 +655,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -678,7 +672,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -695,7 +689,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -712,7 +706,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -814,7 +808,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -837,7 +830,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -903,7 +895,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -920,7 +912,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -937,7 +929,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -954,7 +946,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -1057,7 +1049,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1080,7 +1071,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1146,7 +1136,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -1163,7 +1153,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
@@ -1180,7 +1170,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
@@ -1197,7 +1187,7 @@
         ma_mbta_senior_charlie_card_eligible: false
         ma_mbta_tap_charlie_card_eligible: false
         ma_state_supplement: 0.0
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
@@ -75,7 +75,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -96,7 +95,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -154,28 +152,28 @@
     people:
       head:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       spouse:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child1:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child2:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -265,7 +263,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -286,7 +283,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -336,28 +332,28 @@
     people:
       head:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       spouse:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child1:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child2:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -449,7 +445,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -471,7 +466,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -521,28 +515,28 @@
     people:
       head:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       spouse:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child1:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child2:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15
@@ -635,7 +629,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -657,7 +650,6 @@
         real_estate_taxes: 0
         child_support_expense: 0
         current_pregnancies: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -707,25 +699,25 @@
     people:
       head:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         wic: 0.0
         wic_category: 5
       spouse:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         wic: 0.0
         wic_category: 5
       child1:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         wic: 0.0
         wic_category: 5
       child2:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         wic: 723.15
         wic_category: 4
@@ -816,7 +808,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -838,7 +829,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         other_medical_expenses: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -888,28 +878,28 @@
     people:
       head:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       spouse:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child1:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         ssi: 0.0
         wic: 0.0
         wic_category: 5
       child2:
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         ssi: 0.0
         wic: 723.15

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
@@ -90,7 +90,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -115,7 +114,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: &id001
@@ -179,7 +177,7 @@
         is_disabled: false
         is_medicaid_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -199,7 +197,7 @@
         is_disabled: false
         is_medicaid_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -219,7 +217,7 @@
         is_disabled: false
         is_medicaid_eligible: true
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -239,7 +237,7 @@
         is_disabled: false
         is_medicaid_eligible: true
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -352,7 +350,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -377,7 +374,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -433,7 +429,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -453,7 +449,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -473,7 +469,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -493,7 +489,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -691,7 +687,7 @@
         early_head_start: 0.0
         head_start: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -709,7 +705,7 @@
         early_head_start: 0.0
         head_start: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -727,7 +723,7 @@
         early_head_start: 0.0
         head_start: 0.0
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -745,7 +741,7 @@
         early_head_start: 0.0
         head_start: 20347.29
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -854,7 +850,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -878,7 +873,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -935,7 +929,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -956,7 +950,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -977,7 +971,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -998,7 +992,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -1107,7 +1101,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1131,7 +1124,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1188,7 +1180,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1209,7 +1201,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1230,7 +1222,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -1251,7 +1243,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -1364,7 +1356,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
       child2:
         age: 3
         is_tax_unit_head: false
@@ -1389,7 +1380,6 @@
         child_support_expense: 0
         current_pregnancies: 0
         medicare_quarters_of_coverage: 0
-        medicaid_cost_if_enrolled: 3258.31
     households:
       household:
         members: *id001
@@ -1445,7 +1435,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1465,7 +1455,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1485,7 +1475,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -1505,7 +1495,7 @@
         is_medicaid_eligible: true
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 3258.31
+        modeled_medicaid: 3258.31
         medicaid_category: 1
         msp: 0.0
         msp_category: 0
@@ -1700,7 +1690,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1720,7 +1710,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 9
         msp: 0.0
         msp_category: 0
@@ -1740,7 +1730,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 2
         msp: 0.0
         msp_category: 0
@@ -1760,7 +1750,7 @@
         is_medicaid_eligible: false
         is_medicare_eligible: false
         is_optional_senior_or_disabled_for_medicaid: false
-        medicaid: 0.0
+        modeled_medicaid: 0.0
         medicaid_category: 1
         msp: 0.0
         msp_category: 0

--- a/policyengine_us/tests/policy/baseline/partners/my_friend_ben/2025.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/my_friend_ben/2025.yaml
@@ -66,7 +66,7 @@
   output:
     people:
       '2021359':
-        modeled_medicaid_cost: 4580.0
+        modeled_medicaid: 4580.0
         medicaid_category: 6
         is_optional_senior_or_disabled_for_medicaid: false
         co_state_supplement: 0.0

--- a/policyengine_us/tests/policy/baseline/partners/my_friend_ben/2025.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/my_friend_ben/2025.yaml
@@ -29,7 +29,6 @@
         other_medical_expenses: 0
         is_snap_ineligible_student: true
         is_full_time_college_student: true
-        medicaid_cost_if_enrolled: 4580.0
     households:
       household:
         members:
@@ -67,7 +66,7 @@
   output:
     people:
       '2021359':
-        medicaid: 4580.0
+        modeled_medicaid_cost: 4580.0
         medicaid_category: 6
         is_optional_senior_or_disabled_for_medicaid: false
         co_state_supplement: 0.0

--- a/policyengine_us/variables/gov/hhs/medicaid/costs/modeled_medicaid_cost_if_enrolled.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/costs/modeled_medicaid_cost_if_enrolled.py
@@ -1,0 +1,31 @@
+from policyengine_us.model_api import *
+from policyengine_us.variables.gov.hhs.medicaid.costs.medicaid_group import (
+    MedicaidGroup,
+)
+from policyengine_us.variables.gov.hhs.medicaid.costs.per_capita_cost_helpers import (
+    calculate_per_capita_cost,
+)
+
+
+class modeled_medicaid_cost_if_enrolled(Variable):
+    value_type = float
+    entity = Person
+    label = "Modeled Medicaid cost if enrolled"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "is_medicaid_eligible"
+
+    def formula(person, period, parameters):
+        return calculate_per_capita_cost(
+            person,
+            period,
+            parameters,
+            person("medicaid_group", period),
+            MedicaidGroup,
+            groups=[
+                MedicaidGroup.AGED_DISABLED,
+                MedicaidGroup.CHILD,
+                MedicaidGroup.EXPANSION_ADULT,
+                MedicaidGroup.NON_EXPANSION_ADULT,
+            ],
+        )

--- a/policyengine_us/variables/gov/hhs/medicaid/modeled_medicaid.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/modeled_medicaid.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class modeled_medicaid(Variable):
+    value_type = float
+    entity = Person
+    label = "Modeled Medicaid"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/42/1396a"
+    defined_for = "medicaid_enrolled"
+    adds = ["modeled_medicaid_cost"]

--- a/policyengine_us/variables/gov/hhs/medicaid/modeled_medicaid_cost.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/modeled_medicaid_cost.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class modeled_medicaid_cost(Variable):
+    value_type = float
+    entity = Person
+    label = "Modeled Medicaid cost"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/42/1396a"
+    defined_for = "medicaid_enrolled"
+    adds = ["modeled_medicaid_cost_if_enrolled"]


### PR DESCRIPTION
## Summary

Adds parallel modeled Medicaid variables for API partner household calculations without changing the existing data-backed Medicaid cost path.

- keeps `medicaid_cost_if_enrolled` and `medicaid_cost` as data-backed variables for datasets
- adds `modeled_medicaid_cost_if_enrolled` using the pre-#8499 per-capita Medicaid formula
- adds `modeled_medicaid_cost` gated by Medicaid enrollment
- adds `modeled_medicaid` as the API partner-facing modeled Medicaid benefit amount, mirroring `medicaid` while using the modeled cost path
- updates partner contract fixtures so partners request `modeled_medicaid` instead of sending `medicaid_cost_if_enrolled`
- adds focused YAML tests and a changelog fragment

## Root cause

PR #8499 made `medicaid_cost_if_enrolled` data-backed, which is correct for datasets but removed the formula-backed value API partner household calculations need when they do not provide a Medicaid cost input.

## Partner contract

API partners should not send `medicaid_cost_if_enrolled`. When they want PolicyEngine to estimate Medicaid value for household calculations, they should request `modeled_medicaid`.

## Validation

- `policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/costs -c policyengine_us`
- `policyengine-core test policyengine_us/tests/policy/baseline/partners/amplifi policyengine_us/tests/policy/baseline/partners/my_friend_ben policyengine_us/tests/policy/baseline/partners/impactica -c policyengine_us`
- Static scan confirms partner fixtures no longer contain `medicaid_cost_if_enrolled`, person-level `medicaid`, or `modeled_medicaid_cost` outputs.

Fixes #8533
