### PR TITLE
Add SNAP work program participant input to satisfy the general work requirement

### DIFF
--- a/changelog.d/snap-work-program-participant.added.md
+++ b/changelog.d/snap-work-program-participant.added.md
@@ -1,0 +1,1 @@
+SNAP work program participant input variable, satisfying the general work requirements under 7 CFR 273.7.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.yaml
@@ -79,3 +79,21 @@
         members: [person1, person2]
   output:
     meets_snap_general_work_requirements: [true, true]
+
+- name: Case 8, age 30, not working but a SNAP work program participant.
+  period: 2022
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 0
+    is_snap_work_program_participant: true
+  output:
+    meets_snap_general_work_requirements: true
+
+- name: Case 9, age 30, not working and not a SNAP work program participant.
+  period: 2022
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 0
+    is_snap_work_program_participant: false
+  output:
+    meets_snap_general_work_requirements: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_work_requirements.yaml
@@ -141,3 +141,20 @@
         members: [person1, person2]
   output:
     meets_snap_work_requirements: true
+
+- name: Case 10, work program participant passes the general check but not the ABAWD check.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        is_snap_work_program_participant: true
+        weekly_hours_worked_before_lsr: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+  output:
+    meets_snap_general_work_requirements: true
+    meets_snap_abawd_work_requirements: false
+    meets_snap_work_requirements: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_work_requirements.yaml
@@ -158,3 +158,49 @@
     meets_snap_general_work_requirements: true
     meets_snap_abawd_work_requirements: false
     meets_snap_work_requirements: false
+
+- name: Case 11, non-working parent of a teenager fails without the work program flag.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        is_snap_work_program_participant: false
+        weekly_hours_worked_before_lsr: 0
+      person2:
+        monthly_age: 17
+        is_tax_unit_dependent: true
+        weekly_hours_worked_before_lsr: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    # Neither member passes the general check: the parent is non-exempt
+    # and not working, and the 17-year-old is past the under-16 age
+    # exemption.
+    meets_snap_general_work_requirements: [false, false]
+    meets_snap_work_requirements: false
+
+- name: Case 12, the work program flag makes the same household pass.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        monthly_age: 30
+        is_tax_unit_dependent: false
+        is_snap_work_program_participant: true
+        weekly_hours_worked_before_lsr: 0
+      person2:
+        monthly_age: 17
+        is_tax_unit_dependent: true
+        weekly_hours_worked_before_lsr: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    # The dependent child under 18 waives the ABAWD check (pre-HR1), so
+    # the parent's work program participation alone flips the unit from
+    # failing to passing.
+    meets_snap_general_work_requirements: [true, false]
+    meets_snap_work_requirements: true

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_program_participant.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_program_participant.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class is_snap_work_program_participant(Variable):
+    value_type = bool
+    entity = Person
+    label = "SNAP work program participant"
+    documentation = (
+        "Whether this person participates in, or is willing to participate "
+        "in, a SNAP employment and training program or workfare. Actual "
+        "participation is not required: under 7 CFR 273.7(a)(1), a work "
+        "registrant only has to participate if the state assigns them, and "
+        "disqualification under 7 CFR 273.7(f) applies only to those who "
+        "refuse to comply without good cause. Willingness to comply "
+        "therefore satisfies the general work requirements. This does not "
+        "satisfy the ABAWD work requirement under 7 CFR 273.24, which "
+        "requires actual hours of work or work program participation."
+    )
+    definition_period = MONTH
+    reference = "https://www.law.cornell.edu/cfr/text/7/273.7#a_1"

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_program_participant.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_program_participant.py
@@ -6,15 +6,15 @@ class is_snap_work_program_participant(Variable):
     entity = Person
     label = "SNAP work program participant"
     documentation = (
-        "Whether this person participates in, or is willing to participate "
-        "in, a SNAP employment and training program or workfare. Actual "
-        "participation is not required: under 7 CFR 273.7(a)(1), a work "
-        "registrant only has to participate if the state assigns them, and "
-        "disqualification under 7 CFR 273.7(f) applies only to those who "
-        "refuse to comply without good cause. Willingness to comply "
-        "therefore satisfies the general work requirements. This does not "
-        "satisfy the ABAWD work requirement under 7 CFR 273.24, which "
-        "requires actual hours of work or work program participation."
+        "Whether this person participates in, or otherwise complies with, "
+        "a SNAP employment and training program or workfare assignment. "
+        "Under 7 CFR 273.7(a)(1), non-exempt work registrants must "
+        "participate in an E&T program or workfare if assigned by the "
+        "state agency. Willingness to participate alone does not satisfy "
+        "this input when the person has an assignment requiring "
+        "participation. This does not satisfy the ABAWD work requirement "
+        "under 7 CFR 273.24, which requires actual hours of work or work "
+        "program participation."
     )
     definition_period = MONTH
     reference = "https://www.law.cornell.edu/cfr/text/7/273.7#a_1"

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.py
@@ -33,8 +33,8 @@ class meets_snap_general_work_requirements(Variable):
             | has_incapacitated_person
             | is_working
         )
-        # Non-exempt registrants comply by participating in (or being
-        # willing to participate in) a work program under 7 CFR 273.7(a)(1)
+        # Non-exempt registrants comply by participating in, or otherwise
+        # complying with, a work program under 7 CFR 273.7(a)(1).
         compliant = person("is_snap_work_program_participant", period)
 
         return exempted | compliant

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.py
@@ -12,6 +12,7 @@ class meets_snap_general_work_requirements(Variable):
         p = parameters(period).gov.usda.snap.work_requirements.general
         age = person("monthly_age", period)
         weekly_hours_worked = person("weekly_hours_worked_before_lsr", period.this_year)
+        # Exemptions under 7 CFR 273.7(b)(1):
         # Under 16 or 60 years of age or older are exempted
         worked_exempted_age = p.age_threshold.exempted.calc(age)
         # Unable to work due to a physical or mental limitation
@@ -25,11 +26,15 @@ class meets_snap_general_work_requirements(Variable):
         )
         # Work at least 30 hours a week
         is_working = weekly_hours_worked >= p.weekly_hours_threshold
-
-        return (
+        exempted = (
             worked_exempted_age
             | is_disabled
             | has_child
             | has_incapacitated_person
             | is_working
         )
+        # Non-exempt registrants comply by participating in (or being
+        # willing to participate in) a work program under 7 CFR 273.7(a)(1)
+        compliant = person("is_snap_work_program_participant", period)
+
+        return exempted | compliant


### PR DESCRIPTION
## Summary

Adds `is_snap_work_program_participant`, a boolean input variable (Person, MONTH, defaults to false) for a person who participates in, or otherwise complies with, a SNAP employment and training program or workfare assignment. The input can satisfy the SNAP **general** work requirement. It does not satisfy the ABAWD work requirement.

Fixes #8617

## Regulatory basis

- [7 CFR 273.7(a)(1)](https://www.law.cornell.edu/cfr/text/7/273.7#a_1): non-exempt work registrants must participate in a SNAP E&T program if assigned by the state agency, and must participate in workfare if assigned.
- [7 CFR 273.7(f)](https://www.law.cornell.edu/cfr/text/7/273.7#f): disqualification applies when a person refuses or fails without good cause to comply with applicable work requirements.

The variable documentation now states that willingness to participate alone does not satisfy this input when the person has an assignment requiring participation.

## Scope

- **General check only.** The flag is an OR condition in `meets_snap_general_work_requirements`, whose formula is grouped as `exempted` (the 273.7(b)(1) exemptions, including the 30-hour worker exemption in (b)(1)(vii)) and `compliant` (the (a)(1) work program route).
- **ABAWD unchanged.** The flag does not satisfy [7 CFR 273.24](https://www.law.cornell.edu/cfr/text/7/273.24), which requires actual hours of work or qualifying work program participation. A test case verifies the flag does not leak into the ABAWD check. We continue to collapse the 3-months-in-36 time limit into "must meet the work requirement now" since we don't track the cumulative clock at the moment.
- **Default false** → no baseline, microsimulation, or partner-facing behavior change unless the input is set.

## Downstream note

`medicaid_community_engagement_pass_through_eligible` consumes `meets_snap_general_work_requirements`, so a SNAP recipient with this flag set is also deemed compliant with the HR1 Medicaid community engagement requirement via the pass-through. This is consistent with the pass-through's meaning (complying with SNAP work requirements) but is a new optional input partners may want to know about.

## Test plan

- [x] `make format`
- [x] `policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.yaml -c policyengine_us`
- [x] `policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_work_requirements.yaml -c policyengine_us`
- [ ] CI passes