### PR TITLE
Support filing-status RI CTC stepped phaseout

### DIFF
--- a/changelog.d/ri-ctc-stepped-phaseout-filing-status.fixed.md
+++ b/changelog.d/ri-ctc-stepped-phaseout-filing-status.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Rhode Island contributed Child Tax Credit stepped phaseout to use filing-status-specific thresholds and increments.

--- a/changelog.d/ri-ctc-stepped-phaseout-status.fixed.md
+++ b/changelog.d/ri-ctc-stepped-phaseout-status.fixed.md
@@ -1,1 +1,0 @@
-Fixed the Rhode Island contributed Child Tax Credit stepped phaseout to support filing-status-specific thresholds and increments.

--- a/changelog.d/ri-ctc-stepped-phaseout-status.fixed.md
+++ b/changelog.d/ri-ctc-stepped-phaseout-status.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Rhode Island contributed Child Tax Credit stepped phaseout to support filing-status-specific thresholds and increments.

--- a/policyengine_us/parameters/gov/contrib/states/ri/ctc/stepped_phaseout/increment.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ri/ctc/stepped_phaseout/increment.yaml
@@ -1,9 +1,23 @@
-description: Income increment per step for Rhode Island's stepped CTC phaseout.
-
-values:
-  2027-01-01: 0
+description: Income increment per step for Rhode Island's stepped CTC phaseout, based on filing status.
 
 metadata:
   unit: currency-USD
   label: Rhode Island CTC stepped phaseout increment
   period: year
+  breakdown:
+    - filing_status
+
+JOINT:
+  2027-01-01: 0
+
+HEAD_OF_HOUSEHOLD:
+  2027-01-01: 0
+
+SURVIVING_SPOUSE:
+  2027-01-01: 0
+
+SINGLE:
+  2027-01-01: 0
+
+SEPARATE:
+  2027-01-01: 0

--- a/policyengine_us/parameters/gov/contrib/states/ri/ctc/stepped_phaseout/threshold.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ri/ctc/stepped_phaseout/threshold.yaml
@@ -1,9 +1,23 @@
-description: Income threshold where Rhode Island's stepped CTC phaseout begins.
-
-values:
-  2027-01-01: 0
+description: Income threshold where Rhode Island's stepped CTC phaseout begins, based on filing status.
 
 metadata:
   unit: currency-USD
   label: Rhode Island CTC stepped phaseout threshold
   period: year
+  breakdown:
+    - filing_status
+
+JOINT:
+  2027-01-01: 0
+
+HEAD_OF_HOUSEHOLD:
+  2027-01-01: 0
+
+SURVIVING_SPOUSE:
+  2027-01-01: 0
+
+SINGLE:
+  2027-01-01: 0
+
+SEPARATE:
+  2027-01-01: 0

--- a/policyengine_us/reforms/states/ri/ctc/ri_ctc_reform.py
+++ b/policyengine_us/reforms/states/ri/ctc/ri_ctc_reform.py
@@ -84,11 +84,11 @@ def create_ri_ctc() -> Reform:
             maximum = tax_unit("ri_ctc_maximum", period)
 
             # Check if stepped phaseout is active (non-zero increment)
-            stepped_increment = p.stepped_phaseout.increment
+            stepped_increment = p.stepped_phaseout.increment[filing_status]
             stepped_active = stepped_increment > 0
 
             # Stepped phaseout calculation
-            stepped_threshold = p.stepped_phaseout.threshold
+            stepped_threshold = p.stepped_phaseout.threshold[filing_status]
             rate_per_step = p.stepped_phaseout.rate_per_step
             stepped_excess = max_(agi - stepped_threshold, 0)
             # Number of steps (ceiling of excess / increment, avoiding div by zero)

--- a/policyengine_us/tests/policy/baseline/contrib/states/ri/ctc/ri_ctc_stepped_phaseout.yaml
+++ b/policyengine_us/tests/policy/baseline/contrib/states/ri/ctc/ri_ctc_stepped_phaseout.yaml
@@ -8,8 +8,8 @@
     gov.contrib.states.ri.ctc.in_effect: true
     gov.contrib.states.ri.ctc.amount: 320
     gov.contrib.states.ri.ctc.age_limit: 19
-    gov.contrib.states.ri.ctc.stepped_phaseout.threshold: 261000
-    gov.contrib.states.ri.ctc.stepped_phaseout.increment: 7450
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.SINGLE: 261000
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.SINGLE: 7450
     gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.20
     people:
       parent1:
@@ -38,8 +38,8 @@
     gov.contrib.states.ri.ctc.in_effect: true
     gov.contrib.states.ri.ctc.amount: 320
     gov.contrib.states.ri.ctc.age_limit: 19
-    gov.contrib.states.ri.ctc.stepped_phaseout.threshold: 261000
-    gov.contrib.states.ri.ctc.stepped_phaseout.increment: 7450
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.SINGLE: 261000
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.SINGLE: 7450
     gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.20
     people:
       parent1:
@@ -68,8 +68,8 @@
     gov.contrib.states.ri.ctc.in_effect: true
     gov.contrib.states.ri.ctc.amount: 320
     gov.contrib.states.ri.ctc.age_limit: 19
-    gov.contrib.states.ri.ctc.stepped_phaseout.threshold: 261000
-    gov.contrib.states.ri.ctc.stepped_phaseout.increment: 7450
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.JOINT: 261000
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.JOINT: 7450
     gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.20
     people:
       parent1:

--- a/policyengine_us/tests/policy/baseline/contrib/states/ri/ctc/ri_ctc_stepped_phaseout.yaml
+++ b/policyengine_us/tests/policy/baseline/contrib/states/ri/ctc/ri_ctc_stepped_phaseout.yaml
@@ -8,9 +8,9 @@
     gov.contrib.states.ri.ctc.in_effect: true
     gov.contrib.states.ri.ctc.amount: 320
     gov.contrib.states.ri.ctc.age_limit: 19
-    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.SINGLE: 261000
-    gov.contrib.states.ri.ctc.stepped_phaseout.increment.SINGLE: 7450
-    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.20
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.SINGLE: 261_000
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.SINGLE: 7_450
+    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.2
     people:
       parent1:
         age: 40
@@ -21,7 +21,7 @@
       tax_unit:
         members: [parent1, child1]
         filing_status: SINGLE
-        ri_agi: 200000
+        ri_agi: 200_000
     households:
       household:
         members: [parent1, child1]
@@ -38,9 +38,9 @@
     gov.contrib.states.ri.ctc.in_effect: true
     gov.contrib.states.ri.ctc.amount: 320
     gov.contrib.states.ri.ctc.age_limit: 19
-    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.SINGLE: 261000
-    gov.contrib.states.ri.ctc.stepped_phaseout.increment.SINGLE: 7450
-    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.20
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.SINGLE: 261_000
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.SINGLE: 7_450
+    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.2
     people:
       parent1:
         age: 40
@@ -51,7 +51,7 @@
       tax_unit:
         members: [parent1, child1]
         filing_status: SINGLE
-        ri_agi: 265000  # $4000 over threshold = 1 step
+        ri_agi: 265_000  # $4,000 over threshold = 1 step
     households:
       household:
         members: [parent1, child1]
@@ -68,9 +68,9 @@
     gov.contrib.states.ri.ctc.in_effect: true
     gov.contrib.states.ri.ctc.amount: 320
     gov.contrib.states.ri.ctc.age_limit: 19
-    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.JOINT: 261000
-    gov.contrib.states.ri.ctc.stepped_phaseout.increment.JOINT: 7450
-    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.20
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.JOINT: 261_000
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.JOINT: 7_450
+    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.2
     people:
       parent1:
         age: 40
@@ -86,7 +86,7 @@
       tax_unit:
         members: [parent1, parent2, child1, child2]
         filing_status: JOINT
-        ri_agi: 261000
+        ri_agi: 261_000
     households:
       household:
         members: [parent1, parent2, child1, child2]

--- a/policyengine_us/tests/policy/contrib/states/ri/ctc_reform_test.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ri/ctc_reform_test.yaml
@@ -320,3 +320,71 @@
     ri_ctc_young_child_boost: 0  # 1 child under 6 × $0 = $0
     ri_ctc_maximum: 1_000  # Base: 1 × $1_000 = $1_000; Boost: $0; Total = $1_000
     ri_total_ctc: 1_000
+
+- name: RI CTC - stepped phaseout uses single filer threshold.
+  absolute_error_margin: 0.1
+  period: 2027
+  reforms: policyengine_us.reforms.states.ri.ctc.ri_ctc_reform.ri_ctc
+  input:
+    gov.contrib.states.ri.ctc.in_effect: true
+    gov.contrib.states.ri.ctc.amount: 330
+    gov.contrib.states.ri.ctc.age_limit: 19
+    gov.contrib.states.ri.ctc.refundability.cap: 999_999
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.SINGLE: 88_500
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.SINGLE: 2_875
+    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.2
+    people:
+      person1:
+        age: 35
+        employment_income: 100_000
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1, person2]
+        state_name: RI
+  output:
+    ri_ctc_eligible_children: 1
+    ri_ctc_maximum: 330
+    ri_ctc_phaseout: 264
+    ri_total_ctc: 66
+
+- name: RI CTC - stepped phaseout uses joint filer threshold and increment.
+  absolute_error_margin: 0.1
+  period: 2027
+  reforms: policyengine_us.reforms.states.ri.ctc.ri_ctc_reform.ri_ctc
+  input:
+    gov.contrib.states.ri.ctc.in_effect: true
+    gov.contrib.states.ri.ctc.amount: 330
+    gov.contrib.states.ri.ctc.age_limit: 19
+    gov.contrib.states.ri.ctc.refundability.cap: 999_999
+    gov.contrib.states.ri.ctc.stepped_phaseout.threshold.JOINT: 110_640
+    gov.contrib.states.ri.ctc.stepped_phaseout.increment.JOINT: 3_590
+    gov.contrib.states.ri.ctc.stepped_phaseout.rate_per_step: 0.2
+    people:
+      person1:
+        age: 35
+        employment_income: 117_640
+      person2:
+        age: 35
+      person3:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_name: RI
+  output:
+    ri_ctc_eligible_children: 1
+    ri_ctc_maximum: 330
+    ri_ctc_phaseout: 132
+    ri_total_ctc: 198


### PR DESCRIPTION
## Summary
- make the contributed Rhode Island CTC stepped phaseout threshold and increment parameters filing-status tables
- update the RI CTC phaseout formula to read stepped threshold and increment by filing status
- add single and joint filer test cases using the enacted 2027 threshold/increment values needed by the RI calculator
- polish the touched stepped-phaseout YAML tests with numeric separators and a clearer filing-status changelog fragment

Fixes #8638.

## Verification
- uv run python -m py_compile policyengine_us/reforms/states/ri/ctc/ri_ctc_reform.py
- uv run pytest policyengine_us/tests/test_parameter_files.py -q
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/contrib/states/ri/ctc/ri_ctc_stepped_phaseout.yaml -c policyengine_us
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/states/ri/ctc_reform_test.yaml -c policyengine_us -n "stepped phaseout uses single"
- uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/states/ri/ctc_reform_test.yaml -c policyengine_us -n "stepped phaseout uses joint"
- git diff --check
- direct Simulation smoke test for the new single and joint stepped-phaseout cases: single -> phaseout 264, total 66; joint -> phaseout 132, total 198

Note: local policyengine-core test policyengine_us/tests/policy/contrib/states/ri/ctc_reform_test.yaml -c policyengine_us printed passing dots, then hung before summary under Python 3.14, so I validated the two new cases independently with name-filtered runs.