### PR TITLE
Add source-aligned calibration variables

### DIFF
--- a/changelog.d/source-aligned-calibration-variables.added.md
+++ b/changelog.d/source-aligned-calibration-variables.added.md
@@ -1,0 +1,1 @@
+Added a CBO source-aligned net business income variable for calibration target matching, and made ordinary dividend income the canonical variable while keeping dividend income as a legacy compatibility alias.

--- a/policyengine_us/tests/policy/baseline/gov/cbo/income/cbo_net_business_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/cbo/income/cbo_net_business_income.yaml
@@ -1,0 +1,27 @@
+- name: Case 1, source concept includes sole proprietor partnership S-corporation rental and farm rental income.
+  period: 2024
+  input:
+    people:
+      person1:
+        self_employment_income_before_lsr: 10_000
+        partnership_income: 20_000
+        s_corp_income: 30_000
+        rental_income: 40_000
+        farm_rent_income: 5_000
+      person2:
+        self_employment_income_before_lsr: -1_000
+        partnership_income: 2_000
+        s_corp_income: 3_000
+        rental_income: -4_000
+        farm_rent_income: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    # Self-employment: 10,000 - 1,000 = 9,000
+    # Partnership/S-corp: 20,000 + 30,000 + 2,000 + 3,000 = 55,000
+    # Rental: 40,000 - 4,000 = 36,000
+    # Farm rental: 5,000 + 6,000 = 11,000
+    tax_unit_partnership_s_corp_income: 55_000
+    tax_unit_rental_income: 36_000
+    cbo_net_business_income: 111_000

--- a/policyengine_us/tests/policy/baseline/household/income/person/ordinary_dividend_income.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/ordinary_dividend_income.yaml
@@ -1,0 +1,15 @@
+- name: Ordinary dividend income is qualified plus non-qualified dividend income.
+  period: 2024
+  input:
+    qualified_dividend_income: 600
+    non_qualified_dividend_income: 400
+  output:
+    ordinary_dividend_income: 1_000
+    dividend_income: 1_000
+
+- name: Legacy dividend income alias follows ordinary dividend income when supplied directly.
+  period: 2024
+  input:
+    ordinary_dividend_income: 1_200
+  output:
+    dividend_income: 1_200

--- a/policyengine_us/variables/gov/cbo/income/cbo_net_business_income.py
+++ b/policyengine_us/variables/gov/cbo/income/cbo_net_business_income.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class cbo_net_business_income(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "CBO net business income"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.cbo.gov/system/files/2026-02/"
+        "51138-2026-02-Revenue-Projections.xlsx"
+    )
+    adds = [
+        "self_employment_income",
+        "tax_unit_partnership_s_corp_income",
+        "tax_unit_rental_income",
+        "farm_rent_income",
+    ]

--- a/policyengine_us/variables/household/income/person/dividends/dividend_income.py
+++ b/policyengine_us/variables/household/income/person/dividends/dividend_income.py
@@ -4,11 +4,11 @@ from policyengine_us.model_api import *
 class dividend_income(Variable):
     value_type = float
     entity = Person
-    label = "ordinary dividend income"
-    documentation = "Qualified and non-qualified dividends"
+    label = "dividend income (legacy compatibility alias)"
+    documentation = (
+        "Deprecated legacy compatibility alias for ordinary_dividend_income. "
+        "Use ordinary_dividend_income for new logic."
+    )
     unit = USD
     definition_period = YEAR
-    adds = [
-        "qualified_dividend_income",
-        "non_qualified_dividend_income",
-    ]
+    adds = ["ordinary_dividend_income"]

--- a/policyengine_us/variables/household/income/person/dividends/ordinary_dividend_income.py
+++ b/policyengine_us/variables/household/income/person/dividends/ordinary_dividend_income.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class ordinary_dividend_income(Variable):
+    value_type = float
+    entity = Person
+    label = "ordinary dividend income"
+    documentation = "Qualified and non-qualified dividends"
+    unit = USD
+    definition_period = YEAR
+    reference = "https://www.irs.gov/pub/irs-pdf/f1040.pdf"
+    adds = [
+        "qualified_dividend_income",
+        "non_qualified_dividend_income",
+    ]


### PR DESCRIPTION
## Summary
- add `cbo_net_business_income` for CBO source-aligned calibration targets
- make `ordinary_dividend_income` the canonical computed dividend total from `qualified_dividend_income` + `non_qualified_dividend_income`
- keep `dividend_income` as the legacy compatibility alias from the earlier commit, but do not add a separate SOI dividend variable

## Why
Populace should emit dividend leaves only. A dataset that stores qualified, non-qualified, and total dividends can become internally inconsistent; Populace PR #182 blocks redundant dividend-total exports and relies on PE-US to compute ordinary dividends from leaves.

## Tests
- `uv run ruff check policyengine_us/variables/household/income/person/dividends/ordinary_dividend_income.py policyengine_us/variables/gov/cbo/income/cbo_net_business_income.py`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/income/person/ordinary_dividend_income.yaml policyengine_us/tests/policy/baseline/gov/cbo/income/cbo_net_business_income.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/income/person/market_income.yaml -c policyengine_us`