### PR TITLE
Fix scrambled CCDF coverage metadata in programs.yaml

### DIFF
--- a/changelog.d/fix-programs-yaml-ccdf-metadata.fixed.md
+++ b/changelog.d/fix-programs-yaml-ccdf-metadata.fixed.md
@@ -1,1 +1,1 @@
-Fixed scrambled CCDF program coverage metadata in programs.yaml for Connecticut, Florida, Hawaii, Idaho, Indiana, Kansas, and Kentucky.
+Fixed scrambled CCDF program coverage metadata in programs.yaml for Connecticut, Florida, Hawaii, Idaho, Indiana, Kansas, and Kentucky, and corrected the Hawaii program name, Connecticut status and variable, and Illinois parameter prefix.

--- a/changelog.d/fix-programs-yaml-ccdf-metadata.fixed.md
+++ b/changelog.d/fix-programs-yaml-ccdf-metadata.fixed.md
@@ -1,0 +1,1 @@
+Fixed scrambled CCDF program coverage metadata in programs.yaml for Connecticut, Florida, Hawaii, Idaho, Indiana, Kansas, and Kentucky.

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -492,9 +492,11 @@ programs:
         variable: co_ccap_subsidy
         notes: CCCAP
       - state: CT
-        status: in_progress
+        status: complete
         name: Care 4 Kids
         full_name: Connecticut Care 4 Kids
+        variable: ct_c4k
+        parameter_prefix: gov.states.ct.oec.c4k
       - state: FL
         status: complete
         name: School Readiness
@@ -504,7 +506,7 @@ programs:
       - state: HI
         status: complete
         name: Hawaii Child Care Subsidy
-        full_name: Hawaii Child Care Subsidy (CCAP)
+        full_name: Hawaii Child Care Subsidy
         variable: hi_ccap
         parameter_prefix: gov.states.hi.bessd.ccap
       - state: IL
@@ -512,6 +514,7 @@ programs:
         name: CCAP
         full_name: Child Care Assistance Program (Illinois)
         variable: il_ccap_eligible
+        parameter_prefix: gov.states.il.dhs.ccap
         notes: Only includes eligibility rules
       - state: ID
         status: complete

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -495,44 +495,48 @@ programs:
         status: in_progress
         name: Care 4 Kids
         full_name: Connecticut Care 4 Kids
-        full_name: Florida School Readiness Program
-        full_name: Hawaii Child Care Subsidy (CCAP)
-        name: Hawaii Child Care Subsidy
-        name: School Readiness
-        parameter_prefix: gov.states.fl.doe.sr
-        parameter_prefix: gov.states.hi.bessd.ccap
-        status: complete
-        variable: fl_sr
-        variable: hi_ccap
       - state: FL
+        status: complete
+        name: School Readiness
+        full_name: Florida School Readiness Program
+        variable: fl_sr
+        parameter_prefix: gov.states.fl.doe.sr
       - state: HI
+        status: complete
+        name: Hawaii Child Care Subsidy
+        full_name: Hawaii Child Care Subsidy (CCAP)
+        variable: hi_ccap
+        parameter_prefix: gov.states.hi.bessd.ccap
       - state: IL
         status: complete
         name: CCAP
         full_name: Child Care Assistance Program (Illinois)
         variable: il_ccap_eligible
         notes: Only includes eligibility rules
-        full_name: Idaho Child Care Program
-        full_name: Indiana Child Care and Development Fund Voucher Program
-        full_name: Kansas Child Care Assistance Program
-        full_name: Kentucky Child Care Assistance Program
-        name: CCAP
-        name: ICCP
-        name: Indiana CCDF
-        name: Kansas CCAP
-        parameter_prefix: gov.states.id.dhw.iccp
-        parameter_prefix: gov.states.in.fssa.ccdf
-        parameter_prefix: gov.states.ks.dcf.ccap
-        parameter_prefix: gov.states.ky.dcbs.ccap
-        status: complete
-        variable: id_iccp
-        variable: in_ccdf
-        variable: ks_child_care_subsidies
-        variable: ky_ccap
       - state: ID
+        status: complete
+        name: ICCP
+        full_name: Idaho Child Care Program
+        variable: id_iccp
+        parameter_prefix: gov.states.id.dhw.iccp
       - state: IN
+        status: complete
+        name: Indiana CCDF
+        full_name: Indiana Child Care and Development Fund Voucher Program
+        variable: in_ccdf
+        parameter_prefix: gov.states.in.fssa.ccdf
       - state: KS
+        status: complete
+        name: Kansas CCAP
+        full_name: Kansas Child Care Assistance Program
+        variable: ks_child_care_subsidies
+        parameter_prefix: gov.states.ks.dcf.ccap
       - state: KY
+        status: complete
+        name: CCAP
+        full_name: Kentucky Child Care Assistance Program
+        variable: ky_ccap
+        parameter_prefix: gov.states.ky.dcbs.ccap
       - state: MA
         status: complete
         name: Massachusetts CCFA


### PR DESCRIPTION
## Summary

The CCDF block in `programs.yaml` had corrupted `state_implementations` metadata for **CT, FL, HI, ID, IN, KS, and KY**. An alphabetizer (run in prior per-state CCDF PRs) sorted the mapping keys *within a run of consecutive `- state:` entries*, collapsing the duplicate keys onto the first entry of each run and leaving the rest as attribute-less stubs:

- **CT** absorbed FL's and HI's keys (duplicate `name`/`full_name`/`status`/`variable`/`parameter_prefix`); **FL** and **HI** became bare `- state:` stubs.
- **IL** absorbed ID/IN/KS/KY's keys; **ID**, **IN**, **KS**, and **KY** became bare `- state:` stubs.

YAML last-key-wins means the file still parsed, but the coverage-page metadata served via `/us/metadata` was wrong for these states (e.g., CT resolved to Hawaii's name/variable; FL, HI, ID, IN, KS, KY had no name/variable/status at all).

This PR restores each state's correct entry (reconstructed from the originating per-state PRs) and then corrects three issues found while verifying the restored names against the repo implementation and the administering state agencies.

## Commit 1 — restore the scrambled metadata

After restoration, every CCDF state resolves to a complete entry with no duplicate keys and no stubs:

| State | name | full_name | status | variable | parameter_prefix |
|---|---|---|---|---|---|
| CT | Care 4 Kids | Connecticut Care 4 Kids | (see commit 2) | (see commit 2) | (see commit 2) |
| FL | School Readiness | Florida School Readiness Program | complete | `fl_sr` | `gov.states.fl.doe.sr` |
| HI | Hawaii Child Care Subsidy | (see commit 2) | complete | `hi_ccap` | `gov.states.hi.bessd.ccap` |
| IL | CCAP | Child Care Assistance Program (Illinois) | complete | `il_ccap_eligible` | (see commit 2) |
| ID | ICCP | Idaho Child Care Program | complete | `id_iccp` | `gov.states.id.dhw.iccp` |
| IN | Indiana CCDF | Indiana Child Care and Development Fund Voucher Program | complete | `in_ccdf` | `gov.states.in.fssa.ccdf` |
| KS | Kansas CCAP | Kansas Child Care Assistance Program | complete | `ks_child_care_subsidies` | `gov.states.ks.dcf.ccap` |
| KY | CCAP | Kentucky Child Care Assistance Program | complete | `ky_ccap` | `gov.states.ky.dcbs.ccap` |

## Commit 2 — corrections found during name verification

Each restored name was checked against the repo (variable labels + parameter references) and the administering state agency's official `.gov` site. All names were correct except:

- **HI** — dropped the `(CCAP)` parenthetical: `full_name` → `Hawaii Child Care Subsidy`. Hawaii's program is officially "Child Care Subsidy" (DHS/BESSD; formerly "Child Care Connection Hawaii"). "CCAP" is only PolicyEngine's internal variable/prefix convention (`hi_ccap`, `bessd.ccap`). The canonical `gov/hhs/ccdf/child_care_subsidy_programs.yaml` list also names it "Hawaii Child Care Subsidy".
- **CT** — `in_progress` → `complete`, with `variable: ct_c4k` and `parameter_prefix: gov.states.ct.oec.c4k`. The Care 4 Kids implementation already exists (full benefit-amount computation + eligibility/rates/family-fee tree) and is wired into `child_care_subsidy_programs` like every other complete state, so the entry was stale.
- **IL** — added `parameter_prefix: gov.states.il.dhs.ccap` (parameters exist there; the entry had none).

## Verification

- File parses as valid YAML; a full-file scan confirms **no remaining stub entries and no duplicate keys** in any program block.
- Every referenced variable class and parameter directory was confirmed to exist in the repo.
- The `coverage:` line on the CCDF program already listed all states and was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)