### PR TITLE
Point default US dataset to certified Populace build

### DIFF
--- a/changelog.d/populace-default-dataset.changed.md
+++ b/changelog.d/populace-default-dataset.changed.md
@@ -1,0 +1,1 @@
+- Switch the default US dataset to the certified Populace build (`populace_us_2024`), replacing the Enhanced CPS, and support loading datasets from Hugging Face dataset repositories via `hf://datasets/` URLs.

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -40,7 +40,10 @@ COUNTRY_DIR = Path(__file__).parent
 CURRENT_YEAR = 2024
 DEFAULT_START_DATE = str(CURRENT_YEAR) + "-01-01"
 
-DEFAULT_DATASET = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
+# Certified Populace build (primary-source US microdata), pinned by build id.
+# Populace ships from a Hugging Face *dataset* repo, hence the `hf://datasets/`
+# prefix handled in `_resolve_dataset_path`.
+DEFAULT_DATASET = "hf://datasets/policyengine/populace-us/populace_us_2024.h5@populace-us-2024-c86a631-6e1bcd0271a5-20260619T002242Z"
 
 
 class CountryTaxBenefitSystem(TaxBenefitSystem):
@@ -190,6 +193,24 @@ class Simulation(CoreSimulation):
 
 def _resolve_dataset_path(dataset_str):
     """Resolve a dataset string to a local file path, downloading if needed."""
+    if dataset_str.startswith("hf://datasets/"):
+        # Hugging Face *dataset* repos (e.g. Populace). `download_huggingface_dataset`
+        # assumes a model repo, so resolve dataset repos directly. URL form:
+        # hf://datasets/<owner>/<repo>/<path/to/file>[@<revision>]
+        from huggingface_hub import hf_hub_download
+
+        remainder = dataset_str[len("hf://datasets/") :]
+        owner, repo, *file_parts = remainder.split("/")
+        repo_filename = "/".join(file_parts)
+        version = None
+        if "@" in repo_filename:
+            repo_filename, version = repo_filename.rsplit("@", 1)
+        return hf_hub_download(
+            repo_id=f"{owner}/{repo}",
+            filename=repo_filename,
+            repo_type="dataset",
+            revision=version,
+        )
     if "hf://" in dataset_str:
         from policyengine_core.tools.hugging_face import (
             parse_hf_url,
@@ -255,6 +276,13 @@ class Microsimulation(CoreMicrosimulation):
         )
 
         dataset = kwargs.get("dataset")
+        if dataset is None:
+            # Route the class default through the same interception below as an
+            # explicit dataset, so an entity-level (HDFStore) default such as
+            # Populace is loaded via USSingleYearDataset rather than core's
+            # variable-centric loader.
+            dataset = self.default_dataset
+            kwargs["dataset"] = dataset
         if dataset is not None and isinstance(dataset, str) and "cps_2023" in dataset:
             self.default_input_period = 2023
 

--- a/policyengine_us/tests/microsimulation/test_microsim.py
+++ b/policyengine_us/tests/microsimulation/test_microsim.py
@@ -79,3 +79,25 @@ def test_county_persists_across_periods():
     assert not np.any(county_2025 == County.ALBANY_COUNTY_NY.index), (
         "Should not fall back to Albany county"
     )
+
+
+def test_default_dataset_loads_and_runs():
+    """The no-argument default (certified Populace build) resolves via the
+    hf://datasets/ path and entity-level interception, and produces sane
+    aggregates."""
+    import numpy as np
+    from policyengine_us import Microsimulation
+    from policyengine_us.system import DEFAULT_DATASET
+
+    assert "populace" in DEFAULT_DATASET, (
+        "Default dataset should be the certified Populace build."
+    )
+
+    sim = Microsimulation()  # no dataset -> DEFAULT_DATASET (hf://datasets/...)
+    sim.subsample(1_000)
+    for year in (2024, 2026):
+        hnet = sim.calc("household_net_income", period=year)
+        assert not hnet.isna().any(), f"NaN household net income in {year}."
+    assert sim.calc("adjusted_gross_income", period=2026).sum() > 0, (
+        "Total AGI should be positive on the default dataset."
+    )


### PR DESCRIPTION
## Summary

Switches the default US microdata from the latest Enhanced CPS to the certified Populace build (`populace_us_2024`), and teaches `Microsimulation` to load datasets hosted in Hugging Face **dataset** repositories.

Direct `policyengine-us` users who call `Microsimulation()` with no `dataset` argument currently get the latest Enhanced CPS artifact, whose May-2026 recalibration over-weighted the synthetic top tail and inflated top-end aggregates (root cause tracked in https://github.com/PolicyEngine/policyengine-us-data/issues/1107). Populace is the primary-source build that resolves this. The web app and the `policyengine.py` bundle already pin known-good datasets, so this change closes the gap for direct model users.

## Changes

- `DEFAULT_DATASET` → the pinned certified Populace build `hf://datasets/policyengine/populace-us/populace_us_2024.h5@populace-us-2024-c86a631-6e1bcd0271a5-20260619T002242Z`.
- `_resolve_dataset_path` now handles `hf://datasets/<owner>/<repo>/<file>[@<revision>]`, downloading from HF dataset repos via `hf_hub_download(repo_type="dataset")`. The existing `download_huggingface_dataset` assumes a model repo, so dataset repos need their own resolution.
- `Microsimulation.__init__` now routes the no-argument default through the same entity-level (HDFStore) interception as an explicit dataset, so the Populace default loads via `USSingleYearDataset` instead of core's variable-centric loader.

## Verification

Default `Microsimulation()`, TY2026:

| metric | this PR (Populace) | latest Enhanced CPS |
|---|---|---|
| total AGI | $16.95T | $24.92T |
| claimed itemized deductions | $869.9B | $4,421B |

For reference, SOI total AGI is ~$15.5T for TY2024; the Enhanced CPS figures above are the inflated ones.

Explicit-dataset behavior is unchanged: `Microsimulation(dataset="hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5")` and local `.h5` paths resolve exactly as before. Of the three tests that build the no-argument default, two are `RUN_HEAVY_TESTS`-gated with structural (not magnitude) assertions, and `test_retirement_contribution_limits_include_latest_explicit_irs_values` only reads parameters — it passes locally on the new default.

Populace: https://github.com/PolicyEngine/populace
