### PR TITLE
Update Colorado SSI supplement standards for 2026

### DIFF
--- a/changelog.d/co-ssi-2026.fixed.md
+++ b/changelog.d/co-ssi-2026.fixed.md
@@ -1,0 +1,1 @@
+Update Colorado OAP and AND-CS grant standards for 2026.

--- a/policyengine_us/parameters/gov/states/co/ssa/oap/grant_standard.yaml
+++ b/policyengine_us/parameters/gov/states/co/ssa/oap/grant_standard.yaml
@@ -4,6 +4,7 @@ values:
   2023-01-01: 952
   2024-01-01: 982
   2025-01-01: 1_005
+  2026-01-01: 1_032
 
 metadata:
   unit: currency-USD
@@ -14,5 +15,7 @@ metadata:
       href: https://www.coloradosos.gov/CCR/GenerateRulePdf.do?ruleVersionId=10694#page=57
     - title: ADULT FINANCIAL PROGRAMS | Income Maintenance (Volume 3) | 3.530(A)
       href: https://sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=11264&fileName=9%20CCR%202503-5#page=57
+    - title: ADULT FINANCIAL PROGRAMS | Income Maintenance (Volume 3) | 3.530(A)
+      href: https://www.sos.state.co.us/CCR/GenerateRulePdf.do?fileName=9+CCR+2503-5&ruleVersionId=12428#page=80
     - title: Colorado Department of Human Services | OPERATION MEMO
       href: https://drive.google.com/file/d/1bc_hUAoSzUbyRuMCzcxk2zV7b4RqkwyC/view

--- a/policyengine_us/parameters/gov/states/co/ssa/state_supplement/grant_standard.yaml
+++ b/policyengine_us/parameters/gov/states/co/ssa/state_supplement/grant_standard.yaml
@@ -22,6 +22,7 @@ values:
   2023-01-01: 914
   2024-01-01: 943
   2025-01-01: 967
+  2026-01-01: 994
 
 metadata:
   unit: currency-USD
@@ -36,3 +37,5 @@ metadata:
       href: https://www.coloradosos.gov/CCR/GenerateRulePdf.do?ruleVersionId=5834#page=73
     - title: 9 CCR 2503-5, Section 3.546, AND-CS Program (effective 2023)
       href: https://www.coloradosos.gov/CCR/GenerateRulePdf.do?ruleVersionId=10694#page=73
+    - title: 9 CCR 2503-5, Section 3.546, AND-CS Program
+      href: https://www.sos.state.co.us/CCR/GenerateRulePdf.do?fileName=9+CCR+2503-5&ruleVersionId=12428#page=99

--- a/policyengine_us/tests/policy/baseline/gov/states/co/ssa/oap/co_oap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/ssa/oap/co_oap.yaml
@@ -24,3 +24,12 @@
     ssi: 6_000
   output:
     co_oap: 0
+
+- name: 2026 grant standard
+  period: 2026
+  input:
+    co_oap_eligible: true
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    co_oap: 12_384

--- a/policyengine_us/tests/policy/baseline/gov/states/co/ssa/state_supplement/co_state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/ssa/state_supplement/co_state_supplement.yaml
@@ -117,3 +117,13 @@
     ssi: 5_000
   output:
     co_state_supplement: 4_604
+
+- name: Case 13, 2026 grant standard of 994.
+  absolute_error_margin: 0.1
+  period: 2026
+  input:
+    co_state_supplement_eligible: true
+    ssi_countable_income: 0
+    ssi: 0
+  output:
+    co_state_supplement: 11_928

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/oap.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/oap.yaml
@@ -49,7 +49,7 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 12060.0
+        co_oap: 12384.0
 - name: co_oap_single_resources_above_1500_ineligible (co)
   period: 2026
   absolute_error_margin: 0.1
@@ -101,4 +101,4 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 12060.0
+        co_oap: 12384.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/state_supplement.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/state_supplement.yaml
@@ -103,4 +103,4 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 132.0
+        co_oap: 456.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/tax_credits_composition.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/co/tax_credits_composition.yaml
@@ -101,7 +101,7 @@
       head:
         co_family_affordability_credit: 0.0
         co_state_supplement: 0.0
-        co_oap: 132.0
+        co_oap: 456.0
 - name: statetax_size_2_married_couple_no_children (co)
   period: 2026
   absolute_error_margin: 0.1


### PR DESCRIPTION
## Summary

- Add 2026 Colorado OAP grant standard of $1,032/month.
- Add 2026 Colorado AND-CS state supplement grant standard of $994/month.
- Add focused 2026 YAML regression cases for both variables.

## Source

Colorado Secretary of State, 9 CCR 2503-5, rule version 12428:
- Section 3.530(A): total monthly OAP grant standard is $1,032 effective January 1, 2026.
- Section 3.546(A): total AND-CS grant standard is $994 effective January 1, 2026.

## Validation

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/states/co/ssa/oap/co_oap.yaml policyengine_us/tests/policy/baseline/gov/states/co/ssa/state_supplement/co_state_supplement.yaml -c policyengine_us`
- `git diff --check`

This was exposed by the Axiom Populace parity comparator: current published PE-US is $27/month low for the 2026 Colorado OAP and AND-CS standards. With this branch installed as the oracle, the Axiom comparison passes with 0 mismatches over 4,418 compared values.
