### PR TITLE
Add discrete per-filing-status AGI schedule to MD/OH dependent exemption contrib

### DIFF
--- a/changelog.d/md-oh-dependent-exemption-schedule.added.md
+++ b/changelog.d/md-oh-dependent-exemption-schedule.added.md
@@ -1,0 +1,1 @@
+Add discrete per-filing-status AGI-stepped schedule parameters to the Maryland and Ohio dependent exemption contrib reforms.

--- a/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/head.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/head.yaml
@@ -1,0 +1,28 @@
+description: Under the Maryland dependent exemption reform, head-of-household filers receive this AGI-stepped per-dependent amount. Defaults mirror the baseline personal exemption schedule, so the reform is a no-op at default.
+brackets:
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 3_200
+  - threshold:
+      2021-01-01: 150_000
+    amount:
+      2021-01-01: 1_600
+  - threshold:
+      2021-01-01: 175_000
+    amount:
+      2021-01-01: 800
+  - threshold:
+      2021-01-01: 200_000
+    amount:
+      2021-01-01: 0
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: currency-USD
+  label: Maryland dependent exemption schedule for head of household filers
+  reference:
+    - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(2)
+      href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1
+    - title: Maryland 2025 Resident Tax Forms and Instructions - Exemption Amount Chart
+      href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=12

--- a/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/joint.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/joint.yaml
@@ -1,0 +1,28 @@
+description: Under the Maryland dependent exemption reform, joint filers receive this AGI-stepped per-dependent amount. Defaults mirror the baseline personal exemption schedule, so the reform is a no-op at default.
+brackets:
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 3_200
+  - threshold:
+      2021-01-01: 150_000
+    amount:
+      2021-01-01: 1_600
+  - threshold:
+      2021-01-01: 175_000
+    amount:
+      2021-01-01: 800
+  - threshold:
+      2021-01-01: 200_000
+    amount:
+      2021-01-01: 0
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: currency-USD
+  label: Maryland dependent exemption schedule for joint filers
+  reference:
+    - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(2)
+      href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1
+    - title: Maryland 2025 Resident Tax Forms and Instructions - Exemption Amount Chart
+      href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=12

--- a/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/separate.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/separate.yaml
@@ -1,0 +1,28 @@
+description: Under the Maryland dependent exemption reform, married-filing-separately filers receive this AGI-stepped per-dependent amount. Defaults mirror the baseline personal exemption schedule, so the reform is a no-op at default.
+brackets:
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 3_200
+  - threshold:
+      2021-01-01: 100_000
+    amount:
+      2021-01-01: 1_600
+  - threshold:
+      2021-01-01: 125_000
+    amount:
+      2021-01-01: 800
+  - threshold:
+      2021-01-01: 150_000
+    amount:
+      2021-01-01: 0
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: currency-USD
+  label: Maryland dependent exemption schedule for married filing separate filers
+  reference:
+    - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(1)
+      href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1
+    - title: Maryland 2025 Resident Tax Forms and Instructions - Exemption Amount Chart
+      href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=12

--- a/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/single.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/single.yaml
@@ -1,0 +1,28 @@
+description: Under the Maryland dependent exemption reform, single filers receive this AGI-stepped per-dependent amount. Defaults mirror the baseline personal exemption schedule, so the reform is a no-op at default.
+brackets:
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 3_200
+  - threshold:
+      2021-01-01: 100_000
+    amount:
+      2021-01-01: 1_600
+  - threshold:
+      2021-01-01: 125_000
+    amount:
+      2021-01-01: 800
+  - threshold:
+      2021-01-01: 150_000
+    amount:
+      2021-01-01: 0
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: currency-USD
+  label: Maryland dependent exemption schedule for single filers
+  reference:
+    - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(1)
+      href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1
+    - title: Maryland 2025 Resident Tax Forms and Instructions - Exemption Amount Chart
+      href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=12

--- a/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/md/dependent_exemption/schedule/surviving_spouse.yaml
@@ -1,0 +1,28 @@
+description: Under the Maryland dependent exemption reform, surviving spouse filers receive this AGI-stepped per-dependent amount. Defaults mirror the baseline personal exemption schedule, so the reform is a no-op at default.
+brackets:
+  - threshold:
+      2021-01-01: -.inf
+    amount:
+      2021-01-01: 3_200
+  - threshold:
+      2021-01-01: 150_000
+    amount:
+      2021-01-01: 1_600
+  - threshold:
+      2021-01-01: 175_000
+    amount:
+      2021-01-01: 800
+  - threshold:
+      2021-01-01: 200_000
+    amount:
+      2021-01-01: 0
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: currency-USD
+  label: Maryland dependent exemption schedule for surviving spouse filers
+  reference:
+    - title: Part III - Exemptions Section 10-211 Individuals Other Than Fiduciaries (c)(2)
+      href: https://casetext.com/statute/code-of-maryland/article-tax-general/title-10-income-tax/subtitle-2-maryland-taxable-income-calculations-for-individual/part-iii-exemptions/section-10-211-individuals-other-than-fiduciaries?searchWithin=true&listingIndexId=code-of-maryland.article-tax-general&q=blind&type=statute&sort=relevance&p=1
+    - title: Maryland 2025 Resident Tax Forms and Instructions - Exemption Amount Chart
+      href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=12

--- a/policyengine_us/parameters/gov/contrib/states/oh/dependent_exemption/schedule/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/oh/dependent_exemption/schedule/amount.yaml
@@ -1,0 +1,31 @@
+description: Under the Ohio dependent exemption reform, each eligible dependent receives this MAGI-stepped amount. Defaults mirror the baseline personal exemption schedule, so the reform is a no-op at default.
+brackets:
+  - threshold:
+      2021-01-01: 0
+    amount:
+      2021-01-01: 2_400
+  - threshold:
+      2021-01-01: 40_001
+    amount:
+      2021-01-01: 2_150
+  - threshold:
+      2021-01-01: 80_001
+    amount:
+      2021-01-01: 1_900
+  - threshold:
+      2021-01-01: .inf
+      2025-01-01: 750_000
+      2026-01-01: 500_000
+    amount:
+      2021-01-01: 0
+metadata:
+  type: single_amount
+  threshold_unit: currency-USD
+  amount_unit: currency-USD
+  period: year
+  label: Ohio dependent exemption schedule
+  reference:
+    - title: Ohio Revised Code - Section 5747.025 Personal exemptions (A)(1)(2)(3)
+      href: https://codes.ohio.gov/ohio-revised-code/section-5747.025
+    - title: Ohio Income Tax Form 2025 Instructions (Page 17)
+      href: https://dam.assets.ohio.gov/image/upload/v1767095693/tax.ohio.gov/forms/ohio_individual/individual/2025/it1040-booklet.pdf#page=17

--- a/policyengine_us/reforms/states/md/dependent_exemption/md_dependent_exemption_reform.py
+++ b/policyengine_us/reforms/states/md/dependent_exemption/md_dependent_exemption_reform.py
@@ -32,11 +32,31 @@ def create_md_dependent_exemption() -> Reform:
         def formula(tax_unit, period, parameters):
             p = parameters(period).gov.contrib.states.md.dependent_exemption
             count = tax_unit("md_eligible_dependents_count", period)
-            # Negative amount is a sentinel meaning "use the baseline per-person
-            # AGI-stepped amount" (so in_effect=true at default is a no-op). A
-            # value >= 0 applies a flat per-dependent amount instead.
-            baseline_per = tax_unit("md_personal_exemption", period)
-            per_dependent = where(p.amount < 0, baseline_per, p.amount)
+            # Negative amount is a sentinel meaning "use the discrete AGI-stepped
+            # per-filing-status schedule" (so in_effect=true at default is a
+            # no-op, since the contrib schedule mirrors the baseline). A value
+            # >= 0 applies a flat per-dependent amount instead.
+            filing_status = tax_unit("filing_status", period)
+            filing_statuses = filing_status.possible_values
+            agi = tax_unit("adjusted_gross_income", period)
+            schedule = p.schedule
+            stepped_per = select(
+                [
+                    filing_status == filing_statuses.SINGLE,
+                    filing_status == filing_statuses.SEPARATE,
+                    filing_status == filing_statuses.JOINT,
+                    filing_status == filing_statuses.HEAD_OF_HOUSEHOLD,
+                    filing_status == filing_statuses.SURVIVING_SPOUSE,
+                ],
+                [
+                    schedule.single.calc(agi, right=True),
+                    schedule.separate.calc(agi, right=True),
+                    schedule.joint.calc(agi, right=True),
+                    schedule.head.calc(agi, right=True),
+                    schedule.surviving_spouse.calc(agi, right=True),
+                ],
+            )
+            per_dependent = where(p.amount < 0, stepped_per, p.amount)
             return count * per_dependent
 
     class md_dependent_exemption_phaseout(Variable):

--- a/policyengine_us/reforms/states/oh/dependent_exemption/oh_dependent_exemption_reform.py
+++ b/policyengine_us/reforms/states/oh/dependent_exemption/oh_dependent_exemption_reform.py
@@ -31,12 +31,12 @@ def create_oh_dependent_exemption() -> Reform:
         def formula(tax_unit, period, parameters):
             p = parameters(period).gov.contrib.states.oh.dependent_exemption
             count = tax_unit("oh_eligible_dependents_count", period)
-            # Negative amount sentinel = use the baseline per-person AGI-stepped
-            # amount (no-op default); a value >= 0 applies a flat amount.
-            p_base = parameters(period).gov.states.oh.tax.income.exemptions.personal
+            # Negative amount sentinel = use the discrete MAGI-stepped schedule
+            # (no-op default, since the contrib schedule mirrors the baseline);
+            # a value >= 0 applies a flat per-dependent amount instead.
             agi = tax_unit("oh_agi", period)
-            baseline_per = p_base.amount.calc(agi)
-            per_dependent = where(p.amount < 0, baseline_per, p.amount)
+            stepped_per = p.schedule.amount.calc(agi)
+            per_dependent = where(p.amount < 0, stepped_per, p.amount)
             return count * per_dependent
 
     class oh_dependent_exemption_phaseout(Variable):

--- a/policyengine_us/tests/policy/contrib/states/md/dependent_exemption_reform_test.yaml
+++ b/policyengine_us/tests/policy/contrib/states/md/dependent_exemption_reform_test.yaml
@@ -175,3 +175,37 @@
   # age 18 is not < 18: dependent is excluded and falls back to the personal
   # count. Personal = parent + over-age dependent = 2 * 3,200 = 6,400.
   output: {md_total_personal_exemptions: 6_400}
+
+- name: MD dependent exemption reform - default schedule reproduces the AGI step-down
+  period: 2025
+  reforms: policyengine_us.reforms.states.md.dependent_exemption.md_dependent_exemption_reform.md_dependent_exemption_reform
+  input:
+    gov.contrib.states.md.dependent_exemption.in_effect: true
+    people:
+      parent: {age: 40, employment_income: 130_000}
+      child1: {age: 10, is_tax_unit_dependent: true}
+      child2: {age: 12, is_tax_unit_dependent: true}
+    tax_units: {tax_unit: {members: [parent, child1, child2], filing_status: SINGLE}}
+    households: {household: {members: [parent, child1, child2], state_name: MD}}
+  # At default (amount sentinel -1) the contrib schedule mirrors the baseline.
+  # Single AGI 130,000 is in the (125k, 150k] step, so each exemption is $800.
+  # Personal (1) + dependents (2) = 3 * 800 = 2,400. Confirms the discrete
+  # step-down is driven through the contrib schedule, not just a flat amount.
+  output: {md_total_personal_exemptions: 2_400}
+
+- name: MD dependent exemption reform - schedule per-dependent amount is adjustable
+  period: 2025
+  reforms: policyengine_us.reforms.states.md.dependent_exemption.md_dependent_exemption_reform.md_dependent_exemption_reform
+  input:
+    gov.contrib.states.md.dependent_exemption.in_effect: true
+    gov.contrib.states.md.dependent_exemption.schedule.single[0].amount: 5_000
+    people:
+      parent: {age: 40, employment_income: 40_000}
+      child1: {age: 10, is_tax_unit_dependent: true}
+      child2: {age: 12, is_tax_unit_dependent: true}
+    tax_units: {tax_unit: {members: [parent, child1, child2], filing_status: SINGLE}}
+    households: {household: {members: [parent, child1, child2], state_name: MD}}
+  # Raising the single first-bracket schedule amount to 5,000 drives the
+  # dependent portion only: 2 deps * 5,000 = 10,000. The personal portion keeps
+  # the baseline per-person amount (1 * 3,200). Total = 3,200 + 10,000 = 13,200.
+  output: {md_total_personal_exemptions: 13_200}

--- a/policyengine_us/tests/policy/contrib/states/oh/dependent_exemption_reform_test.yaml
+++ b/policyengine_us/tests/policy/contrib/states/oh/dependent_exemption_reform_test.yaml
@@ -175,3 +175,38 @@
   # age 18 is not < 18: dependent is excluded and falls back to the personal
   # count. Personal = parent + over-age dependent = 2 * 2,400 = 4,800.
   output: {oh_personal_exemptions: 4_800}
+
+- name: OH dependent exemption reform - default schedule reproduces the MAGI step-down
+  period: 2025
+  reforms: policyengine_us.reforms.states.oh.dependent_exemption.oh_dependent_exemption_reform.oh_dependent_exemption_reform
+  input:
+    gov.contrib.states.oh.dependent_exemption.in_effect: true
+    people:
+      parent: {age: 40, employment_income: 50_000}
+      child1: {age: 10, is_tax_unit_dependent: true}
+      child2: {age: 12, is_tax_unit_dependent: true}
+    tax_units: {tax_unit: {members: [parent, child1, child2], filing_status: SINGLE}}
+    households: {household: {members: [parent, child1, child2], state_name: OH}}
+  # At default (amount sentinel -1) the contrib schedule mirrors the baseline.
+  # MAGI 50,000 is in the (40,000, 80,000] step, so each exemption is $2,150.
+  # Personal (1) + dependents (2) = 3 * 2,150 = 6,450. Confirms the discrete
+  # step-down is driven through the contrib schedule, not just a flat amount.
+  output: {oh_personal_exemptions: 6_450}
+
+- name: OH dependent exemption reform - schedule per-dependent amount is adjustable
+  period: 2025
+  reforms: policyengine_us.reforms.states.oh.dependent_exemption.oh_dependent_exemption_reform.oh_dependent_exemption_reform
+  input:
+    gov.contrib.states.oh.dependent_exemption.in_effect: true
+    gov.contrib.states.oh.dependent_exemption.schedule.amount[0].amount: 3_000
+    people:
+      parent: {age: 40, employment_income: 30_000}
+      child1: {age: 10, is_tax_unit_dependent: true}
+      child2: {age: 12, is_tax_unit_dependent: true}
+    tax_units: {tax_unit: {members: [parent, child1, child2], filing_status: SINGLE}}
+    households: {household: {members: [parent, child1, child2], state_name: OH}}
+  # Raising the first-bracket schedule amount to 3,000 drives the dependent
+  # portion only: 2 deps * 3,000 = 6,000 (MAGI 30,000 is in the first step).
+  # The personal portion keeps the baseline per-person amount (1 * 2,400).
+  # Total = 2,400 + 6,000 = 8,400.
+  output: {oh_personal_exemptions: 8_400}


### PR DESCRIPTION
Resolves #8799.

## Problem
The dashboard drives most states' dependent exemption through the `gov.contrib.states.{st}.dependent_exemption` contrib (us#8696). That contrib offers a flat `amount` (or `-1` sentinel reading baseline), a single **linear** phase-out, and `age_limit` — which fits RI cleanly. **MD and OH don't fit**, because their dependent exemption is a **discrete, income-stepped, per-filing-status** schedule, so consumers had to reach into baseline brackets instead.

## Change
Give MD and OH a first-class `schedule` sub-tree in their contrib, mirroring the baseline, so the discrete step-down is adjustable entirely through the contrib (aligned with the rest of the us#8696 family):

- **MD** — per-filing-status bracket params `schedule/{single,separate,joint,head,surviving_spouse}.yaml`, mirroring the baseline §10-211 AGI step-down ($3,200 → $1,600 → $800 → $0 with filing-status-specific cutoffs).
- **OH** — `schedule/amount.yaml`, a MAGI-stepped bracket param mirroring the baseline §5747.025 schedule ($2,400 → $2,150 → $1,900 → $0).

The reform's dependent-exemption *maximum* now reads the stepped per-dependent amount from the contrib `schedule` rather than the baseline params. Defaults equal baseline, so:
- the `-1` `amount` sentinel remains a **no-op** at default (verified by the existing no-op tests),
- a non-negative flat `amount` still overrides the schedule,
- the linear `phaseout` still applies on top.

## Tests
Added to each state's contrib reform test file:
- **default schedule reproduces the AGI/MAGI step-down** — a higher-income unit lands on a lower step purely through the contrib (MD single AGI 130k → $800/exemption; OH MAGI 50k → $2,150/exemption).
- **schedule per-dependent amount is adjustable** — overriding `schedule.single[0].amount` (MD) / `schedule.amount[0].amount` (OH) changes only the dependent portion, leaving the baseline personal portion intact.

All existing no-op / flat-amount / phase-out / age-limit cases are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
