### PR TITLE
Cap DE non-refundable credits per spouse on separate/combined returns

### DIFF
--- a/changelog.d/de-separate-combined-credit-cap.fixed.md
+++ b/changelog.d/de-separate-combined-credit-cap.fixed.md
@@ -1,0 +1,1 @@
+Cap Delaware non-refundable credits at each spouse's own tax before credits on a separate/combined return rather than the combined tax-unit liability.

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
@@ -67,6 +67,46 @@
     de_income_tax_before_non_refundable_credits_unit: 1_750.25
     de_income_tax_before_refundable_credits: 1_650.25
 
+# Regression test for policyengine-taxsim#1007: on a separate/combined return,
+# each spouse's non-refundable credits are capped at that spouse's own tax
+# before credits, so one spouse's surplus personal credit cannot offset the
+# other spouse's tax.
+- name: Separate/combined return caps each spouse's non-refundable credits at their own tax
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 20
+        taxable_interest_income: 10_895.24
+        is_tax_unit_head: true
+      spouse:
+        age: 20
+        taxable_interest_income: 10_895.24
+        is_tax_unit_spouse: true
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, spouse, child]
+        filing_status: JOINT
+    households:
+      household:
+        members: [head, spouse, child]
+        state_code: DE
+  output:
+    de_files_separately: true
+    # Per spouse: taxable income $7,645.24 -> tax $169.16.
+    de_taxable_income_indv: [7_645.24, 7_645.24, 0]
+    de_income_tax_before_non_refundable_credits_indv: [169.16, 169.16, 0]
+    # Personal credit: head column = self + dependent = 2 x $110 = $220;
+    # spouse column = 1 x $110 = $110. Each capped at its own $169.16 tax:
+    # min(220, 169.16) + min(110, 169.16) = 169.16 + 110 = 279.16.
+    # (Pre-fix PE pooled all $330 against the $338.33 combined tax -> $8.33.)
+    de_non_refundable_credits: 279.16
+    de_income_tax_before_refundable_credits: 59.17
+
 #new baseline integration test
 - name: baseline integration test separate
   period: 2022
@@ -224,8 +264,19 @@
       household:
         members: [person1, person2, person3]
         state_fips: 10  # DE
-  output:  # expected results from patched TAXSIM35 2024-04-04 version
-    de_income_tax: 2429.20
+  output:
+    # This couple files separately (Filing Status 4). Per-column tax before
+    # credits: person1 (head) $6.05, person2 (spouse) $3,225.65.
+    # Each spouse's own personal + aged credits ($220) are capped at their own
+    # tax: person1 uses $6.05 (the rest of their $220 is unusable against $6.05
+    # of tax), person2 uses $220. The allocable credits (dependent's $110
+    # personal credit + $252.50 child care credit = $362.50) are placed in
+    # person2's column, which has the remaining capacity, and are fully used.
+    # Total credits = 6.05 + 220 + 362.50 = 588.55; tax = 3,231.70 - 588.55.
+    # The prior expected value ($2,429.20) came from TAXSIM-35, which pools the
+    # credits against combined tax and so wrongly lets person1's unusable
+    # credits offset person2's tax (see policyengine-taxsim#1007).
+    de_income_tax: 2643.15
 
 - name: Tax unit with taxsimid 22359 in k21.its.csv and k21.ots.csv
   absolute_error_margin: 0.01

--- a/policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits.py
@@ -16,9 +16,38 @@ class de_non_refundable_credits(Variable):
         ordered_credits = parameters(
             period
         ).gov.states.de.tax.income.credits.non_refundable
-        return ordered_capped_state_non_refundable_credits(
+        joint_credits = ordered_capped_state_non_refundable_credits(
             tax_unit,
             period,
             ordered_credits,
             "de_income_tax_before_non_refundable_credits_unit",
         )
+        # On a separate/combined return (Filing Status 4) each spouse's
+        # non-refundable credits are limited to that spouse's own tax before
+        # credits, so surplus credit in one column cannot offset the other
+        # spouse's tax.
+        person = tax_unit.members
+        own_credits = person("de_non_refundable_credits_indv", period)
+        indv_tax = person("de_income_tax_before_non_refundable_credits_indv", period)
+        # Each spouse first applies their own (column-tied) credits against
+        # their own tax.
+        own_credits_used = tax_unit.sum(min_(own_credits, indv_tax))
+        # Credits the filers may allocate between columns: dependents' personal
+        # credits, the child/dependent care credit and the non-refundable EITC.
+        # A filer minimizing tax assigns them to the column with the most
+        # remaining tax (Form PIT-RES lets exemptions be allocated between
+        # columns). Place the whole allocable amount in the higher-capacity
+        # column, capped at that column's remaining tax.
+        p = parameters(period).gov.states.de.tax.income.credits.personal_credits
+        dependents = tax_unit("tax_unit_dependents", period)
+        allocable_credits = (
+            dependents * p.personal
+            + tax_unit("de_cdcc_potential", period)
+            + tax_unit("de_non_refundable_eitc_potential", period)
+        )
+        remaining_capacity = max_(indv_tax - own_credits, 0)
+        largest_remaining_capacity = tax_unit.max(remaining_capacity)
+        allocable_used = min_(allocable_credits, largest_remaining_capacity)
+        separate_credits = own_credits_used + allocable_used
+        files_separately = tax_unit("de_files_separately", period)
+        return where(files_separately, separate_credits, joint_credits)

--- a/policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits_indv.py
+++ b/policyengine_us/variables/gov/states/de/tax/income/de_non_refundable_credits_indv.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class de_non_refundable_credits_indv(Variable):
+    value_type = float
+    entity = Person
+    label = "Delaware non-allocable non-refundable credits for each spouse on a separate/combined return"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://revenuefiles.delaware.gov/2025/PITForms_Instructions/Instructions/PIT-RES_Instructions_2025-01.pdf#page=8"
+    defined_for = StateCode.DE
+
+    def formula(person, period, parameters):
+        # On a separate/combined return (Filing Status 4) each spouse's
+        # non-refundable credits are limited to that spouse's own tax before
+        # credits (Form PIT-RES, Line 32 cannot exceed Line 26 per column).
+        # This variable holds the credits that are tied to a specific spouse's
+        # column and cannot be moved: each filer's own personal credit and, if
+        # age 60 or over, their own aged personal credit. Credits that the
+        # filers may allocate between columns (dependents' personal credits,
+        # the child/dependent care credit, the non-refundable EITC) are handled
+        # in de_non_refundable_credits.
+        p = parameters(period).gov.states.de.tax.income.credits.personal_credits
+        is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        personal_credit = is_head_or_spouse * p.personal
+        age = person("age", period)
+        aged_credit = is_head_or_spouse * p.aged.calc(age)
+        return personal_credit + aged_credit


### PR DESCRIPTION
Fixes #8710. **Draft for review** — flagging one TAXSIM-validated test change below.

## What

On a Delaware separate/combined return (Filing Status 4, `de_files_separately = True`), each spouse's non-refundable credits are limited to that spouse's **own** tax before credits (Form PIT-RES Line 32 ≤ Line 26, per column). PolicyEngine previously capped the *pooled* credits against the combined tax-unit liability, so one spouse's surplus personal credit could offset the other spouse's tax.

## Approach

- New person-level `de_non_refundable_credits_indv` holds each spouse's **column-tied** credits (own personal credit + own aged personal credit), which cannot move between columns.
- `de_non_refundable_credits`, when filing separately:
  1. applies each spouse's own credits against their own tax: `Σ min(own_i, tax_i)`;
  2. places the **allocable** credits (dependents' personal credits, child/dependent care credit, non-refundable EITC) in the column with the most remaining capacity, capped there — as a tax-minimizing filer would, since the form allows allocating exemptions between columns.
- Joint filers are unaffected (existing pooled cap retained).

## Results

| Case | Before | After |
|---|---|---|
| #1007 household (MFJ, 2 filers + 1 dep, equal-tax columns) | $8.33 | **$59.17** (≈ form's $58) |
| taxsimid 2682 (head $6.05 tax, spouse $3,225.65 tax, 1 dep + CDCC) | $2,429.20 | **$2,643.15** |

## ⚠️ Test change to review

This updates the existing `taxsimid 2682` integration test: `de_income_tax` **$2,429.20 → $2,643.15**. That prior value came from **TAXSIM-35, which pools the credits against combined tax** — exactly the behavior this PR fixes. In that household the head has only $6.05 of tax, so $213.95 of their own personal+aged credit is unusable; TAXSIM (and old PE) wrongly let it offset the spouse's tax. The new value is the correct per-column result, and is verified to still be lower than filing jointly ($2,705.30), so the couple's separate-filing choice remains valid. I don't have a filled DE form for this synthetic TAXSIM case, so this expected value is derived from the per-column logic confirmed by the #1007 form — please scrutinize.

## Tests

- Added a #1007 regression test (separate/combined, per-column cap → $59.17).
- Full DE suite passes (295 tests) with the 2682 update.

## Known limitation

Allocable credits are placed entirely in the single highest-capacity column. If allocable credits exceed that column's capacity, the remainder is not spilled to the other column (a rare edge case). Noted for reviewer.

## Context

Reported by Daniel Feenberg (NBER TAXSIM) in [PolicyEngine/policyengine-taxsim#1007](https://github.com/PolicyEngine/policyengine-taxsim/issues/1007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
