### PR TITLE
Correct child care program registry metadata in programs.yaml

### DIFF
--- a/changelog.d/update-childcare-program-registry.fixed.md
+++ b/changelog.d/update-childcare-program-registry.fixed.md
@@ -1,0 +1,1 @@
+Correct child care program coverage metadata in programs.yaml (remove duplicate coverage key; mark Alabama, New Jersey, South Carolina, and Virginia child care programs as complete).

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -460,8 +460,7 @@ programs:
     category: Benefits
     agency: HHS
     status: partial
-    coverage: AK, AR, AL, AZ, CA, CO, CT, DE, DC, FL, GA, HI, IA, ID, IL, IN, KS, KY, LA, MA, MD, ME, MN, MO, MS, NC, NH, NJ, PA, RI, SC, TX, VA, VT, WA, WV
-    coverage: AK, AR, AL, AZ, CA, CO, CT, DE, DC, FL, GA, HI, IA, ID, IL, IN, KS, KY, LA, MA, MD, ME, MI, MN, MS, NC, NH, NJ, PA, RI, SC, TX, VA, VT, WA, WV
+    coverage: AK, AR, AL, AZ, CA, CO, CT, DE, DC, FL, GA, HI, IA, ID, IL, IN, KS, KY, LA, MA, MD, ME, MI, MN, MO, MS, NC, NH, NJ, PA, RI, SC, TX, VA, VT, WA, WV
     state_implementations:
       - state: AK
         status: complete
@@ -476,7 +475,7 @@ programs:
         variable: ar_sra
         parameter_prefix: gov.states.ar.ade.oec.sra
       - state: AL
-        status: partial
+        status: complete
         name: Alabama CCSP
         full_name: Alabama Child Care Subsidy Program
         variable: al_ccsp
@@ -577,7 +576,7 @@ programs:
       - state: MI
         status: complete
         name: Michigan CDC
-        full_name: Child Development and Care program
+        full_name: Michigan Child Development and Care Program
         variable: mi_child_care_subsidies
         parameter_prefix: gov.states.mi.mdhhs.ccap
       - state: MS
@@ -604,9 +603,11 @@ programs:
         full_name: New Hampshire Child Care Scholarship Program
         variable: nh_ccap
       - state: NJ
-        status: in_progress
+        status: complete
         name: New Jersey CCAP
         full_name: New Jersey Child Care Assistance Program
+        variable: nj_ccap
+        parameter_prefix: gov.states.nj.njdhs.ccap
       - state: DC
         status: complete
         name: DC CCSP
@@ -633,18 +634,22 @@ programs:
         full_name: Rhode Island Child Care Assistance Program
         variable: ri_ccap
       - state: SC
-        status: in_progress
+        status: complete
         name: South Carolina CCAP
         full_name: South Carolina Child Care Assistance Program
+        variable: sc_ccap
+        parameter_prefix: gov.states.sc.dss.ccap
       - state: TX
         status: complete
         name: Texas CCS
         full_name: Texas Child Care Services
         variable: tx_ccs
       - state: VA
-        status: in_progress
+        status: complete
         name: Virginia CCSP
         full_name: Virginia Child Care Subsidy Program
+        variable: va_ccsp
+        parameter_prefix: gov.states.va.dss.ccsp
       - state: VT
         status: complete
         name: Vermont CCFAP


### PR DESCRIPTION
## Summary

Fixes stale and buggy child care (CCDF) metadata in `policyengine_us/programs.yaml`, the registry served via `/us/metadata` and consumed by the model coverage page. No model logic changes — metadata only.

### Bug fix
- **Duplicate `coverage:` key** in the CCDF block. There were two `coverage:` lines: one listed `MO` but not `MI`, the other `MI` but not `MO`. YAML keeps the last duplicate key, so the effective coverage silently dropped `MO`. Collapsed into a single line listing **both MI and MO**.

### Stale statuses corrected
These programs are fully implemented in the rules engine and wired into the federal `gov.hhs.ccdf.child_care_subsidy_programs` aggregator, but were still marked `in_progress`/`partial` with no `variable`:

| State | Was | Now | Added |
|---|---|---|---|
| AL | `partial` | `complete` | (already had `variable`/`parameter_prefix`) |
| NJ | `in_progress` | `complete` | `variable: nj_ccap`, `parameter_prefix: gov.states.nj.njdhs.ccap` |
| SC | `in_progress` | `complete` | `variable: sc_ccap`, `parameter_prefix: gov.states.sc.dss.ccap` |
| VA | `in_progress` | `complete` | `variable: va_ccsp`, `parameter_prefix: gov.states.va.dss.ccsp` |

### Tidy
- Michigan `full_name`: `Child Development and Care program` → `Michigan Child Development and Care Program` (consistent with other entries).

## Verification
- `programs.yaml` parses with PyYAML; CCDF `state_implementations` has no duplicate states.
- `coverage:` ↔ `state_implementations` are fully consistent (every coverage state has an entry and vice versa).
- Each state marked `complete` appears in the authoritative `gov.hhs.ccdf.child_care_subsidy_programs` roster.

## Test plan
- [x] PyYAML parse + integrity check pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)