### PR TITLE
Fix CA SSP disability payment standard

### DIFF
--- a/changelog.d/8549.fixed.md
+++ b/changelog.d/8549.fixed.md
@@ -1,0 +1,1 @@
+Fixed California SSI state supplement payment standards for disabled recipients identified by SSI disability criteria.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/state_supplement/ca_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/state_supplement/ca_state_supplement.yaml
@@ -15,3 +15,27 @@
     state_code: CA
   output:
     ca_state_supplement: 800
+
+- name: Case 3, disabled SSI recipient receives state supplement.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 45
+        is_tax_unit_head: true
+        meets_ssi_disability_criteria: true
+        ssi_engaged_in_sga: false
+        ssi: 3_458.28
+        immigration_status: CITIZEN
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+        living_arrangements_allow_for_food_preparation: true
+  output:
+    ca_state_supplement_eligible_person: true
+    ca_state_supplement: 4_101.72

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/state_supplement/ca_state_supplement_aged_disabled_count.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/state_supplement/ca_state_supplement_aged_disabled_count.yaml
@@ -75,3 +75,22 @@
         state_code: CA
   output:
     ca_state_supplement_aged_disabled_count: 0
+
+- name: Case 4, SSI disability criteria count as disabled.
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 45
+        is_tax_unit_head: true
+        meets_ssi_disability_criteria: true
+        ssi_engaged_in_sga: false
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: CA
+  output:
+    ca_state_supplement_aged_disabled_count: 1

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/state_supplement/ca_state_supplement_dependent_amount.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/state_supplement/ca_state_supplement_dependent_amount.yaml
@@ -45,3 +45,26 @@
         state_code: CA
   output:
     ca_state_supplement_dependent_amount: 5_988
+
+- name: Case 3, SSI disability criteria qualify a dependent.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 68
+        is_tax_unit_head: true
+      person2:
+        age: 4
+        is_tax_unit_dependent: true
+        meets_ssi_disability_criteria: true
+        ssi_engaged_in_sga: false
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CA
+  output:
+    ca_state_supplement_dependent_amount: 5_988

--- a/policyengine_us/variables/gov/states/ca/cdss/state_supplement/payment_standard/ca_state_supplement_aged_disabled_count.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/state_supplement/payment_standard/ca_state_supplement_aged_disabled_count.py
@@ -13,9 +13,9 @@ class ca_state_supplement_aged_disabled_count(Variable):
         p = parameters(period).gov.states.ca.cdss.state_supplement.payment_standard
         person = spm_unit.members
         # Aged or disabled amount
-        is_disabled = person("is_disabled", period)
+        is_ssi_disabled = person("is_ssi_disabled", period.this_year)
         age = person("monthly_age", period)
         is_aged = age >= p.aged_or_disabled.age_threshold
-        aged_or_disabled = is_aged | is_disabled
+        aged_or_disabled = is_aged | is_ssi_disabled
         eligible = person("ca_state_supplement_eligible_person", period)
         return spm_unit.sum(aged_or_disabled * eligible)

--- a/policyengine_us/variables/gov/states/ca/cdss/state_supplement/payment_standard/ca_state_supplement_dependent_amount.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/state_supplement/payment_standard/ca_state_supplement_dependent_amount.py
@@ -15,12 +15,12 @@ class ca_state_supplement_dependent_amount(Variable):
         person = spm_unit.members
         # Blind amount
         blind = person("is_blind", period)
-        is_disabled = person("is_disabled", period)
+        is_ssi_disabled = person("is_ssi_disabled", period.this_year)
         age = person("monthly_age", period)
         # Dependent amount
         dependent = person("is_tax_unit_dependent", period)
         dependent_age_eligible = age < p.dependent.age_limit
         dependent_count = spm_unit.sum(
-            dependent & dependent_age_eligible & (is_disabled | blind)
+            dependent & dependent_age_eligible & (is_ssi_disabled | blind)
         )
         return dependent_count * p.dependent.amount


### PR DESCRIPTION
Fixes #8549.

## Summary
- Use `is_ssi_disabled` instead of raw `is_disabled` in CA SSP aged/disabled count and dependent amount calculations.
- Add regressions for API inputs that set `meets_ssi_disability_criteria` without legacy `is_disabled`.

## Tests
- `uv run --frozen --python 3.13 python -B -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/ca/cdss/state_supplement -c policyengine_us`
- `uv run --frozen --python 3.13 ruff format --check policyengine_us/variables/gov/states/ca/cdss/state_supplement/payment_standard/ca_state_supplement_aged_disabled_count.py policyengine_us/variables/gov/states/ca/cdss/state_supplement/payment_standard/ca_state_supplement_dependent_amount.py`
- `git diff --check`