### PR TITLE
Route IA CDCC fraction lookup through consolidated taxable income

### DIFF
--- a/changelog.d/add-obbba-schedule-1a-deductions-to-ia-taxable-income.fixed.md
+++ b/changelog.d/add-obbba-schedule-1a-deductions-to-ia-taxable-income.fixed.md
@@ -1,0 +1,1 @@
+Route the Iowa child/dependent care credit fraction lookup through the post-2023 consolidated taxable income so federal Schedule 1-A deductions (OBBBA enhanced senior deduction, qualified tip and overtime income exclusions, and passenger-vehicle loan interest) flow into the Iowa credit base.

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
@@ -39,12 +39,13 @@
 
 - name: IA CDCC inherits the federal Schedule 1-A senior deduction (HoH age 75)
   # Scenario from issue #8563 / PolicyEngine/policyengine-taxsim#953.
-  # Federal taxable income $7,166 falls in the < $10K bracket (75% rate);
-  # legacy IA taxable income $13,166 would fall in the $10K–$20K bracket
+  # Federal taxable income (~$7,166) falls in the < $10K bracket (75% rate);
+  # legacy IA taxable income (~$13,166) would fall in the $10K–$20K bracket
   # (65% rate). The fix routes the post-2023 CDCC through the consolidated
-  # taxable income so OBBBA Schedule 1-A flows through.
+  # taxable income so OBBBA Schedule 1-A flows through. Pinning the legacy
+  # ia_taxable_income guards that the two measures land in different brackets.
   period: 2025
-  absolute_error_margin: 1
+  absolute_error_margin: 0.4
   input:
     people:
       head:
@@ -65,5 +66,6 @@
   output:
     taxable_income: 7_166
     ia_taxable_income_consolidated: 7_166
+    ia_taxable_income: 13_166
     cdcc_potential: 690
     ia_cdcc: 517.5

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
@@ -24,3 +24,46 @@
     state_code: IA
   output:
     ia_cdcc: 0
+
+- name: 2023+ IA CDCC uses ia_taxable_income_consolidated (75% bracket)
+  # Post-HF 2317 (2023+) IA tax base is federal taxable income, so the
+  # CDCC fraction lookup reads ia_taxable_income_consolidated instead
+  # of the legacy ia_taxable_income.
+  period: 2023
+  input:
+    cdcc_potential: 1_000
+    ia_taxable_income_consolidated: 9_999.99
+    state_code: IA
+  output:
+    ia_cdcc: 750
+
+- name: IA CDCC inherits the federal Schedule 1-A senior deduction (HoH age 75)
+  # Scenario from issue #8563 / PolicyEngine/policyengine-taxsim#953.
+  # Federal taxable income $7,166 falls in the < $10K bracket (75% rate);
+  # legacy IA taxable income $13,166 would fall in the $10K–$20K bracket
+  # (65% rate). The fix routes the post-2023 CDCC through the consolidated
+  # taxable income so OBBBA Schedule 1-A flows through.
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      head:
+        age: 75
+        employment_income: 25_000
+        taxable_interest_income: 13_790.65
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        tax_unit_childcare_expenses: 3_500
+    households:
+      household:
+        members: [head, child]
+        state_name: IA
+  output:
+    taxable_income: 7_166
+    ia_taxable_income_consolidated: 7_166
+    cdcc_potential: 690
+    ia_cdcc: 517.5

--- a/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_cdcc.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_cdcc.py
@@ -12,12 +12,26 @@ class ia_cdcc(Variable):
         "https://revenue.iowa.gov/sites/default/files/2023-01/2021%20Expanded%20Instructions_010323.pdf#page=86",
         "https://revenue.iowa.gov/sites/default/files/2023-01/2022IA1040%2841001%29.pdf#page=2",
         "https://revenue.iowa.gov/sites/default/files/2023-03/2022%20Expanded%20Instructions_022023.pdf#page=86",
+        "https://revenue.iowa.gov/taxes/tax-guidance/individual-income-tax/1040-expanded-instructions/child-dependent-care-credit",
     )
     defined_for = StateCode.IA
 
     def formula(tax_unit, period, parameters):
-        # Iowa matches the potential federal credit
+        # Pre-2023: Iowa's tax base used net income (the legacy joint /
+        # indiv path that the dynamically generated ia_taxable_income
+        # resolves to).
         federal_cdcc = tax_unit("cdcc_potential", period)
         taxable_income = tax_unit("ia_taxable_income", period)
+        p = parameters(period).gov.states.ia.tax.income
+        return federal_cdcc * p.credits.child_care.fraction.calc(taxable_income)
+
+    def formula_2023(tax_unit, period, parameters):
+        # The 2022 Iowa tax reform (HF 2317) shifted Iowa's tax base to
+        # federal taxable income, so the post-reform consolidated path
+        # is the operative measure for the CDCC fraction lookup and it
+        # already inherits federal Schedule 1-A deductions such as the
+        # OBBBA enhanced senior deduction.
+        federal_cdcc = tax_unit("cdcc_potential", period)
+        taxable_income = tax_unit("ia_taxable_income_consolidated", period)
         p = parameters(period).gov.states.ia.tax.income
         return federal_cdcc * p.credits.child_care.fraction.calc(taxable_income)


### PR DESCRIPTION
## Summary

Closes #8563.

The Iowa child/dependent care credit fraction lookup compares "taxable income" against bracket thresholds (75 % below \$10K, 65 % to \$20K, etc.). PE-US's `ia_cdcc` was reading the dynamically generated `ia_taxable_income`, which resolves to the legacy `ia_taxable_income_joint` / `_indiv` path that starts from `ia_net_income` (Iowa AGI minus IA deductions). The 2022 IA tax reform (HF 2317) shifted Iowa's tax base to federal taxable income for 2023+, so the credit should compare against `ia_taxable_income_consolidated` instead.

This also fixes the failure surfaced in PolicyEngine/policyengine-taxsim#953. Federal taxable income for the sample HoH-age-75 household is **\$7,166** (correctly netting the OBBBA \$6K enhanced senior deduction), which lands in the \< \$10K 75 % bracket. The legacy path was returning **\$13,166** (missing the senior deduction), landing in the \$10K–\$20K 65 % bracket, so `ia_cdcc` was \$448.50 instead of TaxAct's \$517.50.

Add a `formula_2023` branch that switches the comparand for 2023+. Pre-2023 behavior is preserved by leaving the original `formula` intact (it continues to read the legacy `ia_taxable_income`).

## Test plan

- [x] New integration test from the issue (HoH age 75, \$25K wages, \$13.8K interest, 1 dep, \$3.5K childcare, 2025, IA): `ia_taxable_income_consolidated: 7_166`, `ia_cdcc: 517.5`. Numerically matches TaxAct within \$1.
- [x] New 2023 paired test: \$1K cdcc_potential + \$9,999.99 consolidated taxable income → \$750 (75 % bracket).
- [x] Existing 2021/2022 unit tests unchanged.
- [x] Full IA suite (241 tests) passes.
- [x] \`make format\` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)