### PR TITLE
Fix RCC other-dependent credit semantics

### DIFF
--- a/changelog.d/8552.fixed.md
+++ b/changelog.d/8552.fixed.md
@@ -1,0 +1,1 @@
+Correct the refundable credit conversion per-other-dependent credit to count all non-CTC tax-unit dependents.

--- a/policyengine_us/parameters/gov/contrib/refundable_credit_conversion/credit/per_other_dependent.yaml
+++ b/policyengine_us/parameters/gov/contrib/refundable_credit_conversion/credit/per_other_dependent.yaml
@@ -1,4 +1,4 @@
-description: Provides this flat refundable credit per EITC-qualifying dependent who does not also meet the CTC definition (e.g., children aged 17-18 or full-time students 19-23).
+description: Provides this flat refundable credit per tax-unit dependent who does not also meet the CTC definition.
 metadata:
   unit: currency-USD
   period: year

--- a/policyengine_us/parameters/gov/contrib/refundable_credit_conversion/credit/use_other_dependent_credit.yaml
+++ b/policyengine_us/parameters/gov/contrib/refundable_credit_conversion/credit/use_other_dependent_credit.yaml
@@ -1,4 +1,4 @@
-description: Apply the per-other-dependent flat credit, which counts EITC-qualifying children who do NOT meet the CTC definition. When false, the per_other_dependent amount is ignored.
+description: Apply the per-other-dependent flat credit, which counts tax-unit dependents who do NOT meet the CTC definition. When false, the per_other_dependent amount is ignored.
 metadata:
   unit: bool
   period: year

--- a/policyengine_us/reforms/refundable_credit_conversion/refundable_credit_conversion.py
+++ b/policyengine_us/reforms/refundable_credit_conversion/refundable_credit_conversion.py
@@ -10,9 +10,8 @@ def create_refundable_credit_conversion() -> Reform:
 
       * per-taxpayer (each head of tax unit and spouse if MFJ)
       * per-CTC-qualifying dependent
-      * per-other-dependent (EITC-qualifying child who does NOT meet
-        the CTC definition — e.g., children aged 17-18 or full-time
-        students 19-23)
+      * per-other-dependent (any tax-unit dependent who does NOT meet
+        the CTC definition)
       * per-tax-unit (household)
       * per-earner earnings subsidy (rate times capped earnings per
         worker, where earnings follow the EITC convention of wages
@@ -65,15 +64,13 @@ def create_refundable_credit_conversion() -> Reform:
             else:
                 ctc_dependent_amount = 0
 
-            # Per-other-dependent credit (EITC-qualifying children who
-            # are not CTC-qualifying — e.g., children aged 17-18 or
-            # full-time students aged 19-23). Computed as a population-
-            # aggregate count difference; the max_ guard handles the
-            # rare case where a CTC kid lacks the EITC identification
-            # requirements (ctc_count > eitc_count).
+            # Per-other-dependent credit (all tax-unit dependents who
+            # are not CTC-qualifying). Computed as a population-
+            # aggregate count difference; the max_ guard keeps the
+            # amount non-negative in edge cases.
             if p.credit.use_other_dependent_credit:
-                eitc_count = tax_unit("eitc_child_count", period)
-                other_count = max_(eitc_count - ctc_count, 0)
+                dependent_count = tax_unit("tax_unit_dependents", period)
+                other_count = max_(dependent_count - ctc_count, 0)
                 other_dependent_amount = other_count * p.credit.per_other_dependent
             else:
                 other_dependent_amount = 0

--- a/policyengine_us/tests/policy/contrib/refundable_credit_conversion/dependent_definition.yaml
+++ b/policyengine_us/tests/policy/contrib/refundable_credit_conversion/dependent_definition.yaml
@@ -24,9 +24,9 @@
   output:
     flat_refundable_credit: 1_000  # only the 5yo is CTC-qualifying
 
-- name: Per-other-dependent credit counts EITC kids who fail the CTC test
+- name: Per-other-dependent credit counts non-CTC dependent children
   # Same family — with only the other-dependent toggle on, only the
-  # 17-year-old (EITC-qualifying but not CTC-qualifying) should count.
+  # 17-year-old dependent child past the CTC age cutoff should count.
   period: 2026
   reforms: policyengine_us.reforms.refundable_credit_conversion.refundable_credit_conversion
   input:
@@ -47,9 +47,9 @@
         members: [filer, spouse, young_child, older_child]
         filing_status: JOINT
   output:
-    flat_refundable_credit: 500  # only the 17yo, EITC-eligible but not CTC
+    flat_refundable_credit: 500  # only the 17yo, dependent but not CTC
 
-- name: Both per-dependent toggles split the credit by kid age
+- name: Both per-dependent toggles split the credit by CTC eligibility
   period: 2026
   reforms: policyengine_us.reforms.refundable_credit_conversion.refundable_credit_conversion
   input:
@@ -116,8 +116,9 @@
 
 - name: Set-difference clamp — CTC kid failing EITC ID requirements does not net negative
   # If a single child is CTC-qualifying but fails the EITC identification
-  # requirements (e.g., ITIN-only), then ctc_count = 1 and eitc_count = 0.
-  # The other-dependent count = max_(0 - 1, 0) = 0; we never net negative.
+  # requirements (e.g., ITIN-only), the other-dependent count is still
+  # max_(dependent_count - ctc_count, 0) = max_(1 - 1, 0) = 0; we never
+  # net negative.
   period: 2026
   reforms: policyengine_us.reforms.refundable_credit_conversion.refundable_credit_conversion
   input:
@@ -136,7 +137,7 @@
         members: [filer, child]
         filing_status: SINGLE
   output:
-    flat_refundable_credit: 0  # max_(eitc_count - ctc_count, 0) = max_(-1, 0) = 0
+    flat_refundable_credit: 0  # max_(dependent_count - ctc_count, 0) = 0
 
 - name: Per-dependent toggles off — amounts ignored even with kids present
   period: 2026
@@ -158,3 +159,52 @@
         filing_status: SINGLE
   output:
     flat_refundable_credit: 0
+
+- name: Per-other-dependent credit counts adult dependents
+  period: 2026
+  reforms: policyengine_us.reforms.refundable_credit_conversion.refundable_credit_conversion
+  input:
+    gov.contrib.refundable_credit_conversion.in_effect: true
+    gov.contrib.refundable_credit_conversion.credit.use_other_dependent_credit: true
+    gov.contrib.refundable_credit_conversion.credit.per_other_dependent: 500
+    people:
+      filer:
+        age: 45
+      adult_parent:
+        age: 70
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, adult_parent]
+        filing_status: SINGLE
+  output:
+    flat_refundable_credit: 500
+
+- name: Taxpayer and dependent credits can cover every tax-unit member once
+  period: 2026
+  reforms: policyengine_us.reforms.refundable_credit_conversion.refundable_credit_conversion
+  input:
+    gov.contrib.refundable_credit_conversion.in_effect: true
+    gov.contrib.refundable_credit_conversion.credit.use_taxpayer_credit: true
+    gov.contrib.refundable_credit_conversion.credit.use_ctc_dependent_credit: true
+    gov.contrib.refundable_credit_conversion.credit.use_other_dependent_credit: true
+    gov.contrib.refundable_credit_conversion.credit.per_taxpayer: 1_000
+    gov.contrib.refundable_credit_conversion.credit.per_ctc_dependent: 500
+    gov.contrib.refundable_credit_conversion.credit.per_other_dependent: 250
+    people:
+      filer:
+        age: 45
+      spouse:
+        age: 43
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+      adult_parent:
+        age: 70
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, spouse, child, adult_parent]
+        filing_status: JOINT
+  output:
+    flat_refundable_credit: 2_750  # 2 taxpayers + 1 CTC child + 1 other dependent


### PR DESCRIPTION
## Summary

- Change the refundable credit conversion per-other-dependent credit to count all tax-unit dependents who are not CTC-qualifying children.
- Update parameter descriptions so they no longer describe the credit as limited to EITC-qualifying children.
- Add regression coverage for an adult dependent and a full tax-unit-member coverage scenario.

Fixes #8552.

## Tests

- `uv run python -c 'import os; from policyengine_core.scripts import build_tax_benefit_system; from policyengine_core.tools.test_runner import run_tests; tbs = build_tax_benefit_system("policyengine_us", [], []); status = run_tests(tbs, ["policyengine_us/tests/policy/contrib/refundable_credit_conversion/dependent_definition.yaml"]); print(f"run_tests_status={status}", flush=True); os._exit(status)'`
  - Collected 9 cases and printed 9 passing dots, then stalled before pytest printed its final summary; I killed the stuck process.
