### PR TITLE
Flow OBBBA Schedule 1-A deductions into MT taxable income

### DIFF
--- a/changelog.d/add-obbba-schedule-1a-deductions-to-mt-subtractions.fixed.md
+++ b/changelog.d/add-obbba-schedule-1a-deductions-to-mt-subtractions.fixed.md
@@ -1,0 +1,1 @@
+Flow the federal OBBBA Schedule 1-A deductions (enhanced senior deduction, qualified tip and overtime income exclusions, and passenger-vehicle loan interest) through into Montana taxable income, since Mont. Code Ann. § 15-30-2120 starts from federal taxable income.

--- a/policyengine_us/parameters/gov/states/mt/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/mt/tax/income/subtractions/subtractions.yaml
@@ -12,6 +12,16 @@ values:
     - mt_tuition_subtraction_person
     - mt_old_age_subtraction
     - mt_disability_income_exclusion_person
+  2025-01-01:
+    # Section 15-30-2120 starts from federal taxable income, so federal
+    # OBBBA Schedule 1-A deductions (enhanced senior deduction, qualified
+    # tip and overtime exclusions, and passenger-vehicle loan interest)
+    # flow through into MT taxable income via mt_federal_obbba_subtraction.
+    - mt_interest_exemption_person
+    - mt_tuition_subtraction_person
+    - mt_old_age_subtraction
+    - mt_disability_income_exclusion_person
+    - mt_federal_obbba_subtraction
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/mt/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/mt/tax/income/subtractions/subtractions.yaml
@@ -21,6 +21,8 @@ values:
     - mt_tuition_subtraction_person
     - mt_old_age_subtraction
     - mt_disability_income_exclusion_person
+    # TODO: Remove this subtraction starting in 2029 because the federal
+    # Schedule 1-A deductions expire after 2028.
     - mt_federal_obbba_subtraction
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.yaml
@@ -1,0 +1,71 @@
+- name: MT subtracts the federal OBBBA $6K senior deduction from taxable income (HoH age 75)
+  # Scenario from issue #8562 / PolicyEngine/policyengine-taxsim#948.
+  # Per Mont. Code Ann. § 15-30-2120, MT taxable income starts from
+  # federal taxable income (Form 1040 Line 15), which already nets the
+  # Schedule 1-A senior deduction.
+  period: 2025
+  absolute_error_margin: 5
+  input:
+    people:
+      head:
+        age: 75
+        employment_income: 25_000
+        taxable_interest_income: 17_510.73
+        taxable_pension_income: 12_218.48
+        social_security_retirement: 16_731.73
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        tax_unit_childcare_expenses: 3_500
+    households:
+      household:
+        members: [head, child]
+        state_name: MT
+  output:
+    additional_senior_deduction: 6_000
+    # Per-person; head receives the projection, dependent child sees 0.
+    mt_federal_obbba_subtraction: [6_000, 0]
+    mt_taxable_income_joint: [31_666, 0]
+    mt_income_tax: 1_488
+
+- name: Pre-2025 MT household does not see the OBBBA Schedule 1-A subtraction
+  # The mt_federal_obbba_subtraction entry only appears in the subtractions
+  # parameter list from 2025-01-01 onward, matching the OBBBA effective date.
+  period: 2024
+  input:
+    people:
+      head:
+        age: 75
+        employment_income: 25_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: MT
+  output:
+    # The variable computes the projected federal value (which is zero
+    # pre-2025) but the parameter list does not include it.
+    mt_federal_obbba_subtraction: 0
+
+- name: Non-senior MT household sees zero subtraction from this variable
+  period: 2025
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: MT
+  output:
+    additional_senior_deduction: 0
+    mt_federal_obbba_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.yaml
@@ -69,3 +69,92 @@
   output:
     additional_senior_deduction: 0
     mt_federal_obbba_subtraction: 0
+
+- name: MFJ with both spouses 65+ — head receives the full $12K projection, spouse zero
+  # Both spouses qualify so the federal additional_senior_deduction
+  # doubles to $12_000; the head-only projection keeps mt_subtractions'
+  # Person-level sum from double-counting.
+  period: 2025
+  input:
+    people:
+      head:
+        age: 70
+        employment_income: 30_000
+      spouse:
+        age: 68
+        employment_income: 20_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+    marital_units:
+      marital_unit:
+        members: [head, spouse]
+    households:
+      household:
+        members: [head, spouse]
+        state_name: MT
+  output:
+    additional_senior_deduction: 12_000
+    mt_federal_obbba_subtraction: [12_000, 0]
+
+- name: Senior phaseout — at $75K MAGI single, deduction is unphased
+  # OBBBA SEC. 70103 starts the 6% phaseout at $75K MAGI (single).
+  # At exactly $75K the deduction is still the full $6K.
+  period: 2025
+  input:
+    people:
+      head:
+        age: 70
+        employment_income: 75_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: MT
+  output:
+    additional_senior_deduction: 6_000
+    mt_federal_obbba_subtraction: 6_000
+
+- name: Senior phaseout — fully phased out at $300K MAGI single
+  period: 2025
+  input:
+    people:
+      head:
+        age: 70
+        employment_income: 300_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_name: MT
+  output:
+    additional_senior_deduction: 0
+    mt_federal_obbba_subtraction: 0
+
+- name: Tipped worker (non-senior) — tip_income_deduction flows through to MT subtractions
+  # Exercises the tip_income_deduction branch of the Schedule 1-A sum,
+  # which the senior-only scenarios above never touch.
+  period: 2025
+  input:
+    people:
+      head:
+        age: 30
+        employment_income: 30_000
+        tip_income: 8_000
+        tip_income_deduction_occupation_requirement_met: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        tip_income_deduction_ssn_requirement_met: true
+    households:
+      household:
+        members: [head]
+        state_name: MT
+  output:
+    additional_senior_deduction: 0
+    tip_income_deduction: 8_000
+    mt_federal_obbba_subtraction: 8_000

--- a/policyengine_us/variables/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class mt_federal_obbba_subtraction(Variable):
+    value_type = float
+    entity = Person
+    label = "Montana subtraction for federal OBBBA Schedule 1-A deductions"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.MT
+    reference = (
+        "https://mca.legmt.gov/bills/mca/title_0150/chapter_0300/part_0210/section_0200/0150-0300-0210-0200.html",
+        "https://www.congress.gov/119/bills/hr1/BILLS-119hr1enr.pdf#page=88",
+    )
+
+    def formula(person, period, parameters):
+        is_head = person("is_tax_unit_head", period)
+        senior = person.tax_unit("additional_senior_deduction", period)
+        tips = person.tax_unit("tip_income_deduction", period)
+        overtime = person.tax_unit("overtime_income_deduction", period)
+        auto = person.tax_unit("auto_loan_interest_deduction", period)
+        return is_head * (senior + tips + overtime + auto)

--- a/policyengine_us/variables/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/subtractions/mt_federal_obbba_subtraction.py
@@ -10,7 +10,9 @@ class mt_federal_obbba_subtraction(Variable):
     defined_for = StateCode.MT
     reference = (
         "https://mca.legmt.gov/bills/mca/title_0150/chapter_0300/part_0210/section_0200/0150-0300-0210-0200.html",
+        "https://revenuefiles.mt.gov/files/Forms/Montana-Individual-Income-Tax-Return-Form-2-Instructions/2025_Montana_Individual_Income_Tax_Return_Form_2_Instructions.pdf#page=7",
         "https://www.congress.gov/119/bills/hr1/BILLS-119hr1enr.pdf#page=88",
+        "https://www.congress.gov/119/bills/hr1/BILLS-119hr1enr.pdf#page=96",
     )
 
     def formula(person, period, parameters):


### PR DESCRIPTION
## Summary

Closes #8562.

Per Mont. Code Ann. § 15-30-2120, Montana taxable income starts from **federal taxable income** (Form 1040 Line 15), not federal AGI. Federal taxable income already nets the federal $6K Schedule 1-A senior deduction (OBBBA § 70103, IRC § 151(d)(5)(B)) — plus the qualified tip / overtime / passenger-vehicle loan-interest deductions added by OBBBA.

PE-US's `mt_agi_joint` and `mt_agi_indiv` currently start from `adjusted_gross_income_person` and add back the federal standard deduction via `mt_standard_deduction`. That captures the federal std ded + age-65 addition but misses Schedule 1-A, leaving MT taxable income $6K too high for the originating scenario in PolicyEngine/policyengine-taxsim#948 (HoH age 75, 1 dep: PE-US returned mt_taxable_income $37,666 vs TC-Form-2 $31,665).

Fix per the issue's Approach 2: keep MT starting from AGI but add a new Person-level `mt_federal_obbba_subtraction` that projects the four TaxUnit-level federal OBBBA deductions onto the head, and wire it into the subtractions list at 2025-01-01.

## Test plan

- [x] New integration test from the issue (HoH age 75, \$25K wages, \$17.5K interest, \$12K pension, \$16.7K SS, 1 dep, \$3.5K childcare): `mt_federal_obbba_subtraction: 6000`, `mt_taxable_income_joint: 31_666`, `mt_income_tax: 1_488`. Numerically matches TaxAct Form 2 within \$1.
- [x] Pre-2025 boundary test (period 2024 → subtraction list doesn't include the new variable).
- [x] Non-senior MT household → \$0 subtraction (no Schedule 1-A activity).
- [x] Full MT regression (401 tests) passes.
- [x] \`make format\` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)