### PR TITLE
Fix Rest-runner OOM in dependent-exemption reform-activation test

### DIFF
--- a/changelog.d/fix-dependent-exemption-reform-test-oom.fixed.md
+++ b/changelog.d/fix-dependent-exemption-reform-test-oom.fixed.md
@@ -1,0 +1,1 @@
+Fixed an out-of-memory failure in the Rest CI runner by copying only the gov.contrib.states subtree (with its parent reference severed) in the dependent-exemption reform-activation test, instead of deep-copying the entire parameter tree.

--- a/policyengine_us/tests/policy/contrib/states/test_dependent_exemption_reform_activation.py
+++ b/policyengine_us/tests/policy/contrib/states/test_dependent_exemption_reform_activation.py
@@ -13,13 +13,17 @@ This module covers both outcomes for all eleven states in the PR, mirroring how
 Indiana dynamic-import special case (its package directory ``in`` is a Python
 keyword and cannot be imported with a dotted path).
 
-The parameter tree is deep-copied once (module-scoped fixture) rather than per
-test: deep-copying it 22 times made this module run for ~10 minutes and pushed
-the Python suite past its CI time budget.
+Only the ``gov.contrib.states`` subtree is cloned (module-scoped fixture), and
+the copied root's ``parent`` back-reference is cleared so later parameter
+updates stay contained. Deep-copying ``system.parameters`` wholesale — or any
+subtree without severing ``parent`` — walks the whole tree via that
+back-reference (~1 GB peak). Stacked onto the already-large Python suite, that
+copy OOM-killed the CI "Rest" runner; the cloned subtree peaks at a few MB
+instead.
 """
 
-import copy
 import importlib
+from types import SimpleNamespace
 
 import pytest
 
@@ -131,11 +135,22 @@ def _in_effect_parameter(parameters, state, folder):
 
 @pytest.fixture(scope="module")
 def parameters_all_in_effect():
-    # Deep-copy the parameter tree ONCE and turn every state's contrib reform
-    # on. Each factory reads only its own state's in_effect flag and the
-    # factories do not mutate the tree, so a single shared copy is safe and
-    # keeps this module fast.
-    parameters = copy.deepcopy(system.parameters)
+    # Clone ONLY the gov.contrib.states subtree and turn every state's contrib
+    # reform on. We must NOT deep-copy system.parameters (or any subtree as-is):
+    # every ParameterNode/Parameter holds a ``parent`` back-reference, so the
+    # copy escapes upward and duplicates the whole tree (~1 GB peak), which
+    # OOM-killed the CI runner. Clearing the cloned root's parent keeps updates
+    # contained without mutating the global parameter tree.
+    # The factories only read their own state's in_effect flag under
+    # gov.contrib.states and never touch the parent, so a thin namespace
+    # exposing the copied subtree is sufficient.
+    states_node = system.parameters.gov.contrib.states
+    states_copy = states_node.clone()
+    states_copy.parent = None
+
+    parameters = SimpleNamespace(
+        gov=SimpleNamespace(contrib=SimpleNamespace(states=states_copy))
+    )
     for state, folder, _module, _fn in STATE_CONFIGS:
         _in_effect_parameter(parameters, state, folder).update(
             period="year:2025:1", value=True


### PR DESCRIPTION
## Summary

The `Rest` CI job (`make test-other`, the full Python/pytest suite) has been OOM-killed on `main` since PR #8696 merged:

```
make: *** [Makefile:103: test-other] Killed
policyengine_us/tests/policy/contrib/states/test_dependent_exemption_reform_activation.py
##[error]The operation was canceled.
```

([failing run](https://github.com/PolicyEngine/policyengine-us/actions/runs/28384197087))

## Root cause

The module-scoped fixture in `test_dependent_exemption_reform_activation.py` (added in #8696) did `copy.deepcopy(system.parameters)`. Every `ParameterNode`/`Parameter` holds a `parent` back-reference, so deep-copying **any** subtree — or the root — walks up to the root and duplicates the whole tree.

Measured: **~1061 MB peak, ~440 MB retained**, several seconds. Landing near the end of the Python suite — right after the ~17-minute microsim test has already inflated the process — pushed the runner past the 16 GB cap.

The earlier "Speed up" commit cut 22 deepcopies down to 1, but a single full-tree deepcopy is still enough to OOM.

## Fix

The factories only ever read `parameters.gov.contrib.states.<state>.<folder>.in_effect`, so the whole tree isn't needed. Clone only the `gov.contrib.states` subtree and clear the clone's `parent` so the copy stays contained. `ParameterNode.clone()` rebuilds children downward (never following `parent` upward) and `Parameter.clone()` rebuilds `values_list`, so `.update()` on the clone is fully isolated.

| | Before | After |
|---|---|---|
| copy peak | ~1061 MB | **~2 MB** |
| module runtime | minutes (OOM) | **0.02 s** |

The global parameter tree is never mutated (`in_effect` stays `False`, `states.parent` intact).

## Test plan
- [x] All 22 tests in the module pass (`0.02s`)
- [x] `ruff format` / `ruff check` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)