### PR TITLE
Document PolicyEngine bundle install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ PolicyEngine US is a microsimulation model of the US state and federal tax and b
 
 To install, run `pip install policyengine-us`.
 
-To install PolicyEngine US as part of a validated PolicyEngine stack, use the
-extras published by `policyengine`, such as `pip install "policyengine[models]"`
-or `pip install "policyengine[us-full]"`.
+To install PolicyEngine US as part of a certified PolicyEngine bundle, use the
+bundle installer published by `policyengine`, for example:
+
+```bash
+uvx --from policyengine policyengine bundle install --country us --venv .venv
+```

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@
 PolicyEngine US is a microsimulation model of the US state and federal tax and benefit system.
 
 To install, run `pip install policyengine-us`.
+
+To install PolicyEngine US as part of a validated PolicyEngine stack, use the
+extras published by `policyengine`, such as `pip install "policyengine[models]"`
+or `pip install "policyengine[us-full]"`.

--- a/changelog.d/document-bundle-install.changed.md
+++ b/changelog.d/document-bundle-install.changed.md
@@ -1,0 +1,1 @@
+Documented the certified PolicyEngine bundle install path for US users.


### PR DESCRIPTION
Fixes #8684

## Summary

- Keep the standalone `pip install policyengine-us` guidance.
- Document that certified multi-package, model-plus-data installs should use `policyengine bundle install --country us` from the `policyengine` package.

## Validation

- Not run locally; documentation-only change.