### PR TITLE
Base VT Child Care Contribution on net self-employment earnings (Schedule SE Line 6)

### DIFF
--- a/changelog.d/vt-ccc-self-employment-base.fixed.md
+++ b/changelog.d/vt-ccc-self-employment-base.fixed.md
@@ -1,0 +1,1 @@
+Base the Vermont Child Care Contribution on net self-employment earnings (Schedule SE Line 6) rather than gross self-employment income.

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/integration.yaml
@@ -24,7 +24,11 @@
         members: [person1]
         state_fips: 50
   output:
-    vt_income_tax: 7_963
+    # The Child Care Contribution is now computed on net self-employment
+    # earnings (Schedule SE Line 6 = $101,585) rather than gross
+    # self-employment income ($110,000), lowering it from $60.50 to $55.87 and
+    # vt_income_tax from ~$7,963 to $7,958.51. See policyengine-taxsim#1002.
+    vt_income_tax: 7_958.51
 
 # From GitHub issue #7291: VT capital gains exclusion incorrectly applies to financial instruments
 # Financial instrument gains (stocks/bonds) are NOT eligible for the 40% exclusion.

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/vt_child_care_contributions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/vt_child_care_contributions.yaml
@@ -1,18 +1,27 @@
-- name: In 2024, only 50% of the self-employment income is counted towards the child care contributions
-  period: 2024
-  input:
-    self_employment_income: 10_000
-    state_code: VT
-  output:
-    vt_child_care_contributions: 5.5
+# The Child Care Contribution Worksheet applies the 0.11% rate to net
+# earnings from self-employment (federal Schedule SE, Line 6 =
+# taxable_self_employment_income = 92.35% of net self-employment profit).
 
-- name: In 2025, all of the self-employment income is counted towards the child care contributions
-  period: 2025
+- name: In 2024, only 50% of the net self-employment earnings are counted towards the child care contributions
+  period: 2024
+  absolute_error_margin: 0.01
   input:
     self_employment_income: 10_000
     state_code: VT
   output:
-    vt_child_care_contributions: 11
+    # Net SE earnings = 9,235 (92.35%); 50% counted in 2024:
+    # 9,235 * 0.5 * 0.0011 = 5.08
+    vt_child_care_contributions: 5.08
+
+- name: In 2025, all of the net self-employment earnings are counted towards the child care contributions
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    self_employment_income: 10_000
+    state_code: VT
+  output:
+    # Net SE earnings = 9,235 (92.35%); 9,235 * 0.0011 = 10.16
+    vt_child_care_contributions: 10.16
 
 - name: Only self-employment income is taxed
   period: 2025
@@ -25,12 +34,14 @@
 
 - name: Mixed income
   period: 2025
+  absolute_error_margin: 0.01
   input:
     self_employment_income: 1_000
     employment_income: 10_000
     state_code: VT
   output:
-    vt_child_care_contributions: 1.1
+    # Net SE earnings = 923.50; 923.50 * 0.0011 = 1.02
+    vt_child_care_contributions: 1.02
 
 - name: Negative self-employment income
   period: 2024
@@ -42,8 +53,23 @@
 
 - name: SSTB self-employment income is counted toward the child care contributions
   period: 2025
+  absolute_error_margin: 0.01
   input:
     sstb_self_employment_income: 10_000
     state_code: VT
   output:
-    vt_child_care_contributions: 11
+    # Net SE earnings = 9,235 (92.35%); 9,235 * 0.0011 = 10.16
+    vt_child_care_contributions: 10.16
+
+# Regression test for policyengine-taxsim#1002: the contribution is computed on
+# net self-employment earnings (Schedule SE Line 6), matching the VT Child Care
+# Contribution Worksheet (which yields $81 for this filer), not gross SE income.
+- name: Contribution uses net self-employment earnings, matching the VT worksheet
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    self_employment_income: 79_684.13
+    state_code: VT
+  output:
+    # Net SE earnings = 73,588.30 (92.35%); 73,588.30 * 0.0011 = 80.95
+    vt_child_care_contributions: 80.95

--- a/policyengine_us/variables/gov/states/vt/tax/income/vt_child_care_contributions.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/vt_child_care_contributions.py
@@ -12,7 +12,11 @@ class vt_child_care_contributions(Variable):
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.vt.tax.income.child_care_contributions
         if p.applies:
-            income = add(tax_unit, period, ["total_self_employment_income"])
+            # The Child Care Contribution Worksheet applies the rate to net
+            # earnings from self-employment (federal Schedule SE, Line 6),
+            # i.e. taxable_self_employment_income, not gross self-employment
+            # income.
+            income = add(tax_unit, period, ["taxable_self_employment_income"])
             applicable_income = max_(0, income) * p.rate.income
             return applicable_income * p.rate.contributions
         return 0


### PR DESCRIPTION
Fixes #8725. **Draft for review.**

## What

The Vermont Child Care Contribution for self-employed individuals was computed on **gross** self-employment income, but the Child Care Contribution Worksheet applies the 0.11% rate to **net earnings from self-employment** (federal Schedule SE, Line 6) — `taxable_self_employment_income` (92.35% of net SE profit).

```diff
- income = add(tax_unit, period, ["total_self_employment_income"])
+ income = add(tax_unit, period, ["taxable_self_employment_income"])
```

## Result (matches the VT worksheet)

For the #1002 filer ($79,684.13 self-employment income, 2025):

| | Base | × 0.11% | Result |
|---|---|---|---|
| Before | gross $79,684.13 | 0.0011 | $87.65 |
| **After** | net $73,588.30 (Sch SE L6) | 0.0011 | **$80.95** (worksheet: $81) |

## Tests

- Updated the existing unit tests to the net base (e.g. 2025 $10k SE: $11 → $10.16).
- Added a regression test matching the VT worksheet ($79,684 → $80.95).
- Updated the `taxsim_record_1_2024` integration test: `vt_income_tax` $7,963 → $7,958.51 (the $4.49 change is entirely the corrected CCC base — old CCC $60.50 → new $55.87 on $110k SE income; verified no other effect).
- Full VT suite passes (344 tests).

## Note (out of scope)

As flagged in #8725, `vt_child_care_contributions` is added into `vt_income_tax` but does not flow into the national `state_income_tax` aggregator. Whether the contribution belongs in `state_income_tax` is a separate modeling decision, not addressed here.

## Context

Reported by Daniel Feenberg (NBER TAXSIM) in [PolicyEngine/policyengine-taxsim#1002](https://github.com/PolicyEngine/policyengine-taxsim/issues/1002).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
