### PR TITLE
Remove dead contrib parameters (maryland_child_alliance, second_earner_reform)

### DIFF
--- a/changelog.d/remove-dead-contrib-params.changed.md
+++ b/changelog.d/remove-dead-contrib-params.changed.md
@@ -1,0 +1,1 @@
+Remove unused contrib parameters (maryland_child_alliance, second_earner_reform) and the empty wa reforms package.

--- a/changelog.d/remove-dead-contrib-params.changed.md
+++ b/changelog.d/remove-dead-contrib-params.changed.md
@@ -1,1 +1,1 @@
-Remove unused contrib parameters (maryland_child_alliance, second_earner_reform) and the empty wa reforms package.
+Remove unused contrib parameters (maryland_child_alliance, second_earner_reform).

--- a/policyengine_us/parameters/gov/contrib/maryland_child_alliance/README.md
+++ b/policyengine_us/parameters/gov/contrib/maryland_child_alliance/README.md
@@ -1,1 +1,0 @@
-# Maryland Child Alliance

--- a/policyengine_us/parameters/gov/contrib/maryland_child_alliance/abolish_non_refundable_child_eitc.yaml
+++ b/policyengine_us/parameters/gov/contrib/maryland_child_alliance/abolish_non_refundable_child_eitc.yaml
@@ -1,6 +1,0 @@
-description: Abolish the non-refundable Maryland EITC for tax units with children.
-values:
-  0000-01-01: false
-metadata:
-  unit: bool
-  label: Abolish MD non-refundable EITC for families with children

--- a/policyengine_us/parameters/gov/contrib/maryland_child_alliance/abolish_refundable_child_eitc.yaml
+++ b/policyengine_us/parameters/gov/contrib/maryland_child_alliance/abolish_refundable_child_eitc.yaml
@@ -1,6 +1,0 @@
-description: Abolish the refundable Maryland EITC for tax units with children.
-values:
-  0000-01-01: false
-metadata:
-  unit: bool
-  label: Abolish MD refundable EITC for families with children

--- a/policyengine_us/parameters/gov/contrib/second_earner_reform/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/second_earner_reform/in_effect.yaml
@@ -1,8 +1,0 @@
-description: The second earner tax reform is in effect if this is true.
-metadata:
-  unit: bool
-  period: year
-  label: Second earner tax reform in effect
-
-values:
-  0000-01-01: false


### PR DESCRIPTION
## What

Removes two verified-dead contrib parameter groups (zero readers anywhere):

- `parameters/gov/contrib/maryland_child_alliance/` — 2 params + README, no reform/variable reads them
- `parameters/gov/contrib/second_earner_reform/` — `in_effect.yaml`, no reform consumes it

## Why it's safe

Contrib is entirely opt-in: nothing in the baseline model reads `gov.contrib.*`
except structural reforms that activate only when their `in_effect` parameter is
set. Both removed groups were grep-verified to have **zero readers** in any `.py`,
`.yaml`, `.md`, or test across the repo, so removal cannot change any baseline or
reform output.

## Explicitly left alone (verified live / in use)

- `contrib/congress/wftca/` — LIVE: its `bonus_guaranteed_deduction` variable is in the `adds` of the core `standard_deduction`.
- `child_poverty_impact_dashboard` family (14-state EITC + MD/OH dependent exemption) — in active development.
- Empty `reforms/states/wa/` package kept: deleting it makes the selective (Quick Feedback) test runner fall back to the full contrib/states suite un-sharded and time out. It is inert, so it stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)