### PR TITLE
Run reform YAML tests per-file in a dedicated CI job (fix OOM)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -299,8 +299,25 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
         run: uv run make test-yaml-variables
-      - name: Run tests/policy/reform YAML tests
-        if: always()
+  Reform:
+    name: Full Suite - Reform (per-file)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Turn off default branching
+        shell: bash
+        run: bash ./update_itemization.sh
+      - name: Run tests/policy/reform YAML tests (one batch per file)
         env:
           PYTHONUNBUFFERED: 1
         run: uv run make test-yaml-reform

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -197,8 +197,28 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
         run: uv run make test-yaml-variables
-      - name: Run tests/policy/reform YAML tests
-        if: always()
+  Reform:
+    name: Full Suite - Reform (per-file)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: |
+      (github.repository == 'PolicyEngine/policyengine-us')
+      && (github.event.head_commit.message == 'Update PolicyEngine US')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Turn off default branching
+        shell: bash
+        run: bash ./update_itemization.sh
+      - name: Run tests/policy/reform YAML tests (one batch per file)
         env:
           PYTHONUNBUFFERED: 1
         run: uv run make test-yaml-reform
@@ -207,7 +227,7 @@ jobs:
     if: |
       (github.repository == 'PolicyEngine/policyengine-us')
       && (github.event.head_commit.message == 'Update PolicyEngine US')
-    needs: [Baseline, HouseholdAPIPartners, Contrib, Rest]
+    needs: [Baseline, HouseholdAPIPartners, Contrib, Rest, Reform]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-yaml-no-structural-other:
 	$(BATCH) $(TESTS)/policy/baseline --batches 2 --exclude states
 	$(BATCH) $(TESTS)/policy/baseline/household --batches 1
 	$(BATCH) $(TESTS)/policy/baseline/contrib --batches 1
-	$(BATCH) $(TESTS)/policy/reform --batches 1
+	$(BATCH) $(TESTS)/policy/reform --mode per-file
 test-yaml-no-structural-other-irs:
 	# One subprocess per irs subfolder + trailing batch for loose yamls.
 	$(BATCH) $(TESTS)/policy/baseline/gov/irs --mode per-subdir
@@ -79,7 +79,12 @@ test-yaml-no-structural-other-contrib:
 	$(BATCH) $(TESTS)/policy/baseline/contrib/ubi_center --mode per-file
 	$(BATCH) $(TESTS)/policy/baseline/contrib --exclude ubi_center --mode per-subdir
 test-yaml-reform:
-	$(BATCH) $(TESTS)/policy/reform --batches 1
+	# Reforms are force-applied and deepcopy the full parameter tree
+	# (~5.5 GB peak/file for ctc_linear_phase_out and winship, measured).
+	# Running all files in one subprocess stacks past the 16 GB runner cap
+	# → "runner received a shutdown signal". One batch per file frees each
+	# peak between files; new reform files auto-route.
+	$(BATCH) $(TESTS)/policy/reform --mode per-file
 test-yaml-no-structural-other-ssa:
 	# revenue is heavy enough to need its own 2-batch split; others auto-fan.
 	$(BATCH) $(TESTS)/policy/baseline/gov/ssa/revenue --batches 2

--- a/changelog.d/ci-reform-per-file.fixed.md
+++ b/changelog.d/ci-reform-per-file.fixed.md
@@ -1,0 +1,1 @@
+Run reform YAML tests one file per subprocess in a dedicated CI job to fix out-of-memory failures.

--- a/policyengine_us/tests/test_batched.py
+++ b/policyengine_us/tests/test_batched.py
@@ -156,9 +156,14 @@ def split_into_batches(
 
         return batches if batches else [[str(base_path)]]
 
-    # Special handling for reform tests - run all together in one batch
+    # Special handling for reform tests - one batch per file. Reforms are
+    # force-applied and deepcopy the full parameter tree (~5.5 GB peak/file
+    # for ctc_linear_phase_out and winship, measured); running all files in
+    # one subprocess stacks past the 16 GB runner cap → "runner received a
+    # shutdown signal". A fresh subprocess per file frees each peak between
+    # files.
     if "reform" in str(base_path):
-        return [[str(base_path)]]
+        return [[str(f)] for f in sorted(base_path.rglob("*.yaml"))]
 
     # Special handling for states directory - support excluding specific states
     # and splitting into multiple sequential batches for memory management


### PR DESCRIPTION
## Summary

The **Rest** job on push-to-`main` has been failing (e.g. run [28028999846](https://github.com/PolicyEngine/policyengine-us/actions/runs/28028999846)) at the `Run tests/policy/reform YAML tests` step. The job hung for ~16 minutes with zero output, then died with `The runner has received a shutdown signal` / `The operation was canceled` — **before** its 60-min timeout. That signature is the documented out-of-memory mode on the 16 GB `ubuntu-latest` runner (the VM thrashes into unresponsiveness and is reclaimed), not a clean OOM-kill or a timeout.

## Root cause

`make test-yaml-reform` ran all 8 reform files in **one subprocess** (`--batches 1`), and it was hardcoded to do so in `test_batched.py` regardless of flags. I measured each reform file in isolation:

| File | Cases | Test time | Peak mem footprint |
|---|---:|---:|---:|
| cdcc_single_parent_work_requirement | 5 | 20.6s | 2.93 GB |
| ctc_expansion | 3 | 25.8s | 3.19 GB |
| **ctc_linear_phase_out** | 9 | **145.8s** | **5.57 GB** |
| mo_refundable_eitc | 5 | 18.0s | 2.42 GB |
| oh_refundable_eitc | 4 | 18.5s | 2.57 GB |
| sc_fully_refundable_eitc | 8 | 22.7s | 3.15 GB |
| streamlined_eitc | 7 | 16.1s | 2.65 GB |
| **winship** | 5 | 127.4s | 5.56 GB |

**Two** files peak at ~5.5 GB each (`ctc_linear_phase_out` and `winship`), and even the "light" files are 2.4–3.2 GB. Stacked in one process they pass the 16 GB cap. winship only *appeared* guilty in the log because it's alphabetically last — it's where the accumulating process finally ran out of headroom. This was tipped over the edge by the recently-merged `sc_fully_refundable_eitc` reform adding to the same single batch.

## Fix

Run reform tests **one file per subprocess** so each file's peak is freed between files (peak per process caps at ~5.6 GB, well under 16 GB) and the suite is immune to future reform additions. This mirrors the existing per-file isolation already used for `ubi_center`, `crfb`, `refundable_credit_conversion`, and RI's reform tests.

- `Makefile`: `test-yaml-reform` and `test-yaml-no-structural-other` now use `--mode per-file`.
- `test_batched.py`: the reform special-case returns one batch per file (source-of-truth matches, even without the flag).
- `pr.yaml` / `push.yaml`: reform moves out of the **Rest** job into its own dedicated **Reform** job (runs in parallel; per-file = 8 sequential subprocess batches within that job). Added `Reform` to `Publish.needs`.

## Impact on runner count

The PR workflow goes from **26 → 27** jobs (the new `Reform` job). This is redistribution, not net-new work: the reform step was removed from `Rest` (which is now shorter), and reform now runs in parallel instead of serially after Rest's Python + variables tests. The only added cost is the new job's ~1–2 min setup.

## Test plan

- [x] Each reform file passes when run in isolation (measured above — all green).
- [x] `split_into_batches` yields 8 single-file batches for the reform path (both `--mode per-file` and the special-case fallback).
- [x] `pr.yaml` / `push.yaml` validate with PyYAML; `Rest` no longer runs reform; `Reform` job present; `Publish.needs` includes `Reform`.
- [x] `make format` clean.
- [ ] CI passes (the new `Reform` job is exercised by this PR's `pr.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
