### PR TITLE
Fix states-shard-2 contrib CI OOM (per-file RI isolation + 3-way shard split)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -244,6 +244,8 @@ jobs:
             target: test-yaml-structural-heavy-shard-1
           - group: states-shard-2
             target: test-yaml-structural-heavy-shard-2
+          - group: states-shard-3
+            target: test-yaml-structural-heavy-shard-3
           - group: other-shard-1
             target: test-yaml-structural-other
           - group: other-shard-2

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -139,6 +139,8 @@ jobs:
             target: test-yaml-structural-heavy-shard-1
           - group: states-shard-2
             target: test-yaml-structural-heavy-shard-2
+          - group: states-shard-3
+            target: test-yaml-structural-heavy-shard-3
           - group: other-shard-1
             target: test-yaml-structural-other
           - group: other-shard-2

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,11 @@ test-yaml-structural:
 test-yaml-structural-heavy:
 	$(BATCH) $(TESTS)/policy/contrib/states --batches 1
 test-yaml-structural-heavy-shard-1:
-	$(BATCH) $(TESTS)/policy/contrib/states --batches 1 --shard 1/2
+	$(BATCH) $(TESTS)/policy/contrib/states --batches 1 --shard 1/3
 test-yaml-structural-heavy-shard-2:
-	$(BATCH) $(TESTS)/policy/contrib/states --batches 1 --shard 2/2
+	$(BATCH) $(TESTS)/policy/contrib/states --batches 1 --shard 2/3
+test-yaml-structural-heavy-shard-3:
+	$(BATCH) $(TESTS)/policy/contrib/states --batches 1 --shard 3/3
 test-yaml-structural-other:
 	# refundable_credit_conversion force-applies a reform per case; each
 	# distinct gov.contrib.* combination clones the full tax-benefit system

--- a/changelog.d/ci-states-shard-oom.fixed.md
+++ b/changelog.d/ci-states-shard-oom.fixed.md
@@ -1,0 +1,1 @@
+Fixed states-shard-2 contrib CI OOM by isolating RI's reform tests per subprocess and splitting the heavy-states stage into three shards.

--- a/policyengine_us/tests/test_batched.py
+++ b/policyengine_us/tests/test_batched.py
@@ -129,9 +129,25 @@ def split_into_batches(
     # Memory usage per state varies significantly (1.3 GB - 5.2 GB measured)
     # Note: contrib/congress runs all together (~6.3 GB total, under 7 GB limit)
     if str(base_path).endswith("contrib/states"):
+        # States whose reform YAMLs are heavy enough that running the folder's
+        # files together in one subprocess stacks their peaks past the 16 GB
+        # runner cap → OOM ("runner received a shutdown signal"). Each
+        # force-applied reform deepcopies the full parameter tree (~4-5 GB
+        # peak/case, see #8559); isolating per-file frees each peak between
+        # files. RI is the worst offender — its ctc_reform_test.yaml sweeps
+        # ~66 reform combinations and previously OOMed shard-2 mid-run when it
+        # shared a subprocess with exemption_reform_test.yaml.
+        PER_FILE_STATES = {"ri"}
+
         subdirs = sorted([item for item in base_path.iterdir() if item.is_dir()])
-        # Each state folder becomes its own batch
-        batches = [[str(subdir)] for subdir in subdirs]
+        batches = []
+        for subdir in subdirs:
+            if subdir.name in PER_FILE_STATES:
+                # One batch per YAML so each file gets a fresh subprocess.
+                batches.extend([str(f)] for f in sorted(subdir.rglob("*.yaml")))
+            else:
+                # Each state folder becomes its own batch.
+                batches.append([str(subdir)])
 
         # Also include any root-level YAML files as a separate batch
         root_files = sorted(list(base_path.glob("*.yaml")))
@@ -526,23 +542,33 @@ def main():
     # position rather than requiring manual re-assignment per runner.
     if shard_count is not None:
         all_batch_count = len(batches)
-        ri_batch = (
-            [b for b in batches if Path(b[0]).name == "ri"]
-            if str(test_path).endswith("contrib/states")
-            else []
-        )
+        is_states = str(test_path).endswith("contrib/states")
+
+        def _is_ri(batch):
+            # A batch belongs to RI if its path's state component (the segment
+            # right after contrib/states) is "ri". Works for both the per-file
+            # RI batches (.../states/ri/ctc_reform_test.yaml) and any folder
+            # batch (.../states/ri).
+            parts = Path(batch[0]).parts
+            if "states" not in parts:
+                return False
+            i = parts.index("states")
+            return len(parts) > i + 1 and parts[i + 1] == "ri"
+
+        ri_batches = [b for b in batches if _is_ri(b)] if is_states else []
         batches = batches[shard_idx - 1 :: shard_count]
-        if ri_batch:
-            # RI's CTC reform sweeps ~11 parameter combinations, each cloning
-            # the full tax-benefit system (~10 min total) — far heavier than
-            # any other state. In the plain alphabetical stride it lands on
-            # shard 1 with the other heavy states (ny, ct, ut), making shard 1
-            # ~2x shard 2 and gating the contrib stage. Relocate just RI to the
-            # last shard; every other state keeps its positional assignment.
-            # (Same spirit as the explicit NY split in the Makefile.)
-            batches = [b for b in batches if Path(b[0]).name != "ri"]
+        if ri_batches:
+            # RI's CTC reform sweeps ~66 parameter combinations, each cloning
+            # the full tax-benefit system — far heavier than any other state,
+            # and its files are isolated per-file above. In the plain
+            # alphabetical stride RI lands on a shard with other heavy states
+            # (ny, ct, ut), unbalancing the contrib stage. Relocate all RI
+            # batches to the last shard; every other state keeps its
+            # positional assignment. (Same spirit as the NY split in the
+            # Makefile.)
+            batches = [b for b in batches if not _is_ri(b)]
             if shard_idx == shard_count:
-                batches = batches + ri_batch
+                batches = batches + ri_batches
         print(
             f"Sharding: running shard {shard_idx}/{shard_count} "
             f"({len(batches)} of {all_batch_count} batches)"


### PR DESCRIPTION
## Summary

`Full Suite - Contrib (states-shard-2)` has been OOMing on `main` and on every PR branch. The job ran all of its state batches cleanly, then died on the **RI** batch with `make: *** Terminated` + `The runner has received a shutdown signal` — the GitHub VM-level OOM signature (a 60-min job timeout reports *"exceeded the maximum execution time"*; the internal 30-min batch timeout prints *"⏱️ Timeout"* — neither appeared).

## Root cause

RI's entire folder ran in **one subprocess**, collecting both:
- `ri/ctc_reform_test.yaml` — 11 cases, **~66** `reforms:`/`gov.contrib` blocks
- `ri/exemption_reform_test.yaml` — 4 cases, 14 blocks

Per #8559, each force-applied reform does a `copy.deepcopy(system.parameters)` (~4–5 GB peak/case). It died *during* `exemption_reform_test.yaml` — i.e. **after** ctc had finished in the same subprocess — so ctc's retained memory + exemption's deepcopies stacked past the 16 GB runner cap. The recent filing-status RI CTC stepped-phaseout expansion grew the ctc sweep and tipped it over.

## Fix

- **`test_batched.py`**: split RI's folder **per-file** so each reform YAML runs in a fresh subprocess (peak freed between files) — exactly the remedy #8559 recommends (*"route to per-file/per-subdir like ctc/crfb already do"*). Generalized the RI relocation logic to detect per-file RI batches and pin them to the last shard.
- **`Makefile` + `pr.yaml`**: split the heavy-states stage from **2 → 3 shards** (`states-shard-3`) to rebalance time — shard-2 ran ~43 min vs shard-1's ~25 min, near the 60-min cap.

## Verification

Dry-run of the split + stride + relocation produces **31 batches** distributed **11 / 9 / 11**, with RI's two files isolated as separate subprocesses on shard 3:

```
shard 1/3 (11): al ca de id me mo nc ny pa sc wv
shard 2/3 (9):  ar ct ga il mi ms nd oh ut
shard 3/3 (11): az dc hi ky mn mt nj or va  ri/ctc_reform_test.yaml  ri/exemption_reform_test.yaml
```

## Test plan
- [x] Dry-run confirms per-file RI isolation + balanced 3-shard distribution
- [ ] CI passes (new `states-shard-3` job + no OOM on the RI subprocess)

🤖 Generated with [Claude Code](https://claude.com/claude-code)