### PR TITLE
Update Colorado OAP 2026 grant standard

### DIFF
--- a/changelog.d/co-oap-2026-grant-standard.fixed.md
+++ b/changelog.d/co-oap-2026-grant-standard.fixed.md
@@ -1,0 +1,1 @@
+Updated the Colorado Old Age Pension grant standard for 2026.

--- a/policyengine_us/parameters/gov/states/co/ssa/oap/grant_standard.yaml
+++ b/policyengine_us/parameters/gov/states/co/ssa/oap/grant_standard.yaml
@@ -1,15 +1,18 @@
-description: Grant Standard for OAP
+description: Colorado provides this amount as the grant standard under the Old Age Pension program.
 
 values:
   2023-01-01: 952
   2024-01-01: 982
   2025-01-01: 1_005
+  2026-01-01: 1_032
 
 metadata:
   unit: currency-USD
   period: month
   label: Colorado OAP grant standard
   reference:
+    - title: 9 CCR 2503-5 3.530(A)
+      href: https://www.sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=12428&fileName=9%20CCR%202503-5#page=79
     - title: ADULT FINANCIAL PROGRAMS | Income Maintenance (Volume 3) | 3.530(A)
       href: https://www.coloradosos.gov/CCR/GenerateRulePdf.do?ruleVersionId=10694#page=57
     - title: ADULT FINANCIAL PROGRAMS | Income Maintenance (Volume 3) | 3.530(A)

--- a/policyengine_us/tests/policy/baseline/gov/states/co/ssa/oap/co_oap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/ssa/oap/co_oap.yaml
@@ -24,3 +24,12 @@
     ssi: 6_000
   output:
     co_oap: 0
+
+- name: 2026 grant standard
+  period: 2026
+  input:
+    co_oap_eligible: true
+    ssi_countable_income: 384
+    ssi: 0
+  output:
+    co_oap: 12_000

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/oap.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/oap.yaml
@@ -49,7 +49,7 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 12060.0
+        co_oap: 12384.0
 - name: co_oap_single_resources_above_1500_ineligible (co)
   period: 2026
   absolute_error_margin: 0.1
@@ -101,4 +101,4 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 12060.0
+        co_oap: 12384.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/state_supplement.yaml
@@ -103,4 +103,4 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 132.0
+        co_oap: 456.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/tax_credits_composition.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/tax_credits_composition.yaml
@@ -101,7 +101,7 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 132.0
+        co_oap: 456.0
 - name: statetax_size_2_married_couple_no_children (co)
   period: 2026
   absolute_error_margin: 0.1


### PR DESCRIPTION
## Summary
- add the 2026 Colorado Old Age Pension monthly grant standard of $1,032
- add a 2026 regression test for `co_oap`

## Source
- 9 CCR 2503-5 3.530(A), rule version 12428, page 79

## Tests
- `uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/states/co/ssa/oap -c policyengine_us -v`
- `make format`