### PR TITLE
Exclude use tax from state income tax variables

### DIFF
--- a/changelog.d/exclude-use-tax-state-income.fixed.md
+++ b/changelog.d/exclude-use-tax-state-income.fixed.md
@@ -1,0 +1,1 @@
+Exclude state use tax from state income tax variables and aggregates.

--- a/policyengine_us/parameters/gov/states/household/state_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_income_tax_before_refundable_credits.yaml
@@ -13,7 +13,7 @@ values:
     - hi_income_tax_before_refundable_credits
     - ia_income_tax_before_refundable_credits
     - id_income_tax_before_refundable_credits
-    - il_total_tax
+    - il_income_tax_before_refundable_credits
     - in_income_tax_before_refundable_credits
     - ks_income_tax_before_refundable_credits
     - ky_income_tax_before_refundable_credits

--- a/policyengine_us/parameters/gov/states/household/state_use_tax.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_use_tax.yaml
@@ -1,0 +1,14 @@
+description: All state use tax calculations.
+values:
+  0000-01-01:
+    - ca_use_tax
+    - il_use_tax
+    - in_use_tax
+    - nc_use_tax
+    - ok_use_tax
+    - pa_use_tax
+
+metadata:
+  unit: list
+  period: year
+  label: State use tax

--- a/policyengine_us/tests/policy/baseline/gov/irs/integration/us_itemize.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/integration/us_itemize.yaml
@@ -49,7 +49,7 @@
         members: [person1]
         state_code: IL  # state income tax that does not depend on US tax
   output:
-    state_income_tax: 4_526.4375 
+    state_income_tax: 4_482.4375
     adjusted_gross_income: 100_000
     taxable_income_deductions_if_not_itemizing: 12_550
     taxable_income_deductions_if_itemizing: 8_000 + 10_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/integration.yaml
@@ -108,7 +108,7 @@
         members: [person1, person2]
         state_fips: 6
   output:
-    ca_income_tax: 371
+    ca_income_tax: 366.40564
 
 - name: High income joint filer, state_income_tax includes behavioral health tax.
   absolute_error_margin: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/nc_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/nc_income_tax.yaml
@@ -8,7 +8,7 @@
   output:
     nc_income_tax: 0
 
-- name: NC income tax before credits and use tax amount more than non refundable credits, Case 1
+- name: NC income tax excludes use tax, Case 1
   period: 2023
   input:
     nc_income_tax_before_credits: 1_000
@@ -16,9 +16,9 @@
     nc_use_tax: 500
     state_code: NC
   output:
-    nc_income_tax: 1_200
+    nc_income_tax: 700
 
-- name: NC income tax before credits and use tax amount more than non refundable credits, Case 2
+- name: NC income tax excludes use tax, Case 2
   period: 2023
   input:
     nc_income_tax_before_credits: 100
@@ -26,4 +26,4 @@
     nc_use_tax: 500
     state_code: NC
   output:
-    nc_income_tax: 300
+    nc_income_tax: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/credits/eitc/ok_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/credits/eitc/ok_eitc.yaml
@@ -111,7 +111,7 @@
     # OK CTC = 5% of $1,700 refundable federal CTC.
     ok_child_care_child_tax_credit: 85
     ok_eitc: 174
-    ok_income_tax: -224.8
+    ok_income_tax: -235.97171
 
 - name: OK EITC - 2025 - full year resident
   period: 2025

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.yaml
@@ -6,11 +6,11 @@
     pa_use_tax: 23
     pa_refundable_tax_credits: 411
   output:
-    pa_income_tax_before_refundable_credits: 1_753
-    pa_income_tax: 1_342
-    state_income_tax_before_refundable_credits: 1_753
+    pa_income_tax_before_refundable_credits: 1_730
+    pa_income_tax: 1_319
+    state_income_tax_before_refundable_credits: 1_730
     state_refundable_credits: 411
-    state_income_tax: 1_342
+    state_income_tax: 1_319
     household_state_tax_before_refundable_credits: 1_753
     household_refundable_state_tax_credits: 411
     household_tax_before_refundable_credits: 1_753

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax_excludes_use_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax_excludes_use_tax.yaml
@@ -1,0 +1,129 @@
+- name: California state income tax excludes use tax
+  period: 2026
+  input:
+    state_code: CA
+    ca_income_tax_before_refundable_credits: 100
+    ca_use_tax: 20
+    ca_refundable_credits: 5
+    household_market_income: 1_000
+    household_benefits: 0
+  output:
+    ca_income_tax: 95
+    state_use_tax: 20
+    state_income_tax_before_refundable_credits: 100
+    state_income_tax: 95
+    household_state_tax_before_refundable_credits: 120
+    household_tax_before_refundable_credits: 120
+    household_tax: 115
+    household_net_income: 885
+    spm_unit_state_tax: 115
+    spm_unit_taxes: 115
+
+- name: Illinois state income tax before refundable credits excludes use tax
+  period: 2026
+  input:
+    state_code: IL
+    il_income_tax_before_refundable_credits: 100
+    il_use_tax: 20
+    il_refundable_credits: 5
+    household_market_income: 1_000
+    household_benefits: 0
+  output:
+    il_total_tax: 120
+    il_income_tax: 95
+    state_use_tax: 20
+    state_income_tax_before_refundable_credits: 100
+    state_income_tax: 95
+    household_state_tax_before_refundable_credits: 120
+    household_tax_before_refundable_credits: 120
+    household_tax: 115
+    household_net_income: 885
+    spm_unit_state_tax: 115
+    spm_unit_taxes: 115
+
+- name: Indiana state income tax excludes use tax
+  period: 2026
+  input:
+    state_code: IN
+    in_agi_tax: 100
+    in_529_plan_credit: 30
+    in_use_tax: 20
+    in_refundable_credits: 5
+    household_market_income: 1_000
+    household_benefits: 0
+  output:
+    in_income_tax_before_refundable_credits: 70
+    in_income_tax: 65
+    state_use_tax: 20
+    state_income_tax_before_refundable_credits: 70
+    state_income_tax: 65
+    household_state_tax_before_refundable_credits: 90
+    household_tax_before_refundable_credits: 90
+    household_tax: 85
+    household_net_income: 915
+    spm_unit_state_tax: 85
+    spm_unit_taxes: 85
+
+- name: North Carolina state income tax excludes use tax
+  period: 2026
+  input:
+    state_code: NC
+    nc_income_tax_before_credits: 100
+    nc_non_refundable_credits: 30
+    nc_use_tax: 20
+    household_market_income: 1_000
+    household_benefits: 0
+  output:
+    nc_income_tax: 70
+    state_use_tax: 20
+    state_income_tax_before_refundable_credits: 70
+    state_income_tax: 70
+    household_state_tax_before_refundable_credits: 90
+    household_tax_before_refundable_credits: 90
+    household_tax: 90
+    household_net_income: 910
+    spm_unit_state_tax: 90
+    spm_unit_taxes: 90
+
+- name: Oklahoma state income tax excludes use tax
+  period: 2026
+  input:
+    state_code: OK
+    ok_income_tax_before_refundable_credits: 100
+    ok_use_tax: 20
+    ok_refundable_credits: 5
+    household_market_income: 1_000
+    household_benefits: 0
+  output:
+    ok_income_tax: 95
+    state_use_tax: 20
+    state_income_tax_before_refundable_credits: 100
+    state_income_tax: 95
+    household_state_tax_before_refundable_credits: 120
+    household_tax_before_refundable_credits: 120
+    household_tax: 115
+    household_net_income: 885
+    spm_unit_state_tax: 115
+    spm_unit_taxes: 115
+
+- name: Pennsylvania state income tax excludes use tax
+  period: 2026
+  input:
+    state_code: PA
+    pa_income_tax_after_forgiveness: 100
+    pa_use_tax: 20
+    pa_refundable_tax_credits: 5
+    household_market_income: 1_000
+    household_benefits: 0
+  output:
+    pa_income_tax_before_refundable_credits: 100
+    pa_income_tax: 95
+    state_use_tax: 20
+    state_income_tax_before_refundable_credits: 100
+    state_income_tax: 95
+    household_state_tax_before_refundable_credits: 120
+    household_tax_before_refundable_credits: 120
+    household_tax: 115
+    household_net_income: 885
+    spm_unit_state_tax: 115
+    spm_unit_taxes: 115

--- a/policyengine_us/variables/gov/states/ca/tax/income/ca_income_tax.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/ca_income_tax.py
@@ -10,8 +10,5 @@ class ca_income_tax(Variable):
     definition_period = YEAR
     reference = "https://www.ftb.ca.gov/forms/Search/Home/Confirmation"
 
-    adds = [
-        "ca_income_tax_before_refundable_credits",
-        "ca_use_tax",
-    ]
+    adds = ["ca_income_tax_before_refundable_credits"]
     subtracts = ["ca_refundable_credits"]

--- a/policyengine_us/variables/gov/states/il/tax/income/il_income_tax.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/il_income_tax.py
@@ -9,5 +9,5 @@ class il_income_tax(Variable):
     definition_period = YEAR
     defined_for = StateCode.IL
 
-    adds = ["il_total_tax"]
+    adds = ["il_income_tax_before_refundable_credits"]
     subtracts = ["il_refundable_credits"]

--- a/policyengine_us/variables/gov/states/in/tax/income/in_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/in_income_tax_before_refundable_credits.py
@@ -11,7 +11,7 @@ class in_income_tax_before_refundable_credits(Variable):
     defined_for = StateCode.IN
 
     def formula(tax_unit, period, parameters):
-        tax = add(tax_unit, period, ["in_agi_tax", "in_use_tax"])
+        tax = tax_unit("in_agi_tax", period)
         # Non-refundable 529 credit reduces tax to zero but not below
         credit_529 = tax_unit("in_529_plan_credit", period)
         return max_(tax - credit_529, 0)

--- a/policyengine_us/variables/gov/states/nc/tax/income/nc_income_tax.py
+++ b/policyengine_us/variables/gov/states/nc/tax/income/nc_income_tax.py
@@ -10,9 +10,7 @@ class nc_income_tax(Variable):
     defined_for = StateCode.NC
 
     def formula(tax_unit, period, parameters):
-        tax_before_credits = add(
-            tax_unit, period, ["nc_income_tax_before_credits", "nc_use_tax"]
-        )
+        tax_before_credits = tax_unit("nc_income_tax_before_credits", period)
         # North Carolina provides no refundable income tax credits
         credits = tax_unit("nc_non_refundable_credits", period)
         return max_(0, tax_before_credits - credits)

--- a/policyengine_us/variables/gov/states/ok/tax/income/ok_income_tax.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/ok_income_tax.py
@@ -12,5 +12,5 @@ class ok_income_tax(Variable):
         "https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/current/511-Pkt.pdf"
     )
     defined_for = StateCode.OK
-    adds = ["ok_income_tax_before_refundable_credits", "ok_use_tax"]
+    adds = ["ok_income_tax_before_refundable_credits"]
     subtracts = ["ok_refundable_credits"]

--- a/policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax.py
@@ -10,5 +10,5 @@ class pa_income_tax(Variable):
     reference = "https://www.revenue.pa.gov/FormsandPublications/FormsforIndividuals/PIT/Documents/2021/2021_pa-40in.pdf#page=21"
     defined_for = StateCode.PA
 
-    adds = ["pa_income_tax_after_forgiveness", "pa_use_tax"]
+    adds = ["pa_income_tax_before_refundable_credits"]
     subtracts = ["pa_refundable_tax_credits"]

--- a/policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.py
@@ -9,4 +9,4 @@ class pa_income_tax_before_refundable_credits(Variable):
     definition_period = YEAR
     defined_for = StateCode.PA
 
-    adds = ["pa_income_tax_after_forgiveness", "pa_use_tax"]
+    adds = ["pa_income_tax_after_forgiveness"]

--- a/policyengine_us/variables/gov/states/tax/income/state_use_tax.py
+++ b/policyengine_us/variables/gov/states/tax/income/state_use_tax.py
@@ -1,0 +1,10 @@
+from policyengine_us.model_api import *
+
+
+class state_use_tax(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "state use tax"
+    unit = USD
+    definition_period = YEAR
+    adds = "gov.states.household.state_use_tax"

--- a/policyengine_us/variables/household/expense/tax/spm_unit_state_tax.py
+++ b/policyengine_us/variables/household/expense/tax/spm_unit_state_tax.py
@@ -4,16 +4,18 @@ from policyengine_us.model_api import *
 class spm_unit_state_tax(Variable):
     value_type = float
     entity = SPMUnit
-    label = "State income tax"
+    label = "State tax"
     definition_period = YEAR
     unit = USD
 
-    # state_income_tax is at the tax unit level.
+    # state income and use taxes are at the tax unit level.
     # adds doesn't currently address this case (needs to be split to avoid
     # double-counting), so write a formula.
 
     def formula(spm_unit, period, parameters):
         person = spm_unit.members
         head = person("is_tax_unit_head", period)
-        tax = person.tax_unit("state_income_tax", period)
+        tax = person.tax_unit("state_income_tax", period) + person.tax_unit(
+            "state_use_tax", period
+        )
         return spm_unit.sum(head * tax)

--- a/policyengine_us/variables/household/income/household/household_state_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/household/income/household/household_state_tax_before_refundable_credits.py
@@ -7,4 +7,4 @@ class household_state_tax_before_refundable_credits(Variable):
     label = "household State tax before refundable credits"
     unit = USD
     definition_period = YEAR
-    adds = "gov.states.household.state_income_tax_before_refundable_credits"
+    adds = ["state_income_tax_before_refundable_credits", "state_use_tax"]


### PR DESCRIPTION
## Summary
- exclude state use tax from state income-tax variables in CA, IL, IN, NC, OK, and PA
- add a generic `state_use_tax` aggregate for separately modeled state use tax
- keep broader household/SPM state-tax totals and household net income inclusive of use tax
- point `state_income_tax_before_refundable_credits` at Illinois income tax before refundable credits instead of `il_total_tax`
- add a six-state regression test proving income-tax outputs exclude use tax while total tax/net income still include it

Closes #8607.

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax_excludes_use_tax.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/nc_income_tax.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/pa_income_tax_before_refundable_credits.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/tax/income/state_income_tax.yaml -c policyengine_us`