### PR TITLE
Fix WA WFTC phase-out to use federal phase-out income (max of earned income, AGI)

### DIFF
--- a/changelog.d/wa-wftc-phaseout-income.fixed.md
+++ b/changelog.d/wa-wftc-phaseout-income.fixed.md
@@ -1,0 +1,1 @@
+Base the Washington Working Families Tax Credit phase-out on federal phase-out income (greater of earned income or AGI) rather than earned income alone.

--- a/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
@@ -150,6 +150,60 @@
   output:
     wa_working_families_tax_credit: 640
 
+- name: Case 6b, phase-out keys off federal phase-out income (max of earned income and AGI), not earnings alone.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 40_000
+        unemployment_compensation: 16_000
+        has_tin: true
+        ssn_card_type: CITIZEN
+        is_tax_unit_head: true
+      spouse:
+        age: 40
+        has_tin: true
+        ssn_card_type: CITIZEN
+        is_tax_unit_spouse: true
+      child1:
+        age: 8
+        has_tin: true
+        ssn_card_type: CITIZEN
+        is_tax_unit_dependent: true
+      child2:
+        age: 10
+        has_tin: true
+        ssn_card_type: CITIZEN
+        is_tax_unit_dependent: true
+      child3:
+        age: 12
+        has_tin: true
+        ssn_card_type: CITIZEN
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, spouse, child1, child2, child3]
+        filing_status: JOINT
+        would_file_taxes_voluntarily: true
+        takes_up_eitc: true
+    spm_units:
+      spm_unit:
+        members: [head, spouse, child1, child2, child3]
+    households:
+      household:
+        members: [head, spouse, child1, child2, child3]
+        state_code: WA
+  output:
+    # Earned income ($40,000) is below the 3-child phase-out start (~$54,190),
+    # but AGI ($56,000, incl. $16,000 unemployment) lands inside the phase-out
+    # band. RCW 82.08.0206(3)(b) measures the reduction against the federal
+    # phase-out income = max(earned income, AGI) = $56,000, so the $1,330
+    # maximum tapers at 25.6% over the ~$1,810 of excess to ~$866.57 rather
+    # than paying the full $1,330. See policyengine-taxsim#986.
+    wa_working_families_tax_credit: 866.57
+
 # ESSB 6346 Sec. 901 - WFTC Age Expansion tests (effective 2029)
 
 - name: Case 7, age 18+ without EITC gets WFTC under 2029 age expansion.

--- a/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.py
@@ -124,7 +124,11 @@ class wa_working_families_tax_credit(Variable):
         # amount is reached at the applicable maximum qualifying income.
         # https://app.leg.wa.gov/billsummary?BillNumber=1888&Year=2021&Initiative=false
         phase_out_rate = (max_amount - p.min_amount) / phase_out_start_reduction
-        excess = max_(0, earnings - phase_out_start)
+        # RCW 82.08.0206(3)(b) measures the reduction against the federal
+        # phase-out income (the greater of earned income or AGI) -- the same
+        # measure used for the maximum-qualifying-income ceiling above -- not
+        # earned income alone.
+        excess = max_(0, higher_income - phase_out_start)
         reduction = max_(0, excess * phase_out_rate)
         phased_out_amount = max_amount - reduction
         # minimum benefit applies if calculated amount exceeds zero


### PR DESCRIPTION
Fixes #8680.

## What

The Washington Working Families Tax Credit (WFTC) phase-out reduction was computed on **earned income** alone, but [RCW 82.08.0206(3)(b)](https://app.leg.wa.gov/RCW/default.aspx?cite=82.08.0206) bases the reduction on the **federal phase-out income** — the federal EITC measure, i.e. the greater of earned income or AGI. The credit's eligibility ceiling and `wa_working_families_tax_credit_maximum_qualifying_income` already use `max(earned income, AGI)`; this aligns the taper with them.

```diff
- excess = max_(0, earnings - phase_out_start)
+ excess = max_(0, higher_income - phase_out_start)   # higher_income = max(earnings, AGI)
```

## Impact

Filers whose **AGI exceeds earned income** and lands in the phase-out band (unearned income — unemployment compensation, taxable pension, taxable Social Security — near the top of the eligibility range) were **overpaid**. Filers with earnings ≈ AGI, or income below the band, are unchanged.

### Example (MFJ, 3 children, 2025)

| Household | earnings | AGI | before | after |
|---|---|---|---|---|
| $40k wages + $16k unemployment comp | $40,000 | $56,000 | $1,330 | **$866.57** |
| $52k wages (earnings ≈ AGI) | $52,000 | $52,000 | $1,330 | $1,330 |

## Tests

Added Case 6b to `wa_working_families_tax_credit.yaml` covering the $40k-wages + $16k-UI household (expected $866.57). Full WA WFTC suite (24 cases) passes.

## Context

Surfaced by Daniel Feenberg (NBER TAXSIM) in [PolicyEngine/policyengine-taxsim#986](https://github.com/PolicyEngine/policyengine-taxsim/issues/986). The original household in that issue (earnings ≈ AGI, below the band) is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
