### PR TITLE
Base OK sales tax relief credit TANF exclusion on actual enrollment

### DIFF
--- a/changelog.d/ok-stc-tanf-enrollment.fixed.md
+++ b/changelog.d/ok-stc-tanf-enrollment.fixed.md
@@ -1,0 +1,1 @@
+Base the Oklahoma Sales Tax Relief Credit TANF exclusion on actual enrollment (is_tanf_enrolled) rather than the modeled ok_tanf benefit.

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_stc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_stc.yaml
@@ -37,16 +37,56 @@
 - name: OK STC - 2021 - TANF recipient excluded
   period: 2021
   input:
-    filing_status: HEAD_OF_HOUSEHOLD
-    greater_age_head_spouse: 30
-    tax_unit_dependents: 1
-    tax_unit_size: 2
-    ok_gross_income: 18_000
-    ok_tanf: 2_000
-    state_code: OK
+    people:
+      head:
+        age: 30
+        employment_income: 18_000
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, child]
+    spm_units:
+      spm_unit:
+        members: [head, child]
+        is_tanf_enrolled: true
+    households:
+      household:
+        members: [head, child]
+        state_code: OK
   output:
-    # TANF recipients excluded (TANF includes sales tax relief)
+    # Actual TANF recipients excluded (TANF includes sales tax relief)
     ok_stc: 0
+
+- name: OK STC - 2025 - modeled-TANF-eligible family still gets credit
+  period: 2025
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 12_573
+        taxable_interest_income: 132
+      spouse:
+        age: 40
+      child1: {age: 10}
+      child2: {age: 10}
+      child3: {age: 10}
+      child4: {age: 10}
+    tax_units:
+      tax_unit:
+        members: [head, spouse, child1, child2, child3, child4]
+    spm_units:
+      spm_unit:
+        members: [head, spouse, child1, child2, child3, child4]
+    households:
+      household:
+        members: [head, spouse, child1, child2, child3, child4]
+        state_code: OK
+  output:
+    # Family is not enrolled in TANF (is_tanf_enrolled defaults to false),
+    # so the credit applies even though the model would impute TANF
+    # eligibility. 6 exemptions * $40 = $240. See policyengine-taxsim#988.
+    ok_stc: 240
 
 # 2025 Sales Tax Credit Tests
 

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_stc.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_stc.py
@@ -63,8 +63,11 @@ class ok_stc(Variable):
     def formula(tax_unit, period, parameters):
         # For details, see Form 538-S in the 511 packets referenced above
         p = parameters(period).gov.states.ok.tax.income.credits.sales_tax
-        # Exclusion: TANF recipients are not eligible
-        tanf_ineligible = add(tax_unit, period, ["ok_tanf"]) > 0
+        # Exclusion: TANF recipients are not eligible. Use actual enrollment
+        # (is_tanf_enrolled) rather than the modeled ok_tanf benefit, so that
+        # tax filers who are not receiving TANF still qualify even when the
+        # model would impute TANF eligibility for them.
+        tanf_ineligible = add(tax_unit, period, ["is_tanf_enrolled"]) > 0
         # Get gross household income for eligibility tests
         income = tax_unit("ok_gross_income", period)
         # Pathway 1: Low income (gross income <= $20,000)


### PR DESCRIPTION
## What this changes

The Oklahoma Sales Tax Relief Credit (`ok_stc`, Form 538-S) excluded any tax unit with a **modeled** TANF benefit (`ok_tanf > 0`). For households PolicyEngine imputes as TANF-eligible — e.g. MFJ with 4 children and $12,705 of income — this denied the $240 credit even though the filer is not actually receiving TANF.

Per @hua7450's review on #8632, the exclusion now keys off **actual enrollment** (`is_tanf_enrolled`, a bare input that defaults to `false`):

```python
# before
tanf_ineligible = add(tax_unit, period, ["ok_tanf"]) > 0
# after
tanf_ineligible = add(tax_unit, period, ["is_tanf_enrolled"]) > 0
```

Tax filers who are not enrolled keep the credit; real TANF recipients remain excluded (Form 538-S excludes actual recipients because the sales tax relief is bundled into the TANF grant).

## Tests

- Updated the "TANF recipient excluded" case to set `is_tanf_enrolled: true` instead of `ok_tanf`.
- Added a regression test: the #988 family (MFJ, 4 kids, $12,705) now correctly receives `ok_stc: 240`.
- `ok_stc.yaml` (11) and OK `integration.yaml` (7) pass.

Closes #8632. Surfaced via [PolicyEngine/policyengine-taxsim#988](https://github.com/PolicyEngine/policyengine-taxsim/issues/988).

cc @hua7450 for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
