### PR TITLE
Add CHIP current-coverage input

### DIFF
--- a/changelog.d/8577.added.md
+++ b/changelog.d/8577.added.md
@@ -1,0 +1,1 @@
+Added a CHIP current-coverage input and counted it in reported non-Marketplace coverage checks.

--- a/policyengine_us/parameters/gov/aca/qualifying_non_marketplace_health_coverage.yaml
+++ b/policyengine_us/parameters/gov/aca/qualifying_non_marketplace_health_coverage.yaml
@@ -5,6 +5,7 @@ values:
     - medicaid_enrolled
     - receives_medicaid
     - has_medicaid_health_coverage_at_interview
+    - has_chip_health_coverage_at_interview
     - is_chip_eligible
     - medicare_enrolled
     - has_other_means_tested_health_coverage_at_interview

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/coverage_report_model_conflict.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/coverage_report_model_conflict.yaml
@@ -24,3 +24,11 @@
     has_non_marketplace_direct_purchase_health_coverage_at_interview: true
   output:
     coverage_report_model_conflict: false
+
+- name: Case 4, Marketplace plus reported CHIP coverage conflict is flagged.
+  period: 2025
+  input:
+    has_marketplace_health_coverage_at_interview: true
+    has_chip_health_coverage_at_interview: true
+  output:
+    coverage_report_model_conflict: true

--- a/policyengine_us/tests/policy/baseline/gov/aca/eligibility/has_qualifying_non_marketplace_health_coverage_at_interview.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/aca/eligibility/has_qualifying_non_marketplace_health_coverage_at_interview.yaml
@@ -66,3 +66,19 @@
     receives_medicaid: true
   output:
     has_qualifying_non_marketplace_health_coverage_at_interview: true
+
+- name: Case 7, reported CHIP coverage counts as qualifying non-Marketplace coverage.
+  period: 2025
+  input:
+    medicaid_enrolled: false
+    is_chip_eligible: false
+    has_chip_health_coverage_at_interview: true
+    has_esi: false
+    has_non_marketplace_direct_purchase_health_coverage_at_interview: false
+    has_other_means_tested_health_coverage_at_interview: false
+    has_tricare_health_coverage_at_interview: false
+    has_champva_health_coverage_at_interview: false
+    has_va_health_coverage_at_interview: false
+  output:
+    qualifying_non_marketplace_health_coverage_type_count_at_interview: 1
+    has_qualifying_non_marketplace_health_coverage_at_interview: true

--- a/policyengine_us/variables/household/expense/health/has_chip_health_coverage_at_interview.py
+++ b/policyengine_us/variables/household/expense/health/has_chip_health_coverage_at_interview.py
@@ -6,4 +6,3 @@ class has_chip_health_coverage_at_interview(Variable):
     entity = Person
     label = "Person currently has CHIP health coverage"
     definition_period = YEAR
-

--- a/policyengine_us/variables/household/expense/health/has_chip_health_coverage_at_interview.py
+++ b/policyengine_us/variables/household/expense/health/has_chip_health_coverage_at_interview.py
@@ -1,0 +1,9 @@
+from policyengine_us.model_api import *
+
+
+class has_chip_health_coverage_at_interview(Variable):
+    value_type = bool
+    entity = Person
+    label = "Person currently has CHIP health coverage"
+    definition_period = YEAR
+


### PR DESCRIPTION
Fixes #8577

Testing:
- `policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/aca/eligibility/has_qualifying_non_marketplace_health_coverage_at_interview.yaml policyengine_us/tests/policy/baseline/gov/aca/eligibility/coverage_report_model_conflict.yaml -c policyengine_us` (10 passed)