### PR TITLE
Add Massachusetts CSFP county filtering

### DIFF
--- a/changelog.d/ma-csfp-county-filtering.fixed.md
+++ b/changelog.d/ma-csfp-county-filtering.fixed.md
@@ -1,0 +1,1 @@
+Restricted Massachusetts Commodity Supplemental Food Program eligibility to covered counties.

--- a/policyengine_us/parameters/gov/states/ma/dese/csfp/counties.yaml
+++ b/policyengine_us/parameters/gov/states/ma/dese/csfp/counties.yaml
@@ -1,0 +1,24 @@
+description: Massachusetts defines the following counties as covered counties under the Commodity Supplemental Food Program.
+
+# Counties are derived from the distribution sites of The Greater Boston Food Bank,
+# the sole local agency under the Massachusetts CSFP State Plan.
+metadata:
+  unit: list
+  period: year
+  label: Massachusetts Commodity Supplemental Food Program covered counties
+  reference:
+    - title: Massachusetts Department of Elementary and Secondary Education Food Distribution Programs
+      href: https://www.doe.mass.edu/cnp/food_dist.html
+    - title: Massachusetts Commodity Supplemental Food Program State Plan
+      href: https://www.doe.mass.edu/cnp/csfp-state-plan.docx
+    - title: The Greater Boston Food Bank Commodity Supplemental Food Program distribution sites
+      href: https://www.gbfb.org/what-we-do/our-programs/commodity-supplemental-food-program/
+
+values:
+  2025-01-01:
+    - BRISTOL_COUNTY_MA
+    - ESSEX_COUNTY_MA
+    - MIDDLESEX_COUNTY_MA
+    - NORFOLK_COUNTY_MA
+    - PLYMOUTH_COUNTY_MA
+    - SUFFOLK_COUNTY_MA

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/dese/csfp/ma_dese_csfp_county_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/dese/csfp/ma_dese_csfp_county_eligible.yaml
@@ -1,0 +1,67 @@
+- name: Case 1, Massachusetts household in a CSFP covered county.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+        county_str: SUFFOLK_COUNTY_MA
+  output:
+    ma_dese_csfp_county_eligible: true
+
+- name: Case 2, Massachusetts household in another CSFP covered county.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+        county_str: PLYMOUTH_COUNTY_MA
+  output:
+    ma_dese_csfp_county_eligible: true
+
+- name: Case 3, Massachusetts household in a county without CSFP distribution sites.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+        county_str: BARNSTABLE_COUNTY_MA
+  output:
+    ma_dese_csfp_county_eligible: false
+
+- name: Case 4, Massachusetts household in central Massachusetts outside CSFP covered counties.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+        county_str: WORCESTER_COUNTY_MA
+  output:
+    ma_dese_csfp_county_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program_eligible.yaml
@@ -259,3 +259,39 @@
         county_str: ANDREW_COUNTY_MO
   output:
     commodity_supplemental_food_program_eligible: true
+
+- name: Case 11, Massachusetts senior in a CSFP covered county is eligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+        school_meal_fpg_ratio: 1.4
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+        county_str: MIDDLESEX_COUNTY_MA
+  output:
+    commodity_supplemental_food_program_eligible: true
+
+- name: Case 12, Massachusetts senior outside CSFP covered counties is not eligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+        school_meal_fpg_ratio: 1.0
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+        county_str: BARNSTABLE_COUNTY_MA
+  output:
+    commodity_supplemental_food_program_eligible: false

--- a/policyengine_us/variables/gov/states/ma/dese/csfp/ma_dese_csfp_county_eligible.py
+++ b/policyengine_us/variables/gov/states/ma/dese/csfp/ma_dese_csfp_county_eligible.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class ma_dese_csfp_county_eligible(Variable):
+    value_type = bool
+    entity = Household
+    definition_period = YEAR
+    label = "Massachusetts DESE CSFP county eligible"
+    defined_for = StateCode.MA
+    reference = (
+        "https://www.doe.mass.edu/cnp/food_dist.html",
+        "https://www.gbfb.org/what-we-do/our-programs/commodity-supplemental-food-program/",
+    )
+
+    def formula(household, period, parameters):
+        county = household("county_str", period)
+        p = parameters(period).gov.states.ma.dese.csfp
+        return np.isin(county, p.counties)

--- a/policyengine_us/variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py
+++ b/policyengine_us/variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py
@@ -21,10 +21,14 @@ class commodity_supplemental_food_program_eligible(Variable):
         in_tx = state_code == StateCode.TX
         in_ks = state_code == StateCode.KS
         in_mo = state_code == StateCode.MO
+        in_ma = state_code == StateCode.MA
         income_eligible = where(in_tx, tx_income_eligible, federal_income_eligible)
         ks_county_eligible = person.household("ks_dcf_csfp_county_eligible", period)
         mo_county_eligible = person.household("mo_dhss_csfp_county_eligible", period)
-        county_eligible = where(in_ks, ks_county_eligible, True) & where(
-            in_mo, mo_county_eligible, True
+        ma_county_eligible = person.household("ma_dese_csfp_county_eligible", period)
+        county_eligible = (
+            where(in_ks, ks_county_eligible, True)
+            & where(in_mo, mo_county_eligible, True)
+            & where(in_ma, ma_county_eligible, True)
         )
         return age_eligible & income_eligible & county_eligible

--- a/policyengine_us/variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py
+++ b/policyengine_us/variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py
@@ -26,9 +26,9 @@ class commodity_supplemental_food_program_eligible(Variable):
         ks_county_eligible = person.household("ks_dcf_csfp_county_eligible", period)
         mo_county_eligible = person.household("mo_dhss_csfp_county_eligible", period)
         ma_county_eligible = person.household("ma_dese_csfp_county_eligible", period)
-        county_eligible = (
-            where(in_ks, ks_county_eligible, True)
-            & where(in_mo, mo_county_eligible, True)
-            & where(in_ma, ma_county_eligible, True)
+        county_eligible = select(
+            [in_ks, in_mo, in_ma],
+            [ks_county_eligible, mo_county_eligible, ma_county_eligible],
+            default=True,
         )
         return age_eligible & income_eligible & county_eligible


### PR DESCRIPTION
## Summary

- Adds `ma_dese_csfp_county_eligible` gating the Commodity Supplemental Food Program by Massachusetts county, following the Kansas (#8585) and Missouri precedents.
- Adds `gov/states/ma/dese/csfp/counties.yaml` listing the six covered counties.
- Gates federal CSFP eligibility by the Massachusetts county variable when `state_code` is `MA`.

## Program research

Massachusetts CSFP is administered by the **Department of Elementary and Secondary Education (DESE), Office for Food and Nutrition Programs** — not MDAR (which runs MEFAP/SFMNP) — hence the `gov/states/ma/dese/csfp/` path. The [MA CSFP State Plan](https://www.doe.mass.edu/cnp/csfp-state-plan.docx) names DESE as the distributing agency and **The Greater Boston Food Bank as the sole local agency**; the [DESE food distribution page](https://www.doe.mass.edu/cnp/food_dist.html) confirms this.

No government document enumerates counties directly, so the covered counties are derived from [GBFB's 35+ CSFP distribution sites](https://www.gbfb.org/what-we-do/our-programs/commodity-supplemental-food-program/), each mapped to its county (same derivation approach as the KS site list and MO site map):

| County | Example CSFP site towns |
|---|---|
| Bristol | New Bedford, Taunton, Attleboro, Fairhaven, Acushnet |
| Essex | Lawrence, Lynn, Peabody, Danvers, Marblehead |
| Middlesex | Lowell, Somerville, Medford, Newton, Waltham, Billerica |
| Norfolk | Quincy, Randolph, Brookline, Milton |
| Plymouth | Wareham, Rochester |
| Suffolk | Boston, Chelsea, Revere |

Counties verified as **not** served:
- **Barnstable, Dukes, Nantucket** — inside GBFB's *general* nine-county territory but have no CSFP sites
- **Worcester** — Worcester County Food Bank has no CSFP program
- **Hampden, Hampshire, Franklin, Berkshire** — Food Bank of Western Massachusetts runs the state-funded "Brown Bag: Food for Elders" program, not federal CSFP

## Changes

- `parameters/gov/states/ma/dese/csfp/counties.yaml` — six covered counties, effective 2025-01-01
- `variables/gov/states/ma/dese/csfp/ma_dese_csfp_county_eligible.py` — household-level county check (mirrors `ks_dcf_csfp_county_eligible`)
- `variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py` — adds the MA county gate alongside KS and MO
- `tests/policy/baseline/gov/states/ma/dese/csfp/ma_dese_csfp_county_eligible.yaml` — covered counties (Suffolk, Plymouth) and uncovered counties (Barnstable, Worcester)
- `tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program_eligible.yaml` — integrated MA cases

## Testing

- Direct county tests plus integrated federal CSFP eligibility tests (validated in CI)
- `make format` run before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)