### PR TITLE
Fix Alameda County name string in in_ala

### DIFF
--- a/changelog.d/fix-in-ala-county-string.fixed.md
+++ b/changelog.d/fix-in-ala-county-string.fixed.md
@@ -1,0 +1,1 @@
+Fix Alameda County name string in `in_ala` so it matches the all-caps county enum name (`ALAMEDA_COUNTY_CA`).

--- a/policyengine_us/variables/gov/local/ca/ala/in_ala.py
+++ b/policyengine_us/variables/gov/local/ca/ala/in_ala.py
@@ -9,4 +9,4 @@ class in_ala(Variable):
 
     def formula(household, period, parameters):
         county = household("county_str", period)
-        return county == "Alameda_COUNTY_CA"
+        return county == "ALAMEDA_COUNTY_CA"

--- a/uv.lock
+++ b/uv.lock
@@ -2974,7 +2974,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.702.1"
+version = "1.721.1"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary

`in_ala` checks whether a household is in Alameda County, CA. Its formula compared `county_str` against the literal `"Alameda_COUNTY_CA"`, but `county_str` returns the county **enum name** — which is `ALAMEDA_COUNTY_CA` (all caps), matching the convention used by every other county (`LOS_ANGELES_COUNTY_CA`, `RIVERSIDE_COUNTY_CA`, etc.). The mixed-case literal never matched, so the formula never identified Alameda County.

This corrects the string to `"ALAMEDA_COUNTY_CA"`.

## Note on behavior

`county` defaults to `first_county_in_state`, which is the alphabetically-first county in the state — for CA that is Alameda. So CA households that do not explicitly set a county/`county_fips` now resolve to `in_ala == True` and become eligible for Alameda General Assistance (`defined_for = "in_ala"`) in microsimulation contexts. This is the intended correction of the string bug.

## Files

- `policyengine_us/variables/gov/local/ca/ala/in_ala.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)