### PR TITLE
Rebalance contrib structural shards to prevent per-batch timeout flakes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -250,6 +250,8 @@ jobs:
             target: test-yaml-structural-other
           - group: other-shard-2
             target: test-yaml-structural-other-shard-2
+          - group: other-shard-3
+            target: test-yaml-structural-other-shard-3
           - group: congress
             target: test-yaml-structural-congress
     steps:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -145,6 +145,8 @@ jobs:
             target: test-yaml-structural-other
           - group: other-shard-2
             target: test-yaml-structural-other-shard-2
+          - group: other-shard-3
+            target: test-yaml-structural-other-shard-3
           - group: congress
             target: test-yaml-structural-congress
     steps:

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,11 @@ test-yaml-structural-heavy-shard-2:
 test-yaml-structural-heavy-shard-3:
 	$(BATCH) $(TESTS)/policy/contrib/states --batches 1 --shard 3/3
 test-yaml-structural-other:
-	# refundable_credit_conversion force-applies a reform per case; each
-	# distinct gov.contrib.* combination clones the full tax-benefit system
-	# (~5 GB peak/file). Auto-batching grouped all its files into one
-	# subprocess, stacking the peaks past the runner cap → OOM. Isolate
-	# per-file so each peak is freed between files (same as ctc/crfb below).
-	$(BATCH) $(TESTS)/policy/contrib --exclude states,ctc,ubi_center,federal,harris,treasury,crfb,congress,refundable_credit_conversion
-	$(BATCH) $(TESTS)/policy/contrib/refundable_credit_conversion --mode per-file
+	# Per-subdir so every remaining contrib folder runs in its own subprocess,
+	# instead of stacking ~20 light files into one ~13-min catch-all batch that
+	# risked the 30-min per-batch timeout on slow runners. ssa is excluded (it
+	# has no YAML tests — only a pytest .py run elsewhere).
+	$(BATCH) $(TESTS)/policy/contrib --exclude states,ctc,ubi_center,federal,harris,treasury,crfb,congress,refundable_credit_conversion,ssa --mode per-subdir
 test-yaml-structural-other-shard-2:
 	# ctc + crfb are microsim-heavy: per-file isolation keeps RAM under the cap.
 	$(BATCH) $(TESTS)/policy/contrib/ctc --mode per-file
@@ -44,6 +42,12 @@ test-yaml-structural-other-shard-2:
 	$(BATCH) $(TESTS)/policy/contrib/federal --batches 1
 	$(BATCH) $(TESTS)/policy/contrib/harris --batches 1
 	$(BATCH) $(TESTS)/policy/contrib/treasury --batches 1
+test-yaml-structural-other-shard-3:
+	# refundable_credit_conversion force-applies a reform per case; each distinct
+	# gov.contrib.* combination clones the full tax-benefit system (~5 GB peak/
+	# file). Per-file isolation frees each peak between files; run on its own
+	# shard so its ~27-min sweep no longer stacks onto other-shard-1.
+	$(BATCH) $(TESTS)/policy/contrib/refundable_credit_conversion --mode per-file
 test-yaml-structural-congress:
 	# One subprocess per congress proposal; new proposals auto-route.
 	$(BATCH) $(TESTS)/policy/contrib/congress --mode per-subdir

--- a/changelog.d/ci-rebalance-contrib-shards.fixed.md
+++ b/changelog.d/ci-rebalance-contrib-shards.fixed.md
@@ -1,0 +1,1 @@
+Rebalance the contrib structural test shards to prevent intermittent 30-minute per-batch timeout failures: split the other-shard-1 catch-all into per-subdir batches and move refundable_credit_conversion to a new other-shard-3.


### PR DESCRIPTION
## Problem

`Full Suite - Contrib (other-shard-1)` intermittently fails — most recently on #8653, where it was stuck on its catch-all batch and the step timed out. It passed on the two prior runs of the same branch, so it's a **boundary flake**, not a deterministic failure.

## Root cause (measured)

I measured every folder/file in `other-shard-1` on a 17 GB machine (≈ the 16 GB runner), each in its own process:

| item | time | peak RSS | files |
|---|---:|---:|---:|
| tax_exempt | 596 s | 4.0 GB | 1 |
| aca | 295 s | 4.95 GB | 3 |
| snap | 238 s | 3.6 GB | 2 |
| taxsim | 175 s | 4.2 GB | 14 |
| …9 more light folders/files | 54–160 s | 2.6–3.7 GB | 1–2 |

Two findings:
1. **It's time-bound, not memory-bound** — nothing exceeds ~5 GB, so it isn't OOMing; it's hitting `test_batched.py`'s **30-minute per-batch timeout** on slow/contended runners (the contrib matrix jobs share physical hosts).
2. **`other-shard-1` was overloaded**: its "catch-all" batch lumped **~21 light files (~13 min)** into one subprocess, and it *also* ran `refundable_credit_conversion`'s 9 per-file batches (**~27 min**) — making it by far the longest contrib job.

## Fix

- **`other-shard-1` → `--mode per-subdir`**: every contrib folder becomes its own batch. The 21-file catch-all is gone; the longest single batch drops from ~13 min to ~10 min (`tax_exempt`, an irreducible 1-file folder). `ssa` is excluded (no YAML tests — only a pytest `.py` run elsewhere).
- **New `other-shard-3`**: `refundable_credit_conversion --mode per-file` moves to its own shard, taking ~27 min off `other-shard-1`.
- Registered `other-shard-3` in **both** `pr.yaml` and `push.yaml`.

**No coverage change** — the same files run, just rebatched across one extra shard. This PR edits the workflows, so its own CI run exercises the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)