### PR TITLE
Wire vt_renter_credit into state_property_tax_credits aggregate

### DIFF
--- a/changelog.d/wire-vt-renter-credit-into-state-property-tax-credits.fixed.md
+++ b/changelog.d/wire-vt-renter-credit-into-state-property-tax-credits.fixed.md
@@ -1,0 +1,1 @@
+Wire the Vermont renter credit into the state property tax credits aggregate.

--- a/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
@@ -92,6 +92,7 @@ values:
     - ny_real_property_tax_credit
     - ok_ptc
     - ri_property_tax_credit
+    - vt_renter_credit
     - wi_homestead_credit
     - wi_property_tax_credit
     - wv_homestead_excess_property_tax_credit
@@ -111,6 +112,7 @@ values:
     - ny_real_property_tax_credit
     - ok_ptc
     - ri_property_tax_credit
+    - vt_renter_credit
     - wi_homestead_credit
     - wi_property_tax_credit
     - wv_homestead_excess_property_tax_credit
@@ -133,6 +135,7 @@ values:
     - ny_real_property_tax_credit
     - ok_ptc
     - ri_property_tax_credit
+    - vt_renter_credit
     - wi_homestead_credit
     - wi_property_tax_credit
     - wv_homestead_excess_property_tax_credit
@@ -158,6 +161,7 @@ values:
     - pa_property_tax_or_rent_rebate
     - ri_property_tax_credit
     - ut_homeowner_renter_relief
+    - vt_renter_credit
     - wi_homestead_credit
     - wi_property_tax_credit
     - wv_homestead_excess_property_tax_credit
@@ -182,6 +186,7 @@ values:
     - ok_ptc
     - ri_property_tax_credit
     - ut_homeowner_renter_relief
+    - vt_renter_credit
     - wi_homestead_credit
     - wi_property_tax_credit
     - wv_homestead_excess_property_tax_credit

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/vt_renter_credit_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/vt_renter_credit_in_aggregate.yaml
@@ -17,3 +17,45 @@
   output:
     vt_renter_credit: 1_729
     taxsim_state_property_tax_credit: 1_729
+
+- name: Non-VT household does not pick up the VT renter credit via the aggregate
+  period: 2024
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 20_000
+        rent: 12_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: NH
+  output:
+    vt_renter_credit: 0
+    taxsim_state_property_tax_credit: 0
+
+- name: Pre-2021 VT household excludes vt_renter_credit from the aggregate
+  period: 2020
+  # The 2020 snapshot inherits the 2016 list, which does not yet
+  # include vt_renter_credit. The underlying variable can still
+  # compute a non-zero value via parameter extrapolation, so this
+  # test specifically guards the year-keyed gating in the aggregate.
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 20_000
+        rent: 12_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: VT
+        county: CHITTENDEN_COUNTY_VT
+  output:
+    taxsim_state_property_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/vt_renter_credit_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/vt_renter_credit_in_aggregate.yaml
@@ -1,0 +1,19 @@
+- name: VT renter credit flows into the state property tax credits aggregate
+  period: 2024
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 20_000
+        rent: 12_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: VT
+        county: CHITTENDEN_COUNTY_VT
+  output:
+    vt_renter_credit: 1_729
+    taxsim_state_property_tax_credit: 1_729


### PR DESCRIPTION
## Summary

Closes #8555.

`vt_renter_credit` (32 V.S.A. § 6066(b)) computes the Vermont Renter Credit but was not flowing into any aggregate. Add it to `gov.states.household.state_property_tax_credits` for each year the credit's parameters are defined in PE-US (2021 onward), so it flows through `taxsim_state_property_tax_credit` alongside other state property/renter credits.

Per VT DOR ([GB-1128](https://tax.vermont.gov/myvtax/RCC-146-instructions)), the credit is administered on form RCC-146 and is paid as a separate check unless the filer elects to apply it to IN-111, so it stays out of `vt_refundable_credits` / `vt_income_tax` — mirroring how `nd_renters_refund` is handled (aggregate-only, not in `nd_refundable_credits`).

## Test plan

- [x] New integration test: Chittenden County renter, $20K wages, $12K rent, 2024 → `vt_renter_credit: 1_729` flows through to `taxsim_state_property_tax_credit: 1_729`.
- [x] Cross-state control: non-VT (NH) household with the same renter profile → `vt_renter_credit: 0`, `taxsim_state_property_tax_credit: 0`.
- [x] Pre-2021 year-gating: VT household in 2020 → `taxsim_state_property_tax_credit: 0` (the variable extrapolates to non-zero but the aggregate respects the year-keyed list).
- [x] Existing `test_state_property_tax_credit_matches_configured_component_sum` still passes (8/8 in `test_legacy_state_umbrellas.py`).
- [x] Full VT + household suite (344+ tests) passes.
- [x] `make format` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)