### PR TITLE
Use allowed federal CDCC (not potential) in OK Child Care/Child Tax Credit

### DIFF
--- a/changelog.d/ok-cdcc-allowed-credit.fixed.md
+++ b/changelog.d/ok-cdcc-allowed-credit.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Oklahoma Child Care/Child Tax Credit to use the allowed federal child care credit (cdcc, after the federal tax-liability limit) instead of the pre-limit potential (cdcc_potential), which overstated the credit for filers whose federal CDCC is limited by federal tax.

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_child_care_child_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_child_care_child_tax_credit.yaml
@@ -1,8 +1,9 @@
 # Oklahoma Child Care/Child Tax Credit Tests
-# Per Form 511-NR instructions page 11
+# Per Form 511 instructions ("20% of the credit for child care expenses
+# allowed by the IRC") and Schedule 511-F worksheet.
 # Credit = GREATER of:
 #   - 5% of federal CTC
-#   - 20% of federal CDCC
+#   - 20% of the federal CDCC ALLOWED (cdcc, after the federal tax limit)
 # AGI limit: $100,000 (MFJ)
 # Prorated for part-year residents by OK AGI / Federal AGI ratio
 
@@ -11,7 +12,7 @@
   input:
     adjusted_gross_income: 40_000
     ok_agi: 20_000
-    cdcc_potential: 2_000
+    cdcc: 2_000
     ok_federal_ctc: 3_000
     state_code: OK
   output:
@@ -29,7 +30,7 @@
   input:
     adjusted_gross_income: 50_000
     ok_agi: 50_000
-    cdcc_potential: 500
+    cdcc: 500
     ok_federal_ctc: 4_000
     state_code: OK
   output:
@@ -44,7 +45,7 @@
   input:
     adjusted_gross_income: 60_000
     ok_agi: 60_000
-    cdcc_potential: 3_000
+    cdcc: 3_000
     ok_federal_ctc: 2_000
     state_code: OK
   output:
@@ -58,7 +59,7 @@
   input:
     adjusted_gross_income: 120_000
     ok_agi: 120_000
-    cdcc_potential: 2_000
+    cdcc: 2_000
     ok_federal_ctc: 4_000
     state_code: OK
   output:
@@ -70,7 +71,7 @@
   input:
     adjusted_gross_income: 100_000
     ok_agi: 100_000
-    cdcc_potential: 1_500
+    cdcc: 1_500
     ok_federal_ctc: 3_000
     state_code: OK
   output:
@@ -85,7 +86,7 @@
   input:
     adjusted_gross_income: 45_000
     ok_agi: 45_000
-    cdcc_potential: 0
+    cdcc: 0
     ok_federal_ctc: 0
     state_code: OK
   output:
@@ -96,7 +97,7 @@
   input:
     adjusted_gross_income: 80_000
     ok_agi: 40_000
-    cdcc_potential: 2_000
+    cdcc: 2_000
     ok_federal_ctc: 4_000
     state_code: OK
   output:
@@ -106,6 +107,27 @@
     # Part-year ratio: 40,000 / 80,000 = 0.5
     # Final credit: $400 * 0.5 = $200
     ok_child_care_child_tax_credit: 200
+
+# Regression test for #8775/#8776: the OK credit must use the federal CDCC
+# ALLOWED (cdcc), not the pre-tax-limit potential (cdcc_potential). Here the
+# allowed credit (518.45) is far below the potential (1,680); using the
+# potential would overstate the credit to $336 instead of the correct $197.
+- name: OK CTC/CDCC - 2025 - uses allowed federal CDCC, not the potential
+  period: 2025
+  absolute_error_margin: 0.1
+  input:
+    adjusted_gross_income: 28_810
+    ok_agi: 28_810
+    cdcc: 518.45
+    cdcc_potential: 1_680
+    ok_federal_ctc: 3_946.43
+    state_code: OK
+  output:
+    # 20% CDCC allowed: 518.45 * 0.20 = 103.69
+    # 5% CTC: 3,946.43 * 0.05 = 197.32
+    # Greater is CTC: 197.32 (would be 336 if it used cdcc_potential)
+    ok_child_care_child_tax_credit: 197.32
+    taxsim_ok_child_tax_credit_component: 197.32
 
 - name: OK CTC includes federal non-refundable CTC used against unearned-income tax
   period: 2025

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/ok_child_care_child_tax_credit.py
@@ -26,14 +26,14 @@ class ok_child_care_child_tax_credit(Variable):
 
     Calculation steps:
     1. Check AGI eligibility (federal AGI <= $100,000)
-    2. Calculate OK CDCC: federal_cdcc_potential * 20%
+    2. Calculate OK CDCC: federal CDCC allowed (cdcc) * 20%
     3. Calculate OK CTC: federal CTC allowed * 5%
     4. Take the greater of OK CDCC or OK CTC
     5. Prorate by (OK AGI / Federal AGI)
 
     Example 1 - CDCC is greater:
     - Federal AGI: $60,000 (eligible)
-    - Federal CDCC potential: $2,000
+    - Federal CDCC allowed: $2,000
     - Federal CTC: $4,000
     - OK CDCC: $2,000 * 20% = $400
     - OK CTC: $4,000 * 5% = $200
@@ -41,14 +41,18 @@ class ok_child_care_child_tax_credit(Variable):
 
     Example 2 - CTC is greater:
     - Federal AGI: $60,000 (eligible)
-    - Federal CDCC potential: $500
+    - Federal CDCC allowed: $500
     - Federal CTC: $6,000
     - OK CDCC: $500 * 20% = $100
     - OK CTC: $6,000 * 5% = $300
     - Credit (before proration): max($100, $300) = $300
 
-    Note: Uses cdcc_potential (not actual CDCC) because Oklahoma matches
-    the potential credit amount regardless of federal tax liability.
+    Note: Uses the federal child care credit AS ALLOWED (cdcc, Form 2441
+    line 11 / the credit after the federal tax-liability limitation), per
+    the 2025 Form 511 instructions ("20% of the credit for child care
+    expenses allowed by the IRC") and the Schedule 511-F worksheet
+    ("Enter your federal child care credit"). The "greater of 20% CDCC or
+    5% CTC" structure already protects low-tax filers via the CTC path.
     """
 
     def formula(tax_unit, period, parameters):
@@ -56,8 +60,9 @@ class ok_child_care_child_tax_credit(Variable):
         # Step 1: Determine AGI eligibility (must be <= $100,000)
         us_agi = tax_unit("adjusted_gross_income", period)
         agi_eligible = us_agi <= p.child.agi_limit
-        # Step 2: Calculate OK CDCC amount (20% of federal potential)
-        us_cdcc = tax_unit("cdcc_potential", period)
+        # Step 2: Calculate OK CDCC amount (20% of the federal child care
+        # credit ALLOWED, i.e. after the federal tax-liability limit).
+        us_cdcc = tax_unit("cdcc", period)
         ok_cdcc = us_cdcc * p.child.cdcc_fraction
         # Step 3: Calculate OK CTC amount (5% of federal CTC allowed)
         us_ctc = tax_unit("ok_federal_ctc", period)

--- a/policyengine_us/variables/gov/states/ok/tax/income/credits/taxsim_ok_child_tax_credit_component.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/credits/taxsim_ok_child_tax_credit_component.py
@@ -13,7 +13,9 @@ class taxsim_ok_child_tax_credit_component(Variable):
         # OK's combined credit is max(CDCC_portion, CTC_portion).
         # This extracts the CTC portion by checking if CTC > CDCC.
         p = parameters(period).gov.states.ok.tax.income.credits.child
-        us_cdcc = tax_unit("cdcc_potential", period)
+        # Federal child care credit AS ALLOWED (after the federal
+        # tax-liability limit), matching ok_child_care_child_tax_credit.
+        us_cdcc = tax_unit("cdcc", period)
         ok_cdcc = us_cdcc * p.cdcc_fraction
         us_ctc = tax_unit("ok_federal_ctc", period)
         ok_ctc = us_ctc * p.ctc_fraction


### PR DESCRIPTION
## What this does

Fixes the Oklahoma Child Care/Child Tax Credit to use the **allowed** federal child care credit instead of the pre-tax-limit potential. Fixes #8659 (duplicate #8776 closed).

## Root cause

`ok_child_care_child_tax_credit` (and `taxsim_ok_child_tax_credit_component`) applied the 20% child-care factor to `cdcc_potential` — the federal CDCC **before** the federal tax-liability limitation (Form 2441 line 9a). Oklahoma instead uses the federal child care credit **as allowed** (Form 2441 line 11):
- 2025 Form 511 instructions (p.11, p.25): "20% of the credit for child care expenses **allowed by the IRC**."
- 2025 Schedule 511-F worksheet (p.47) line 1: "**Enter your federal child care credit**."

This overstated the credit for filers whose federal CDCC is limited by federal tax. Reported by Daniel Feenberg (NBER TAXSIM); TaxAct Form 511 is ground truth.

| | Federal CDCC used | 20% × CDCC | 5% × CTC | OK credit |
|---|---|---|---|---|
| OK Form 511 (TaxAct) | $518 (allowed) | $103.69 | $197.32 | **$197** |
| PolicyEngine (before) | $1,680 (potential) | $336.00 | $197.32 | **$336** |
| PolicyEngine (after) | $518 (allowed) | $103.69 | $197.32 | **$197** ✓ |

## Fix

- `ok_child_care_child_tax_credit.py`: `cdcc_potential` → `cdcc`; docstring/examples updated to the allowed-credit basis.
- `taxsim_ok_child_tax_credit_component.py`: same `cdcc_potential` → `cdcc` (used to split the combined credit).
- The "greater of 20% CDCC or 5% CTC" structure already protects low-tax filers via the CTC path, so the pre-limit amount is unnecessary.

## Tests

- Retargeted the unit cases to the allowed-credit basis (provide `cdcc` instead of `cdcc_potential`; expected values unchanged).
- **Added a regression test** mirroring the reported case: allowed `cdcc` = 518.45 with `cdcc_potential` = 1,680 set higher → credit is the 5%-CTC path **$197.32**, not the overstated 20%-of-potential $336. A revert to `cdcc_potential` would fail it.
- **All 9 cases pass locally** (`py 3.11`); `ruff` clean.

Fixes #8659 (duplicate #8776 closed). Related: PolicyEngine/policyengine-taxsim#1032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)