### PR TITLE
Update HI TANF Standard of Assistance rate from 48% to 62% (effective March 1, 2025)

### DIFF
--- a/changelog.d/hi-tanf-soa-rate-increase.changed.md
+++ b/changelog.d/hi-tanf-soa-rate-increase.changed.md
@@ -1,0 +1,1 @@
+Updated Hawaii TANF Standard of Assistance rate from 48% to 62% of the standard of need, effective March 1, 2025.

--- a/policyengine_us/parameters/gov/states/hi/dhs/tanf/standard_of_assistance/rate.yaml
+++ b/policyengine_us/parameters/gov/states/hi/dhs/tanf/standard_of_assistance/rate.yaml
@@ -3,6 +3,7 @@ description: Hawaii sets the Standard of Assistance to this share of the Standar
 values:
   2007-07-01: 0.5
   2009-07-01: 0.48
+  2025-03-01: 0.62
 
 metadata:
   unit: /1
@@ -13,3 +14,5 @@ metadata:
       href: https://humanservices.hawaii.gov/wp-content/uploads/2018/02/Section-346-54-HRS-Public-Assistance-Expenditures-Report-2016.pdf#page=1
     - title: Hawaii TANF State Plan 11.1 Income and Benefit Standards (Effective October 1, 2023)
       href: https://humanservices.hawaii.gov/wp-content/uploads/2024/12/Hawaii_TANF_State_Plan_Signed_Certified-Eff_20231001.pdf#page=22
+    - title: Hawaii DHS BESSD Section 346-51.5 HRS TANF Report to the 33rd Legislature (March 20, 2025) - allowance increased from 48% to 62% of the standard of need effective March 1, 2025
+      href: https://humanservices.hawaii.gov/wp-content/uploads/2024/11/RYamane_2025-HRS-Sect-346-51.5-TANF-Legislative-Report-DHS-BESSD-signed.pdf#page=5

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/dhs/tanf/hi_tanf_max_benefit_standard.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/dhs/tanf/hi_tanf_max_benefit_standard.yaml
@@ -41,6 +41,30 @@
     # 939 * 0.48 * 0.80 = 360.58
     hi_tanf_max_benefit_standard: 360.58
 
+- name: Case 4, family of 3 after the March 1 2025 rate increase (48% to 62%).
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 5
+      person3:
+        age: 3
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: HI
+  output:
+    # SON (size 3): 1590
+    # SOA = 1590 * 0.62 = 985.80
+    # After 20% mandatory-work reduction: 985.80 * 0.80 = 788.64
+    hi_tanf_max_benefit_standard: 788.64
+
 - name: Case 3, non-Hawaii household returns zero.
   period: 2024-01
   absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/dhs/tanf/hi_tanf_maximum_benefit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/dhs/tanf/hi_tanf_maximum_benefit.yaml
@@ -1,6 +1,8 @@
 # Hawaii TANF maximum benefit reflects the steady-state mandatory-work
-# Standard of Assistance: SON × SOA rate (0.48) × (1 - mandatory-work
-# reduction (0.20)). This matches the figure reported by CBPP and the
+# Standard of Assistance: SON × SOA rate × (1 - mandatory-work
+# reduction (0.20)). The SOA rate is 0.48 through February 2025 and
+# 0.62 from March 1, 2025 (DHS BESSD § 346-51.5 HRS report). This
+# matches the figure reported by CBPP and the
 # Urban Welfare Rules Database (CBPP "Continued Increases in TANF
 # Benefit Levels", May 2024 / Feb 2025) and Hawaii TANF State Plan
 # 11.1, footnote 4.
@@ -241,3 +243,24 @@
   output:
     # 3872 × 0.48 × 0.80 = 1486.848 (caps at size 10)
     hi_tanf_maximum_benefit: 1_486.848
+
+- name: Case 10, family of 3 after the March 1 2025 rate increase (48% to 62%).
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 28
+      person3:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: HI
+  output:
+    # 1590 × 0.62 × 0.80 = 788.64 (DHS worked example: $610 -> $789)
+    hi_tanf_maximum_benefit: 788.64

--- a/policyengine_us/variables/gov/states/hi/dhs/tanf/hi_tanf_maximum_benefit.py
+++ b/policyengine_us/variables/gov/states/hi/dhs/tanf/hi_tanf_maximum_benefit.py
@@ -21,7 +21,9 @@ class hi_tanf_maximum_benefit(Variable):
         # Standard of Need (SON) = 100% of 2006 Hawaii FPG.
         son = p.standard_of_need.amount[capped_size]
 
-        # Standard of Assistance (SOA) = SON × 48% per HI TANF State Plan 11.1.
+        # Standard of Assistance (SOA) = SON × the standard-of-assistance
+        # rate (48% per HI TANF State Plan 11.1; raised to 62% effective
+        # March 1, 2025 per the DHS BESSD § 346-51.5 HRS report).
         soa = son * p.standard_of_assistance.rate
 
         # Per HI TANF State Plan 11.1 footnote 4: SOA is further reduced by 20%


### PR DESCRIPTION
## Summary
Hawaii increased the TANF/TAONF monthly assistance allowance from **48% to 62%** of the standard of need, effective **March 1, 2025**. This updates `gov.states.hi.dhs.tanf.standard_of_assistance.rate` (previously `2009-07-01: 0.48`) so benefits from March 2025 onward are correct.

The **standard of need** itself ($1,590 for a family of 3) is unchanged — it remains frozen at 100% of the 2006 Hawaii FPL. Only the assistance-allowance rate (share of the standard of need actually paid) increased.

Closes #8654

## Change
| | Rate | SOA (family of 3) | After 20% mandatory-work reduction |
|---|---|---|---|
| Before (2009-07-01) | 0.48 | $763.20 | $610.56 (CBPP's $610) |
| After (2025-03-01) | 0.62 | $985.80 | **$788.64** |

DHS worked example: *"family of three with no income will see a change from $610 (with the 20% reduction) to $789, an increase of $179 per month."* Statutory band per HRS §346-53: floor 48%, ceiling 62.5%.

## Sources
- Hawaii DHS BESSD §346-51.5 HRS TANF Report to the 33rd Legislature (March 20, 2025), [p.5](https://humanservices.hawaii.gov/wp-content/uploads/2024/11/RYamane_2025-HRS-Sect-346-51.5-TANF-Legislative-Report-DHS-BESSD-signed.pdf#page=5) — states the 48%→62% change and the $610→$789 example
- HRS §346-53 (allowance floor 48%, ceiling 62.5% of need)
- NCCP 2025/26 TANF brief (Hawaii ~$985); [Hawaii Public Radio, Oct 9 2025](https://www.hawaiipublicradio.org/local-news/2025-10-09/400m-stockpile-low-income-families-effects-of-federal-cuts) confirming implementation

## Files
- `parameters/gov/states/hi/dhs/tanf/standard_of_assistance/rate.yaml` — added `2025-03-01: 0.62` + reference
- `variables/gov/states/hi/dhs/tanf/hi_tanf_maximum_benefit.py` — generalized the now-parameter-driven comment
- `tests/.../hi_tanf_maximum_benefit.yaml`, `tests/.../hi_tanf_max_benefit_standard.yaml` — added post-change family-of-3 cases at `2026-01` (→ $788.64)

## Test plan
- [x] All 78 Hawaii TANF YAML tests pass locally (`policyengine-core test ... -c policyengine_us`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)