### PR TITLE
Fix YAML syntax error in partner API impact notice workflow

### DIFF
--- a/.github/workflows/partner-api-impact-notice.yaml
+++ b/.github/workflows/partner-api-impact-notice.yaml
@@ -1,4 +1,4 @@
-name: Partner API impact notice
+name: Partner API impact Notice
 
 on:
   pull_request_target:

--- a/.github/workflows/partner-api-impact-notice.yaml
+++ b/.github/workflows/partner-api-impact-notice.yaml
@@ -65,8 +65,7 @@ jobs:
           file_list=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d' | head -20 | sed 's/^/- /')
 
           if [ "${file_count}" -gt 20 ]; then
-            file_list="${file_list}
-- ...and $((file_count - 20)) more. See the PR file diff for the full list."
+            file_list=$(printf '%s\n- ...and %d more. See the PR file diff for the full list.' "${file_list}" $((file_count - 20)))
           fi
 
           payload=$(

--- a/.github/workflows/partner-api-impact-notice.yaml
+++ b/.github/workflows/partner-api-impact-notice.yaml
@@ -1,4 +1,4 @@
-name: Partner API impact Notice
+name: Partner API impact notice
 
 on:
   pull_request_target:

--- a/changelog.d/fix-partner-notice-yaml.fixed.md
+++ b/changelog.d/fix-partner-notice-yaml.fixed.md
@@ -1,0 +1,1 @@
+Fixed YAML syntax error in partner API impact notice workflow.


### PR DESCRIPTION
## Summary
- Fixes invalid YAML in `.github/workflows/partner-api-impact-notice.yaml` that has made every run of the workflow fail since #8534 merged.
- Replaces a literal-newline multi-line shell string with `printf`, so the surrounding YAML block scalar stays valid.

## Why this PR is needed
The workflow merged in #8534 fails on every run with:

> Invalid workflow file: .github/workflows/partner-api-impact-notice.yaml#L81
> You have an error in your yaml syntax on line 81

Actual root cause is at line 69 (the GH parser error points downstream): the shell continuation line `- ...and $((file_count - 20)) more...` starts at column 1, with no indentation. YAML's `|` block scalar requires every content line to be indented to at least the base indent. The unindented `-` was interpreted as the end of the block scalar and the start of a new sequence item under `jobs:`, which is invalid.

Ruby's Psych YAML parser accepted the file (which is why the original PR's `ruby -e 'YAML.load_file ...'` validation passed), but libyaml / PyYAML / the GitHub Actions parser reject it.

## Fix
Build the truncation suffix with `printf` instead of an embedded literal newline inside a double-quoted shell string. Output is identical; YAML is well-formed.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/partner-api-impact-notice.yaml'))"` — passes
- `make format` — clean
- Workflow run will be observable on the next PR that touches `policyengine_us/tests/policy/baseline/partners/**` after this merges (since `pull_request_target` runs from the base branch).

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, open a follow-up PR that touches a partner test file and confirm the workflow runs green and posts to Slack