### PR TITLE
Model SNAP student employment & training and work incentive placement exemptions

### DIFF
--- a/changelog.d/snap-student-program-placement-exemptions.added.md
+++ b/changelog.d/snap-student-program-placement-exemptions.added.md
@@ -1,0 +1,1 @@
+- Modeled the SNAP student employment and training (7 CFR 273.5(b)(11)) and work incentive program (7 CFR 273.5(b)(4)) placement exemptions via the new `is_snap_employment_training_student` and `is_snap_work_incentive_student` inputs, combined as `is_snap_employment_training_or_work_incentive_student`.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/student/is_snap_employment_training_or_work_incentive_student.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/student/is_snap_employment_training_or_work_incentive_student.yaml
@@ -1,0 +1,31 @@
+- name: Neither program applies
+  period: 2022
+  input:
+    is_snap_employment_training_student: false
+    is_snap_work_incentive_student: false
+  output:
+    is_snap_employment_training_or_work_incentive_student: false
+
+- name: Employment and training program only
+  period: 2022
+  input:
+    is_snap_employment_training_student: true
+    is_snap_work_incentive_student: false
+  output:
+    is_snap_employment_training_or_work_incentive_student: true
+
+- name: Work incentive program only
+  period: 2022
+  input:
+    is_snap_employment_training_student: false
+    is_snap_work_incentive_student: true
+  output:
+    is_snap_employment_training_or_work_incentive_student: true
+
+- name: Both programs apply
+  period: 2022
+  input:
+    is_snap_employment_training_student: true
+    is_snap_work_incentive_student: true
+  output:
+    is_snap_employment_training_or_work_incentive_student: true

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/student/is_snap_ineligible_student.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/student/is_snap_ineligible_student.yaml
@@ -90,3 +90,84 @@
         members: [parent1, parent2, child]
   output:
     is_snap_ineligible_student: [false, false, false]
+
+- name: Full-time college student placed in school through an employment and training program is exempt
+  period: 2022
+  input:
+    is_full_time_college_student: true
+    age: 20
+    is_disabled: false
+    weekly_hours_worked_before_lsr: 0
+    is_parent: false
+    is_snap_employment_training_student: true
+  output:
+    is_snap_ineligible_student: false
+
+- name: Half-time college student placed in school through an employment and training program is exempt
+  period: 2022
+  input:
+    is_part_time_college_student: true
+    age: 20
+    is_disabled: false
+    weekly_hours_worked_before_lsr: 0
+    is_parent: false
+    is_snap_employment_training_student: true
+  output:
+    is_snap_ineligible_student: false
+
+- name: College student age 50 or older is exempt
+  period: 2022
+  input:
+    is_full_time_college_student: true
+    age: 50
+    is_disabled: false
+    weekly_hours_worked_before_lsr: 0
+    is_parent: false
+  output:
+    is_snap_ineligible_student: false
+
+- name: Disabled college student is exempt
+  period: 2022
+  input:
+    is_full_time_college_student: true
+    age: 25
+    is_disabled: true
+    weekly_hours_worked_before_lsr: 0
+    is_parent: false
+  output:
+    is_snap_ineligible_student: false
+
+- name: College student working at least 20 hours per week is exempt
+  period: 2022
+  input:
+    is_full_time_college_student: true
+    age: 25
+    is_disabled: false
+    weekly_hours_worked_before_lsr: 20
+    is_parent: false
+  output:
+    is_snap_ineligible_student: false
+
+- name: College student participating in federal work study is exempt
+  period: 2022
+  input:
+    is_full_time_college_student: true
+    age: 25
+    is_disabled: false
+    weekly_hours_worked_before_lsr: 0
+    is_federal_work_study_participant: true
+    is_parent: false
+  output:
+    is_snap_ineligible_student: false
+
+- name: College student enrolled through a work incentive program is exempt
+  period: 2022
+  input:
+    is_full_time_college_student: true
+    age: 25
+    is_disabled: false
+    weekly_hours_worked_before_lsr: 0
+    is_parent: false
+    is_snap_work_incentive_student: true
+  output:
+    is_snap_ineligible_student: false

--- a/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_employment_training_or_work_incentive_student.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_employment_training_or_work_incentive_student.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class is_snap_employment_training_or_work_incentive_student(Variable):
+    value_type = bool
+    entity = Person
+    label = "SNAP student placed in higher education through an employment and training or work incentive program"
+    documentation = (
+        "Whether this person was placed in or enrolled in an institution of "
+        "higher education through a qualifying employment and training program "
+        "(7 CFR 273.5(b)(11)) or work incentive program (7 CFR 273.5(b)(4)). "
+        "Single override point for partners; equivalent to either underlying "
+        "input being true."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/cfr/text/7/273.5#b",
+        "https://www.law.cornell.edu/uscode/text/7/2015#e",
+    )
+
+    def formula(person, period, parameters):
+        employment_training = person("is_snap_employment_training_student", period)
+        work_incentive = person("is_snap_work_incentive_student", period)
+        return employment_training | work_incentive

--- a/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_employment_training_student.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_employment_training_student.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class is_snap_employment_training_student(Variable):
+    value_type = bool
+    entity = Person
+    label = "SNAP student placed in higher education through an employment and training program"
+    documentation = (
+        "Whether this person was placed in an institution of higher education "
+        "through a qualifying employment and training program (WIOA, a SNAP "
+        "E&T program, the Trade Act, or a state or local program). Mere "
+        "enrollment in college or in unrelated job training does not qualify: "
+        "the placement must come through the program."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/cfr/text/7/273.5#b_11",
+        "https://www.law.cornell.edu/uscode/text/7/2015#e_3",
+    )

--- a/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_ineligible_student.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_ineligible_student.py
@@ -26,9 +26,14 @@ class is_snap_ineligible_student(Variable):
         # Exception 2: Not physically or mentally fit (disabled)
         meets_disability_exception = person("is_disabled", period)
 
-        # Exception 3: Assignment through workforce/employment programs
-        # (WIOA, career/technical ed, remedial/basic education)
-        # Not modeled
+        # Exceptions 3 and 7: Placed in or enrolled in an institution of
+        # higher education through a qualifying program — an employment and
+        # training program (Exception 3: WIOA, SNAP E&T career/technical or
+        # remedial coursework, the Trade Act, or a state or local program) or
+        # a title IV work incentive / JOBS / TANF work program (Exception 7).
+        meets_program_placement_exception = person(
+            "is_snap_employment_training_or_work_incentive_student", period
+        )
 
         # Exception 4: Employed at least 20 hours per week or work-study
         meets_work_hours_exception = person("meets_snap_work_exception", period)
@@ -44,15 +49,15 @@ class is_snap_ineligible_student(Variable):
         tanf = person("tanf_person", period)
         receives_tanf = tanf > 0
 
-        # Exception 7: Enrolled as result of participation in work incentive
-        # program under title IV (TANF work programs) or successor programs
-        # Not modeled
+        # Exception 7 is combined with Exception 3 above via
+        # is_snap_employment_training_or_work_incentive_student.
 
         # A higher education student is INELIGIBLE if they do NOT meet ANY
         # of the eight exceptions
         return ~(
             meets_age_exception
             | meets_disability_exception
+            | meets_program_placement_exception
             | meets_work_hours_exception
             | meets_parent_exception
             | receives_tanf

--- a/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_work_incentive_student.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_work_incentive_student.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class is_snap_work_incentive_student(Variable):
+    value_type = bool
+    entity = Person
+    label = "SNAP student enrolled in higher education through a work incentive program"
+    documentation = (
+        "Whether this person was enrolled in an institution of higher "
+        "education as a result of participation in a work incentive program "
+        "under title IV of the Social Security Act (the Job Opportunities and "
+        "Basic Skills program or its TANF successor). Mere participation in a "
+        "work program does not qualify: the enrollment must result from the "
+        "program."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/cfr/text/7/273.5#b_4",
+        "https://www.law.cornell.edu/uscode/text/7/2015#e_7",
+    )

--- a/policyengine_us/variables/gov/usda/snap/eligibility/student/meets_snap_parent_exception.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/student/meets_snap_parent_exception.py
@@ -7,8 +7,8 @@ class meets_snap_parent_exception(Variable):
     label = "Meets SNAP student parent exception"
     definition_period = YEAR
     reference = (
-        "https://www.law.cornell.edu/uscode/text/7/2015#e_5, "
-        "https://www.law.cornell.edu/uscode/text/7/2015#e_8"
+        "https://www.law.cornell.edu/uscode/text/7/2015#e_5",
+        "https://www.law.cornell.edu/uscode/text/7/2015#e_8",
     )
 
     def formula(person, period, parameters):


### PR DESCRIPTION
## Summary

Models the two SNAP higher-education student exemptions that turn on being placed in or enrolled in an institution of higher education **through** an employment-and-training or work-incentive program. Both were previously flagged "Not modeled" in `is_snap_ineligible_student`.

Closes #8750

## Regulatory authority

| Exemption | Statute | Regulation |
|---|---|---|
| Exception 3 — placed through an employment & training program (WIOA Title I, a SNAP E&T program limited to career/technical or remedial coursework, the Trade Act §236, or a state/local E&T program) | 7 USC 2015(e)(3) | 7 CFR 273.5(b)(11) |
| Exception 7 — enrolled as a result of participation in a title-IV work incentive program (JOBS / its TANF-work-program successor) | 7 USC 2015(e)(7) | 7 CFR 273.5(b)(4) |

Citation note: the SNAP student TANF-receipt exemption is `(b)(3)` / `(e)(6)` — a separate provision — and is already modeled via `tanf_person > 0`. The two exemptions here are `(b)(11)`/`(e)(3)` and `(b)(4)`/`(e)(7)`.

## What changed

| Variable | Entity / Period | Role |
|---|---|---|
| `is_snap_employment_training_student` (new) | Person / YEAR | Bare input for Exception 3. `(b)(11)` / `(e)(3)`. |
| `is_snap_work_incentive_student` (new) | Person / YEAR | Bare input for Exception 7. `(b)(4)` / `(e)(7)`. |
| `is_snap_employment_training_or_work_incentive_student` (new) | Person / YEAR | Formula `OR` of the two inputs — a single override point for partners. |
| `is_snap_ineligible_student` (modified) | Person / YEAR | Consumes the combined variable; the two "Not modeled" stubs are removed. |
| `meets_snap_parent_exception` (fix) | Person / YEAR | Corrected a malformed `reference` (a missing comma had concatenated its two URLs into one string). |

```
is_snap_employment_training_student ──┐  (e)(3)/(b)(11)
                                      ├─► is_snap_employment_training_or_work_incentive_student ──► is_snap_ineligible_student
is_snap_work_incentive_student      ──┘  (e)(7)/(b)(4)
```

## Design notes

- **Faithful to the statute's causal requirement.** Both exemptions require the school enrollment to come *through* the program, not mere participation/enrollment. Each input's `documentation` states this explicitly, so a screener maps only the affirmative "placed-through-program" fact.
- **One input per statutory provision** (distinct citations preserved), plus a combined formula variable so a partner can override a **single** variable for the whole placement exemption, or set the two granular inputs for citation-precise data.
- **Pure inputs.** The two inputs have no formula/`defined_for` and default to `False`; the half-time-or-more higher-education gate stays on the consumer (`is_snap_ineligible_student` is `defined_for = "is_snap_higher_ed_student"`).
- **Non-breaking.** Default-`False` inputs leave `is_snap_ineligible_student` unchanged everywhere until a data source populates them, so existing behavior and partner contract tests are unaffected.

## Partner context

An API partner (MyFriendBen) currently overrides `is_snap_ineligible_student` directly. With this change they can instead feed inputs — either overriding `is_snap_employment_training_or_work_incentive_student` at one point, or mapping their `student_job_training_program` flag to `is_snap_employment_training_student`.

## Tests

- New unit test for the combined variable — 4 cases (neither / E&T only / work-incentive only / both).
- Integration flow-through in `is_snap_ineligible_student.yaml`: E&T placement, work-incentive placement, plus the previously-untested exemptions (age 50+, disability, 20 hours/week, work-study) so every modeled exemption is now exercised end-to-end.
- Input-purity tests (`test_input_variable_definitions.py`) confirm the two new inputs are pure data inputs.

## Test plan

- [x] SNAP student YAML tests pass (44 cases)
- [x] Input-purity + SNAP-student-TANF core tests pass
- [ ] CI passes
