### PR TITLE
Add Medicaid community engagement treatment-program exclusion

### DIFF
--- a/changelog.d/8574.added.md
+++ b/changelog.d/8574.added.md
@@ -1,0 +1,1 @@
+Added a Medicaid community engagement treatment-program exclusion input.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -244,3 +244,23 @@
     medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: false
+
+- name: Case 27, treatment program participant is excluded from community engagement.
+  period: 2027
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    is_in_medicaid_community_engagement_treatment_program: true
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 28, non-participant remains subject to community engagement.
+  period: 2027
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    is_in_medicaid_community_engagement_treatment_program: false
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: false

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_in_medicaid_community_engagement_treatment_program.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_in_medicaid_community_engagement_treatment_program.py
@@ -5,8 +5,7 @@ class is_in_medicaid_community_engagement_treatment_program(Variable):
     value_type = bool
     entity = Person
     label = (
-        "Participates in qualifying treatment program for Medicaid community "
-        "engagement"
+        "Participates in qualifying treatment program for Medicaid community engagement"
     )
     definition_period = YEAR
     default_value = False
@@ -17,4 +16,3 @@ class is_in_medicaid_community_engagement_treatment_program(Variable):
         "commitments are not modeled."
     )
     reference = "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf"
-

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_in_medicaid_community_engagement_treatment_program.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_in_medicaid_community_engagement_treatment_program.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class is_in_medicaid_community_engagement_treatment_program(Variable):
+    value_type = bool
+    entity = Person
+    label = (
+        "Participates in qualifying treatment program for Medicaid community "
+        "engagement"
+    )
+    definition_period = YEAR
+    default_value = False
+    documentation = (
+        "Whether the person participates in a qualifying drug addiction or "
+        "alcoholic treatment and rehabilitation program for the Medicaid "
+        "community engagement exclusion. State-specific minimum time "
+        "commitments are not modeled."
+    )
+    reference = "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf"
+

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -68,6 +68,9 @@ class medicaid_work_requirement_eligible(Variable):
             "is_medically_frail_or_has_special_medical_needs_for_medicaid_ce",
             period,
         )
+        treatment_program_participant = person(
+            "is_in_medicaid_community_engagement_treatment_program", period
+        )
         # Current and recent incarceration exclusions/exceptions.
         is_incarcerated = person("is_incarcerated", period)
         was_recently_incarcerated = person(
@@ -90,6 +93,7 @@ class medicaid_work_requirement_eligible(Variable):
             | eligible_veteran
             | eligible_disabled
             | medically_frail
+            | treatment_program_participant
             | is_incarcerated
             | was_recently_incarcerated
         )


### PR DESCRIPTION
Fixes #8574

Testing:
- `policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml -c policyengine_us` (28 passed)