### PR TITLE
Balance contrib states CI shards by relocating Rhode Island

### DIFF
--- a/changelog.d/balance-contrib-states-shards.fixed.md
+++ b/changelog.d/balance-contrib-states-shards.fixed.md
@@ -1,0 +1,1 @@
+Relocate the Rhode Island contrib reform tests to the lighter states shard so the two states-shard CI runners are balanced.

--- a/policyengine_us/tests/test_batched.py
+++ b/policyengine_us/tests/test_batched.py
@@ -497,7 +497,23 @@ def main():
     # position rather than requiring manual re-assignment per runner.
     if shard_count is not None:
         all_batch_count = len(batches)
+        ri_batch = (
+            [b for b in batches if Path(b[0]).name == "ri"]
+            if str(test_path).endswith("contrib/states")
+            else []
+        )
         batches = batches[shard_idx - 1 :: shard_count]
+        if ri_batch:
+            # RI's CTC reform sweeps ~11 parameter combinations, each cloning
+            # the full tax-benefit system (~10 min total) — far heavier than
+            # any other state. In the plain alphabetical stride it lands on
+            # shard 1 with the other heavy states (ny, ct, ut), making shard 1
+            # ~2x shard 2 and gating the contrib stage. Relocate just RI to the
+            # last shard; every other state keeps its positional assignment.
+            # (Same spirit as the explicit NY split in the Makefile.)
+            batches = [b for b in batches if Path(b[0]).name != "ri"]
+            if shard_idx == shard_count:
+                batches = batches + ri_batch
         print(
             f"Sharding: running shard {shard_idx}/{shard_count} "
             f"({len(batches)} of {all_batch_count} batches)"


### PR DESCRIPTION
## Summary

`Full Suite - Contrib (states-shard-1)` runs ~2x longer than `states-shard-2` (~39 min vs ~22 min on recent runs) and is the longest job in the contrib stage, gating it.

## Cause

`test_batched.py` shards `contrib/states` by **alphabetical position** (`batches[shard_idx-1::shard_count]`), which is uncorrelated with cost. Rhode Island's CTC reform (`ri/ctc_reform_test.yaml`) sweeps ~11 distinct `gov.contrib.states.ri.ctc.*` parameter combinations, and each distinct combination makes the YAML runner clone the entire tax-benefit system — ~10 min total for that one folder, by far the heaviest state. The alphabetical stride happened to place RI on shard 1 alongside the other heavy states (ny, ct, ut), so shard 1 carried ~2x the load.

## Fix

Relocate **only the RI batch** to the last shard. Every other state keeps its existing positional assignment, so the alphabetical auto-split (new state folders distribute across runners without manual edits) is preserved. Scoped to `contrib/states`, so baseline `gov/states` sharding is unaffected.

Measured per-state CI times put the result at **shard-1 ~29 min / shard-2 ~33 min** (was ~39 / ~22), bringing the two runners within ~4 min of each other.

## Notes

- The `"ri"` pin is static: if a future state becomes the heaviest, it gets re-pinned. This mirrors the existing explicit NY split in the Makefile (`"NY credits clone the tax_benefit_system per scenario … split explicitly"`).
- A cost-aware (combo-weighted) auto-balancer was considered but rejected in favor of keeping the simple positional split; relocating the single dominant folder captures essentially the same critical-path win.

## Verification

- Complete and disjoint coverage of all 29 `contrib/states` folders; deterministic across runners; no non-RI state changes shard.
- `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
