### PR TITLE
Derive TX CEAP countable income from state plan income sources

### DIFF
--- a/changelog.d/tx-ceap-income-sources.changed.md
+++ b/changelog.d/tx-ceap-income-sources.changed.md
@@ -1,0 +1,1 @@
+Texas CEAP countable income now follows the state plan income sources list instead of IRS gross income.

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/income/age_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/income/age_threshold.yaml
@@ -1,0 +1,13 @@
+description: Texas counts income received by household members at or above this age under the Comprehensive Energy Assistance Program.
+values:
+  2023-10-01: 18
+
+metadata:
+  unit: year
+  period: year
+  label: Texas CEAP income counting age threshold
+  reference:
+    - title: Texas LIHEAP State Plan FY 2026, Section 1.9 (page 9)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/26-LIHEAP-Plan-Amend1.pdf#page=9
+    - title: 10 Tex. Admin. Code § 6.4(b) and (d)(20) - Income Determination
+      href: https://www.law.cornell.edu/regulations/texas/10-Tex-Admin-Code-SS-6-4

--- a/policyengine_us/parameters/gov/states/tx/tdhca/ceap/income/sources.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tdhca/ceap/income/sources.yaml
@@ -1,0 +1,48 @@
+description: Texas counts these income sources when determining eligibility under the Comprehensive Energy Assistance Program.
+values:
+  2023-10-01:
+    # Wages and commissions
+    - employment_income
+    # Net receipts from self-employment and independent contract work
+    # per 10 TAC 6.4(c)(1)
+    - self_employment_income
+    - farm_operations_income
+    # Net gambling or lottery winnings count per 10 TAC 6.4(c)(2);
+    # we track gross winnings at the moment
+    - gambling_winnings
+    - unemployment_compensation
+    - strike_benefits
+    # Counted excluding the Medicare deduction; we don't track
+    # Medicare premium withholding at the moment
+    - social_security
+    - ssi
+    - pension_income
+    - retirement_distributions
+    - general_assistance
+    # Royalties included in rental income
+    - rental_income
+    - alimony_income
+    - interest_income
+    - dividend_income
+    # Counted except means-tested veterans pensions under
+    # 38 U.S.C. 1315, 1521, 1541, and 1542, which we don't
+    # track separately
+    - veterans_benefits
+    # Temporary Assistance for Needy Families benefits are counted
+    # at the SPM unit level in tx_ceap_countable_income
+    # Excluded per 10 TAC 6.4(d): capital gains, child support
+    # received, jury duty compensation, gifts, loans, lump sums,
+    # tax refunds, compensation for injury, foster care payments,
+    # education assistance, reimbursements, and benefits from the
+    # Supplemental Nutrition Assistance Program and the Special
+    # Supplemental Nutrition Program for Women, Infants, and Children
+
+metadata:
+  unit: list
+  period: year
+  label: Texas CEAP countable income sources
+  reference:
+    - title: Texas LIHEAP State Plan FY 2026, Sections 1.8-1.9 (pages 8-9)
+      href: https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/26-LIHEAP-Plan-Amend1.pdf#page=8
+    - title: 10 Tex. Admin. Code § 6.4(c)-(d) - Income Determination
+      href: https://www.law.cornell.edu/regulations/texas/10-Tex-Admin-Code-SS-6-4

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap.yaml
@@ -2,7 +2,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 0
+    employment_income: 0
     spm_unit_size: 1
     state_code: TX
     electricity_expense: 3_000
@@ -14,7 +14,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 5_000
+    employment_income: 5_000
     spm_unit_size: 4
     state_code: TX
     electricity_expense: 1_000
@@ -26,7 +26,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 20_000
+    employment_income: 20_000
     spm_unit_size: 4
     state_code: TX
     electricity_expense: 2_500
@@ -38,7 +38,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 40_000
+    employment_income: 40_000
     spm_unit_size: 4
     state_code: TX
     electricity_expense: 3_000
@@ -50,7 +50,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 80_000
+    employment_income: 80_000
     spm_unit_size: 1
     state_code: TX
     electricity_expense: 3_000
@@ -63,7 +63,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 0
+    employment_income: 0
     spm_unit_size: 1
     state_code: TX
     electricity_expense: 0
@@ -75,7 +75,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 0
+    employment_income: 0
     spm_unit_size: 1
     state_code: TX
     electricity_expense: 0
@@ -87,7 +87,7 @@
   absolute_error_margin: 0.1
   period: 2025
   input:
-    irs_gross_income: 0
+    employment_income: 0
     spm_unit_size: 1
     state_code: TX
     electricity_expense: 3_000
@@ -100,7 +100,7 @@
   period: 2024
   input:
     # 50% FPG for HH of 4 = $15,600 (FPG 2024 = $31,200 * 0.5)
-    irs_gross_income: 15_600
+    employment_income: 15_600
     spm_unit_size: 4
     state_code: TX
     electricity_expense: 3_000

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_countable_income.yaml
@@ -1,0 +1,156 @@
+- name: Case 1, adult employment income is counted.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income: 20_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ceap_countable_income: 20_000
+
+- name: Case 2, earned income of a child under 18 is excluded.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income: 20_000
+      person2:
+        age: 16
+        employment_income: 5_000
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    tx_ceap_countable_income: 20_000
+
+- name: Case 3, income of a person at exactly age 18 is counted.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 18
+        employment_income: 10_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ceap_countable_income: 10_000
+
+- name: Case 4, Social Security and Supplemental Security Income are counted.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 70
+        social_security: 9_000
+        ssi: 3_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # 9,000 Social Security + 3,000 SSI = 12,000
+    tx_ceap_countable_income: 12_000
+
+- name: Case 5, Temporary Assistance for Needy Families benefits are counted.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 35
+    spm_units:
+      spm_unit:
+        members: [person1]
+        tanf: 3_600
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ceap_countable_income: 3_600
+
+- name: Case 6, capital gains and child support received are excluded.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 35
+        long_term_capital_gains: 10_000
+        child_support_received: 6_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    tx_ceap_countable_income: 0
+
+- name: Case 7, multiple countable sources combine across members.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 70
+        social_security: 12_000
+        pension_income: 6_000
+      person2:
+        age: 40
+        unemployment_compensation: 4_000
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        tanf: 1_200
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    # 12,000 Social Security + 6,000 pension + 4,000 unemployment
+    # + 1,200 TANF = 23,200
+    tx_ceap_countable_income: 23_200
+
+- name: Case 8, household not in Texas has no countable income.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income: 20_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: AR
+  output:
+    tx_ceap_countable_income: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_eligible.yaml
@@ -2,7 +2,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 20_000
+    employment_income: 20_000
     spm_unit_size: 1
     state_code: TX
   output:
@@ -14,7 +14,7 @@
   input:
     # 150% FPG for HH of 4 = $46,800; 60% SMI ~ $56,680
     # Income must exceed both limits to be ineligible
-    irs_gross_income: 60_000
+    employment_income: 60_000
     spm_unit_size: 4
     state_code: TX
     is_snap_eligible: false
@@ -25,7 +25,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 0
+    employment_income: 0
     spm_unit_size: 1
     state_code: TX
   output:
@@ -35,7 +35,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 10_000
+    employment_income: 10_000
     spm_unit_size: 1
     state_code: CA
   output:
@@ -46,7 +46,7 @@
   period: 2024
   input:
     # 50% FPG for HH of 1 = $7,580 (FPG 2024 = $15,060 * 0.5)
-    irs_gross_income: 7_580
+    employment_income: 7_580
     spm_unit_size: 1
     state_code: TX
   output:
@@ -57,7 +57,7 @@
   period: 2025
   input:
     # In FY 2025, only 150% FPG applies (SMI threshold removed)
-    irs_gross_income: 50_000
+    employment_income: 50_000
     spm_unit_size: 4
     state_code: TX
     is_snap_eligible: false
@@ -68,7 +68,7 @@
   absolute_error_margin: 0.1
   period: 2024
   input:
-    irs_gross_income: 80_000
+    employment_income: 80_000
     spm_unit_size: 1
     state_code: TX
     is_snap_eligible: true

--- a/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap.py
+++ b/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap.py
@@ -16,7 +16,7 @@ class tx_ceap(Variable):
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.tx.tdhca.ceap.utility_assistance
 
-        income = add(spm_unit, period, ["irs_gross_income"])
+        income = spm_unit("tx_ceap_countable_income", period)
         fpg = spm_unit("spm_unit_fpg", period)
 
         # Determine FPG ratio for income bracket

--- a/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_countable_income.py
+++ b/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_countable_income.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class tx_ceap_countable_income(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "Texas Comprehensive Energy Assistance Program (CEAP) countable income"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.TX
+    reference = (
+        "https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/26-LIHEAP-Plan-Amend1.pdf#page=8",
+        "https://www.law.cornell.edu/regulations/texas/10-Tex-Admin-Code-SS-6-4",
+    )
+    adds = ["tx_ceap_countable_income_person", "tanf"]

--- a/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_countable_income_person.py
+++ b/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_countable_income_person.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class tx_ceap_countable_income_person(Variable):
+    value_type = float
+    entity = Person
+    label = "Texas Comprehensive Energy Assistance Program (CEAP) countable income for this person"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.TX
+    reference = (
+        "https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/26-LIHEAP-Plan-Amend1.pdf#page=8",
+        "https://www.law.cornell.edu/regulations/texas/10-Tex-Admin-Code-SS-6-4",
+    )
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.tx.tdhca.ceap.income
+        total = add(person, period, p.sources)
+        age = person("age", period)
+        return total * (age >= p.age_threshold)

--- a/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_eligible.py
+++ b/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_eligible.py
@@ -16,7 +16,7 @@ class tx_ceap_eligible(Variable):
         p = parameters(period).gov.states.tx.tdhca.ceap
         p_hhs = parameters(period).gov.hhs.liheap
 
-        income = add(spm_unit, period, ["irs_gross_income"])
+        income = spm_unit("tx_ceap_countable_income", period)
 
         # FPG-based limit (always applies)
         fpg = spm_unit("spm_unit_fpg", period)


### PR DESCRIPTION
## Summary
Replaces `irs_gross_income` with a state-plan-based countable income calculation for the Texas Comprehensive Energy Assistance Program (CEAP).

Closes #8628

## Regulatory Authority
- [FY 2026 Texas LIHEAP State Plan, Sections 1.8–1.9 (pp. 8–9)](https://www.tdhca.texas.gov/sites/default/files/community-affairs/docs/26-LIHEAP-Plan-Amend1.pdf#page=8) — countable income checklist
- [10 TAC §6.4 — Income Determination](https://www.law.cornell.edu/regulations/texas/10-Tex-Admin-Code-SS-6-4) — authoritative inclusion/exclusion rules (the plan's "Other" catch-all defers to this rule)

## Why
The IRS gross income concept diverges from the CEAP income definition in both directions:
- **Missed by IRS gross income**: full Social Security (vs. `taxable_social_security`, often $0 for low-income retirees — and retirees get no categorical pathway), SSI, TANF, General Assistance, VA benefits, post-2018 alimony.
- **Wrongly counted by IRS gross income**: capital gains (10 TAC §6.4(d)(1)), and all income of household members under 18 — including child SSI/survivor benefits payable to an adult (§6.4(b), (d)(20)).

## Implementation
| File | Purpose |
|---|---|
| `parameters/.../ceap/income/sources.yaml` | `unit: list` of person-level countable sources |
| `parameters/.../ceap/income/age_threshold.yaml` | 18 — income counted only for members at/above this age |
| `tx_ceap_countable_income_person` | person-level sum of sources, zeroed for members under 18 |
| `tx_ceap_countable_income` | SPM-unit aggregate: `adds = [person amounts, tanf]` |
| `tx_ceap_eligible.py`, `tx_ceap.py` | swap in the new variable |

Uses modeled `ssi`/`tanf`/`general_assistance` (not `_reported` shims), consistent with every other countable-income source list in the repo (SNAP unearned, WIC, school meals).

## Simplifications (noted as YAML comments)
| What | Source | Why |
|---|---|---|
| Social Security counted gross | Plan §1.9 counts SSA benefits excluding the Medicare deduction | We don't track Medicare premium withholding at the moment |
| All `veterans_benefits` counted | Plan excepts means-tested VA pensions (38 USC 1315/1521/1541/1542) | We don't track VA benefit components separately at the moment |
| Gambling winnings counted gross | 10 TAC §6.4(c)(2) counts net | We track gross winnings at the moment |
| TANF one-time payments not excepted | Plan counts TANF "except for one-time payments" | We don't distinguish one-time TANF payments |

## Related observation (not in this PR)
The categorical eligibility check in `tx_ceap_eligible` uses `is_ssi_eligible`, but Plan §1.4a requires *receiving* SSI payments (`ssi > 0`). Left unchanged to keep this PR scoped to the income definition.

## Test plan
- [x] New `tx_ceap_countable_income.yaml` — 8 cases: adult income counted, child earned income excluded, age-18 boundary, SSI/SS counted, TANF counted, capital gains/child support excluded, multi-member combination, non-TX zero
- [x] Existing `tx_ceap_eligible.yaml` / `tx_ceap.yaml` updated to input `employment_income` instead of `irs_gross_income` (values unchanged)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)