### PR TITLE
Fix California investment interest itemized deductions

### DIFF
--- a/changelog.d/ca-investment-interest-deduction.fixed.md
+++ b/changelog.d/ca-investment-interest-deduction.fixed.md
@@ -1,0 +1,1 @@
+Fixed California itemized deductions double-counting investment interest expense.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/ca_investment_interest_expense_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/ca_investment_interest_expense_deduction.yaml
@@ -1,0 +1,17 @@
+- name: Case 1, net investment income below investment interest.
+  period: 2026
+  input:
+    state_code: CA
+    investment_interest_expense: 10_000
+    investment_expenses: 2_000
+  output:
+    ca_investment_interest_expense_deduction: 8_000
+
+- name: Case 2, investment expenses exceed investment interest.
+  period: 2026
+  input:
+    state_code: CA
+    investment_interest_expense: 10_000
+    investment_expenses: 12_000
+  output:
+    ca_investment_interest_expense_deduction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions.yaml
@@ -5,7 +5,7 @@
     filing_status: SINGLE
     adjusted_gross_income: 100_000
     medical_expense_deduction: 10_000
-    ca_investment_interest_deduction: 5_000
+    ca_investment_interest_expense_deduction: 5_000
   output:
     ca_itemized_deductions: 15_000
 
@@ -16,7 +16,7 @@
     filing_status: SINGLE
     adjusted_gross_income: 212_288 + 50_000
     medical_expense_deduction: 10_000
-    ca_investment_interest_deduction: 5_000
+    ca_investment_interest_expense_deduction: 5_000
   output:
     ca_itemized_deductions: 12_000  # medical expenses not subject to limitation
 
@@ -27,7 +27,7 @@
     filing_status: SINGLE
     adjusted_gross_income: 100_000
     charitable_deduction: 10_000
-    ca_investment_interest_deduction: 5_000
+    ca_investment_interest_expense_deduction: 5_000
   output:
     ca_itemized_deductions: 15_000
 
@@ -38,7 +38,7 @@
     filing_status: SINGLE
     adjusted_gross_income: 212_288 + 50_000
     charitable_deduction: 10_000
-    ca_investment_interest_deduction: 5_000
+    ca_investment_interest_expense_deduction: 5_000
   output:
     ca_itemized_deductions: 12_000  # charity subject to limitation
 

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions_pre_limitation.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions_pre_limitation.yaml
@@ -1,0 +1,17 @@
+- name: Case 1, investment interest is not counted twice.
+  period: 2026
+  input:
+    state_code: CA
+    investment_interest_expense: 10_000
+  output:
+    ca_itemized_deductions_pre_limitation: 10_000
+
+- name: Case 2, California investment interest replaces federal investment interest.
+  period: 2026
+  input:
+    state_code: CA
+    investment_interest_expense: 10_000
+    investment_expenses: 2_000
+    real_estate_taxes: 5_000
+  output:
+    ca_itemized_deductions_pre_limitation: 13_000

--- a/policyengine_us/variables/gov/states/ca/tax/income/deductions/ca_investment_interest_expense_deduction.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/deductions/ca_investment_interest_expense_deduction.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class ca_investment_interest_expense_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "California investment interest expense deduction"
+    unit = USD
+    reference = "https://www.ftb.ca.gov/forms/2025/2025-3526.pdf"
+    definition_period = YEAR
+    defined_for = StateCode.CA
+
+    def formula(tax_unit, period, parameters):
+        # FTB 3526 line 1.
+        investment_interest_expense = add(
+            tax_unit, period, ["investment_interest_expense"]
+        )
+        # FTB 3526 line 5.
+        investment_expenses = add(tax_unit, period, ["investment_expenses"])
+        # Simplified FTB 3526 line 6. Carryforwards and investment income
+        # elections are not separately modeled here.
+        net_investment_income = max_(
+            0, investment_interest_expense - investment_expenses
+        )
+        # FTB 3526 line 8.
+        return min_(investment_interest_expense, net_investment_income)

--- a/policyengine_us/variables/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions_pre_limitation.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions_pre_limitation.py
@@ -14,7 +14,8 @@ class ca_itemized_deductions_pre_limitation(Variable):
     defined_for = StateCode.CA
 
     adds = [
-        "ca_investment_interest_deduction",
-        "real_estate_taxes",
         "itemized_deductions_less_salt",
+        "ca_investment_interest_expense_deduction",
+        "real_estate_taxes",
     ]
+    subtracts = ["investment_interest_expense"]


### PR DESCRIPTION
## Summary

Fixes #8605.

California itemized deductions now replace the investment-interest component included in the federal/non-SALT itemized deduction base with the California investment interest expense deduction, instead of adding the California amount on top of an already-included investment interest expense.

This adds a separate `ca_investment_interest_expense_deduction` variable for the FTB 3526 line 8 deduction amount and keeps the existing `ca_investment_interest_deduction` adjustment variable behavior intact.

## Verification

- `uv run ruff check policyengine_us/variables/gov/states/ca/tax/income/deductions/ca_investment_interest_expense_deduction.py policyengine_us/variables/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions_pre_limitation.py`
- `uv run ruff format --check policyengine_us/variables/gov/states/ca/tax/income/deductions/ca_investment_interest_expense_deduction.py policyengine_us/variables/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions_pre_limitation.py`
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/ca_investment_interest_expense_deduction.yaml policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions_pre_limitation.yaml policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/itemized/ca_itemized_deductions.yaml policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/deductions/ca_investment_interest_deduction.yaml`

PolicyBench reproducer `us:scenario_097:state_income_tax_before_refundable_credits` changes from `36,233.50` to `37,171.91` because `ca_itemized_deductions_pre_limitation` no longer includes the same `$10,090.42` investment interest expense twice.
