### PR TITLE
Avoid county fallback when FIPS is valid

### DIFF
--- a/changelog.d/county-fips-fallback.fixed.md
+++ b/changelog.d/county-fips-fallback.fixed.md
@@ -1,0 +1,1 @@
+Avoid calculating the default county fallback when county FIPS inputs fully determine household counties.

--- a/policyengine_us/tests/core/test_county_fips_fallback.py
+++ b/policyengine_us/tests/core/test_county_fips_fallback.py
@@ -76,3 +76,19 @@ def test_county_with_mixed_fips_preserves_known_rows_and_falls_back():
         "ALAMEDA_COUNTY_CA",
     ]
     assert simulation.tracer.get_nb_requests("first_county_in_state") == 1
+
+
+def test_county_with_invalid_fips_uses_first_county_fallback():
+    situation = _two_household_situation()
+    situation["households"]["household_1"]["county_fips"] = {"2026": "99999"}
+    situation["households"]["household_2"]["county_fips"] = {"2026": "88888"}
+    simulation = Simulation(situation=situation)
+    simulation.trace = True
+
+    county_str = simulation.calculate("county_str", 2026)
+
+    assert county_str.tolist() == [
+        "ALBANY_COUNTY_NY",
+        "ALAMEDA_COUNTY_CA",
+    ]
+    assert simulation.tracer.get_nb_requests("first_county_in_state") == 1

--- a/policyengine_us/tests/core/test_county_fips_fallback.py
+++ b/policyengine_us/tests/core/test_county_fips_fallback.py
@@ -1,0 +1,78 @@
+from policyengine_us import Simulation
+
+
+def _two_household_situation() -> dict:
+    return {
+        "people": {
+            "person_1": {"age": {"2026": 30}},
+            "person_2": {"age": {"2026": 40}},
+        },
+        "tax_units": {
+            "tax_unit_1": {"members": ["person_1"]},
+            "tax_unit_2": {"members": ["person_2"]},
+        },
+        "spm_units": {
+            "spm_unit_1": {"members": ["person_1"]},
+            "spm_unit_2": {"members": ["person_2"]},
+        },
+        "families": {
+            "family_1": {"members": ["person_1"]},
+            "family_2": {"members": ["person_2"]},
+        },
+        "households": {
+            "household_1": {
+                "members": ["person_1"],
+                "state_code": {"2026": "NY"},
+                "county_fips": {"2026": "36059"},
+            },
+            "household_2": {
+                "members": ["person_2"],
+                "state_code": {"2026": "CA"},
+                "county_fips": {"2026": "06037"},
+            },
+        },
+    }
+
+
+def test_county_with_valid_fips_skips_first_county_fallback():
+    simulation = Simulation(situation=_two_household_situation())
+    simulation.trace = True
+
+    county_str = simulation.calculate("county_str", 2026)
+
+    assert county_str.tolist() == [
+        "NASSAU_COUNTY_NY",
+        "LOS_ANGELES_COUNTY_CA",
+    ]
+    assert simulation.tracer.get_nb_requests("first_county_in_state") == 0
+
+
+def test_county_with_missing_fips_uses_first_county_fallback():
+    situation = _two_household_situation()
+    situation["households"]["household_1"]["county_fips"] = {"2026": ""}
+    situation["households"]["household_2"]["county_fips"] = {"2026": ""}
+    simulation = Simulation(situation=situation)
+    simulation.trace = True
+
+    county_str = simulation.calculate("county_str", 2026)
+
+    assert county_str.tolist() == [
+        "ALBANY_COUNTY_NY",
+        "ALAMEDA_COUNTY_CA",
+    ]
+    assert simulation.tracer.get_nb_requests("first_county_in_state") == 1
+
+
+def test_county_with_mixed_fips_preserves_known_rows_and_falls_back():
+    situation = _two_household_situation()
+    situation["households"]["household_2"]["county_fips"] = {"2026": ""}
+    simulation = Simulation(situation=situation)
+    simulation.trace = True
+
+    county_str = simulation.calculate("county_str", 2026)
+
+    assert county_str.tolist() == [
+        "NASSAU_COUNTY_NY",
+        "ALAMEDA_COUNTY_CA",
+    ]
+    assert simulation.tracer.get_nb_requests("first_county_in_state") == 1

--- a/policyengine_us/tools/geography/county_helpers.py
+++ b/policyengine_us/tools/geography/county_helpers.py
@@ -1,7 +1,12 @@
 from importlib import resources
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
+
+from policyengine_us.variables.household.demographic.geographic.county.county_enum import (
+    County,
+)
 
 
 DATA_FOLDER = Path("data")
@@ -34,3 +39,25 @@ def load_county_fips_dataset() -> pd.DataFrame:
     )
     with package_dataset.open("rb") as dataset_file:
         return _read_county_fips_dataset(dataset_file)
+
+
+def map_county_string_to_enum(
+    county_name: "pd.Series[str]", state_code: "pd.Series[str]"
+) -> "pd.Series[int]":
+    """Helper function to map county name and state code to County enum value."""
+    county_key = county_name.apply(
+        lambda name: (
+            name.replace(" ", "_")
+            .replace("-", "_")
+            .replace(".", "")
+            .replace("'", "_")
+            .strip()
+            .upper()
+        )
+    )
+    county_state = county_key.str.cat(state_code, sep="_")
+    county_names = pd.Series(
+        np.arange(len(County._member_names_)),
+        index=County._member_names_,
+    )
+    return county_names[county_state]

--- a/policyengine_us/tools/geography/county_helpers.py
+++ b/policyengine_us/tools/geography/county_helpers.py
@@ -1,12 +1,7 @@
 from importlib import resources
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
-
-from policyengine_us.variables.household.demographic.geographic.county.county_enum import (
-    County,
-)
 
 
 DATA_FOLDER = Path("data")
@@ -39,25 +34,3 @@ def load_county_fips_dataset() -> pd.DataFrame:
     )
     with package_dataset.open("rb") as dataset_file:
         return _read_county_fips_dataset(dataset_file)
-
-
-def map_county_string_to_enum(
-    county_name: "pd.Series[str]", state_code: "pd.Series[str]"
-) -> "pd.Series[int]":
-    """Helper function to map county name and state code to County enum value."""
-    county_key = county_name.apply(
-        lambda name: (
-            name.replace(" ", "_")
-            .replace("-", "_")
-            .replace(".", "")
-            .replace("'", "_")
-            .strip()
-            .upper()
-        )
-    )
-    county_state = county_key.str.cat(state_code, sep="_")
-    county_names = pd.Series(
-        np.arange(len(County._member_names_)),
-        index=County._member_names_,
-    )
-    return county_names[county_state]

--- a/policyengine_us/variables/household/demographic/geographic/county/county.py
+++ b/policyengine_us/variables/household/demographic/geographic/county/county.py
@@ -1,14 +1,24 @@
 from policyengine_us.model_api import *
 from policyengine_core.simulations import Simulation
-from policyengine_us.tools.geography.county_helpers import (
-    map_county_string_to_enum,
-)
 from policyengine_us.variables.household.demographic.geographic.county.county_enum import (
     County,
 )
 from policyengine_us.tools.geography.county_helpers import (
     load_county_fips_dataset,
 )
+
+
+def _county_enum_names(counties: "pd.DataFrame") -> "np.ndarray":
+    county_key = (
+        counties["county_name"]
+        .str.replace(" ", "_", regex=False)
+        .str.replace("-", "_", regex=False)
+        .str.replace(".", "", regex=False)
+        .str.replace("'", "_", regex=False)
+        .str.strip()
+        .str.upper()
+    )
+    return county_key.str.cat(counties["state"], sep="_").to_numpy(dtype=object)
 
 
 class county(Variable):
@@ -36,26 +46,29 @@ class county(Variable):
         # First look if county FIPS is provided; if so, map to county name
         county_fips: "pd.Series[str]" | None = household("county_fips", period)
 
-        result = household("first_county_in_state", period)
         county_fips = np.asarray(county_fips).astype(str)
         known_fips = county_fips != ""
-        if known_fips.any():
-            COUNTY_FIPS_DATASET: "pd.DataFrame" = load_county_fips_dataset()
-            counties = pd.merge(
-                pd.DataFrame({"county_fips": county_fips[known_fips]}),
-                COUNTY_FIPS_DATASET,
-                on="county_fips",
-                how="left",
-            )
-            valid_fips = counties["county_name"].notna().to_numpy()
-            if not valid_fips.any():
-                return result
-            known_indices = np.where(known_fips)[0]
-            county_name = counties.loc[valid_fips, "county_name"]
-            state_code = counties.loc[valid_fips, "state"]
-            result = np.array(result, copy=True)
-            result[known_indices[valid_fips]] = map_county_string_to_enum(
-                county_name,
-                state_code,
-            ).to_numpy()
+        if not known_fips.any():
+            return household("first_county_in_state", period)
+
+        COUNTY_FIPS_DATASET: "pd.DataFrame" = load_county_fips_dataset()
+        counties = pd.merge(
+            pd.DataFrame({"county_fips": county_fips[known_fips]}),
+            COUNTY_FIPS_DATASET,
+            on="county_fips",
+            how="left",
+        )
+        valid_fips = counties["county_name"].notna().to_numpy()
+        if known_fips.all() and valid_fips.all():
+            return County.encode(_county_enum_names(counties))
+
+        result = household("first_county_in_state", period)
+        if not valid_fips.any():
+            return result
+
+        known_indices = np.where(known_fips)[0]
+        result = np.array(result, copy=True)
+        result[known_indices[valid_fips]] = np.asarray(
+            County.encode(_county_enum_names(counties.loc[valid_fips]))
+        )
         return result

--- a/policyengine_us/variables/household/demographic/geographic/county/county.py
+++ b/policyengine_us/variables/household/demographic/geographic/county/county.py
@@ -5,20 +5,8 @@ from policyengine_us.variables.household.demographic.geographic.county.county_en
 )
 from policyengine_us.tools.geography.county_helpers import (
     load_county_fips_dataset,
+    map_county_string_to_enum,
 )
-
-
-def _county_enum_names(counties: "pd.DataFrame") -> "np.ndarray":
-    county_key = (
-        counties["county_name"]
-        .str.replace(" ", "_", regex=False)
-        .str.replace("-", "_", regex=False)
-        .str.replace(".", "", regex=False)
-        .str.replace("'", "_", regex=False)
-        .str.strip()
-        .str.upper()
-    )
-    return county_key.str.cat(counties["state"], sep="_").to_numpy(dtype=object)
 
 
 class county(Variable):
@@ -60,7 +48,10 @@ class county(Variable):
         )
         valid_fips = counties["county_name"].notna().to_numpy()
         if known_fips.all() and valid_fips.all():
-            return County.encode(_county_enum_names(counties))
+            return map_county_string_to_enum(
+                counties["county_name"],
+                counties["state"],
+            ).to_numpy()
 
         result = household("first_county_in_state", period)
         if not valid_fips.any():
@@ -68,7 +59,10 @@ class county(Variable):
 
         known_indices = np.where(known_fips)[0]
         result = np.array(result, copy=True)
-        result[known_indices[valid_fips]] = np.asarray(
-            County.encode(_county_enum_names(counties.loc[valid_fips]))
-        )
+        county_name = counties.loc[valid_fips, "county_name"]
+        state_code = counties.loc[valid_fips, "state"]
+        result[known_indices[valid_fips]] = map_county_string_to_enum(
+            county_name,
+            state_code,
+        ).to_numpy()
         return result


### PR DESCRIPTION
Fixes #8773

## Summary
- Map valid `county_fips` rows directly in `county` before requesting the default county fallback.
- Keep `first_county_in_state` unchanged and only use it when FIPS is missing or invalid.
- Reuse the existing `map_county_string_to_enum` helper instead of duplicating county enum conversion in `county.py`.

## Runtime impact
Valid FIPS-only county calculations no longer request `first_county_in_state`. This avoids the default-county fallback path for single-household or other county calculations where FIPS fully determines county.

## Tests
- `./.venv/bin/python -m pytest policyengine_us/tests/core/test_county_fips_fallback.py`
- `./.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/demographic/geographic/county -c policyengine_us`
- `./.venv/bin/python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/household/demographic/household/county_str.yaml -c policyengine_us`
- `./.venv/bin/python -m pytest policyengine_us/tests/utilities/test_load_county_fips_dataset.py policyengine_us/tests/core/test_vectorized_reductions.py -k 'county or load_county'`
- `make format`
- `uv run ruff format --check policyengine_us/tools/geography/county_helpers.py policyengine_us/variables/household/demographic/geographic/county/county.py policyengine_us/tests/core/test_county_fips_fallback.py`
- `uv run ruff check policyengine_us/tools/geography/county_helpers.py policyengine_us/variables/household/demographic/geographic/county/county.py policyengine_us/tests/core/test_county_fips_fallback.py`