### PR TITLE
SNAP: confer categorical eligibility on cash TANF receipt

### DIFF
--- a/changelog.d/snap-cash-tanf-categorical-eligibility.fixed.md
+++ b/changelog.d/snap-cash-tanf-categorical-eligibility.fixed.md
@@ -1,0 +1,1 @@
+Confer SNAP categorical eligibility on households receiving cash TANF, bypassing the income and asset tests in non-BBCE states, and honor partner-reported SSI in the categorical eligibility SSI check.

--- a/policyengine_us/parameters/gov/usda/snap/categorical_eligibility.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/categorical_eligibility.yaml
@@ -4,7 +4,7 @@ values:
   2009-01-01:
     - ssi
     - is_tanf_non_cash_eligible
-    # - tanf # Currently only available in IL.
+    - tanf
 
 metadata:
   reference:
@@ -13,3 +13,5 @@ metadata:
       # Refers to 42 U.S.C. 601, which is TANF:
     - title: 42 U.S. Code Part A—Block Grants to States for Temporary Assistance for Needy Families
       href: https://www.law.cornell.edu/uscode/text/42/chapter-7/subchapter-IV/part-A
+    - title: 7 CFR 273.2(j)(2) Categorical eligibility for certain recipients
+      href: https://www.law.cornell.edu/cfr/text/7/273.2#j_2

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.yaml
@@ -55,3 +55,20 @@
     social_security_disability: 1
   output:
     meets_snap_categorical_eligibility: false
+
+- name: Cash TANF receipt creates eligibility without BBCE.
+  period: 2022-01
+  input:
+    is_tanf_non_cash_eligible: false
+    tanf: 3_000
+  output:
+    meets_snap_categorical_eligibility: true
+
+- name: Reported SSI creates eligibility when use_reported_ssi is true.
+  period: 2022
+  input:
+    is_tanf_non_cash_eligible: false
+    use_reported_ssi: true
+    ssi_reported: 1
+  output:
+    meets_snap_categorical_eligibility: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ca.yaml
@@ -10,7 +10,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54540
+        employment_income_before_lsr: 54540
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -18,7 +18,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -26,7 +26,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id001
@@ -72,7 +72,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54640
+        employment_income_before_lsr: 54640
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -80,7 +80,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -88,7 +88,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id002
@@ -134,7 +134,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54740
+        employment_income_before_lsr: 54740
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -142,7 +142,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -150,7 +150,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id003
@@ -196,7 +196,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -204,7 +204,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -212,7 +212,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id004
@@ -261,7 +261,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -269,7 +269,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -277,7 +277,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id005
@@ -327,7 +327,7 @@
         is_disabled: true
         is_usda_disabled: true
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -335,7 +335,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -343,7 +343,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id006
@@ -392,7 +392,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: LEGAL_PERMANENT_RESIDENT
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -400,7 +400,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -408,7 +408,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id007
@@ -454,7 +454,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: REFUGEE
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -462,7 +462,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -470,7 +470,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id008
@@ -502,7 +502,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 856.32
+        snap: 999.36
         is_snap_eligible: true
 - name: snap_head_immigration_undocumented (ca)
   period: 2026
@@ -516,7 +516,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: UNDOCUMENTED
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -524,7 +524,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -532,7 +532,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id009

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/la.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/la.yaml
@@ -10,7 +10,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54540
+        employment_income_before_lsr: 54540
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -18,7 +18,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -26,7 +26,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id001
@@ -72,7 +72,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54640
+        employment_income_before_lsr: 54640
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -80,7 +80,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -88,7 +88,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id002
@@ -134,7 +134,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54740
+        employment_income_before_lsr: 54740
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -142,7 +142,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -150,7 +150,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id003
@@ -196,7 +196,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -204,7 +204,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -212,7 +212,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id004
@@ -247,7 +247,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 3688.49
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_age_60_assets_4000_elderly (la)
   period: 2026
@@ -261,7 +261,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -269,7 +269,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -277,7 +277,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id005
@@ -312,7 +312,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 3688.49
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_disabled_assets_4000 (la)
   period: 2026
@@ -327,7 +327,7 @@
         is_disabled: true
         is_usda_disabled: true
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -335,7 +335,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -343,7 +343,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id006
@@ -378,7 +378,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 3688.49
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_immigration_lpr (la)
   period: 2026
@@ -392,7 +392,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: LEGAL_PERMANENT_RESIDENT
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -400,7 +400,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -408,7 +408,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id007
@@ -440,7 +440,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 3688.49
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_immigration_refugee (la)
   period: 2026
@@ -454,7 +454,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: REFUGEE
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -462,7 +462,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -470,7 +470,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id008
@@ -502,7 +502,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 804.42
+        snap: 2912.22
         is_snap_eligible: true
 - name: snap_head_immigration_undocumented (la)
   period: 2026
@@ -516,7 +516,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: UNDOCUMENTED
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -524,7 +524,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -532,7 +532,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id009
@@ -564,5 +564,5 @@
   output:
     spm_units:
       spm_unit:
-        snap: 804.42
+        snap: 2912.22
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ma.yaml
@@ -10,7 +10,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54540
+        employment_income_before_lsr: 54540
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -18,7 +18,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -26,7 +26,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id001
@@ -59,7 +59,7 @@
     spm_units:
       spm_unit:
         snap: 0.0
-        is_snap_eligible: false
+        is_snap_eligible: true
 - name: snap_income_at_binding_gross_limit_54640 (ma)
   period: 2026
   absolute_error_margin: 0.1
@@ -72,7 +72,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54640
+        employment_income_before_lsr: 54640
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -80,7 +80,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -88,7 +88,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id002
@@ -121,7 +121,7 @@
     spm_units:
       spm_unit:
         snap: 0.0
-        is_snap_eligible: false
+        is_snap_eligible: true
 - name: snap_income_just_above_binding_gross_limit_54640 (ma)
   period: 2026
   absolute_error_margin: 0.1
@@ -134,7 +134,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54740
+        employment_income_before_lsr: 54740
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -142,7 +142,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -150,7 +150,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id003
@@ -196,7 +196,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -204,7 +204,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -212,7 +212,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id004
@@ -247,7 +247,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2036.09
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_age_60_assets_4000_elderly (ma)
   period: 2026
@@ -261,7 +261,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -269,7 +269,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -277,7 +277,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id005
@@ -312,7 +312,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2036.09
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_disabled_assets_4000 (ma)
   period: 2026
@@ -327,7 +327,7 @@
         is_disabled: true
         is_usda_disabled: true
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -335,7 +335,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -343,7 +343,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id006
@@ -378,7 +378,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2036.09
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_immigration_lpr (ma)
   period: 2026
@@ -392,7 +392,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: LEGAL_PERMANENT_RESIDENT
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -400,7 +400,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -408,7 +408,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id007
@@ -440,7 +440,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2036.09
+        snap: 5796.29
         is_snap_eligible: true
 - name: snap_head_immigration_refugee (ma)
   period: 2026
@@ -454,7 +454,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: REFUGEE
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -462,7 +462,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -470,7 +470,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id008
@@ -502,7 +502,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 287.68
+        snap: 2912.22
         is_snap_eligible: true
 - name: snap_head_immigration_undocumented (ma)
   period: 2026
@@ -516,7 +516,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: UNDOCUMENTED
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -524,7 +524,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -532,7 +532,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id009
@@ -564,5 +564,5 @@
   output:
     spm_units:
       spm_unit:
-        snap: 287.68
+        snap: 2912.22
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/wa.yaml
@@ -10,7 +10,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54540
+        employment_income_before_lsr: 54540
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -18,7 +18,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -26,7 +26,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id001
@@ -59,7 +59,7 @@
     spm_units:
       spm_unit:
         snap: 0.0
-        is_snap_eligible: false
+        is_snap_eligible: true
 - name: snap_income_at_binding_gross_limit_54640 (wa)
   period: 2026
   absolute_error_margin: 0.1
@@ -72,7 +72,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54640
+        employment_income_before_lsr: 54640
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -80,7 +80,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -88,7 +88,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id002
@@ -121,7 +121,7 @@
     spm_units:
       spm_unit:
         snap: 0.0
-        is_snap_eligible: false
+        is_snap_eligible: true
 - name: snap_income_just_above_binding_gross_limit_54640 (wa)
   period: 2026
   absolute_error_margin: 0.1
@@ -134,7 +134,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 54740
+        employment_income_before_lsr: 54740
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -142,7 +142,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -150,7 +150,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id003
@@ -196,7 +196,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -204,7 +204,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -212,7 +212,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id004
@@ -247,7 +247,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2889.29
+        snap: 5133.89
         is_snap_eligible: true
 - name: snap_head_age_60_assets_4000_elderly (wa)
   period: 2026
@@ -261,7 +261,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -269,7 +269,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -277,7 +277,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id005
@@ -312,7 +312,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2889.29
+        snap: 5133.89
         is_snap_eligible: true
 - name: snap_head_disabled_assets_4000 (wa)
   period: 2026
@@ -327,7 +327,7 @@
         is_disabled: true
         is_usda_disabled: true
         immigration_status_str: CITIZEN
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -335,7 +335,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -343,7 +343,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id006
@@ -378,7 +378,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2889.29
+        snap: 5133.89
         is_snap_eligible: true
 - name: snap_head_immigration_lpr (wa)
   period: 2026
@@ -392,7 +392,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: LEGAL_PERMANENT_RESIDENT
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -400,7 +400,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -408,7 +408,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id007
@@ -440,7 +440,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 2889.29
+        snap: 5133.89
         is_snap_eligible: true
 - name: snap_head_immigration_refugee (wa)
   period: 2026
@@ -454,7 +454,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: REFUGEE
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -462,7 +462,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -470,7 +470,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id008
@@ -502,7 +502,7 @@
   output:
     spm_units:
       spm_unit:
-        snap: 287.68
+        snap: 2249.82
         is_snap_eligible: true
 - name: snap_head_immigration_undocumented (wa)
   period: 2026
@@ -516,7 +516,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: UNDOCUMENTED
-        employment_income: 20000
+        employment_income_before_lsr: 20000
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -524,7 +524,7 @@
         is_tax_unit_dependent: false
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
       child1:
         age: 5
         is_tax_unit_head: false
@@ -532,7 +532,7 @@
         is_tax_unit_dependent: true
         is_disabled: false
         immigration_status_str: CITIZEN
-        employment_income: 0
+        employment_income_before_lsr: 0
     households:
       household:
         members: &id009
@@ -564,5 +564,5 @@
   output:
     spm_units:
       spm_unit:
-        snap: 287.68
+        snap: 2249.82
         is_snap_eligible: true

--- a/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
@@ -13,7 +13,5 @@ class meets_snap_categorical_eligibility(Variable):
         programs = parameters(period).gov.usda.snap.categorical_eligibility
         spm_level_programs = [program for program in programs if program != "ssi"]
         person = spm_unit.members
-        all_members_receive_ssi = spm_unit.all(
-            person("applicable_ssi", period) > 0
-        )
+        all_members_receive_ssi = spm_unit.all(person("applicable_ssi", period) > 0)
         return all_members_receive_ssi | (add(spm_unit, period, spm_level_programs) > 0)

--- a/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py
@@ -13,5 +13,7 @@ class meets_snap_categorical_eligibility(Variable):
         programs = parameters(period).gov.usda.snap.categorical_eligibility
         spm_level_programs = [program for program in programs if program != "ssi"]
         person = spm_unit.members
-        all_members_receive_ssi = spm_unit.all(person("ssi", period) > 0)
+        all_members_receive_ssi = spm_unit.all(
+            person("applicable_ssi", period) > 0
+        )
         return all_members_receive_ssi | (add(spm_unit, period, spm_level_programs) > 0)


### PR DESCRIPTION
## Summary

Cash TANF receipt now confers SNAP categorical eligibility, and the all-members SSI check honors partner-reported SSI.

Closes #8752

## Background

A household receiving cash TANF is **categorically eligible** for SNAP under federal law — both the income and asset tests are bypassed (7 CFR 273.2(j)(2); 7 U.S.C. § 2014(a)). This "pure"/cash categorical eligibility is **federal and mandatory in every state**, distinct from broad-based categorical eligibility (BBCE), which is a state option.

Previously, `meets_snap_categorical_eligibility` only fired on all-members SSI and `is_tanf_non_cash_eligible` (BBCE). The direct cash-`tanf` trigger was commented out behind a stale "Currently only available in IL" note — `tanf` now aggregates 51 state cash-TANF programs. As a result, a household in a **non-BBCE state** (e.g., Kansas) receiving cash TANF with countable assets over the federal SNAP limit was incorrectly denied. Because TANF income limits sit far below SNAP's (KS ≈ 30% FPL vs SNAP's 130% gross), the practical effect of this fix is the **asset-test bypass**.

## Changes

- **`parameters/gov/usda/snap/categorical_eligibility.yaml`** — add `tanf` to the program list; add the `7 CFR 273.2(j)(2)` reference.
- **`variables/gov/usda/snap/eligibility/meets_snap_categorical_eligibility.py`** — read `applicable_ssi` instead of `ssi` in the all-members SSI check, so partner-reported SSI (`use_reported_ssi=True` + `ssi_reported`) is honored. With the default `use_reported_ssi=False`, `applicable_ssi == ssi`, so this part does **not** change the baseline.
- Tests for the cash-TANF path and the reported-SSI path.
- Changelog fragment.

## Partner fixture fix (surfaced by this change)

Adding `tanf` to cat-elig exposed a latent bug in the SNAP `analytics_coverage` partner fixtures (ca/la/ma/wa): they set **`employment_income`** (a derived variable) instead of **`employment_income_before_lsr`** (the actual input). In the YAML runner's `build_from_dict` path, that leaves `employment_income_before_lsr` at 0, so TANF saw **$0 earnings** and paid spurious benefits — which flipped `is_snap_eligible` once cat-elig keyed off `tanf`. This PR switches those fixtures to `employment_income_before_lsr` and regenerates the affected expected values (each verified against a fresh-system computation). The broader fixture cleanup is tracked in **#8802**.

## Baseline impact

Adding `tanf` makes every **modeled** cash-TANF recipient categorically eligible for SNAP, which **shifts the national SNAP baseline** — this warrants an impact run / team review before merge. The `applicable_ssi` change is gated behind `use_reported_ssi` (off by default) and does **not** shift the baseline.

## Test plan
- [x] `meets_snap_categorical_eligibility` + `is_snap_eligible` YAML tests pass
- [x] 4 SNAP partner fixtures pass (36 cases) and match a fresh-system computation (0 mismatches)
- [x] federal SNAP (317) + state SNAP (MD/CA, 13) pass locally
- [ ] CI passes
