### PR TITLE
Fix Maine PTFC senior benefit base (mis-typed marginal scale) (#8813)

### DIFF
--- a/changelog.d/fix-me-ptfc-senior-benefit-base.fixed.md
+++ b/changelog.d/fix-me-ptfc-senior-benefit-base.fixed.md
@@ -1,0 +1,1 @@
+Fix Maine property tax fairness credit senior benefit base, which never applied at the age-65 threshold because its enhanced-base parameter was mistyped as a marginal scale.

--- a/changelog.d/fix-me-ptfc-senior-benefit-base.fixed.md
+++ b/changelog.d/fix-me-ptfc-senior-benefit-base.fixed.md
@@ -1,1 +1,1 @@
-Fix Maine property tax fairness credit senior benefit base, which never applied at the age-65 threshold because its enhanced-base parameter was mistyped as a marginal scale.
+Fix Maine property tax fairness credit senior benefit base, which never applied at the age-65 threshold because its enhanced-base parameter was mistyped as a marginal scale, and which no longer inflation-adjusts for 2026 onward because its uprating block was misplaced on the bracket instead of the amount.

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/property_tax/benefit_base/senior.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/property_tax/benefit_base/senior.yaml
@@ -1,4 +1,4 @@
-description: Maine allows for this property tax fairness credit benefit base for seniors.
+description: Maine provides this property tax fairness credit benefit base for seniors.
 
 brackets:
   - threshold:
@@ -12,10 +12,11 @@ brackets:
       2024-01-01: 4_000
       2025-01-01: 4_100
     metadata:
-      uprating: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
+      uprating:
+        parameter: gov.irs.uprating
+        rounding:
+          type: downwards
+          interval: 50
 
 metadata:
   type: single_amount
@@ -34,7 +35,7 @@ metadata:
     - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit Line 7
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=2
     - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit Line 7
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=2
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=2
     - title: 2025 Form 1040ME Schedule PTFC/STFC Line 7-8 (senior benefit base)
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=2
   period: year

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/property_tax/benefit_base/senior.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/property_tax/benefit_base/senior.yaml
@@ -18,7 +18,9 @@ brackets:
         interval: 50
 
 metadata:
-  unit: currency-USD
+  type: single_amount
+  threshold_unit: year
+  amount_unit: currency-USD
   reference:
     # This senior benefit base takes effect in 2024 
     - title: §5219-KK. Property tax fairness credit for tax (1) (A-1) (4)

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/property_tax/benefit_base/senior.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/property_tax/benefit_base/senior.yaml
@@ -4,33 +4,34 @@ brackets:
   - threshold:
       2018-01-01: 0
     amount:
-      2018-01-01: 0 
+      2018-01-01: 0
   - threshold:
       2018-01-01: 65
     amount:
-      2018-01-01: 0
-      2024-01-01: 4_000
-      2025-01-01: 4_100
-    metadata:
-      uprating:
-        parameter: gov.irs.uprating
-        rounding:
-          type: downwards
-          interval: 50
+      values:
+        2018-01-01: 0
+        2024-01-01: 4_000
+        2025-01-01: 4_100
+      metadata:
+        uprating:
+          parameter: gov.irs.uprating
+          rounding:
+            type: downwards
+            interval: 50
 
 metadata:
   type: single_amount
   threshold_unit: year
   amount_unit: currency-USD
   reference:
-    # This senior benefit base takes effect in 2024 
+    # This senior benefit base takes effect in 2024
     - title: §5219-KK. Property tax fairness credit for tax (1) (A-1) (4)
       href: https://legislature.maine.gov/statutes/36/title36sec5219-KK.html
     - title: §5403. Annual adjustments for inflation 6-Property tax fairness credit
       href: https://legislature.maine.gov/statutes/36/title36sec5403.html
-    - title: 2021 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit 
+    - title: 2021 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/21_1040me_sched_pstfc_dwnldff.pdf#page=2
-    - title: 2022 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit 
+    - title: 2022 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_pstfc_ff.pdf#page=2
     - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit Line 7
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=2

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/property_tax_fairness_credit/me_property_tax_fairness_credit_base_cap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/property_tax_fairness_credit/me_property_tax_fairness_credit_base_cap.yaml
@@ -1,5 +1,6 @@
 - name: Case 1, filing single with no dependent and no income 
   period: 2022
+  absolute_error_margin: 0.1
   input:
     state_code: ME
     filing_status: SINGLE
@@ -13,6 +14,7 @@
 
 - name: Case 2, filing single with 3 dependnet and high income
   period: 2022
+  absolute_error_margin: 0.1
   input:
     state_code: ME
     filing_status: SINGLE
@@ -26,6 +28,7 @@
 
 - name: Case 3, filing single with 3 dependnet and some income
   period: 2022
+  absolute_error_margin: 0.1
   input:
     state_code: ME
     filing_status: SINGLE
@@ -39,6 +42,7 @@
   
 - name: Case 4, in 2024, filing single with no dependent and no income
   period: 2024
+  absolute_error_margin: 0.1
   input:
     state_code: ME
     filing_status: SINGLE
@@ -125,5 +129,33 @@
     me_property_tax_fairness_credit_countable_rent_property_tax: 5_000
     age_head: 65
     age_spouse: 0
+  output:
+    me_property_tax_fairness_credit_base_cap: 1_700
+
+- name: Age exactly 64 filer in 2025 does not receive the senior benefit base (discriminating mirror of the age-65 case)
+  period: 2025
+  absolute_error_margin: 0.1
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    ctc_qualifying_children: 0
+    me_sales_and_property_tax_fairness_credit_income: 60_000
+    me_property_tax_fairness_credit_countable_rent_property_tax: 5_000
+    age_head: 64
+    age_spouse: 0
+  output:
+    me_property_tax_fairness_credit_base_cap: 150
+
+- name: MFJ with one spouse age 67 receives the senior benefit base via greater_age_head_spouse
+  period: 2025
+  absolute_error_margin: 0.1
+  input:
+    state_code: ME
+    filing_status: JOINT
+    ctc_qualifying_children: 0
+    me_sales_and_property_tax_fairness_credit_income: 60_000
+    me_property_tax_fairness_credit_countable_rent_property_tax: 5_000
+    age_head: 60
+    age_spouse: 67
   output:
     me_property_tax_fairness_credit_base_cap: 1_700

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/property_tax_fairness_credit/me_property_tax_fairness_credit_base_cap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/property_tax_fairness_credit/me_property_tax_fairness_credit_base_cap.yaml
@@ -109,3 +109,21 @@
     age_spouse: 0
   output:
     me_property_tax_fairness_credit_base_cap: 1_700
+
+# Regression for the senior benefit base at the exact age-65 threshold. The
+# senior scale must be a SingleAmountTaxScale (inclusive at the threshold) so it
+# returns $4,100 at age 65; a marginal scale returned $0 there, silently falling
+# back to the $2,550 non-senior single base (would give $150, not $1,700).
+- name: Age exactly 65 filer 2025 senior benefit base applies at the threshold
+  period: 2025
+  absolute_error_margin: 0.1
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    ctc_qualifying_children: 0
+    me_sales_and_property_tax_fairness_credit_income: 60_000
+    me_property_tax_fairness_credit_countable_rent_property_tax: 5_000
+    age_head: 65
+    age_spouse: 0
+  output:
+    me_property_tax_fairness_credit_base_cap: 1_700

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/property_tax_fairness_credit/me_property_tax_fairness_credit_base_cap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/property_tax_fairness_credit/me_property_tax_fairness_credit_base_cap.yaml
@@ -159,3 +159,23 @@
     age_spouse: 67
   output:
     me_property_tax_fairness_credit_base_cap: 1_700
+
+# Verifies the senior benefit base inflation-adjusts for 2026+ per 36 M.R.S.
+# §5403 (uprated by gov.irs.uprating, floored to $50): 2025 $4,100 -> 2026
+# $4,150. At $60K income (4% = $2,400) the uncapped credit is $4,150 - $2,400
+# = $1,750, below the $2,000 senior cap, so the output exposes the uprated
+# base directly. This discriminates a working uprating from a base left flat
+# at $4,100 (which would give $1,700).
+- name: Age 65+ filer 2026 senior benefit base uprates to $4,150 (inflation-adjusted)
+  period: 2026
+  absolute_error_margin: 0.1
+  input:
+    state_code: ME
+    filing_status: SINGLE
+    ctc_qualifying_children: 0
+    me_sales_and_property_tax_fairness_credit_income: 60_000
+    me_property_tax_fairness_credit_countable_rent_property_tax: 5_000
+    age_head: 66
+    age_spouse: 0
+  output:
+    me_property_tax_fairness_credit_base_cap: 1_750


### PR DESCRIPTION
Fixes #8813.

## Problem

The Maine Property Tax Fairness Credit under-computed the credit for filers whose older of head/spouse is **exactly age 65+** (tax years 2024+): the enhanced senior benefit base silently never applied.

## Root cause

`parameters/.../fairness/property_tax/benefit_base/senior.yaml` was missing `metadata.type: single_amount`, so its `brackets` loaded as a `MarginalAmountTaxScale` instead of a `SingleAmountTaxScale`. The marginal scale treats the bracket threshold as **exclusive**, so `senior.calc(65)` returned `0` at the exact threshold. The guard in `me_property_tax_fairness_credit_base_cap` (`senior_benefit_base != 0`) then fell back to the non-senior single base.

(This is why the existing age-66 test passed — above the threshold the marginal scale coincidentally returns the right amount; only age exactly 65 was broken.)

## Fix

- Add `type: single_amount` (plus `threshold_unit: year` / `amount_unit: currency-USD`, matching the sibling `cap.yaml`) to `senior.yaml`.
- Add an **age-exactly-65** regression test to `me_property_tax_fairness_credit_base_cap.yaml`: 2025 single filer, income \$60,000, countable rent property tax \$5,000 → base cap **\$1,700** (senior base \$4,100 − 4% × income). Before the fix this returned \$150 (fallback to the \$2,550 single base).

## References
- 2025 Form 1040ME Schedule PTFC/STFC (lines 7-9, 12)
- 36 MRS §5219-KK

🤖 Generated with [Claude Code](https://claude.com/claude-code)