### PR TITLE
Add Contra Costa County General Assistance

### DIFF
--- a/changelog.d/ca-contra-costa-ga.added.md
+++ b/changelog.d/ca-contra-costa-ga.added.md
@@ -1,0 +1,1 @@
+Added Contra Costa County, CA General Assistance program.

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/age_threshold.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/age_threshold.yaml
@@ -1,0 +1,12 @@
+description: Contra Costa County limits the General Assistance program to individuals of this age or older.
+metadata:
+  label: Contra Costa County General Assistance age eligibility threshold
+  unit: year
+  period: year
+  reference:
+    - title: Contra Costa County EHSD - General Assistance
+      href: https://ehsd.org/aging-and-adult-services/general-assistance/
+    - title: Legal Services of Northern California - General Assistance
+      href: https://lsnc.net/self-help/general-assistance-county-aid
+values:
+  2011-01-01: 18

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/amount/married.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/amount/married.yaml
@@ -1,0 +1,10 @@
+description: Contra Costa County provides a cash grant of this amount to married filers under the General Assistance program.
+metadata:
+  label: Contra Costa County General Assistance married amount
+  period: month
+  unit: currency-USD
+  reference:
+    - title: Contra Costa County EHSD - General Assistance
+      href: https://ehsd.org/aging-and-adult-services/general-assistance/
+values:
+  2024-01-01: 454

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/amount/married.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/amount/married.yaml
@@ -7,4 +7,8 @@ metadata:
     - title: Contra Costa County EHSD - General Assistance
       href: https://ehsd.org/aging-and-adult-services/general-assistance/
 values:
-  2024-01-01: 454
+  # The single rate ($336) is unchanged from the 2011 WCLP grant table to the
+  # current EHSD page, so the GA grant standards appear frozen. We apply the
+  # current $454 couple rate back to 2011-01-01 on that same stability basis
+  # (the EHSD page lists $336 single and $454 couple together, undated).
+  2011-01-01: 454

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/amount/single.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/amount/single.yaml
@@ -1,0 +1,12 @@
+description: Contra Costa County provides a cash grant of this amount to single filers under the General Assistance program.
+metadata:
+  label: Contra Costa County General Assistance single amount
+  period: month
+  unit: currency-USD
+  reference:
+    - title: Western Center on Law & Poverty - General Relief Grant Levels 2011 ($178 housing + $158 food/needs = $336)
+      href: https://wclp.org/wp-content/uploads/2015/06/gr_grantlevels_2011.pdf#page=1
+    - title: Contra Costa County EHSD - General Assistance
+      href: https://ehsd.org/aging-and-adult-services/general-assistance/
+values:
+  2011-01-01: 336

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/countable_income/sources.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/countable_income/sources.yaml
@@ -1,0 +1,17 @@
+description: Contra Costa County accounts for these income sources when determining eligibility for the General Assistance program.
+values:
+  2011-01-01:
+    - employment_income
+    - self_employment_income
+    - sstb_self_employment_income
+    - social_security
+    - unemployment_compensation
+    - veterans_benefits
+
+metadata:
+  unit: list
+  period: year
+  label: Contra Costa County General Assistance income sources
+  reference:
+    - title: Contra Costa County EHSD - General Assistance
+      href: https://ehsd.org/aging-and-adult-services/general-assistance/

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/personal_property/limit.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/personal_property/limit.yaml
@@ -1,0 +1,12 @@
+description: Contra Costa County limits the General Assistance program to households with up to this personal property amount.
+metadata:
+  label: Contra Costa County General Assistance personal property limit amount
+  unit: currency-USD
+  period: year
+  reference:
+    - title: Contra Costa County EHSD - General Assistance
+      href: https://ehsd.org/aging-and-adult-services/general-assistance/
+    - title: Contra Costa County EHSD - General Assistance Brochure (GA-80, Rev. 7/2024)
+      href: https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2
+values:
+  2011-01-01: 500

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/personal_property/limit.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/personal_property/limit.yaml
@@ -6,7 +6,5 @@ metadata:
   reference:
     - title: Contra Costa County EHSD - General Assistance
       href: https://ehsd.org/aging-and-adult-services/general-assistance/
-    - title: Contra Costa County EHSD - General Assistance Brochure (GA-80, Rev. 7/2024)
-      href: https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2
 values:
   2011-01-01: 500

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/qualified_immigration_status.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/qualified_immigration_status.yaml
@@ -1,0 +1,17 @@
+description: Contra Costa County considers these statuses as qualified immigrants under the General Assistance program.
+values:
+  2011-01-01:
+    - CITIZEN
+    - REFUGEE
+    - ASYLEE
+    - CUBAN_HAITIAN_ENTRANT
+    - PAROLED_ONE_YEAR
+    - LEGAL_PERMANENT_RESIDENT
+
+metadata:
+  label: Contra Costa County General Assistance qualified immigration statuses
+  period: year
+  unit: list
+  reference:
+    - title: Contra Costa County EHSD - General Assistance
+      href: https://ehsd.org/aging-and-adult-services/general-assistance/

--- a/policyengine_us/parameters/gov/local/ca/cc/general_assistance/qualified_immigration_status.yaml
+++ b/policyengine_us/parameters/gov/local/ca/cc/general_assistance/qualified_immigration_status.yaml
@@ -5,7 +5,6 @@ values:
     - REFUGEE
     - ASYLEE
     - CUBAN_HAITIAN_ENTRANT
-    - PAROLED_ONE_YEAR
     - LEGAL_PERMANENT_RESIDENT
 
 metadata:

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -1332,6 +1332,16 @@ programs:
     variable: ca_ala_general_assistance
     parameter_prefix: gov.local.ca.ala.ga
 
+  - id: ca_cc_general_assistance
+    name: Contra Costa County General Assistance
+    full_name: Contra Costa County General Assistance
+    category: Benefits
+    agency: Local
+    status: complete
+    coverage: Contra Costa County
+    variable: ca_cc_general_assistance
+    parameter_prefix: gov.local.ca.cc.general_assistance
+
   - id: nyc_income_tax
     name: NYC income tax
     full_name: New York City Income Tax

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance.yaml
@@ -1,0 +1,320 @@
+# Contra Costa County General Assistance (GA) — top-level fill-the-gap benefit.
+# Benefit = max_(grant standard - max_(countable income, 0), 0).
+# Single MAP = $336/month, couple MAP = $454/month.
+# Zero-benefit cases assert both the amount and the eligibility boolean; positive
+# cases assert eligibility == true.
+
+- name: Single eligible adult with low income receives a positive fill-the-gap grant.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 300 * 12  # $300/month countable
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    # 336 single MAP - 300 countable = 36
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance: 36
+
+- name: Couple of two eligible adults receives a positive fill-the-gap grant.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 35
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12  # $100/month countable
+      person2:
+        age: 33
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+    households:
+      household:
+        members: [person1, person2]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    # 454 couple MAP - 100 countable = 354
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance: 354
+
+- name: Negative self-employment income caps the grant at the MAP, not above it.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        self_employment_income: -6_000 * 12  # -$6,000/month business loss, no other income
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    # Countable income = -6,000. The explicit formula floors income at zero:
+    # max_(336 - max_(-6000, 0), 0) = 336. An adds/subtracts framework would
+    # instead give 336 - (-6000) = 6,336 (inflated) -- this is the regression guard.
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance: 336
+
+- name: Asset limit boundary - $499 personal property is eligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 499
+        employment_income: 300 * 12  # $300/month countable
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    # 336 single MAP - 300 countable = 36
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance: 36
+
+- name: Asset limit boundary - $501 personal property is ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 501  # exceeds the $500 limit
+        employment_income: 300 * 12
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Categorical exclusion - receiving SSI makes the unit ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12
+        ssi: 100
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Categorical exclusion - receiving SSDI makes the unit ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12
+        social_security_disability: 1_200
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Categorical exclusion - receiving unemployment compensation makes the unit ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12
+        unemployment_compensation: 1_200
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Categorical exclusion - receiving CA state disability insurance makes the unit ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12
+        ca_state_disability_insurance: 1_200
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: No-children gate - adult with a dependent child is ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12  # income below MAP, but the no-children gate fails
+      child1:
+        age: 5
+        is_tax_unit_head_or_spouse: false
+    households:
+      household:
+        members: [person1, child1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, child1]
+  output:
+    spm_unit_count_children: 1
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Immigration - a qualified refugee adult is eligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: REFUGEE
+        personal_property: 0
+        employment_income: 300 * 12  # $300/month countable
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    # 336 single MAP - 300 countable = 36
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance: 36
+
+- name: Immigration - a non-qualified (undocumented) adult is ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: UNDOCUMENTED
+        personal_property: 0
+        employment_income: 300 * 12
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Age - an applicant under 18 is ineligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 17
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Out of jurisdiction - an otherwise-eligible unit in another county gets nothing (defined_for gate).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 300 * 12  # would yield $36 in Contra Costa
+    households:
+      household:
+        members: [person1]
+        county: ALAMEDA_COUNTY_CA  # not Contra Costa -> in_cc is false
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance.yaml
@@ -318,3 +318,45 @@
   output:
     ca_cc_general_assistance_income_eligible: false
     ca_cc_general_assistance: 0
+
+- name: Single eligible adult with no income receives the full $336 grant.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    # 336 single MAP - 0 countable = 336 (full fill-the-gap grant)
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance: 336
+
+- name: Boundary - income exactly at the $336 single MAP yields no grant (strict gate).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 336 * 12  # $336/month countable == MAP
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance.yaml
@@ -230,8 +230,10 @@
       spm_unit:
         members: [person1, child1]
   output:
-    spm_unit_count_children: 1
-    ca_cc_general_assistance_income_eligible: false
+    # Income alone passes ($100 < $336 MAP), but the dependent child fails the
+    # composite eligibility gate (ca_cc_general_assistance_eligible), so no benefit.
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance_eligible: false
     ca_cc_general_assistance: 0
 
 - name: Immigration - a qualified refugee adult is eligible.
@@ -359,4 +361,30 @@
         members: [person1]
   output:
     ca_cc_general_assistance_income_eligible: false
+    ca_cc_general_assistance: 0
+
+- name: Endogenous SSI - an aged adult who qualifies for SSI (computed, not input) is excluded.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 67  # aged -> categorically SSI-eligible
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0  # under the SSI resource limit
+        # No earned income and no ssi input: the model computes ssi > 0 (takeup
+        # defaults to True), which bars GA via the categorical exclusion.
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    # Absent SSI this adult would be income-eligible ($0 < $336), but a computed
+    # ssi > 0 makes them categorically ineligible -> no eligible person -> $0.
+    ca_cc_general_assistance_eligible_person: false
+    ca_cc_general_assistance_eligible: false
     ca_cc_general_assistance: 0

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_base_amount.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_base_amount.yaml
@@ -65,3 +65,36 @@
         members: [person1]
   output:
     ca_cc_general_assistance_base_amount: 0
+
+- name: Three eligible adults fall through to the single grant standard of $336.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 0
+      person2:
+        age: 32
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 0
+      person3:
+        age: 34
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 0
+    households:
+      household:
+        members: [person1, person2, person3]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+  output:
+    # num_eligible == 3 -> where(num_eligible == 2, ...) is false -> single $336
+    ca_cc_general_assistance_base_amount: 336

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_base_amount.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_base_amount.yaml
@@ -1,0 +1,67 @@
+# Grant standard (MAP): single (1 eligible person) = $336/month;
+# couple (2 eligible persons) = $454/month (unit total).
+- name: One eligible adult receives the single grant standard of $336.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 0
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_base_amount: 336
+
+- name: Two eligible adults receive the couple grant standard of $454.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 0
+      person2:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 0
+    households:
+      household:
+        members: [person1, person2]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    ca_cc_general_assistance_base_amount: 454
+
+- name: No eligible persons yields a base amount of zero.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 100  # receiving SSI makes the person ineligible
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_base_amount: 0

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.yaml
@@ -66,7 +66,7 @@
   output:
     ca_cc_general_assistance_maximum_grant: 0
 
-- name: Three eligible adults fall through to the single grant standard of $336.
+- name: Three eligible adults (should not happen) fall through to the single $336 standard.
   period: 2024-01
   input:
     people:
@@ -96,5 +96,6 @@
       spm_unit:
         members: [person1, person2, person3]
   output:
-    # num_eligible == 3 -> where(num_eligible == 2, ...) is false -> single $336
+    # 3+ eligible adults should not occur in practice (each adult/couple is a
+    # separate GA case); num_eligible != 2 -> single $336 as a safe default.
     ca_cc_general_assistance_maximum_grant: 336

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.yaml
@@ -18,7 +18,7 @@
       spm_unit:
         members: [person1]
   output:
-    ca_cc_general_assistance_base_amount: 336
+    ca_cc_general_assistance_maximum_grant: 336
 
 - name: Two eligible adults receive the couple grant standard of $454.
   period: 2024-01
@@ -44,9 +44,9 @@
       spm_unit:
         members: [person1, person2]
   output:
-    ca_cc_general_assistance_base_amount: 454
+    ca_cc_general_assistance_maximum_grant: 454
 
-- name: No eligible persons yields a base amount of zero.
+- name: No eligible persons yields a maximum grant of zero.
   period: 2024-01
   input:
     people:
@@ -64,7 +64,7 @@
       spm_unit:
         members: [person1]
   output:
-    ca_cc_general_assistance_base_amount: 0
+    ca_cc_general_assistance_maximum_grant: 0
 
 - name: Three eligible adults fall through to the single grant standard of $336.
   period: 2024-01
@@ -97,4 +97,4 @@
         members: [person1, person2, person3]
   output:
     # num_eligible == 3 -> where(num_eligible == 2, ...) is false -> single $336
-    ca_cc_general_assistance_base_amount: 336
+    ca_cc_general_assistance_maximum_grant: 336

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_age_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_age_eligible.yaml
@@ -1,0 +1,23 @@
+- name: Adult aged 18 meets the age threshold.
+  period: 2024-01
+  input:
+    age: 18
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_age_eligible: true
+
+- name: Adult aged 30 meets the age threshold.
+  period: 2024-01
+  input:
+    age: 30
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_age_eligible: true
+
+- name: Minor aged 17 does not meet the age threshold.
+  period: 2024-01
+  input:
+    age: 17
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_age_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible.yaml
@@ -1,0 +1,85 @@
+# Composite SPM-unit eligibility: at least one eligible person AND no dependent
+# children AND income below the grant standard.
+- name: Otherwise-eligible single adult with low income and no children is eligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 300 * 12  # $300/month countable < $336 MAP
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible: true
+
+- name: Adult with income below MAP but a dependent child is not eligible (no-children gate).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 100 * 12  # income passes, but the child gate fails
+      child1:
+        age: 5
+        is_tax_unit_head_or_spouse: false
+    households:
+      household:
+        members: [person1, child1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, child1]
+  output:
+    ca_cc_general_assistance_income_eligible: true
+    ca_cc_general_assistance_eligible: false
+
+- name: No eligible person (SSI recipient) is not eligible even with zero income.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        ssi: 100  # categorically ineligible -> no eligible person
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible: false
+
+- name: Income at or above the grant standard is not eligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 400 * 12  # $400/month countable > $336 MAP
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible_person.yaml
@@ -1,0 +1,181 @@
+# Per-person eligibility: age >= 18 AND personal property <= $500 AND qualified
+# immigration status AND NOT receiving SSI/SSDI/UIB/SDI AND tax-unit head or spouse.
+- name: Fully eligible adult.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 400
+        ssi: 0
+        social_security_disability: 0
+        unemployment_compensation: 0
+        ca_state_disability_insurance: 0
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: true
+
+- name: Ineligible because under age 18.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 17
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 400
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false
+
+- name: Ineligible because personal property exceeds the $500 limit.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 600
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false
+
+- name: Ineligible because of a non-qualified immigration status.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: UNDOCUMENTED
+        personal_property: 400
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false
+
+- name: Ineligible because not a tax-unit head or spouse.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: false
+        immigration_status: CITIZEN
+        personal_property: 400
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false
+
+- name: Ineligible because receiving SSI.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 400
+        ssi: 100
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false
+
+- name: Ineligible because receiving SSDI.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 400
+        social_security_disability: 1_200
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false
+
+- name: Ineligible because receiving unemployment compensation.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 400
+        unemployment_compensation: 1_200
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false
+
+- name: Ineligible because receiving CA state disability insurance.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 400
+        ca_state_disability_insurance: 1_200
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_eligible_person: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.yaml
@@ -29,3 +29,11 @@
     county: CONTRA_COSTA_COUNTY_CA
   output:
     ca_cc_general_assistance_immigration_status_eligible: false
+
+- name: Paroled for one year is not a qualified status (time-limited parole).
+  period: 2024-01
+  input:
+    immigration_status: PAROLED_ONE_YEAR
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_immigration_status_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.yaml
@@ -1,0 +1,31 @@
+- name: US citizen is a qualified immigration status.
+  period: 2024-01
+  input:
+    immigration_status: CITIZEN
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_immigration_status_eligible: true
+
+- name: Refugee is a qualified immigration status.
+  period: 2024-01
+  input:
+    immigration_status: REFUGEE
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_immigration_status_eligible: true
+
+- name: Legal permanent resident is a qualified immigration status.
+  period: 2024-01
+  input:
+    immigration_status: LEGAL_PERMANENT_RESIDENT
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_immigration_status_eligible: true
+
+- name: Undocumented is not a qualified immigration status.
+  period: 2024-01
+  input:
+    immigration_status: UNDOCUMENTED
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_immigration_status_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.yaml
@@ -63,3 +63,23 @@
   output:
     spm_unit_count_children: 1
     ca_cc_general_assistance_income_eligible: false
+
+- name: Boundary - income exactly at the $336 single MAP is ineligible (strict < gate).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 336 * 12  # $336/month countable == MAP, not strictly below
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.yaml
@@ -1,5 +1,6 @@
-# Income eligible when countable income < grant standard (MAP) AND the unit has no
-# dependent children (strict no-children gate). Single MAP = $336/month.
+# Income eligible when countable income < the grant standard (MAP). Single MAP =
+# $336/month. The no-dependent-children and eligible-person gates live in
+# ca_cc_general_assistance_eligible, not here.
 - name: Eligible single adult with income below the $336 single MAP and no children.
   period: 2024-01
   input:
@@ -38,30 +39,6 @@
       spm_unit:
         members: [person1]
   output:
-    ca_cc_general_assistance_income_eligible: false
-
-- name: Ineligible adult with income below MAP but a dependent child (strict gate).
-  period: 2024-01
-  input:
-    people:
-      person1:
-        age: 30
-        is_tax_unit_head_or_spouse: true
-        immigration_status: CITIZEN
-        personal_property: 0
-        employment_income: 300 * 12  # below MAP, but the no-children gate fails
-      child1:
-        age: 5
-        is_tax_unit_head_or_spouse: false
-    households:
-      household:
-        members: [person1, child1]
-        county: CONTRA_COSTA_COUNTY_CA
-    spm_units:
-      spm_unit:
-        members: [person1, child1]
-  output:
-    spm_unit_count_children: 1
     ca_cc_general_assistance_income_eligible: false
 
 - name: Boundary - income exactly at the $336 single MAP is ineligible (strict < gate).

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.yaml
@@ -1,0 +1,65 @@
+# Income eligible when countable income < grant standard (MAP) AND the unit has no
+# dependent children (strict no-children gate). Single MAP = $336/month.
+- name: Eligible single adult with income below the $336 single MAP and no children.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 300 * 12  # $300/month countable < $336 MAP
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: true
+
+- name: Ineligible single adult with income above the $336 single MAP.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 400 * 12  # $400/month countable > $336 MAP
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_income_eligible: false
+
+- name: Ineligible adult with income below MAP but a dependent child (strict gate).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        immigration_status: CITIZEN
+        personal_property: 0
+        employment_income: 300 * 12  # below MAP, but the no-children gate fails
+      child1:
+        age: 5
+        is_tax_unit_head_or_spouse: false
+    households:
+      household:
+        members: [person1, child1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, child1]
+  output:
+    spm_unit_count_children: 1
+    ca_cc_general_assistance_income_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_personal_property_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_personal_property_eligible.yaml
@@ -1,0 +1,49 @@
+# Asset limit is $500. Formula is personal_property <= limit,
+# so $500 exactly is eligible.
+- name: Personal property of $499 is below the $500 limit.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        personal_property: 499
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_personal_property_eligible: true
+
+- name: Personal property of exactly $500 is at the limit and eligible.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        personal_property: 500
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_personal_property_eligible: true
+
+- name: Personal property of $501 exceeds the $500 limit.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        personal_property: 501
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_personal_property_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_personal_property_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_personal_property_eligible.yaml
@@ -47,3 +47,23 @@
         members: [person1]
   output:
     ca_cc_general_assistance_personal_property_eligible: false
+
+# Personal property is summed across all SPM-unit members, so two members each
+# holding $300 ($600 total) exceed the $500 limit.
+- name: Two members with $300 each ($600 total) exceed the $500 limit.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        personal_property: 300
+      person2:
+        personal_property: 300
+    households:
+      household:
+        members: [person1, person2]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    ca_cc_general_assistance_personal_property_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/in_cc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/in_cc.yaml
@@ -1,0 +1,13 @@
+- name: Contra Costa County is True
+  period: 2024
+  input:
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    in_cc: true
+
+- name: Not Contra Costa County is False
+  period: 2024
+  input:
+    county: ALAMEDA_COUNTY_CA
+  output:
+    in_cc: false

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income.yaml
@@ -1,0 +1,40 @@
+# SPMUnit countable income sums each head/spouse member's countable income.
+- name: Single adult with employment income.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        employment_income: 500 * 12  # $500/month
+    households:
+      household:
+        members: [person1]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    ca_cc_general_assistance_countable_income: 500
+
+- name: Two head/spouse members' income sums to the unit total.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        employment_income: 500 * 12  # $500/month
+      person2:
+        age: 30
+        is_tax_unit_head_or_spouse: true
+        social_security: 200 * 12  # $200/month
+    households:
+      household:
+        members: [person1, person2]
+        county: CONTRA_COSTA_COUNTY_CA
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    ca_cc_general_assistance_countable_income: 700  # 500 + 200

--- a/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income_person.yaml
@@ -1,0 +1,32 @@
+# Per-person countable income sums the income sources in countable_income/sources.yaml,
+# only for tax-unit heads or spouses. Sources are annual; the monthly variable
+# auto-divides by 12.
+- name: Head/spouse employment income counts at the monthly level.
+  period: 2024-01
+  input:
+    age: 30
+    is_tax_unit_head_or_spouse: true
+    employment_income: 1_200 * 12  # $1,200/month
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_countable_income_person: 1_200
+
+- name: Non-head/spouse income is excluded.
+  period: 2024-01
+  input:
+    age: 30
+    is_tax_unit_head_or_spouse: false
+    employment_income: 1_200 * 12
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_countable_income_person: 0
+
+- name: Negative self-employment income produces negative countable income.
+  period: 2024-01
+  input:
+    age: 30
+    is_tax_unit_head_or_spouse: true
+    self_employment_income: -6_000 * 12  # -$6,000/month business loss
+    county: CONTRA_COSTA_COUNTY_CA
+  output:
+    ca_cc_general_assistance_countable_income_person: -6_000

--- a/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance.py
@@ -8,15 +8,12 @@ class ca_cc_general_assistance(Variable):
     label = "Contra Costa County General Assistance"
     definition_period = MONTH
     defined_for = "ca_cc_general_assistance_income_eligible"
-    reference = (
-        "https://ehsd.org/aging-and-adult-services/general-assistance/",
-        # Fill-the-gap: the grant standard minus net countable income.
-        "https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2",
-    )
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
 
     def formula(spm_unit, period, parameters):
         base_amount = spm_unit("ca_cc_general_assistance_base_amount", period)
         countable_income = spm_unit("ca_cc_general_assistance_countable_income", period)
-        # Floor countable income at zero so net-negative flows (e.g. self-
-        # employment losses) cannot inflate the grant above the standard.
+        # Fill-the-gap: the grant standard minus net countable income. Floor
+        # countable income at zero so net-negative flows (e.g. self-employment
+        # losses) cannot inflate the grant above the standard.
         return max_(base_amount - max_(countable_income, 0), 0)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance(Variable):
+    value_type = float
+    entity = SPMUnit
+    unit = USD
+    label = "Contra Costa County General Assistance"
+    definition_period = MONTH
+    defined_for = "ca_cc_general_assistance_income_eligible"
+    reference = (
+        "https://ehsd.org/aging-and-adult-services/general-assistance/",
+        # Fill-the-gap: the grant standard minus net countable income.
+        "https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2",
+    )
+
+    def formula(spm_unit, period, parameters):
+        base_amount = spm_unit("ca_cc_general_assistance_base_amount", period)
+        countable_income = spm_unit("ca_cc_general_assistance_countable_income", period)
+        # Floor countable income at zero so net-negative flows (e.g. self-
+        # employment losses) cannot inflate the grant above the standard.
+        return max_(base_amount - max_(countable_income, 0), 0)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance.py
@@ -7,13 +7,13 @@ class ca_cc_general_assistance(Variable):
     unit = USD
     label = "Contra Costa County General Assistance"
     definition_period = MONTH
-    defined_for = "ca_cc_general_assistance_income_eligible"
+    defined_for = "ca_cc_general_assistance_eligible"
     reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
 
     def formula(spm_unit, period, parameters):
-        base_amount = spm_unit("ca_cc_general_assistance_base_amount", period)
+        maximum_grant = spm_unit("ca_cc_general_assistance_maximum_grant", period)
         countable_income = spm_unit("ca_cc_general_assistance_countable_income", period)
-        # Fill-the-gap: the grant standard minus net countable income. Floor
+        # Fill-the-gap: the maximum grant minus net countable income. Floor
         # countable income at zero so net-negative flows (e.g. self-employment
-        # losses) cannot inflate the grant above the standard.
-        return max_(base_amount - max_(countable_income, 0), 0)
+        # losses) cannot inflate the grant above the maximum.
+        return max_(maximum_grant - max_(countable_income, 0), 0)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance_base_amount.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance_base_amount.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_base_amount(Variable):
+    value_type = float
+    entity = SPMUnit
+    unit = USD
+    label = "Contra Costa County General Assistance base amount"
+    definition_period = MONTH
+    defined_for = "ca_cc_general_assistance_eligible_person"
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
+
+    def formula(spm_unit, period, parameters):
+        p = parameters(period).gov.local.ca.cc.general_assistance.amount
+        eligible_persons = spm_unit.members(
+            "ca_cc_general_assistance_eligible_person", period
+        )
+        num_eligible = spm_unit.sum(eligible_persons)
+        # When two adults in the unit are eligible we apply the couple grant. We
+        # do not verify that the two eligible adults are married to each other;
+        # we don't track marital pairing within the SPM unit at the moment.
+        return where(num_eligible == 2, p.married, p.single)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.py
@@ -16,7 +16,10 @@ class ca_cc_general_assistance_maximum_grant(Variable):
             "ca_cc_general_assistance_eligible_person", period
         )
         num_eligible = spm_unit.sum(eligible_persons)
-        # When two adults in the unit are eligible we apply the couple grant. We
-        # do not verify that the two eligible adults are married to each other;
-        # we don't track marital pairing within the SPM unit at the moment.
+        # GA aids a single adult ($336) or an eligible couple ($454). Exactly two
+        # eligible adults get the couple grant; we do not verify they are married
+        # to each other (marital pairing is not tracked within the SPM unit).
+        # NOTE: 3+ eligible adults in one SPM unit should not happen in practice
+        # -- each adult or couple is a separate GA case -- so any count other than
+        # two falls through to the single standard as a safe default.
         return where(num_eligible == 2, p.married, p.single)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/ca_cc_general_assistance_maximum_grant.py
@@ -1,11 +1,11 @@
 from policyengine_us.model_api import *
 
 
-class ca_cc_general_assistance_base_amount(Variable):
+class ca_cc_general_assistance_maximum_grant(Variable):
     value_type = float
     entity = SPMUnit
     unit = USD
-    label = "Contra Costa County General Assistance base amount"
+    label = "Contra Costa County General Assistance maximum grant"
     definition_period = MONTH
     defined_for = "ca_cc_general_assistance_eligible_person"
     reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_age_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_age_eligible.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_age_eligible(Variable):
+    value_type = bool
+    entity = Person
+    definition_period = MONTH
+    label = (
+        "Eligible for Contra Costa County General Assistance based on age requirements"
+    )
+    defined_for = "in_cc"
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.local.ca.cc.general_assistance
+        age = person("monthly_age", period)
+        return age >= p.age_threshold

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_eligible(Variable):
+    value_type = bool
+    entity = SPMUnit
+    label = "Eligible for Contra Costa County General Assistance"
+    definition_period = MONTH
+    defined_for = "in_cc"
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
+
+    def formula(spm_unit, period, parameters):
+        has_eligible_person = (
+            add(spm_unit, period, ["ca_cc_general_assistance_eligible_person"]) > 0
+        )
+        # General Assistance serves adults without dependent children; families
+        # with children are directed to CalWORKs. A dependent child is a minor
+        # (is_child) who is also a tax-unit dependent. In practice every minor is
+        # a tax-unit dependent (only adults can be a tax-unit head or spouse), so
+        # this currently equals the count of minor children in the unit.
+        person = spm_unit.members
+        is_dependent_child = person("is_child", period.this_year) & person(
+            "is_tax_unit_dependent", period.this_year
+        )
+        no_dependent_children = spm_unit.sum(is_dependent_child) == 0
+        income_eligible = spm_unit("ca_cc_general_assistance_income_eligible", period)
+        return has_eligible_person & no_dependent_children & income_eligible

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible_person.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible_person.py
@@ -20,6 +20,10 @@ class ca_cc_general_assistance_eligible_person(Variable):
         # Ineligible if receiving SSI, SSDI, unemployment (UIB), or California
         # State Disability Insurance (SDI). SSDI, UIB, and SDI are YEAR-defined;
         # we read the full annual value with period.this_year and test receipt (> 0).
+        # Only SSDI bars eligibility here; Social Security retirement/survivors
+        # benefits (the broader `social_security` aggregate) are not a categorical
+        # bar -- they instead count toward the gap via the
+        # general_assistance.countable_income.sources list.
         receives_categorical = (
             (person("ssi", period) > 0)
             | (person("social_security_disability", period.this_year) > 0)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible_person.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_eligible_person.py
@@ -1,0 +1,36 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_eligible_person(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible person for Contra Costa County General Assistance"
+    definition_period = MONTH
+    defined_for = "in_cc"
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
+
+    def formula(person, period, parameters):
+        age_eligible = person("ca_cc_general_assistance_age_eligible", period)
+        personal_property_eligible = person.spm_unit(
+            "ca_cc_general_assistance_personal_property_eligible", period
+        )
+        immigration_status_eligible = person(
+            "ca_cc_general_assistance_immigration_status_eligible", period
+        )
+        # Ineligible if receiving SSI, SSDI, unemployment (UIB), or California
+        # State Disability Insurance (SDI). SSDI, UIB, and SDI are YEAR-defined;
+        # we read the full annual value with period.this_year and test receipt (> 0).
+        receives_categorical = (
+            (person("ssi", period) > 0)
+            | (person("social_security_disability", period.this_year) > 0)
+            | (person("unemployment_compensation", period.this_year) > 0)
+            | (person("ca_state_disability_insurance", period.this_year) > 0)
+        )
+        is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        return (
+            age_eligible
+            & personal_property_eligible
+            & immigration_status_eligible
+            & ~receives_categorical
+            & is_head_or_spouse
+        )

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.py
@@ -10,6 +10,11 @@ class ca_cc_general_assistance_immigration_status_eligible(Variable):
     reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
 
     def formula(person, period, parameters):
+        # The EHSD criterion is being "legally in the country with no limitation
+        # on your stay," so time-limited statuses do not qualify. PAROLED_ONE_YEAR
+        # is excluded because parole is granted for a fixed period and confers no
+        # indefinite right to remain -- matching the Santa Clara (SCC) and San
+        # Mateo (SMC) County GA implementations, which also exclude it.
         p = parameters(period).gov.local.ca.cc.general_assistance
         immigration_status = person("immigration_status", period.this_year)
         immigration_status_str = immigration_status.decode_to_str()

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_immigration_status_eligible.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_immigration_status_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for the Contra Costa County General Assistance due to immigration status"
+    definition_period = MONTH
+    defined_for = "in_cc"
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.local.ca.cc.general_assistance
+        immigration_status = person("immigration_status", period.this_year)
+        immigration_status_str = immigration_status.decode_to_str()
+        return np.isin(immigration_status_str, p.qualified_immigration_status)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.py
@@ -7,12 +7,9 @@ class ca_cc_general_assistance_income_eligible(Variable):
     label = "Eligible for Contra Costa County General Assistance based on income requirements"
     definition_period = MONTH
     defined_for = "in_cc"
-    reference = (
-        "https://ehsd.org/aging-and-adult-services/general-assistance/",
-        # Adults with dependent children apply for CalWORKs instead, so the unit
-        # must have no children (GA-80 brochure, "adult without dependent children").
-        "https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2",
-    )
+    # The EHSD program page states GA serves "an adult without dependent
+    # children"; families with children are directed to CalWORKs.
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
 
     def formula(spm_unit, period, parameters):
         income = spm_unit("ca_cc_general_assistance_countable_income", period)

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.py
@@ -7,14 +7,11 @@ class ca_cc_general_assistance_income_eligible(Variable):
     label = "Eligible for Contra Costa County General Assistance based on income requirements"
     definition_period = MONTH
     defined_for = "in_cc"
-    # The EHSD program page states GA serves "an adult without dependent
-    # children"; families with children are directed to CalWORKs.
     reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
 
     def formula(spm_unit, period, parameters):
         income = spm_unit("ca_cc_general_assistance_countable_income", period)
-        base_amount = spm_unit("ca_cc_general_assistance_base_amount", period)
-        # General Assistance serves adults without dependent children; families
-        # with children are directed to CalWORKs.
-        no_children = spm_unit("spm_unit_count_children", period.this_year) == 0
-        return (income < base_amount) & no_children
+        maximum_grant = spm_unit("ca_cc_general_assistance_maximum_grant", period)
+        # Countable income must be strictly below the grant standard ("earnings
+        # less than the maximum allowable grant").
+        return income < maximum_grant

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_income_eligible.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_income_eligible(Variable):
+    value_type = bool
+    entity = SPMUnit
+    label = "Eligible for Contra Costa County General Assistance based on income requirements"
+    definition_period = MONTH
+    defined_for = "in_cc"
+    reference = (
+        "https://ehsd.org/aging-and-adult-services/general-assistance/",
+        # Adults with dependent children apply for CalWORKs instead, so the unit
+        # must have no children (GA-80 brochure, "adult without dependent children").
+        "https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2",
+    )
+
+    def formula(spm_unit, period, parameters):
+        income = spm_unit("ca_cc_general_assistance_countable_income", period)
+        base_amount = spm_unit("ca_cc_general_assistance_base_amount", period)
+        # General Assistance serves adults without dependent children; families
+        # with children are directed to CalWORKs.
+        no_children = spm_unit("spm_unit_count_children", period.this_year) == 0
+        return (income < base_amount) & no_children

--- a/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_personal_property_eligible.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/eligibility/ca_cc_general_assistance_personal_property_eligible.py
@@ -1,0 +1,21 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_personal_property_eligible(Variable):
+    value_type = bool
+    entity = SPMUnit
+    definition_period = MONTH
+    label = "Meets property limit for Contra Costa County General Assistance"
+    defined_for = "in_cc"
+    reference = (
+        "https://ehsd.org/aging-and-adult-services/general-assistance/",
+        # Resource exclusions (home, one vehicle <= $4,500, jewelry, property-tax
+        # escrow, cash < $50) are listed in the GA-80 brochure but are not modeled
+        # separately; we treat `personal_property` as the net countable-asset figure.
+        "https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2",
+    )
+
+    def formula(spm_unit, period, parameters):
+        p = parameters(period).gov.local.ca.cc.general_assistance.personal_property
+        personal_property = add(spm_unit, period.this_year, ["personal_property"])
+        return personal_property <= p.limit

--- a/policyengine_us/variables/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_countable_income(Variable):
+    value_type = float
+    entity = SPMUnit
+    unit = USD
+    definition_period = MONTH
+    label = "Contra Costa County General Assistance countable income"
+    defined_for = "in_cc"
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
+
+    adds = ["ca_cc_general_assistance_countable_income_person"]

--- a/policyengine_us/variables/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income_person.py
+++ b/policyengine_us/variables/gov/local/ca/cc/ga/income/ca_cc_general_assistance_countable_income_person.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class ca_cc_general_assistance_countable_income_person(Variable):
+    value_type = float
+    entity = Person
+    unit = USD
+    definition_period = MONTH
+    label = "Contra Costa County General Assistance countable income for each person"
+    defined_for = "is_tax_unit_head_or_spouse"
+    reference = "https://ehsd.org/aging-and-adult-services/general-assistance/"
+
+    adds = "gov.local.ca.cc.general_assistance.countable_income.sources"

--- a/policyengine_us/variables/gov/local/ca/cc/in_cc.py
+++ b/policyengine_us/variables/gov/local/ca/cc/in_cc.py
@@ -1,0 +1,12 @@
+from policyengine_us.model_api import *
+
+
+class in_cc(Variable):
+    value_type = bool
+    entity = Household
+    definition_period = YEAR
+    label = "Is in Contra Costa County"
+
+    def formula(household, period, parameters):
+        county = household("county_str", period)
+        return county == "CONTRA_COSTA_COUNTY_CA"


### PR DESCRIPTION
## Summary
Implements Contra Costa County, California's General Assistance (GA) program — a county-administered indigent cash-assistance program under California Welfare & Institutions Code § 17000 et seq. GA pays the gap between a grant standard and the recipient's net countable income to adults without dependent children who are ineligible for other cash aid.

Administered by the Contra Costa County Employment and Human Services Department (EHSD). Files live under `gov/local/ca/cc/`, parallel to the existing Alameda County GA implementation at `gov/local/ca/ala/ga/`.

Closes #8592

## Regulatory authority
- CA Welfare & Institutions Code § 17000 / § 17001 (county duty to relieve indigent residents; Board of Supervisors sets the standards of aid)
- Contra Costa County EHSD — General Assistance program page: https://ehsd.org/aging-and-adult-services/general-assistance/
- EHSD GA brochure (GA-80, Rev. 7/2024): https://ehsd.org/wp-content/uploads/2024/08/GA-Brochure_ENGLISH_July2024_FA_Digital.pdf#page=2
- Western Center on Law & Poverty, 2011 General Relief grant levels (Contra Costa = $336): https://wclp.org/wp-content/uploads/2015/06/gr_grantlevels_2011.pdf

## Benefit
Fill-the-gap: `max_(grant standard - max_(countable income, 0), 0)`, where the grant standard is `ca_cc_general_assistance_maximum_grant`. The inner `max_(income, 0)` floors countable income at zero so net-negative flows (e.g. self-employment losses) cannot inflate the grant above the standard.

| Grant standard | Monthly amount | Effective | Source |
|---|---|---|---|
| Single | $336 | 2011-01-01 | WCLP 2011 table ($178 housing + $158 food/needs); still $336 on the current EHSD page |
| Couple (2 eligible adults) | $454 | 2011-01-01 | Current EHSD page ($454/mo for an employable couple); back-dated to 2011 on the same frozen-standards basis as the single rate (see Verification notes) |

## Eligibility
The benefit gates on `ca_cc_general_assistance_eligible` (SPM unit), which ANDs three checks:

| Requirement | How modeled |
|---|---|
| At least one eligible person | `ca_cc_general_assistance_eligible_person` (per person: age ≥ 18, personal property ≤ $500, qualified immigration status, head/spouse, **not** receiving SSI/SSDI/UIB/SDI) |
| No dependent children | `is_child & is_tax_unit_dependent` summed to the SPM unit == 0 (families → CalWORKs) |
| Countable income < grant standard | `ca_cc_general_assistance_income_eligible`: `income < maximum_grant` ("earnings less than the maximum allowable grant") |
| Contra Costa County residence | `in_cc` (`county_str == CONTRA_COSTA_COUNTY_CA`) |

Per-person checks (age ≥ 18; personal property ≤ $500; qualified immigration status — CITIZEN, REFUGEE, ASYLEE, CUBAN_HAITIAN_ENTRANT, LEGAL_PERMANENT_RESIDENT; not receiving SSI/SSDI/UIB/SDI via `ssi`, `social_security_disability`, `unemployment_compensation`, `ca_state_disability_insurance`) live in `ca_cc_general_assistance_eligible_person`.

## Updates from review
This branch incorporates `/review-program` findings plus follow-up refactors:
- **Eligibility structure.** `ca_cc_general_assistance_income_eligible` is now purely the income test (`income < maximum_grant`); a new composite `ca_cc_general_assistance_eligible` ANDs has-eligible-person, no-dependent-children, and income eligibility, and the benefit gates on it (mirrors the San Mateo #8360 structure). The no-children rule no longer lives inside the income variable.
- **Renamed** `ca_cc_general_assistance_base_amount` → `ca_cc_general_assistance_maximum_grant` — it is the full grant standard, not a base that gets supplemented.
- **Dependent children** modeled as `is_child & is_tax_unit_dependent` (explicit; equal to the minor-child count in the current model, since only adults can head/spouse a tax unit).
- **Couple amount dating.** $454 now dated **2011-01-01** (was 2024-01-01): the single rate is corroborated at $336 from 2011 (WCLP) through today, so the standards appear frozen and the couple rate is applied back on the same basis (the EHSD page lists $336 single and $454 couple together).
- **Immigration status.** Dropped `PAROLED_ONE_YEAR` — time-limited parole conflicts with EHSD's "no limitation on your stay" criterion; aligns with Santa Clara (#8358) and San Mateo (#8360) County GA.
- **Reference accuracy.** Re-anchored the personal-property limit, fill-the-gap, and no-children references from the GA-80 brochure (which does not print those figures) to the EHSD program page.
- **Tests.** Added income=0→$336, income==$336→ineligible/$0 (strict `<`), three eligible adults→single $336, personal property summed across members, composite-eligibility cases, and an **endogenous SSI** integration test (an aged adult whose SSI the model computes — not forced as input — is excluded from GA). Test count 46 → 56.
- **Comment.** Clarified that only SSDI bars eligibility, while OASDI retirement/survivors count as income.

## Verification notes / known simplifications
- **Couple amount dated on a stability assumption.** $454 appears only on the (undated) EHSD page. Because the single rate is independently corroborated as unchanged at $336 since 2011, the GA standards are treated as frozen and the couple rate is applied back to 2011-01-01.
- **No earned-income disregard modeled.** CC's exact disregard (if any) is not published on the EHSD page or brochure; matches the Alameda GA precedent.
- **Immigration-status list.** CC does not publish an explicit qualified-status enumeration; the EHSD criterion is the broad "non-citizen legally in the country with no limitation on your stay." The modeled list maps that criterion onto the closest enum members. `DEPORTATION_WITHHELD` / `CONDITIONAL_ENTRANT` (used by #8358 / #8360) are not added here because the EHSD page does not enumerate them for Contra Costa.
- **SSI exclusion scope.** GA excludes people *actually receiving* SSI (`ssi > 0`). Unlike San Mateo (#8360), CC does not additionally exclude CAPI-eligible applicants (the aged/blind/disabled-LPR SSI off-ramp); the "apply for potential income" rule is therefore only partially modeled.
- **Household sizes ≥ 3** are not separately sourced; 3+ eligible adults fall through to the single amount, and any 2 eligible adults are treated as a couple (marital pairing is not tracked within the SPM unit).
- **Personal-property limit.** The $500 figure is the EHSD page value. The GA-80 brochure's granular asset rules (home, one vehicle ≤ $4,500, cash < $50) are separate exclusions and are not modeled; `personal_property` is treated as the net countable-asset figure.
- **Authoritative grant table unobtainable online.** The Contra Costa GA Standard Practices Manual / Board resolution is not published online; the CCWRO Public Assistance Tables checked contain no GA/GR section.

## Not modeled (by design)
- 90-day / 3-month-in-12 employable time limit (lifetime/cumulative limits are a known framework limitation)
- Reimbursement/loan agreement (Form SSP-14)
- Special Need Allowance, shared-housing reduction, vendor/in-kind rent payment
- 15-day residency-duration requirement; granular resource exclusions

## Files
```
parameters/gov/local/ca/cc/general_assistance/
variables/gov/local/ca/cc/ga/
  ca_cc_general_assistance.py            (fill-the-gap benefit; gates on ..._eligible)
  ca_cc_general_assistance_maximum_grant.py   (grant standard: single/couple)
  eligibility/
    ca_cc_general_assistance_eligible.py        (composite SPM-unit gate)
    ca_cc_general_assistance_eligible_person.py (per-person categorical checks)
    ca_cc_general_assistance_income_eligible.py (pure income test)
    ca_cc_general_assistance_age_eligible.py
    ca_cc_general_assistance_immigration_status_eligible.py
    ca_cc_general_assistance_personal_property_eligible.py
  income/  (+ in_cc.py)
tests/policy/baseline/gov/local/ca/cc/ga/
programs.yaml  (registered ca_cc_general_assistance)
```

## Reference implementation
- Alameda County GA: `policyengine_us/variables/gov/local/ca/ala/ga/`
- Sibling county GA PRs: Santa Clara #8358, San Mateo #8360

## Test plan
- [x] 56 unit/YAML tests pass locally (`policyengine-core test policyengine_us/tests/policy/baseline/gov/local/ca/cc/`)
- [x] `make format` clean (ruff format + check)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
