### PR TITLE
Increase non-NY state baseline test batches 4→6 to prevent CI OOM

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -179,9 +179,9 @@ jobs:
       matrix:
         include:
           - group: states-non-ny-shard-1
-            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 4 --exclude ny --shard 1/2
+            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 6 --exclude ny --shard 1/2
           - group: states-non-ny-shard-2
-            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 4 --exclude ny --shard 2/2
+            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 6 --exclude ny --shard 2/2
           - group: states-ny
             cmd: make test-yaml-no-structural-states-ny
           - group: irs-household

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -68,9 +68,9 @@ jobs:
       matrix:
         include:
           - group: states-non-ny-shard-1
-            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 4 --exclude ny --shard 1/2
+            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 6 --exclude ny --shard 1/2
           - group: states-non-ny-shard-2
-            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 4 --exclude ny --shard 2/2
+            cmd: python policyengine_us/tests/test_batched.py policyengine_us/tests/policy/baseline/gov/states --batches 6 --exclude ny --shard 2/2
           - group: states-ny
             cmd: make test-yaml-no-structural-states-ny
           - group: irs-household

--- a/changelog.d/ci-increase-state-test-batches.fixed.md
+++ b/changelog.d/ci-increase-state-test-batches.fixed.md
@@ -1,0 +1,1 @@
+Increase the non-NY state baseline test batch count from 4 to 6 in the PR and push CI workflows to prevent intermittent out-of-memory failures on the states-non-ny shards.


### PR DESCRIPTION
## Problem

`Full Suite - Baseline (states-non-ny-shard-2)` intermittently fails with:

```
##[error]The runner has received a shutdown signal. This can happen when the
         runner service is stopped, or a manually started runner is canceled.
```

This is an **out-of-memory kill**, not a test/logic failure (it dies at ~28 min, well under the 60-min `timeout-minutes`, and every test passes in isolation). The heartbeat shows the process progressively slowing — single tests taking minutes — the signature of swap thrashing before the OOM.

## Root cause

The runner splits the 52 non-NY state folders into 4 chunks (13 each) then strides them across 2 shards, so **shard-2's Batch 1 runs 13 states / ~976 YAML files in a single `policyengine-core` process**. Per-state isolated peak RSS measured locally:

| metric | value |
|---|---|
| range across 26 shard-2 states | **1.84 GB (sd) – 4.27 GB (ma)** |
| base tax-benefit-system floor | ~1.8 GB (even 7-file states) |
| heaviest CI batch | shard-2 Batch 1 = **976 files** |

All 26 states **pass** individually — it's purely memory. Because memory accumulates across files within a subprocess, 13 states stacking on the ~1.8 GB base exceeds the 16 GB runner.

## Fix

Raise `--batches 4 → 6` in **both** `pr.yaml` and `push.yaml`:

| | shard-1 batches | shard-2 batches | heaviest batch |
|---|---|---|---|
| before (`4`) | 3 | 2 | **976 files** |
| after (`6`) | 4 | 3 | **648 files** (−33%) |

This adds one batch per shard and breaks up the overloaded `ia…mo` batch, pulling peak memory back under the cap. **No test logic changes** — same coverage, smaller subprocesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)