### PR TITLE
Fix contrib CI: isolate refundable_credit_conversion per-file + balance states shards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,13 @@ test-yaml-structural-heavy-shard-1:
 test-yaml-structural-heavy-shard-2:
 	$(BATCH) $(TESTS)/policy/contrib/states --batches 1 --shard 2/2
 test-yaml-structural-other:
-	$(BATCH) $(TESTS)/policy/contrib --exclude states,ctc,ubi_center,federal,harris,treasury,crfb,congress
+	# refundable_credit_conversion force-applies a reform per case; each
+	# distinct gov.contrib.* combination clones the full tax-benefit system
+	# (~5 GB peak/file). Auto-batching grouped all its files into one
+	# subprocess, stacking the peaks past the runner cap → OOM. Isolate
+	# per-file so each peak is freed between files (same as ctc/crfb below).
+	$(BATCH) $(TESTS)/policy/contrib --exclude states,ctc,ubi_center,federal,harris,treasury,crfb,congress,refundable_credit_conversion
+	$(BATCH) $(TESTS)/policy/contrib/refundable_credit_conversion --mode per-file
 test-yaml-structural-other-shard-2:
 	# ctc + crfb are microsim-heavy: per-file isolation keeps RAM under the cap.
 	$(BATCH) $(TESTS)/policy/contrib/ctc --mode per-file

--- a/changelog.d/balance-contrib-states-shards.fixed.md
+++ b/changelog.d/balance-contrib-states-shards.fixed.md
@@ -1,0 +1,1 @@
+Relocate the Rhode Island contrib reform tests to the lighter states shard so the two states-shard CI runners are balanced.

--- a/changelog.d/fix-rcc-contrib-oom.fixed.md
+++ b/changelog.d/fix-rcc-contrib-oom.fixed.md
@@ -1,0 +1,1 @@
+Isolate refundable credit conversion contrib tests per-file so the other-shard-1 batch no longer exceeds the CI runner memory cap.

--- a/policyengine_us/tests/test_batched.py
+++ b/policyengine_us/tests/test_batched.py
@@ -497,7 +497,23 @@ def main():
     # position rather than requiring manual re-assignment per runner.
     if shard_count is not None:
         all_batch_count = len(batches)
+        ri_batch = (
+            [b for b in batches if Path(b[0]).name == "ri"]
+            if str(test_path).endswith("contrib/states")
+            else []
+        )
         batches = batches[shard_idx - 1 :: shard_count]
+        if ri_batch:
+            # RI's CTC reform sweeps ~11 parameter combinations, each cloning
+            # the full tax-benefit system (~10 min total) — far heavier than
+            # any other state. In the plain alphabetical stride it lands on
+            # shard 1 with the other heavy states (ny, ct, ut), making shard 1
+            # ~2x shard 2 and gating the contrib stage. Relocate just RI to the
+            # last shard; every other state keeps its positional assignment.
+            # (Same spirit as the explicit NY split in the Makefile.)
+            batches = [b for b in batches if Path(b[0]).name != "ri"]
+            if shard_idx == shard_count:
+                batches = batches + ri_batch
         print(
             f"Sharding: running shard {shard_idx}/{shard_count} "
             f"({len(batches)} of {all_batch_count} batches)"


### PR DESCRIPTION
Two related fixes to the contrib CI stage.

---

## 1. Fix `other-shard-1` OOM — isolate refundable_credit_conversion per-file

Closes #8559.

`Full Suite - Contrib (other-shard-1)` was OOM-failing on `main` (e.g. push run [26797821037](https://github.com/PolicyEngine/policyengine-us/actions/runs/26797821037)). The batcher's `auto` mode grouped all of `contrib/refundable_credit_conversion/` into **one subprocess**; each test force-applies the reform, and the YAML runner clones the entire tax-benefit system once per distinct `gov.contrib.*` combination. Run back-to-back in one process, the ~4–5 GB peaks stack past the 16 GB `ubuntu-latest` cap and the runner is killed (log: ran `dependent_definition` → `earnings_credit` → `flat_credit`, then `Terminated` mid-run on `integration.yaml`).

**Fix:** exclude the directory from the auto-batched general run and run it `--mode per-file`, so each file gets its own subprocess and memory frees between files — the same pattern already used for `ctc`/`crfb`. The `.py` autoloader is unaffected (it runs in the Rest job via plain pytest). Verified locally: per-file batcher exits 0, all 37 tests pass, peak RSS ~5.9 GB (one file at a time).

## 2. Balance the states shards — relocate Rhode Island

Closes #8570.

`Full Suite - Contrib (states-shard-1)` ran ~2x longer than `states-shard-2` (~39–44 min vs ~22 min) and gated the contrib stage. `test_batched.py` shards `contrib/states` by alphabetical position, which is uncorrelated with cost: RI's CTC reform sweeps ~11 parameter combinations (each a full system clone, ~10 min total) and the stride placed it on shard 1 with the other heavy states (ny, ct, ut).

**Fix:** relocate **only the RI batch** to the lighter shard; every other state keeps its positional assignment, so the alphabetical auto-split (new states distribute without manual edits) is preserved. Scoped to `contrib/states` so baseline sharding is unaffected. Brings the two runners to ~29 / ~33 min. The `"ri"` pin is static — if a future state becomes the heaviest it gets re-pinned, mirroring the existing explicit NY split in the Makefile.

---

## Files
- `Makefile` — per-file isolation for `refundable_credit_conversion`
- `policyengine_us/tests/test_batched.py` — relocate RI to the lighter states shard
- `changelog.d/*.fixed.md` — one fragment per fix

## Verification
- other-shard-1 passes in CI; refundable per-file batcher verified locally (37 tests, exit 0, ~5.9 GB peak).
- states sharding: complete & disjoint coverage of all 29 `contrib/states` folders, deterministic, no non-RI state changes shard.
- `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
