### PR TITLE
Add Arizona HB 4168 (2026) individual income tax changes

### DIFF
--- a/changelog.d/az-hb4168-2026-income-tax.added.md
+++ b/changelog.d/az-hb4168-2026-income-tax.added.md
@@ -1,0 +1,1 @@
+Added Arizona HB 4168 (2026) individual income tax changes: $125 under-17 dependent credit, capped full-amount charitable standard deduction add-on, $10,000 itemized SALT cap, and new dependent care and IRC 530A distribution subtractions (all effective 2026).

--- a/policyengine_us/parameters/gov/states/az/tax/income/credits/dependent_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/credits/dependent_credit/amount.yaml
@@ -19,7 +19,7 @@ metadata:
   - title: Arizona State Legislature Title 43 - Taxation of Income, Chapter 10, Article 5, 43-1073.01 (B), (1) & (2)
     href: https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01073-01.htm
   - title: Arizona HB 4168 (2026), Sec. 21 amending 43-1073.01(B)(1)
-    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
+    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=31
 brackets:
   - threshold:
       2021-01-01: 0

--- a/policyengine_us/parameters/gov/states/az/tax/income/credits/dependent_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/credits/dependent_credit/amount.yaml
@@ -18,11 +18,14 @@ metadata:
     href: https://azdor.gov/forms/individual/form-140a-arizona-resident-personal-income-tax-booklet
   - title: Arizona State Legislature Title 43 - Taxation of Income, Chapter 10, Article 5, 43-1073.01 (B), (1) & (2)
     href: https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01073-01.htm
+  - title: Arizona HB 4168 (2026), Sec. 21 amending 43-1073.01(B)(1)
+    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
 brackets:
   - threshold:
       2021-01-01: 0
     amount:
       2021-01-01: 100
+      2026-01-01: 125
   - threshold:
       2021-01-01: 17
     amount:

--- a/policyengine_us/parameters/gov/states/az/tax/income/deductions/itemized/salt_cap.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/deductions/itemized/salt_cap.yaml
@@ -1,0 +1,14 @@
+description: Arizona limits the state and local tax itemized deduction to this amount, in lieu of the federal deduction allowed under Internal Revenue Code section 164(b)(7).
+values:
+  2018-01-01: .inf
+  2026-01-01: 10_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: Arizona itemized state and local tax deduction cap
+  reference:
+    - title: A.R.S. 43-1042(D)
+      href: https://www.azleg.gov/ars/43/01042.htm
+    - title: Arizona HB 4168 (2026), Sec. 17, amending A.R.S. 43-1042(D)
+      href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf

--- a/policyengine_us/parameters/gov/states/az/tax/income/deductions/itemized/salt_cap.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/deductions/itemized/salt_cap.yaml
@@ -11,4 +11,4 @@ metadata:
     - title: A.R.S. 43-1042(D)
       href: https://www.azleg.gov/ars/43/01042.htm
     - title: Arizona HB 4168 (2026), Sec. 17, amending A.R.S. 43-1042(D)
-      href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
+      href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=31

--- a/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/cap.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/cap.yaml
@@ -1,0 +1,28 @@
+description: Arizona caps the increased standard deduction for charitable contributions at this amount, depending on the filing status.
+metadata:
+  label: Arizona increased standard deduction for charitable contributions cap
+  period: year
+  unit: currency-USD
+  breakdown:
+  - az_filing_status
+  reference:
+  - title: Arizona HB 4168 (2026), Sec. 16 amending 43-1041(I)(2)(a)-(b)
+    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
+  - title: 43-1041. Optional standard deduction Line I
+    href: https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01041.htm
+
+# HB 4168 sets the cap at $1,000 for single/married-filing-separately filers
+# and $2,000 for joint filers. The bill is silent on head of household, so we
+# apply the $1,000 single-filer cap to head of household filers.
+JOINT:
+  2018-01-01: 0
+  2026-01-01: 2_000
+HEAD_OF_HOUSEHOLD:
+  2018-01-01: 0
+  2026-01-01: 1_000
+SINGLE:
+  2018-01-01: 0
+  2026-01-01: 1_000
+SEPARATE:
+  2018-01-01: 0
+  2026-01-01: 1_000

--- a/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/cap.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/cap.yaml
@@ -7,13 +7,19 @@ metadata:
   - az_filing_status
   reference:
   - title: Arizona HB 4168 (2026), Sec. 16 amending 43-1041(I)(2)(a)-(b)
-    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
+    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=30
   - title: 43-1041. Optional standard deduction Line I
     href: https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01041.htm
+  - title: 26 U.S.C. 170(p) Charitable deduction for individuals who do not itemize
+    href: https://www.law.cornell.edu/uscode/text/26/170#p
 
-# HB 4168 sets the cap at $1,000 for single/married-filing-separately filers
-# and $2,000 for joint filers. The bill is silent on head of household, so we
-# apply the $1,000 single-filer cap to head of household filers.
+# HB 4168 caps the increased standard deduction at $1,000 for single/married-
+# filing-separately filers and $2,000 for joint filers; the bill is silent on
+# head of household. Arizona's add-on equals the IRC 170(c) contribution amount
+# and mirrors the federal above-the-line charitable deduction under IRC 170(p),
+# which caps non-joint filers (single, married-filing-separately, and head of
+# household) at $1,000 and joint filers at $2,000. Head of household is a non-
+# joint filing status, so it uses the $1,000 non-joint cap.
 JOINT:
   2018-01-01: 0
   2026-01-01: 2_000

--- a/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/rate.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/rate.yaml
@@ -17,7 +17,7 @@ metadata:
   - title: 43-1041. Optional standard deduction Line I
     href: https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01041.htm
   - title: Arizona HB 4168 (2026), Sec. 16 amending 43-1041(I)(1)-(2)
-    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
+    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=30
 
 values:
   2019-01-01: 0.25

--- a/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/rate.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/deductions/standard/increased/rate.yaml
@@ -16,6 +16,8 @@ metadata:
     href: https://azdor.gov/sites/default/files/2023-03/FORMS_INDIVIDUAL_2021_140BOOKLET.pdf#page=43
   - title: 43-1041. Optional standard deduction Line I
     href: https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01041.htm
+  - title: Arizona HB 4168 (2026), Sec. 16 amending 43-1041(I)(1)-(2)
+    href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
 
 values:
   2019-01-01: 0.25
@@ -23,3 +25,4 @@ values:
   2023-01-01: 0.31
   2024-01-01: 0.33
   2025-01-01: 0.34
+  2026-01-01: 0

--- a/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
@@ -27,6 +27,24 @@ values:
     - overtime_income_deduction # MCTCP worksheet Line 3 (Sch 1-A Line 21)
     - auto_loan_interest_deduction # MCTCP worksheet Line 4 (Sch 1-A Line 30)
     - additional_senior_deduction # MCTCP worksheet Line 5 (Sch 1-A Line 37)
+  # HB 4168 (2026): auto loan interest sunsets after TY2025 (43-1022(36));
+  # adds child & dependent care and IRC 530A distribution subtractions.
+  2026-01-01:
+    - us_govt_interest # Line 28
+    - az_public_pension_exclusion # Line 29a
+    - az_long_term_capital_gains_subtraction # Line 20 - 24
+    - az_military_retirement_subtraction # Line 29b
+    - taxable_social_security # Line 30
+    - military_service_income # Line 32
+    - az_529_college_savings_plan_subtraction # Line 34a
+    - az_529a_able_account_subtraction # Line 34b
+    - az_adoption_expense_subtraction # Other subtractions - Item D
+    - az_families_tax_rebate_subtraction # Line 36, Item U
+    - tip_income_deduction # 43-1022(31)
+    - overtime_income_deduction # 43-1022(32)
+    - additional_senior_deduction # 43-1022(35)
+    - az_dependent_care_expense_subtraction # 43-1022(34)
+    - az_530a_distribution_subtraction # 43-1022(33)
 metadata:
   unit: list
   period: year
@@ -48,3 +66,5 @@ metadata:
       href: https://azdor.gov/sites/default/files/2023-03/FORMS_INDIVIDUAL_2021_140BOOKLET.pdf#page=25
     - title: 43-1022. Subtractions from Arizona gross income
       href: https://www.azleg.gov/ars/43/01022.htm
+    - title: Arizona HB 4168 (2026), Sec. 15, amending A.R.S. 43-1022(31)-(36)
+      href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf

--- a/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
@@ -67,4 +67,4 @@ metadata:
     - title: 43-1022. Subtractions from Arizona gross income
       href: https://www.azleg.gov/ars/43/01022.htm
     - title: Arizona HB 4168 (2026), Sec. 15, amending A.R.S. 43-1022(31)-(36)
-      href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf
+      href: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=28

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/dependent_credit/az_dependent_tax_credit.yaml
@@ -311,3 +311,99 @@
         state_code: AZ
   output:
     az_dependent_tax_credit: 100
+# HB 4168 (2026): the under-17 dependent credit amount rises from $100 to $125.
+# The 17+ amount ($25) and the AGI phase-out are unchanged.
+- name: 2026 - Single with one young dependent, increased amount
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_dependent: true
+        age: 10
+    tax_units:
+      tax_unit:
+        members:
+        - person1
+        adjusted_gross_income: 200000
+        filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
+    households:
+      household:
+        members:
+        - person1
+        state_code: AZ
+  output:
+    # Under 17 in 2026 = $125 (was $100 in 2025)
+    az_dependent_tax_credit: 125
+- name: 2026 - Single with one older dependent, amount unchanged
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_dependent: true
+        age: 17
+    tax_units:
+      tax_unit:
+        members:
+        - person1
+        adjusted_gross_income: 200000
+        filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
+    households:
+      household:
+        members:
+        - person1
+        state_code: AZ
+  output:
+    # Age 17+ stays $25
+    az_dependent_tax_credit: 25
+- name: 2026 - One young and one old dependent, mixed amounts
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_dependent: true
+        age: 10
+      person2:
+        is_tax_unit_dependent: true
+        age: 17
+    tax_units:
+      tax_unit:
+        members:
+        - person1
+        - person2
+        adjusted_gross_income: 200000
+        filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
+    households:
+      household:
+        members:
+        - person1
+        - person2
+        state_code: AZ
+  output:
+    # Young: $125 + Old: $25 = $150
+    az_dependent_tax_credit: 150
+- name: 2026 - Single with partial phase-out, increased amount
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_dependent: true
+        age: 10
+    tax_units:
+      tax_unit:
+        members:
+        - person1
+        adjusted_gross_income: 205000
+        filing_status: SINGLE
+        az_income_tax_before_non_refundable_credits: 1000000
+    households:
+      household:
+        members:
+        - person1
+        state_code: AZ
+  output:
+    # Over $200,000 by $5,000: ceil(5,000/1,000) = 5 increments * 5% = 25%
+    # $125 * (1 - 0.25) = $93.75 (phase-out mechanics unchanged)
+    az_dependent_tax_credit: 93.75

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.yaml
@@ -75,11 +75,54 @@
   period: 2022
   input:
     state_code: AZ
-    interest_deduction: 200 
-    casualty_loss_deduction: 300 
+    interest_deduction: 200
+    casualty_loss_deduction: 300
     other_medical_expenses: 600
-    charitable_deduction: 700 
+    charitable_deduction: 700
     az_charitable_contributions_credit_potential: 800
     state_sales_tax: 0
   output:
     az_itemized_deductions: 1_100
+
+# HB 4168 (2026): Arizona caps the SALT itemized deduction at $10,000
+# (A.R.S. 43-1042(D)). Before 2026 the cap is infinite, so the full SALT
+# deduction passes through unchanged.
+
+- name: Large SALT deduction passes through in 2025 (no cap)
+  absolute_error_margin: 0.01
+  period: 2025
+  input:
+    state_code: AZ
+    salt_deduction: 15_000
+    charitable_deduction: 0
+    az_charitable_contributions_credit_potential: 0
+    itemized_medical_expenses: 0
+  output:
+    # 2025 cap is infinite: full $15,000 SALT included
+    az_itemized_deductions: 15_000
+
+- name: Large SALT deduction capped at $10,000 in 2026
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    state_code: AZ
+    salt_deduction: 15_000
+    charitable_deduction: 0
+    az_charitable_contributions_credit_potential: 0
+    itemized_medical_expenses: 0
+  output:
+    # 2026 cap is $10,000: min($15,000, $10,000) = $10,000
+    az_itemized_deductions: 10_000
+
+- name: SALT deduction below cap unaffected in 2026
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    state_code: AZ
+    salt_deduction: 8_000
+    charitable_deduction: 0
+    az_charitable_contributions_credit_potential: 0
+    itemized_medical_expenses: 0
+  output:
+    # min($8,000, $10,000) = $8,000
+    az_itemized_deductions: 8_000

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.yaml
@@ -68,3 +68,52 @@
   output:
     # ($10,000 - $1,500) * 0.34 = $2,890
     az_increased_standard_deduction_for_charitable_contributions: 2_890
+
+# HB 4168 (2026): rate drops to 0 and the add-on becomes the full charitable
+# contribution amount, capped by filing status ($1,000 single/separate/HOH,
+# $2,000 joint). The rate-based and cap-based regimes do not overlap.
+
+- name: test for 2026 single filer over cap
+  period: 2026
+  input:
+    state_code: AZ
+    filing_status: SINGLE
+    charitable_deduction: 1_500
+    az_charitable_contributions_credit_potential: 0
+  output:
+    # rate (0) * 1_500 + min($1,500, $1,000 single cap) = $1,000
+    az_increased_standard_deduction_for_charitable_contributions: 1_000
+
+- name: test for 2026 single filer under cap
+  period: 2026
+  input:
+    state_code: AZ
+    filing_status: SINGLE
+    charitable_deduction: 600
+    az_charitable_contributions_credit_potential: 0
+  output:
+    # rate (0) * 600 + min($600, $1,000 single cap) = $600
+    az_increased_standard_deduction_for_charitable_contributions: 600
+
+- name: test for 2026 joint filer over cap
+  period: 2026
+  input:
+    state_code: AZ
+    filing_status: JOINT
+    charitable_deduction: 2_500
+    az_charitable_contributions_credit_potential: 0
+  output:
+    # rate (0) * 2_500 + min($2,500, $2,000 joint cap) = $2,000
+    az_increased_standard_deduction_for_charitable_contributions: 2_000
+
+- name: test for 2026 cap applied after charitable contributions credit
+  period: 2026
+  input:
+    state_code: AZ
+    filing_status: SINGLE
+    charitable_deduction: 1_200
+    az_charitable_contributions_credit_potential: 400
+  output:
+    # charitable after credit = max($1,200 - $400, 0) = $800
+    # rate (0) * 800 + min($800, $1,000 single cap) = $800
+    az_increased_standard_deduction_for_charitable_contributions: 800

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/integration.yaml
@@ -64,20 +64,22 @@
     az_increased_standard_deduction_for_charitable_contributions: 1_000
     # Standard deduction: $23,625 base + $1,000 add-on = $24,625
     az_standard_deduction: 24_625
-    # Dependent care: max($5,000 - $1,200, 0) = $3,800
-    az_dependent_care_expense_subtraction: 3_800
+    # Dependent care: cdcc_relevant_expenses = min($5,000, $3,000 §21 cap for
+    # 1 QI, $80,000 earnings) = $3,000; subtraction = max($3,000 - $1,200, 0)
+    # = $1,800
+    az_dependent_care_expense_subtraction: 1_800
     # 530A distribution subtraction: $1,000
     az_530a_distribution_subtraction: 1_000
-    # az_subtractions includes both new subtractions: $3,800 + $1,000 = $4,800
-    az_subtractions: 4_800
-    # AZ AGI = $80,000 - $4,800 = $75,200
-    az_agi: 75_200
-    # Taxable income = $75,200 - $24,625 = $50,575
-    az_taxable_income: 50_575
-    # Tax before credits = $50,575 * 2.5% = $1,264.375
-    az_income_tax_before_non_refundable_credits: 1_264.375
-    # AZ income tax = $1,264.375 - $125 dependent credit = $1,139.375
-    az_income_tax: 1_139.375
+    # az_subtractions includes both new subtractions: $1,800 + $1,000 = $2,800
+    az_subtractions: 2_800
+    # AZ AGI = $80,000 - $2,800 = $77,200
+    az_agi: 77_200
+    # Taxable income = $77,200 - $24,625 = $52,575
+    az_taxable_income: 52_575
+    # Tax before credits = $52,575 * 2.5% = $1,314.375
+    az_income_tax_before_non_refundable_credits: 1_314.375
+    # AZ income tax = $1,314.375 - $125 dependent credit = $1,189.375
+    az_income_tax: 1_189.375
 
 # Confirms the pre-2026 regime is UNCHANGED for the identical household.
 # In 2025: dependent credit is $100, charitable add-on uses the 0.34 rate

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/integration.yaml
@@ -26,3 +26,99 @@
     az_property_tax_credit_agi: 3_766.08
     # Income $3,766.08 > threshold $3,751 for single, so not eligible
     az_property_tax_credit: 0
+
+# HB 4168 (2026): combined-effect integration test. A single adult with one
+# dependent (head of household) exercising all five changes at once:
+#   1. Dependent credit: under-17 amount is $125 (was $100).
+#   2. Charitable add-on: capped at the $1,000 HOH cap (full $1,500 would have
+#      applied pre-cap; 2025 add-on would have been $1,500 * 0.34 = $510).
+#   3. Dependent care subtraction: childcare expenses minus CDCC.
+#   4. 530A distribution subtraction.
+#   5. New subtractions flow into az_subtractions / az_agi.
+- name: HB 4168 (2026) combined effect - HOH with dependent
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income: 80_000
+      person2:
+        age: 10
+        is_tax_unit_dependent: true
+        az_530a_distribution: 1_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        charitable_deduction: 1_500
+        tax_unit_childcare_expenses: 5_000
+        cdcc: 1_200
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AZ
+  output:
+    az_filing_status: HEAD_OF_HOUSEHOLD
+    # Dependent credit: under-17 = $125 in 2026
+    az_dependent_tax_credit: 125
+    # Charitable add-on: min($1,500, $1,000 HOH cap) = $1,000
+    az_increased_standard_deduction_for_charitable_contributions: 1_000
+    # Standard deduction: $23,625 base + $1,000 add-on = $24,625
+    az_standard_deduction: 24_625
+    # Dependent care: max($5,000 - $1,200, 0) = $3,800
+    az_dependent_care_expense_subtraction: 3_800
+    # 530A distribution subtraction: $1,000
+    az_530a_distribution_subtraction: 1_000
+    # az_subtractions includes both new subtractions: $3,800 + $1,000 = $4,800
+    az_subtractions: 4_800
+    # AZ AGI = $80,000 - $4,800 = $75,200
+    az_agi: 75_200
+    # Taxable income = $75,200 - $24,625 = $50,575
+    az_taxable_income: 50_575
+    # Tax before credits = $50,575 * 2.5% = $1,264.375
+    az_income_tax_before_non_refundable_credits: 1_264.375
+    # AZ income tax = $1,264.375 - $125 dependent credit = $1,139.375
+    az_income_tax: 1_139.375
+
+# Confirms the pre-2026 regime is UNCHANGED for the identical household.
+# In 2025: dependent credit is $100, charitable add-on uses the 0.34 rate
+# ($510), and the new dependent-care / 530A subtractions are NOT in the 2025
+# subtractions list, so az_subtractions stays $0 and az_agi is unchanged.
+- name: HB 4168 pre-2026 unchanged - HOH with dependent (2025)
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income: 80_000
+      person2:
+        age: 10
+        is_tax_unit_dependent: true
+        az_530a_distribution: 1_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        charitable_deduction: 1_500
+        tax_unit_childcare_expenses: 5_000
+        cdcc: 1_200
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AZ
+  output:
+    az_filing_status: HEAD_OF_HOUSEHOLD
+    # Dependent credit: under-17 = $100 in 2025 (unchanged regime)
+    az_dependent_tax_credit: 100
+    # Charitable add-on: $1,500 * 0.34 rate = $510 (rate regime, no cap)
+    az_increased_standard_deduction_for_charitable_contributions: 510
+    # Standard deduction: $23,625 base + $510 add-on = $24,135
+    az_standard_deduction: 24_135
+    # New subtractions are NOT in the 2025 list, so az_subtractions stays $0
+    az_subtractions: 0
+    # AZ AGI unchanged by the new subtractions: $80,000
+    az_agi: 80_000
+    # Taxable income = $80,000 - $24,135 = $55,865
+    az_taxable_income: 55_865
+    # Tax before credits = $55,865 * 2.5% = $1,396.625
+    az_income_tax_before_non_refundable_credits: 1_396.625
+    # AZ income tax = $1,396.625 - $100 dependent credit = $1,296.625
+    az_income_tax: 1_296.625

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/az_530a_distribution_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/az_530a_distribution_subtraction.yaml
@@ -1,0 +1,57 @@
+# HB 4168 (2026): A.R.S. 43-1022(33) subtracts distributions from an
+# IRC 530A account. The tax-unit subtraction sums the person-level
+# az_530a_distribution amounts.
+
+- name: Case 1, single filer with a 530A distribution.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        az_530a_distribution: 1_500
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: AZ
+  output:
+    az_530a_distribution_subtraction: 1_500
+
+- name: Case 2, joint filers with two 530A distributions.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        az_530a_distribution: 1_000
+      person2:
+        az_530a_distribution: 800
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AZ
+  output:
+    # $1,000 + $800 = $1,800
+    az_530a_distribution_subtraction: 1_800
+
+- name: Case 3, no 530A distribution.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        az_530a_distribution: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: AZ
+  output:
+    az_530a_distribution_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.yaml
@@ -1,0 +1,35 @@
+# HB 4168 (2026): A.R.S. 43-1022(34) subtracts IRC 21 child and dependent
+# care expenses that exceed the federal IRC 21 credit (CDCC). No cap. The
+# subtraction is floored at zero.
+
+- name: Case 1, childcare expenses exceed the federal credit.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    state_code: AZ
+    tax_unit_childcare_expenses: 5_000
+    cdcc: 1_200
+  output:
+    # max($5,000 - $1,200, 0) = $3,800
+    az_dependent_care_expense_subtraction: 3_800
+
+- name: Case 2, childcare expenses below the federal credit, floored at zero.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    state_code: AZ
+    tax_unit_childcare_expenses: 1_000
+    cdcc: 1_500
+  output:
+    # max($1,000 - $1,500, 0) = $0
+    az_dependent_care_expense_subtraction: 0
+
+- name: Case 3, no childcare expenses.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    state_code: AZ
+    tax_unit_childcare_expenses: 0
+    cdcc: 0
+  output:
+    az_dependent_care_expense_subtraction: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.yaml
@@ -1,13 +1,16 @@
 # HB 4168 (2026): A.R.S. 43-1022(34) subtracts IRC 21 child and dependent
-# care expenses that exceed the federal IRC 21 credit (CDCC). No cap. The
-# subtraction is floored at zero.
+# care expenses for a qualifying individual that exceed the federal IRC 21
+# credit (CDCC). The expense base is cdcc_relevant_expenses, which applies the
+# IRC 21 dollar and earned-income limits and equals 0 when there is no
+# qualifying individual (count_cdcc_eligible == 0). The subtraction is floored
+# at zero.
 
 - name: Case 1, childcare expenses exceed the federal credit.
   absolute_error_margin: 0.01
   period: 2026
   input:
     state_code: AZ
-    tax_unit_childcare_expenses: 5_000
+    cdcc_relevant_expenses: 5_000
     cdcc: 1_200
   output:
     # max($5,000 - $1,200, 0) = $3,800
@@ -18,7 +21,7 @@
   period: 2026
   input:
     state_code: AZ
-    tax_unit_childcare_expenses: 1_000
+    cdcc_relevant_expenses: 1_000
     cdcc: 1_500
   output:
     # max($1,000 - $1,500, 0) = $0
@@ -29,7 +32,61 @@
   period: 2026
   input:
     state_code: AZ
-    tax_unit_childcare_expenses: 0
+    cdcc_relevant_expenses: 0
     cdcc: 0
   output:
     az_dependent_care_expense_subtraction: 0
+
+# Regression (flagged by Daphne): a dependent who is NOT an IRC 21 qualifying
+# individual (age 14, over the CDCC child-age limit of 13, not disabled)
+# generates no subtraction even with childcare expenses and earnings, because
+# cdcc_relevant_expenses is 0 when count_cdcc_eligible == 0.
+- name: Case 4, no IRC 21 qualifying individual yields no subtraction.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 40_000
+      person2:
+        age: 14
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_childcare_expenses: 5_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AZ
+  output:
+    count_cdcc_eligible: 0
+    cdcc: 0
+    az_dependent_care_expense_subtraction: 0
+
+# Positive case: a young qualifying child (age 5) with childcare expenses that
+# exceed the federal CDCC. The subtraction equals cdcc_relevant_expenses - cdcc.
+- name: Case 5, young qualifying child with expenses exceeding the federal credit.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 40_000
+      person2:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_childcare_expenses: 5_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AZ
+  output:
+    # cdcc_relevant_expenses = min($5,000, $3,000 limit, $40,000 earnings)
+    #   = $3,000
+    # cdcc = $3,000 * 0.37 rate = $1,110
+    # subtraction = max($3,000 - $1,110, 0) = $1,890
+    az_dependent_care_expense_subtraction: 1_890

--- a/policyengine_us/variables/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/deductions/itemized/az_itemized_deductions.py
@@ -11,6 +11,7 @@ class az_itemized_deductions(Variable):
     defined_for = StateCode.AZ
     reference = (
         "https://law.justia.com/codes/arizona/2022/title-43/section-43-1042/",
+        "https://www.azleg.gov/ars/43/01042.htm",
         "https://azdor.gov/forms/individual/itemized-deduction-adjustments-form",
         "https://azdor.gov/forms/individual/form-140-resident-personal-income-tax-form-calculating",
     )
@@ -19,6 +20,9 @@ class az_itemized_deductions(Variable):
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.irs.deductions
+        az_itemized = parameters(period).gov.states.az.tax.income.deductions.itemized
+        # Medical and charitable are handled separately below; the state and
+        # local tax deduction is also handled separately so Arizona can cap it.
         deductions = [
             deduction
             for deduction in p.itemized_deductions
@@ -26,9 +30,18 @@ class az_itemized_deductions(Variable):
             not in [
                 "medical_expense_deduction",
                 "charitable_deduction",
+                "salt_deduction",
             ]
         ]
         federal_deductions = add(tax_unit, period, deductions)
+        # Per A.R.S. 43-1042(D) (HB 4168, TY2026+), Arizona caps the state and
+        # local tax itemized deduction in lieu of IRC 164(b)(7). The cap is a
+        # flat amount before 2026 (the cap parameter is infinite, so the full
+        # federal SALT deduction passes through unchanged).
+        # NOTE: The bill states a single $10,000 cap with no single-vs-MFJ
+        # split, so it applies as a flat amount regardless of filing status.
+        salt_deduction = tax_unit("salt_deduction", period)
+        capped_salt_deduction = min_(salt_deduction, az_itemized.salt_cap)
         # Arizona allows a complete deduction for medical and dental expenses
         medical_expenses = tax_unit("itemized_medical_expenses", period)
 
@@ -49,4 +62,9 @@ class az_itemized_deductions(Variable):
         # to claim the Arizona charitable contributions credit
         # Since the Arizona charitable contributions credit is based on contributions
         # to qulalifying foster care organizations, we do not reduce the salt deduction
-        return federal_deductions + medical_expenses + charitable_deduction_after_credit
+        return (
+            federal_deductions
+            + capped_salt_deduction
+            + medical_expenses
+            + charitable_deduction_after_credit
+        )

--- a/policyengine_us/variables/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/deductions/standard/az_increased_standard_deduction_for_charitable_contributions.py
@@ -19,4 +19,13 @@ class az_increased_standard_deduction_for_charitable_contributions(Variable):
         charitable_deduction_after_credit = max_(
             charitable_deduction - charitable_contributions_credit, 0
         )
-        return p.rate * charitable_deduction_after_credit
+        # Through TY2025, the add-on is a share of charitable contributions
+        # (the rate). From TY2026 (HB 4168), the rate is zero and the add-on
+        # becomes the full IRC 170(c) charitable contribution amount, capped
+        # by filing status. The two regimes do not overlap.
+        rate_based_amount = p.rate * charitable_deduction_after_credit
+        filing_status = tax_unit("az_filing_status", period)
+        capped_full_amount = min_(
+            charitable_deduction_after_credit, p.cap[filing_status]
+        )
+        return rate_based_amount + capped_full_amount

--- a/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution.py
@@ -9,5 +9,5 @@ class az_530a_distribution(Variable):
     definition_period = YEAR
     reference = (
         "https://www.azleg.gov/ars/43/01022.htm",
-        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf",
+        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=28",
     )

--- a/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class az_530a_distribution(Variable):
+    value_type = float
+    entity = Person
+    label = "Distribution from an Internal Revenue Code section 530A account"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.azleg.gov/ars/43/01022.htm",
+        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf",
+    )

--- a/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution_subtraction.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution_subtraction.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class az_530a_distribution_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = (
+        "Arizona Internal Revenue Code section 530A account distribution subtraction"
+    )
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.AZ
+    reference = (
+        "https://www.azleg.gov/ars/43/01022.htm",
+        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf",
+    )
+
+    adds = ["az_530a_distribution"]

--- a/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution_subtraction.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_530a_distribution_subtraction.py
@@ -12,7 +12,7 @@ class az_530a_distribution_subtraction(Variable):
     defined_for = StateCode.AZ
     reference = (
         "https://www.azleg.gov/ars/43/01022.htm",
-        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf",
+        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=28",
     )
 
     adds = ["az_530a_distribution"]

--- a/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class az_dependent_care_expense_subtraction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Arizona dependent care expense subtraction"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.AZ
+    reference = (
+        "https://www.azleg.gov/ars/43/01022.htm",
+        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf",
+    )
+
+    def formula(tax_unit, period, parameters):
+        # A.R.S. 43-1022(34) (HB 4168, TY2026+): the amount of child and
+        # dependent care expenses under IRC 21 paid or incurred for the taxable
+        # year that exceeds the amount of the federal credit received under
+        # IRC 21. The bill sets no cap.
+        expenses = tax_unit("tax_unit_childcare_expenses", period)
+        federal_credit = tax_unit("cdcc", period)
+        return max_(expenses - federal_credit, 0)

--- a/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/subtractions/az_dependent_care_expense_subtraction.py
@@ -10,14 +10,17 @@ class az_dependent_care_expense_subtraction(Variable):
     defined_for = StateCode.AZ
     reference = (
         "https://www.azleg.gov/ars/43/01022.htm",
-        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168P.pdf",
+        "https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf#page=28",
     )
 
     def formula(tax_unit, period, parameters):
-        # A.R.S. 43-1022(34) (HB 4168, TY2026+): the amount of child and
-        # dependent care expenses under IRC 21 paid or incurred for the taxable
-        # year that exceeds the amount of the federal credit received under
-        # IRC 21. The bill sets no cap.
-        expenses = tax_unit("tax_unit_childcare_expenses", period)
+        # A.R.S. 43-1022(34) (HB 4168, TY2026+): "the amount of child and
+        # dependent care expenses for a qualifying individual under section 21
+        # of the internal revenue code paid or incurred ... that exceeds the
+        # amount of the federal credit ... under section 21." The expense base
+        # is cdcc_relevant_expenses, which applies the IRC 21 dollar and
+        # earned-income limits and equals 0 when there is no qualifying
+        # individual (count_cdcc_eligible == 0).
+        expenses = tax_unit("cdcc_relevant_expenses", period)
         federal_credit = tax_unit("cdcc", period)
         return max_(expenses - federal_credit, 0)


### PR DESCRIPTION
## What this does

Implements the household-relevant individual income tax provisions of **Arizona HB 4168** (2026 omnibus taxation bill, "taxation; omnibus; 2026-2027"), all effective **TY2026** per the bill's Sec. 35.B retroactivity clause. Bill text: https://www.azleg.gov/legtext/57leg/2R/bills/HB4168H.pdf

Closes #8714.

## Changes (all effective 2026-01-01)

| Provision | Statute | Change |
|---|---|---|
| **Dependent credit** | 43-1073.01 | Under-17 amount **$100 → $125** (17+ stays $25; phaseouts unchanged) |
| **Charitable standard-deduction add-on** | 43-1041(I) | Rate-based regime ends after TY2025; replaced with the **full IRC 170(c) contribution amount capped at $1,000** (single/MFS/HoH) **/ $2,000** (MFJ) |
| **Itemized SALT cap** | 43-1042(D) | New **$10,000 flat cap** on the state/local tax itemized deduction (in lieu of IRC 164(b)(7)), decoupling AZ from the higher federal OBBBA cap |
| **New subtractions** | 43-1022 | Add child & dependent care (IRC 21 expenses exceeding the federal CDCC) and **IRC 530A** account distributions |
| **Car-loan interest subtraction** | 43-1022 | Sunsets after TY2025 — dropped from the 2026 subtractions list |

## Implementation notes

- **Backward compatible**: the SALT cap parameter is `.inf` before 2026 and the charitable cap is `0` before 2026, so the rate-based charitable regime and uncapped SALT pass through unchanged for ≤TY2025. The full pre-2026 AZ regression suite passes.
- The charitable add-on switches cleanly: through TY2025 the rate (0.34) applies and the cap is 0; from TY2026 the rate is 0 and the cap applies — the two regimes never overlap.
- The $10,000 SALT cap text states no single-vs-MFJ split, so it is applied as a flat amount per return (noted in a code comment). The bill is also silent on the HoH charitable cap, so the $1,000 single cap is applied to HoH (noted in the parameter).
- 530A distributions are modeled via a new person-level input variable (no federal 530A source variable exists yet) summed to the tax unit.

## Already conformed — intentionally not changed

- **Standard deduction amounts** ($15,750 / $23,625 / $31,500): already present at 2025-01-01 via federal conformity (`uprating: gov.irs.uprating`).
- **Adoption subtraction** ($5,000 / $10,000): already present at 2026-01-01.
- **Tips / overtime / senior subtractions**: already modeled (2025).
- **IRC conformity date** (43-105): handled via federal linkage.
- **Repealed/amended corporate credits** (43-1074, 43-1161, 43-1170, etc.): not modeled in PolicyEngine.

## Tests

Added YAML tests for each change (dependent credit, charitable cap, SALT cap, dependent-care subtraction, 530A subtraction) plus integration tests confirming the combined 2026 effect and that a 2025 household is unchanged. **All AZ income tax tests pass (284 cases, no regressions).** Changelog fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
