### PR TITLE
Fix NJ filing-threshold phantom tax

### DIFF
--- a/changelog.d/fix-nj-filing-threshold-phantom-tax.fixed.md
+++ b/changelog.d/fix-nj-filing-threshold-phantom-tax.fixed.md
@@ -1,0 +1,1 @@
+Zero the New Jersey pre-credit liability before refundable credits flow through when AGI is at or below the filing threshold.

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax.yaml
@@ -17,16 +17,45 @@
   output:
     nj_income_tax: 0
 
-- name: NJ income tax below filing threshold but tax is negative because of refundable credits.
+- name: Below the filing threshold, tax is zeroed before applying refundable credits
   period: 2022
   input:
     state_code: NJ
     nj_agi: 19_999
     filing_status: JOINT
+    # Per N.J.S.A. 54A:2-4, the pre-credit liability is wiped before
+    # credits flow through; the full $1,001 of credits is refunded
+    # rather than netted against the $1,000 of bracket-schedule tax.
     nj_income_tax_before_refundable_credits: 1_000
     nj_refundable_credits: 1_001
   output:
-    nj_income_tax: -1
+    nj_income_tax: -1_001
+
+- name: NJ joint at $20K gross income owes no tax, full refundable credits
+  period: 2025
+  input:
+    people:
+      head: {age: 40}
+      spouse: {age: 40, employment_income: 20_000}
+      k1: {age: 2}
+      k2: {age: 11}
+    tax_units:
+      tax_unit:
+        members: [head, spouse, k1, k2]
+        tax_unit_childcare_expenses: 3_000
+    marital_units:
+      m:
+        members: [head, spouse]
+      m1:
+        members: [k1]
+      m2:
+        members: [k2]
+    households:
+      household:
+        members: [head, spouse, k1, k2]
+        state_name: NJ
+  output:
+    nj_income_tax: -3_860.8
 
 - name: NJ income tax above filing threshold so tax is calculated amount minus refundable credits.
   period: 2022

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax.yaml
@@ -57,6 +57,29 @@
   output:
     nj_income_tax: -3_860.8
 
+- name: AGI exactly at the SINGLE filing threshold still zeroes pre-credit tax
+  period: 2022
+  input:
+    state_code: NJ
+    nj_agi: 10_000
+    filing_status: SINGLE
+    nj_income_tax_before_refundable_credits: 500
+    nj_refundable_credits: 200
+  output:
+    # <= comparison: $10,000 is still inside the no-tax zone.
+    nj_income_tax: -200
+
+- name: AGI one dollar above the SINGLE filing threshold falls through to schedule
+  period: 2022
+  input:
+    state_code: NJ
+    nj_agi: 10_001
+    filing_status: SINGLE
+    nj_income_tax_before_refundable_credits: 500
+    nj_refundable_credits: 200
+  output:
+    nj_income_tax: 300
+
 - name: NJ income tax above filing threshold so tax is calculated amount minus refundable credits.
   period: 2022
   input:

--- a/policyengine_us/variables/gov/states/nj/tax/income/nj_income_tax.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/nj_income_tax.py
@@ -15,10 +15,11 @@ class nj_income_tax(Variable):
         filing_status = tax_unit("filing_status", period)
         income_tax = tax_unit("nj_income_tax_before_refundable_credits", period)
         refundable_credits = tax_unit("nj_refundable_credits", period)
-        # if AGI is at or below filing threshold, tax should not be positive,
-        #  but tax could still be negative if filer is due refundable credits
+        # N.J.S.A. 54A:2-4 zeroes tax for filers at or below the filing
+        # threshold; refundable credits then flow through against zero tax
+        # rather than against the bracket-schedule amount.
         return where(
             agi <= p.filing_threshold[filing_status],
-            min_(0, income_tax - refundable_credits),
+            -refundable_credits,
             income_tax - refundable_credits,
         )

--- a/policyengine_us/variables/gov/states/nj/tax/income/nj_income_tax.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/nj_income_tax.py
@@ -8,6 +8,10 @@ class nj_income_tax(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.NJ
+    reference = (
+        "https://law.justia.com/codes/new-jersey/title-54a/section-54a-2-4/",
+        "https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf#page=5",
+    )
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.nj.tax.income


### PR DESCRIPTION
## Summary

Closes #8550.

`nj_income_tax` returned `min_(0, income_tax − refundable_credits)` when AGI was at or below the filing threshold, which netted the bracket-schedule tax (statutorily zeroed under N.J.S.A. 54A:2-4) against refundable credits and understated refunds by exactly the phantom tax amount. Replace with `-refundable_credits` in the below-threshold branch.

## Test plan

- [x] Add the integration test from the issue: joint filer, 2 deps, \$20K wages → `nj_income_tax: -3_860.8`.
- [x] Update the existing test (`nj_agi: 19_999`, \$1,000 tax, \$1,001 credits) that asserted the buggy `-1` to the correct `-1_001`.
- [x] Full NJ regression passes (521 tests).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)