### PR TITLE
Add New Jersey S4531 Child Tax Credit reform

### DIFF
--- a/changelog.d/nj-s4531-ctc-reform.added.md
+++ b/changelog.d/nj-s4531-ctc-reform.added.md
@@ -1,0 +1,1 @@
+Add a contributed reform for New Jersey S4531 Child Tax Credit increases.

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/fifth.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/fifth.yaml
@@ -1,0 +1,13 @@
+description: New Jersey provides this amount for the fifth Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 250
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit fifth bracket amount
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/first.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/first.yaml
@@ -1,0 +1,13 @@
+description: New Jersey provides this amount for the first Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 1_250
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit first bracket amount
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/fourth.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/fourth.yaml
@@ -1,0 +1,13 @@
+description: New Jersey provides this amount for the fourth Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 500
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit fourth bracket amount
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/second.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/second.yaml
@@ -1,0 +1,13 @@
+description: New Jersey provides this amount for the second Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 1_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit second bracket amount
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/third.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/amount/third.yaml
@@ -1,0 +1,13 @@
+description: New Jersey provides this amount for the third Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 750
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit third bracket amount
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/in_effect.yaml
@@ -1,0 +1,13 @@
+description: New Jersey Senate Bill No. 4531 Child Tax Credit increase applies if this is true.
+values:
+  0000-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: New Jersey S4531 Child Tax Credit increase in effect
+  reference:
+    - title: S4531 - New Jersey Child Tax Credit temporary increase
+      href: https://www.njleg.state.nj.us/bill-search/2026/S4531
+    - title: S4531 introduced bill text
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/fifth.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/fifth.yaml
@@ -1,0 +1,13 @@
+description: New Jersey limits taxable income to this amount for the fifth Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 80_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit fifth bracket income limit
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/first.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/first.yaml
@@ -1,0 +1,13 @@
+description: New Jersey limits taxable income to this amount for the first Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 30_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit first bracket income limit
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/fourth.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/fourth.yaml
@@ -1,0 +1,13 @@
+description: New Jersey limits taxable income to this amount for the fourth Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 60_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit fourth bracket income limit
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/second.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/second.yaml
@@ -1,0 +1,13 @@
+description: New Jersey limits taxable income to this amount for the second Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 40_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit second bracket income limit
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/third.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/income_limit/third.yaml
@@ -1,0 +1,13 @@
+description: New Jersey limits taxable income to this amount for the third Child Tax Credit income bracket under Senate Bill No. 4531.
+values:
+  2026-01-01: 50_000
+
+metadata:
+  unit: currency-USD
+  period: year
+  label: New Jersey S4531 Child Tax Credit third bracket income limit
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/parameters/gov/contrib/states/nj/s4531/temporary_increase/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/nj/s4531/temporary_increase/in_effect.yaml
@@ -1,0 +1,17 @@
+description: New Jersey Senate Bill No. 4531 temporary Child Tax Credit amount schedule applies if this is true.
+values:
+  0000-01-01: false
+  2026-01-01: true
+  2029-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: New Jersey S4531 temporary Child Tax Credit amount schedule in effect
+  reference:
+    - title: S4531 introduced bill text, Section 1(a)
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2
+    - title: S4531 introduced bill text, Section 2
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=3
+    - title: S4531 Senate Budget and Appropriations Committee statement
+      href: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -236,6 +236,9 @@ from .states.nj.stay_nj import (
 from .states.nj.anchor import (
     create_nj_anchor_reform,
 )
+from .states.nj.s4531 import (
+    create_nj_s4531_reform,
+)
 from .refundable_credit_conversion import (
     create_refundable_credit_conversion_reform,
 )
@@ -512,6 +515,7 @@ def create_structural_reforms_from_parameters(parameters, period):
     )
     nj_stay_nj = create_nj_stay_nj_reform(parameters, period)
     nj_anchor = create_nj_anchor_reform(parameters, period)
+    nj_s4531 = create_nj_s4531_reform(parameters, period)
     working_parents_tax_relief_act = create_working_parents_tax_relief_act_reform(
         parameters, period
     )
@@ -639,6 +643,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         sc_fully_refundable_eitc,
         nj_stay_nj,
         nj_anchor,
+        nj_s4531,
         working_parents_tax_relief_act,
         refundable_credit_conversion,
     ]

--- a/policyengine_us/reforms/states/nj/s4531/__init__.py
+++ b/policyengine_us/reforms/states/nj/s4531/__init__.py
@@ -1,0 +1,4 @@
+from .nj_s4531 import (
+    create_nj_s4531_reform,
+    nj_s4531_reform,
+)

--- a/policyengine_us/reforms/states/nj/s4531/nj_s4531.py
+++ b/policyengine_us/reforms/states/nj/s4531/nj_s4531.py
@@ -42,9 +42,7 @@ def create_nj_s4531() -> Reform:
 
             taxable_income = tax_unit("nj_taxable_income", period)
             if p_reform.in_effect and p_reform.temporary_increase.in_effect:
-                amount_per_qualifying_child = s4531_amount(
-                    taxable_income, p_reform
-                )
+                amount_per_qualifying_child = s4531_amount(taxable_income, p_reform)
             else:
                 amount_per_qualifying_child = p_baseline.amount.calc(taxable_income)
 

--- a/policyengine_us/reforms/states/nj/s4531/nj_s4531.py
+++ b/policyengine_us/reforms/states/nj/s4531/nj_s4531.py
@@ -1,0 +1,85 @@
+from policyengine_us.model_api import *
+from policyengine_core.periods import period as period_
+
+
+def create_nj_s4531() -> Reform:
+    def s4531_amount(taxable_income, p):
+        return select(
+            [
+                taxable_income <= p.income_limit.first,
+                taxable_income <= p.income_limit.second,
+                taxable_income <= p.income_limit.third,
+                taxable_income <= p.income_limit.fourth,
+                taxable_income <= p.income_limit.fifth,
+            ],
+            [
+                p.amount.first,
+                p.amount.second,
+                p.amount.third,
+                p.amount.fourth,
+                p.amount.fifth,
+            ],
+            default=0,
+        )
+
+    class nj_ctc(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "New Jersey Child Tax Credit"
+        unit = USD
+        definition_period = YEAR
+        reference = (
+            "https://www.njleg.state.nj.us/bill-search/2026/S4531",
+            "https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF#page=2",
+            "https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF#page=1",
+        )
+        defined_for = "nj_ctc_eligible"
+
+        def formula(tax_unit, period, parameters):
+            p = parameters(period)
+            p_baseline = p.gov.states.nj.tax.income.credits.ctc
+            p_reform = p.gov.contrib.states.nj.s4531
+
+            taxable_income = tax_unit("nj_taxable_income", period)
+            if p_reform.in_effect and p_reform.temporary_increase.in_effect:
+                amount_per_qualifying_child = s4531_amount(
+                    taxable_income, p_reform
+                )
+            else:
+                amount_per_qualifying_child = p_baseline.amount.calc(taxable_income)
+
+            person = tax_unit.members
+            age_eligible = person("age", period) < p_baseline.age_limit
+            dependent = person("is_tax_unit_dependent", period)
+            count_eligible = tax_unit.sum(age_eligible & dependent)
+
+            return count_eligible * amount_per_qualifying_child
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(nj_ctc)
+
+    return reform
+
+
+def create_nj_s4531_reform(parameters, period, bypass: bool = False):
+    if bypass:
+        return create_nj_s4531()
+
+    p = parameters.gov.contrib.states.nj.s4531
+
+    reform_active = False
+    current_period = period_(period)
+
+    for _ in range(5):
+        if p(current_period).in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
+        return create_nj_s4531()
+    return None
+
+
+nj_s4531_reform = create_nj_s4531_reform(None, None, bypass=True)

--- a/policyengine_us/tests/policy/contrib/states/nj/s4531/nj_s4531.yaml
+++ b/policyengine_us/tests/policy/contrib/states/nj/s4531/nj_s4531.yaml
@@ -1,0 +1,197 @@
+- name: Case 1, S4531 provides $1,250 per young child at or below $30,000.
+  period: 2026
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        nj_taxable_income: 30_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ctc: 1_250
+
+- name: Case 2, S4531 provides $1,000 per young child above $30,000 and at or below $40,000.
+  period: 2026
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+      person3:
+        age: 3
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        nj_taxable_income: 40_000
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: NJ
+  output:
+    nj_ctc: 2_000
+
+- name: Case 3, S4531 provides $750 per young child above $40,000 and at or below $50,000.
+  period: 2026
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        nj_taxable_income: 50_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ctc: 750
+
+- name: Case 4, S4531 provides $500 per young child above $50,000 and at or below $60,000.
+  period: 2027
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        nj_taxable_income: 60_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ctc: 500
+
+- name: Case 5, S4531 provides $250 per young child above $60,000 and at or below $80,000.
+  period: 2028
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        nj_taxable_income: 80_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ctc: 250
+
+- name: Case 6, S4531 expires after taxable year 2028.
+  period: 2029
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        nj_taxable_income: 70_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    # Baseline amount for this bracket resumes after 2028.
+    nj_ctc: 200
+
+- name: Case 7, S4531 does not change the child age limit.
+  period: 2026
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 6
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        nj_taxable_income: 30_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ctc: 0
+
+- name: Case 8, S4531 does not change married filing separately ineligibility.
+  period: 2026
+  absolute_error_margin: 0.01
+  reforms: policyengine_us.reforms.states.nj.s4531.nj_s4531_reform
+  input:
+    gov.contrib.states.nj.s4531.in_effect: true
+    people:
+      person1:
+        age: 30
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SEPARATE
+        nj_taxable_income: 30_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    nj_ctc_eligible: false
+    nj_ctc: 0


### PR DESCRIPTION
## Summary
- Add a contributed New Jersey S4531 Child Tax Credit reform under `gov.contrib.states.nj.s4531`.
- Temporarily replace NJ CTC per-child amounts for taxable years 2026, 2027, and 2028 with the S4531 schedule.
- Preserve existing NJ CTC eligibility, child age, refundability, and post-2028 baseline amounts.
- Use explicit upper-income thresholds so exact statutory boundaries like $30,000 and $40,000 remain in the lower bracket.

Closes #8735.

## Sources
- S4531 bill page: https://www.njleg.state.nj.us/bill-search/2026/S4531
- Introduced bill text: https://pub.njleg.gov/Bills/2026/S5000/4531_I1.PDF
- Senate Budget and Appropriations Committee statement: https://pub.njleg.gov/Bills/2026/S5000/4531_S1.PDF

## Tests
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/contrib/states/nj/s4531/nj_s4531.yaml -c policyengine_us`
- `uv run pytest policyengine_us/tests/test_parameter_files.py`
- `uv run python -c "from policyengine_us.reforms.reforms import create_structural_reforms_from_parameters; print('ok')"`
- `git diff --check`