### PR TITLE
Unwire UT Homeowner/Renter Relief from income tax refundable credits

### DIFF
--- a/changelog.d/unwire-ut-homeowner-renter-relief-from-income-tax.fixed.md
+++ b/changelog.d/unwire-ut-homeowner-renter-relief-from-income-tax.fixed.md
@@ -1,0 +1,1 @@
+Remove the Utah Homeowner's/Renter's Relief from Utah income tax refundable credits, since it is administered on Form TC-90CB rather than Form TC-40. The credit remains in the household-level state property tax credits aggregate.

--- a/policyengine_us/parameters/gov/states/ut/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ut/tax/income/credits/refundable.yaml
@@ -1,16 +1,18 @@
-description: Utah provides these refundable income tax credits.
+description: Utah provides these refundable income tax credits on Form TC-40.
 values:
-  2025-01-01:
-    - ut_homeowner_renter_relief
+  # Utah does not currently administer any refundable credits on the TC-40
+  # income tax return. The Homeowner's/Renter's Relief (Utah Code
+  # § 59-2A-205 / § 59-2A-305) is administered on a separate refund
+  # application (Form TC-90CB) and flows through the household-level
+  # state_property_tax_credits aggregate instead.
+  2025-01-01: []
 
 metadata:
   unit: list
   period: year
   label: Utah refundable credits
   reference:
-    - title: Utah State Tax Commission Homeowner's or Renter's Relief
+    - title: Utah State Tax Commission Form TC-40 instructions
+      href: https://tax.utah.gov/forms/current/tc-40inst.pdf
+    - title: Utah State Tax Commission Homeowner's or Renter's Relief (Form TC-90CB)
       href: https://tax.utah.gov/relief/homeowner-renter-relief/
-    - title: Utah Code Section 59-2a-205
-      href: https://le.utah.gov/xcode/Title59/Chapter2A/C59-2a_2026010120250507.pdf#page=11
-    - title: Utah Code Section 59-2a-305
-      href: https://le.utah.gov/xcode/Title59/Chapter2A/C59-2a_2026010120250507.pdf#page=14

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_refundable_credits.yaml
@@ -1,0 +1,24 @@
+- name: UT has no refundable credits on Form TC-40 — the Homeowner/Renter Relief is administered on Form TC-90CB
+  period: 2025
+  input:
+    people:
+      head:
+        age: 75
+        employment_income: 25_000
+        social_security_retirement: 12_123.58
+        rent: 18_363.48
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: UT
+  output:
+    # vt_renter_credit-style structural pattern: the credit is non-zero
+    # but it does not appear on the income tax return — it flows through
+    # the household-level state_property_tax_credits aggregate instead.
+    ut_homeowner_renter_relief: 429
+    ut_refundable_credits: 0
+    ut_income_tax: 0
+    taxsim_state_property_tax_credit: 429

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/credits/ut_refundable_credits.yaml
@@ -1,4 +1,7 @@
 - name: UT has no refundable credits on Form TC-40 — the Homeowner/Renter Relief is administered on Form TC-90CB
+  # Scenario from issue #8561 / PolicyEngine/policyengine-taxsim#947.
+  # TAXSIM-35 and TaxAct (Form TC-40) both return $0 siitax for this
+  # household; PE-US previously returned -$429.
   period: 2025
   input:
     people:
@@ -22,3 +25,66 @@
     ut_refundable_credits: 0
     ut_income_tax: 0
     taxsim_state_property_tax_credit: 429
+
+- name: Non-UT household does not pick up Utah refundable credits via the aggregate
+  period: 2025
+  input:
+    people:
+      head:
+        age: 75
+        employment_income: 25_000
+        social_security_retirement: 12_123.58
+        rent: 18_363.48
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: NH
+  output:
+    ut_homeowner_renter_relief: 0
+    ut_refundable_credits: 0
+
+- name: Pre-2025 UT household excludes ut_homeowner_renter_relief from ut_refundable_credits
+  # The aggregate parameter only starts 2025-01-01; pre-2025 the list
+  # is unset, so the relief never appeared in TC-40 refundable credits.
+  period: 2024
+  input:
+    people:
+      head:
+        age: 75
+        employment_income: 25_000
+        social_security_retirement: 12_123.58
+        rent: 18_363.48
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: UT
+  output:
+    ut_refundable_credits: 0
+
+- name: Non-zero UT income tax — rewiring leaves typical filers' liability unchanged
+  # Higher-wage UT household with no rent: ut_homeowner_renter_relief is
+  # zero, ut_income_tax is positive, and ut_refundable_credits stays 0.
+  # Guards against silently changing TC-40 outcomes for non-relief filers.
+  period: 2025
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 100_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: UT
+  output:
+    ut_homeowner_renter_relief: 0
+    ut_refundable_credits: 0
+    ut_income_tax: 4_500


### PR DESCRIPTION
## Summary

Closes #8561.

`ut_homeowner_renter_relief` (Utah Code § 59-2A-205 / § 59-2A-305) is administered on a separate refund application ([Form TC-90CB](https://files.tax.utah.gov/tax/forms/current/tc-90cb.pdf)) rather than on Form TC-40, the income tax return. The credit was previously routed through `gov.states.ut.tax.income.credits.refundable` → `ut_refundable_credits` → `ut_income_tax`, producing a phantom `-$429` siitax in cases like PolicyEngine/policyengine-taxsim#947 while TAXSIM-35 and TaxAct return $0.

Remove `ut_homeowner_renter_relief` from the income-tax refundable-credit list. The credit continues to flow through the household-level `state_property_tax_credits` aggregate (already wired for 2025+ and 2026+).

This matches the existing structural pattern for VT Renter Credit, MN Renter's Credit, and PA Property Tax/Rent Rebate — all administered on separate forms and excluded from their state's income-tax refundable credits.

## Test plan

- [x] New integration test from the issue: age 75, \$25K wages, \$12K SS, \$18K rent, 2025, UT — `ut_homeowner_renter_relief: 429`, `ut_refundable_credits: 0`, `ut_income_tax: 0`, `taxsim_state_property_tax_credit: 429`.
- [x] Full UT suite (175 tests) passes.
- [x] \`make format\` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)