### PR TITLE
Add KS TANF child earned income exemption and incapacitated-person care deduction

### DIFF
--- a/changelog.d/ks-tanf-child-earnings-and-care-deduction.added.md
+++ b/changelog.d/ks-tanf-child-earnings-and-care-deduction.added.md
@@ -1,0 +1,2 @@
+- Excluded children's earned income from Kansas TANF gross-income and countable income per KEESM 6410.
+- Added a Kansas TANF earned income deduction for the care of an incapacitated person per K.A.R. 30-4-111(b)(3).

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/integration.yaml
@@ -611,3 +611,198 @@
     ks_tanf_eligible: true
     # Benefit: 349 - 164 = 185
     ks_tanf: 185
+
+- name: Case 17, working teenager's earned income is exempt.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income_before_lsr: 6_000  # $500/month
+      person2:
+        age: 8
+        is_tax_unit_dependent: true
+      person3:
+        age: 16  # working teenager
+        is_tax_unit_dependent: true
+        employment_income_before_lsr: 3_600  # $300/month
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        spm_unit_cash_assets: 500
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: KS
+  output:
+    # Per KEESM 6410: person3 (age 16) is a child, so their $300/month earnings
+    # are exempt as income -- excluded from both the gross-income test and
+    # countable income. Without the exemption, gross income ($800) would exceed
+    # 30% FPL for a family of 3 (~$670) and the family would be ineligible.
+    # person1: $500 - $90 = $410, * 0.40 = $164
+    # person3: $300 - $90 = $210, * 0.40 = $84 (computed, but exempt)
+    spm_unit_size: 3
+    ks_tanf_earned_income_after_deductions: [164, 0, 84]
+    ks_tanf_countable_earned_income: 164
+    ks_tanf_countable_income: 164
+    ks_tanf_maximum_benefit: 386
+    ks_tanf_gross_income_eligible: true
+    ks_tanf_income_eligible: true
+    ks_tanf_eligible: true
+    # Benefit: 386 - 164 = 222
+    ks_tanf: 222
+
+- name: Case 18, incapacitated person care expenses reduce countable income.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income_before_lsr: 6_000  # $500/month
+        care_expenses: 1_200  # $100/month, care of an incapacitated person
+      person2:
+        age: 8
+        is_tax_unit_dependent: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        spm_unit_cash_assets: 500
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    # Per K.A.R. 30-4-111(b)(3): care expenses for an incapacitated person are
+    # deducted after the $90 and 60% disregards, with no cap.
+    # person1: $500 - $90 = $410, * 0.40 = $164
+    # Care expenses: $100/month -> countable earned: $164 - $100 = $64
+    spm_unit_size: 2
+    ks_tanf_earned_income_after_deductions: [164, 0]
+    ks_tanf_countable_earned_income: 64
+    ks_tanf_countable_income: 64
+    ks_tanf_maximum_benefit: 309  # Group I, size 2: 217 + 92
+    ks_tanf_gross_income_eligible: true
+    ks_tanf_income_eligible: true
+    ks_tanf_eligible: true
+    # Benefit: 309 - 64 = 245
+    ks_tanf: 245
+
+# Cases 19 and 20 are a matched pair: identical household and identical $400/month
+# earnings, differing only in whether the earner is a child. They isolate the
+# KEESM 6410 child earned income exemption -- the child earner's family keeps the
+# full benefit, while the non-student adult earner's family has that income counted.
+
+- name: Case 19, child's $400/month earnings are fully exempt, benefit unreduced.
+  period: 2025-01
+  input:
+    people:
+      person1:  # parent, no income
+        age: 35
+      person2:  # young child, keeps the family demographically eligible
+        age: 5
+        is_tax_unit_dependent: true
+      person3:  # working child (age 16)
+        age: 16
+        is_tax_unit_dependent: true
+        employment_income_before_lsr: 4_800  # $400/month
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        spm_unit_cash_assets: 500
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: KS
+  output:
+    # person3 (age 16) is a child, so their $400/month is exempt as income
+    # (KEESM 6410). The family has zero countable income and receives the full
+    # Group I size-3 payment standard -- exactly as if the child earned nothing.
+    spm_unit_size: 3
+    ks_tanf_countable_earned_income: 0
+    ks_tanf_countable_income: 0
+    ks_tanf_gross_income_eligible: true
+    ks_tanf_maximum_benefit: 386
+    ks_tanf_eligible: true
+    ks_tanf: 386
+
+- name: Case 20, same earnings from a non-student adult are counted, benefit reduced.
+  period: 2025-01
+  input:
+    people:
+      person1:  # parent, no income
+        age: 35
+      person2:  # young child, keeps the family demographically eligible
+        age: 5
+        is_tax_unit_dependent: true
+      person3:  # 18-year-old, not in school -> not a child
+        age: 18
+        is_in_secondary_school: false
+        is_tax_unit_dependent: true
+        employment_income_before_lsr: 4_800  # $400/month
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        spm_unit_cash_assets: 500
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: KS
+  output:
+    # person3 (age 18, not in secondary school) is not a child, so their
+    # $400/month is counted. Only the earner's status differs from Case 19.
+    # person3: $400 - $90 = $310, * 0.40 = $124
+    spm_unit_size: 3
+    ks_tanf_countable_earned_income: 124
+    ks_tanf_countable_income: 124
+    ks_tanf_gross_income_eligible: true
+    ks_tanf_maximum_benefit: 386
+    ks_tanf_eligible: true
+    # Benefit: 386 - 124 = 262 (vs the full 386 in Case 19)
+    ks_tanf: 262
+
+- name: Case 21, same household as Case 18 but with no care expenses.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income_before_lsr: 6_000  # $500/month
+      person2:
+        age: 8
+        is_tax_unit_dependent: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        spm_unit_cash_assets: 500
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    # Identical to Case 18 but with no care_expenses.
+    # person1: $500 - $90 = $410, * 0.40 = $164 countable earned (no deduction).
+    # Case 18's $100/month care deduction is exactly the $245 - $145 = $100
+    # benefit difference, proving care_expenses reduces countable income.
+    spm_unit_size: 2
+    ks_tanf_earned_income_after_deductions: [164, 0]
+    ks_tanf_countable_earned_income: 164
+    ks_tanf_countable_income: 164
+    ks_tanf_maximum_benefit: 309
+    ks_tanf_eligible: true
+    # Benefit: 309 - 164 = 145 (vs 245 in Case 18; the $100 gap is the care deduction)
+    ks_tanf: 145

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/integration.yaml
@@ -662,36 +662,41 @@
       person1:
         age: 40
         employment_income_before_lsr: 6_000  # $500/month
-        care_expenses: 1_200  # $100/month, care of an incapacitated person
       person2:
         age: 8
         is_tax_unit_dependent: true
+      person3:  # disabled adult dependent receiving the care
+        age: 60
+        is_disabled: true
+        is_tax_unit_dependent: true
+        care_expenses: 1_200  # $100/month, care of an incapacitated person
     spm_units:
       spm_unit:
-        members: [person1, person2]
+        members: [person1, person2, person3]
         spm_unit_cash_assets: 500
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members: [person1, person2, person3]
     households:
       household:
-        members: [person1, person2]
+        members: [person1, person2, person3]
         state_code: KS
   output:
-    # Per K.A.R. 30-4-111(b)(3): care expenses for an incapacitated person are
-    # deducted after the $90 and 60% disregards, with no cap.
+    # Per K.A.R. 30-4-111(b)(3): care expenses for an incapacitated person in
+    # the family group (person3) are deducted after the $90 and 60%
+    # disregards, with no cap.
     # person1: $500 - $90 = $410, * 0.40 = $164
     # Care expenses: $100/month -> countable earned: $164 - $100 = $64
-    spm_unit_size: 2
-    ks_tanf_earned_income_after_deductions: [164, 0]
+    spm_unit_size: 3
+    ks_tanf_earned_income_after_deductions: [164, 0, 0]
     ks_tanf_countable_earned_income: 64
     ks_tanf_countable_income: 64
-    ks_tanf_maximum_benefit: 309  # Group I, size 2: 217 + 92
+    ks_tanf_maximum_benefit: 386  # Group I, size 3
     ks_tanf_gross_income_eligible: true
     ks_tanf_income_eligible: true
     ks_tanf_eligible: true
-    # Benefit: 309 - 64 = 245
-    ks_tanf: 245
+    # Benefit: 386 - 64 = 322
+    ks_tanf: 322
 
 # Cases 19 and 20 are a matched pair: identical household and identical $400/month
 # earnings, differing only in whether the earner is a child. They isolate the
@@ -782,6 +787,47 @@
       person2:
         age: 8
         is_tax_unit_dependent: true
+      person3:  # same disabled adult dependent, but no care expenses claimed
+        age: 60
+        is_disabled: true
+        is_tax_unit_dependent: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        spm_unit_cash_assets: 500
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: KS
+  output:
+    # Identical to Case 18 but with no care_expenses.
+    # person1: $500 - $90 = $410, * 0.40 = $164 countable earned (no deduction).
+    # Case 18's $100/month care deduction is exactly the $322 - $222 = $100
+    # benefit difference, proving care_expenses reduces countable income.
+    spm_unit_size: 3
+    ks_tanf_earned_income_after_deductions: [164, 0, 0]
+    ks_tanf_countable_earned_income: 164
+    ks_tanf_countable_income: 164
+    ks_tanf_maximum_benefit: 386
+    ks_tanf_eligible: true
+    # Benefit: 386 - 164 = 222 (vs 322 in Case 18; the $100 gap is the care deduction)
+    ks_tanf: 222
+
+- name: Case 22, 18-year-old student heading her own case has earnings counted.
+  period: 2025-01
+  input:
+    people:
+      person1:  # teen parent, 18, in secondary school, heads her own case
+        age: 18
+        is_in_secondary_school: true
+        is_tax_unit_dependent: false
+        employment_income_before_lsr: 4_800  # $400/month
+      person2:
+        age: 1
+        is_tax_unit_dependent: true
     spm_units:
       spm_unit:
         members: [person1, person2]
@@ -794,15 +840,16 @@
         members: [person1, person2]
         state_code: KS
   output:
-    # Identical to Case 18 but with no care_expenses.
-    # person1: $500 - $90 = $410, * 0.40 = $164 countable earned (no deduction).
-    # Case 18's $100/month care deduction is exactly the $245 - $145 = $100
-    # benefit difference, proving care_expenses reduces countable income.
+    # person1 meets KEESM 6410's age/student test, but heads her own case
+    # rather than being a dependent child, so she is acting in her own
+    # behalf and her earnings are NOT exempt.
+    # person1: $400 - $90 = $310, * 0.40 = $124
     spm_unit_size: 2
-    ks_tanf_earned_income_after_deductions: [164, 0]
-    ks_tanf_countable_earned_income: 164
-    ks_tanf_countable_income: 164
-    ks_tanf_maximum_benefit: 309
+    ks_tanf_child_earned_income_exempt: [false, true]
+    ks_tanf_countable_earned_income: 124
+    ks_tanf_countable_income: 124
+    ks_tanf_maximum_benefit: 309  # Group I, size 2
+    ks_tanf_gross_income_eligible: true
     ks_tanf_eligible: true
-    # Benefit: 309 - 164 = 145 (vs 245 in Case 18; the $100 gap is the care deduction)
-    ks_tanf: 145
+    # Benefit: 309 - 124 = 185
+    ks_tanf: 185

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_child_earned_income_exempt.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_child_earned_income_exempt.yaml
@@ -1,0 +1,55 @@
+# Kansas TANF child earned income exemption (KEESM 6410)
+# A child's earned income is exempt if the child is under age 18, or under
+# age 19 and working toward a high school diploma or its equivalent
+# (secondary school student).
+
+- name: Case 1, child under 18 is exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 10
+  output:
+    ks_tanf_child_earned_income_exempt: true
+
+- name: Case 2, 17-year-old is exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 17
+  output:
+    ks_tanf_child_earned_income_exempt: true
+
+- name: Case 3, 18-year-old not in secondary school is not exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 18
+    is_in_secondary_school: false
+  output:
+    ks_tanf_child_earned_income_exempt: false
+
+- name: Case 4, 18-year-old in secondary school is exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 18
+    is_in_secondary_school: true
+  output:
+    ks_tanf_child_earned_income_exempt: true
+
+- name: Case 5, 19-year-old in secondary school is not exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 19
+    is_in_secondary_school: true
+  output:
+    ks_tanf_child_earned_income_exempt: false
+
+- name: Case 6, adult is not exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 40
+  output:
+    ks_tanf_child_earned_income_exempt: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_child_earned_income_exempt.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_child_earned_income_exempt.yaml
@@ -1,13 +1,16 @@
 # Kansas TANF child earned income exemption (KEESM 6410)
 # A child's earned income is exempt if the child is under age 18, or under
 # age 19 and working toward a high school diploma or its equivalent
-# (secondary school student).
+# (secondary school student). The exemption applies to children in the case
+# (dependents), not to a person acting in their own behalf (e.g., a teen
+# parent heading their own case).
 
 - name: Case 1, child under 18 is exempt.
   period: 2025-01
   input:
     state_code: KS
     age: 10
+    is_tax_unit_dependent: true
   output:
     ks_tanf_child_earned_income_exempt: true
 
@@ -16,6 +19,7 @@
   input:
     state_code: KS
     age: 17
+    is_tax_unit_dependent: true
   output:
     ks_tanf_child_earned_income_exempt: true
 
@@ -25,15 +29,17 @@
     state_code: KS
     age: 18
     is_in_secondary_school: false
+    is_tax_unit_dependent: true
   output:
     ks_tanf_child_earned_income_exempt: false
 
-- name: Case 4, 18-year-old in secondary school is exempt.
+- name: Case 4, 18-year-old dependent in secondary school is exempt.
   period: 2025-01
   input:
     state_code: KS
     age: 18
     is_in_secondary_school: true
+    is_tax_unit_dependent: true
   output:
     ks_tanf_child_earned_income_exempt: true
 
@@ -43,6 +49,7 @@
     state_code: KS
     age: 19
     is_in_secondary_school: true
+    is_tax_unit_dependent: true
   output:
     ks_tanf_child_earned_income_exempt: false
 
@@ -51,5 +58,26 @@
   input:
     state_code: KS
     age: 40
+  output:
+    ks_tanf_child_earned_income_exempt: false
+
+- name: Case 7, 18-year-old student heading her own case is not exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 18
+    is_in_secondary_school: true
+    is_tax_unit_dependent: false
+  output:
+    # Meets the age/student test, but is not a dependent child in the case
+    # (acting in her own behalf per KEESM 6410), so no exemption.
+    ks_tanf_child_earned_income_exempt: false
+
+- name: Case 8, minor acting in their own behalf is not exempt.
+  period: 2025-01
+  input:
+    state_code: KS
+    age: 16
+    is_tax_unit_dependent: false
   output:
     ks_tanf_child_earned_income_exempt: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_countable_earned_income.yaml
@@ -80,6 +80,7 @@
         ks_tanf_earned_income_after_deductions: 200
       person2:
         age: 10
+        is_tax_unit_dependent: true
         ks_tanf_earned_income_after_deductions: 150
     spm_units:
       spm_unit:
@@ -103,6 +104,7 @@
       person2:
         age: 18
         is_in_secondary_school: true
+        is_tax_unit_dependent: true
         ks_tanf_earned_income_after_deductions: 150
     spm_units:
       spm_unit:
@@ -142,10 +144,22 @@
 - name: Case 10, incapacitated person care expense deduction.
   period: 2025-01
   input:
-    state_code: KS
-    ks_tanf_earned_income_after_deductions: 400
-    care_expenses: 1_200  # $100/month for the care of an incapacitated person
-    childcare_expenses: 0
+    people:
+      person1:
+        age: 30
+        ks_tanf_earned_income_after_deductions: 400
+      person2:  # disabled adult dependent receiving the care
+        age: 60
+        is_disabled: true
+        care_expenses: 1_200  # $100/month for the care of an incapacitated person
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        childcare_expenses: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
   output:
     # K.A.R. 30-4-111(b)(3): $400 - $100 care expense = $300 (no cap)
     ks_tanf_countable_earned_income: 300
@@ -157,19 +171,24 @@
       person1:
         age: 30
         ks_tanf_earned_income_after_deductions: 400
-        care_expenses: 1_200  # $100/month for care of an incapacitated person
       person2:
         age: 10
+        is_tax_unit_dependent: true
         ks_tanf_earned_income_after_deductions: 150
+      person3:  # disabled adult dependent receiving the care
+        age: 60
+        is_disabled: true
+        care_expenses: 1_200  # $100/month for care of an incapacitated person
     spm_units:
       spm_unit:
-        members: [person1, person2]
+        members: [person1, person2, person3]
         childcare_expenses: 0
     households:
       household:
-        members: [person1, person2]
+        members: [person1, person2, person3]
         state_code: KS
   output:
     # person2 (age 10) is a child; earnings exempt (KEESM 6410). person1's
-    # $400 counts, less the $100 care expense (K.A.R. 30-4-111(b)(3)) = $300.
+    # $400 counts, less the $100 care expense for person3
+    # (K.A.R. 30-4-111(b)(3)) = $300.
     ks_tanf_countable_earned_income: 300

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_countable_earned_income.yaml
@@ -1,6 +1,6 @@
 # Kansas TANF countable earned income test
 # Sums person-level earned income after deductions,
-# then subtracts dependent care (no cap per KEESM 7224)
+# then subtracts dependent care (no cap per KEESM 7211)
 
 - name: Case 1, no earned income.
   period: 2025-01
@@ -148,4 +148,28 @@
     childcare_expenses: 0
   output:
     # K.A.R. 30-4-111(b)(3): $400 - $100 care expense = $300 (no cap)
+    ks_tanf_countable_earned_income: 300
+
+- name: Case 11, exempt child earner and care deduction combine.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 30
+        ks_tanf_earned_income_after_deductions: 400
+        care_expenses: 1_200  # $100/month for care of an incapacitated person
+      person2:
+        age: 10
+        ks_tanf_earned_income_after_deductions: 150
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        childcare_expenses: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    # person2 (age 10) is a child; earnings exempt (KEESM 6410). person1's
+    # $400 counts, less the $100 care expense (K.A.R. 30-4-111(b)(3)) = $300.
     ks_tanf_countable_earned_income: 300

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_countable_earned_income.yaml
@@ -70,3 +70,82 @@
   output:
     # person2's 150 is masked out; only person1's 200 counts
     ks_tanf_countable_earned_income: 200
+
+- name: Case 7, child's earned income excluded.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 30
+        ks_tanf_earned_income_after_deductions: 200
+      person2:
+        age: 10
+        ks_tanf_earned_income_after_deductions: 150
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        childcare_expenses: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    # person2 (age 10) is a child; earned income exempt (KEESM 6410)
+    ks_tanf_countable_earned_income: 200
+
+- name: Case 8, 18-year-old secondary school student's earned income excluded.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 30
+        ks_tanf_earned_income_after_deductions: 200
+      person2:
+        age: 18
+        is_in_secondary_school: true
+        ks_tanf_earned_income_after_deductions: 150
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        childcare_expenses: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    # person2 (18, in secondary school) is a child; earnings exempt (KEESM 6410)
+    ks_tanf_countable_earned_income: 200
+
+- name: Case 9, 18-year-old not in school has earned income counted.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 30
+        ks_tanf_earned_income_after_deductions: 200
+      person2:
+        age: 18
+        is_in_secondary_school: false
+        ks_tanf_earned_income_after_deductions: 150
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        childcare_expenses: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    # person2 (18, not in school) is not a child; earnings counted: 200 + 150
+    ks_tanf_countable_earned_income: 350
+
+- name: Case 10, incapacitated person care expense deduction.
+  period: 2025-01
+  input:
+    state_code: KS
+    ks_tanf_earned_income_after_deductions: 400
+    care_expenses: 1_200  # $100/month for the care of an incapacitated person
+    childcare_expenses: 0
+  output:
+    # K.A.R. 30-4-111(b)(3): $400 - $100 care expense = $300 (no cap)
+    ks_tanf_countable_earned_income: 300

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_gross_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_gross_income_eligible.yaml
@@ -131,6 +131,7 @@
         tanf_gross_earned_income: 400
       person2:
         age: 10
+        is_tax_unit_dependent: true
         tanf_gross_earned_income: 200
     spm_units:
       spm_unit:

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_gross_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/tanf/ks_tanf_gross_income_eligible.yaml
@@ -121,3 +121,27 @@
     # size-3 threshold $666.25 -> ineligible. The full 4-person SPM size would
     # give $803.75 and wrongly pass.
     ks_tanf_gross_income_eligible: false
+
+- name: Case 9, exempt child's earnings excluded from the gross-income test.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 30
+        tanf_gross_earned_income: 400
+      person2:
+        age: 10
+        tanf_gross_earned_income: 200
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    # Assistance unit size = 2 (threshold $528.75). person2 (age 10) is a
+    # child, so its $200 earned income is exempt (KEESM 6410): counted gross
+    # = $400 < $528.75 -> eligible. Counting the child's $200 would give $600
+    # and wrongly fail.
+    ks_tanf_gross_income_eligible: true

--- a/policyengine_us/variables/gov/states/ks/dcf/tanf/eligibility/ks_tanf_gross_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ks/dcf/tanf/eligibility/ks_tanf_gross_income_eligible.py
@@ -9,6 +9,7 @@ class ks_tanf_gross_income_eligible(Variable):
     definition_period = MONTH
     reference = (
         "https://ksrevisor.gov/statutes/chapters/ch39/039_007_0009.html",
+        "https://content.dcf.ks.gov/ees/keesm/current/keesm6410.htm",
         "https://www.dcf.ks.gov/services/ees/Documents/Reports/TANF%20State%20Plan%20FFY%202024%20-%202026.pdf",
     )
     defined_for = StateCode.KS
@@ -19,9 +20,13 @@ class ks_tanf_gross_income_eligible(Variable):
         # recipients are excluded from the assistance unit (KEESM 4113), so
         # they are left out of both the counted income and the poverty-
         # guideline household size used for the threshold.
+        #
+        # Per KEESM 6410: a child's earned income is exempt as income, so it is
+        # excluded from the gross-income test.
         person = spm_unit.members
         is_member = person("ks_tanf_is_assistance_unit_member", period.this_year)
-        earned = person("tanf_gross_earned_income", period)
+        child_income_exempt = person("ks_tanf_child_earned_income_exempt", period)
+        earned = person("tanf_gross_earned_income", period) * ~child_income_exempt
         unearned = person("tanf_gross_unearned_income", period)
         gross_income = spm_unit.sum((earned + unearned) * is_member)
         size = spm_unit("ks_tanf_assistance_unit_size", period.this_year)

--- a/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_child_earned_income_exempt.py
+++ b/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_child_earned_income_exempt.py
@@ -15,6 +15,10 @@ class ks_tanf_child_earned_income_exempt(Variable):
         # toward a high school diploma or its equivalent. This matches the
         # federal TANF minor-child definition (45 CFR 260.30), so we reuse the
         # federal student and non-student age limits.
+        #
+        # KEESM 6410 excludes emancipated minors (and minors acting in their
+        # own behalf); we don't track emancipation status at the moment, so
+        # that carve-out is not modeled.
         age = person("age", period.this_year)
         is_student = person("is_in_secondary_school", period.this_year)
         p = parameters(period).gov.hhs.tanf.cash.eligibility.age_limit

--- a/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_child_earned_income_exempt.py
+++ b/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_child_earned_income_exempt.py
@@ -16,11 +16,13 @@ class ks_tanf_child_earned_income_exempt(Variable):
         # federal TANF minor-child definition (45 CFR 260.30), so we reuse the
         # federal student and non-student age limits.
         #
-        # KEESM 6410 excludes emancipated minors (and minors acting in their
-        # own behalf); we don't track emancipation status at the moment, so
-        # that carve-out is not modeled.
+        # KEESM 6410 does not exempt a person acting in their own behalf
+        # (e.g., a teen parent heading their own case), so the exemption is
+        # limited to dependents. We don't track legal emancipation at the
+        # moment.
         age = person("age", period.this_year)
         is_student = person("is_in_secondary_school", period.this_year)
+        is_dependent = person("is_tax_unit_dependent", period.this_year)
         p = parameters(period).gov.hhs.tanf.cash.eligibility.age_limit
         age_limit = where(is_student, p.student, p.non_student)
-        return age < age_limit
+        return is_dependent & (age < age_limit)

--- a/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_child_earned_income_exempt.py
+++ b/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_child_earned_income_exempt.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class ks_tanf_child_earned_income_exempt(Variable):
+    value_type = bool
+    entity = Person
+    label = "Kansas TANF child whose earned income is exempt"
+    definition_period = MONTH
+    reference = "https://content.dcf.ks.gov/ees/keesm/current/keesm6410.htm"
+    defined_for = StateCode.KS
+
+    def formula(person, period, parameters):
+        # Per KEESM 6410: a child's earned income is exempt as income in the
+        # month received for a child under age 18, or under age 19 if working
+        # toward a high school diploma or its equivalent. This matches the
+        # federal TANF minor-child definition (45 CFR 260.30), so we reuse the
+        # federal student and non-student age limits.
+        age = person("age", period.this_year)
+        is_student = person("is_in_secondary_school", period.this_year)
+        p = parameters(period).gov.hhs.tanf.cash.eligibility.age_limit
+        age_limit = where(is_student, p.student, p.non_student)
+        return age < age_limit

--- a/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_countable_earned_income.py
+++ b/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_countable_earned_income.py
@@ -9,6 +9,8 @@ class ks_tanf_countable_earned_income(Variable):
     definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/regulations/kansas/K-A-R-30-4-110",
+        "https://www.law.cornell.edu/regulations/kansas/K-A-R-30-4-111",
+        "https://content.dcf.ks.gov/ees/keesm/current/keesm6410.htm",
         "https://content.dcf.ks.gov/ees/keesm/current/keesm7110.htm",
         "https://content.dcf.ks.gov/ees/keesm/current/keesm7224.htm",
     )
@@ -16,18 +18,27 @@ class ks_tanf_countable_earned_income(Variable):
 
     def formula(spm_unit, period, parameters):
         # Per K.A.R. 30-4-110, KEESM 7110, and KEESM 7224:
-        # Sum assistance-unit members' earned income after $90 and 60%
-        # deductions, then subtract dependent care expenses. SSI recipients are
-        # excluded from the assistance unit (KEESM 4113), so their earnings are
-        # not counted.
+        # Sum assistance-unit members' earned income after the $90 and 60%
+        # deductions, then subtract care expenses. SSI recipients are excluded
+        # from the assistance unit (KEESM 4113), so their earnings are not
+        # counted.
         #
-        # Per KEESM 7224: Dependent care is applied after $90 and 60% disregards.
-        # There is NO cap on dependent care deduction in Kansas TANF.
+        # Per KEESM 6410: a child's earned income is exempt as income in the
+        # month received, so it is excluded from countable earned income.
         person = spm_unit.members
         is_member = person("ks_tanf_is_assistance_unit_member", period.this_year)
+        child_income_exempt = person("ks_tanf_child_earned_income_exempt", period)
         earned_after_deductions = person(
             "ks_tanf_earned_income_after_deductions", period
         )
-        countable_earned = spm_unit.sum(earned_after_deductions * is_member)
-        dependent_care = spm_unit("childcare_expenses", period)
-        return max_(countable_earned - dependent_care, 0)
+        counted = is_member & ~child_income_exempt
+        countable_earned = spm_unit.sum(earned_after_deductions * counted)
+        # Per K.A.R. 30-4-111(b)(3): after the $90 and 60% disregards, deduct
+        # reasonable expenses for child care and for the care of an
+        # incapacitated person. Neither deduction is capped in Kansas.
+        childcare_expenses = spm_unit("childcare_expenses", period)
+        incapacitated_care_expenses = add(spm_unit, period, ["care_expenses"])
+        return max_(
+            countable_earned - childcare_expenses - incapacitated_care_expenses,
+            0,
+        )

--- a/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_countable_earned_income.py
+++ b/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_countable_earned_income.py
@@ -12,12 +12,12 @@ class ks_tanf_countable_earned_income(Variable):
         "https://www.law.cornell.edu/regulations/kansas/K-A-R-30-4-111",
         "https://content.dcf.ks.gov/ees/keesm/current/keesm6410.htm",
         "https://content.dcf.ks.gov/ees/keesm/current/keesm7110.htm",
-        "https://content.dcf.ks.gov/ees/keesm/current/keesm7224.htm",
+        "https://content.dcf.ks.gov/ees/keesm/current/keesm7200.htm",
     )
     defined_for = StateCode.KS
 
     def formula(spm_unit, period, parameters):
-        # Per K.A.R. 30-4-110, KEESM 7110, and KEESM 7224:
+        # Per K.A.R. 30-4-110, KEESM 7110, and KEESM 7211:
         # Sum assistance-unit members' earned income after the $90 and 60%
         # deductions, then subtract care expenses. SSI recipients are excluded
         # from the assistance unit (KEESM 4113), so their earnings are not
@@ -33,9 +33,12 @@ class ks_tanf_countable_earned_income(Variable):
         )
         counted = is_member & ~child_income_exempt
         countable_earned = spm_unit.sum(earned_after_deductions * counted)
-        # Per K.A.R. 30-4-111(b)(3): after the $90 and 60% disregards, deduct
-        # reasonable expenses for child care and for the care of an
-        # incapacitated person. Neither deduction is capped in Kansas.
+        # Per K.A.R. 30-4-111(b)(3) and KEESM 7211: after the $90 and 60%
+        # disregards, deduct reasonable expenses for child care or for the
+        # care of an incapacitated person. Kansas applies no dollar cap.
+        # KEESM 7211 also requires the cared-for dependent to be in the
+        # assistance unit; we don't enforce that, since these expenses are
+        # only tracked at the unit level at the moment.
         childcare_expenses = spm_unit("childcare_expenses", period)
         incapacitated_care_expenses = add(spm_unit, period, ["care_expenses"])
         return max_(

--- a/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_countable_earned_income.py
+++ b/policyengine_us/variables/gov/states/ks/dcf/tanf/income/ks_tanf_countable_earned_income.py
@@ -37,8 +37,9 @@ class ks_tanf_countable_earned_income(Variable):
         # disregards, deduct reasonable expenses for child care or for the
         # care of an incapacitated person. Kansas applies no dollar cap.
         # KEESM 7211 also requires the cared-for dependent to be in the
-        # assistance unit; we don't enforce that, since these expenses are
-        # only tracked at the unit level at the moment.
+        # assistance unit; we don't enforce that at the moment. care_expenses
+        # is attributed to the person receiving care and is summed unit-wide
+        # here, mirroring the unit-level childcare_expenses input.
         childcare_expenses = spm_unit("childcare_expenses", period)
         incapacitated_care_expenses = add(spm_unit, period, ["care_expenses"])
         return max_(


### PR DESCRIPTION
## Summary
Fixes two Kansas TANF earned-income issues in one PR.

Closes #8808
Closes #8809

### Issue #8808 — exclude children's earned income (KEESM 6410)
[KEESM 6410](https://content.dcf.ks.gov/ees/keesm/current/keesm6410.htm) (in the 6400 **Exempt Income** chapter) makes a child's earned income *"exempt as income in the month received"* — for TANF, a child under age 18, or under age 19 if working toward a high school diploma or its equivalent. Because it is **exempt income** (not a budgeting disregard), it is excluded from **both** the gross-income eligibility test and countable income.

New person-level variable `ks_tanf_child_earned_income_exempt` encodes the test as `is_tax_unit_dependent & (age < where(is_in_secondary_school, age_limit.student, age_limit.non_student))`, reusing the existing federal `gov.hhs.tanf.cash.eligibility.age_limit` parameters (18 / 19) — the same 45 CFR § 260.30 minor-child definition the federal TANF code already uses. The dependent gate keeps the exemption to children in the case: KEESM 6410 does not exempt a person acting in their own behalf (e.g., an 18-year-old student heading her own case). Only *earned* income is exempt; the child's unearned income still counts.

### Issue #8809 — incapacitated-person care deduction (K.A.R. 30-4-111(b)(3))
[K.A.R. 30-4-111(b)(3)](https://www.law.cornell.edu/regulations/kansas/K-A-R-30-4-111) allows a deduction, after the $90 and 60% disregards and with **no cap**, for "reasonable expenses for child care **or** expenses for the care of an incapacitated person." `ks_tanf_countable_earned_income` now deducts the existing `care_expenses` variable alongside `childcare_expenses`. No new input variable was needed. `care_expenses` is attributed to the person receiving care and summed unit-wide, mirroring the unit-level `childcare_expenses` input; KEESM 7211's family-group membership requirement on the cared-for person is not enforced at the moment.

## Regulatory authority
- K.A.R. 30-4-110 and 30-4-111 (earned income and its deductions)
- KEESM 6410 (children's earnings — exempt income)
- KEESM 7110 / 7224 (earned income; dependent care, no cap)

## Files changed
- `variables/gov/states/ks/dcf/tanf/income/ks_tanf_child_earned_income_exempt.py` (new)
- `variables/gov/states/ks/dcf/tanf/income/ks_tanf_countable_earned_income.py`
- `variables/gov/states/ks/dcf/tanf/eligibility/ks_tanf_gross_income_eligible.py`
- Tests: new `ks_tanf_child_earned_income_exempt.yaml`; additions to `ks_tanf_countable_earned_income.yaml`, `ks_tanf_gross_income_eligible.yaml`, and `integration.yaml`

## Note on scope
Issue #8808's text scoped the change to countable income; because KEESM 6410 classifies these earnings as *exempt income*, this PR also excludes them from the gross-income test. Integration Case 17 demonstrates why: a working teen's wages would otherwise push the family over the 30%-FPL gross test despite the exemption.

## Test plan
Matched-pair integration tests isolate each rule (identical household, one variable changed):
- **Child exemption** — Case 19 (earner age 16) vs Case 20 (earner age 18, not in school): same $400/mo earnings → countable income 0 vs 124, benefit $386 vs $262.
- **Own-behalf gate** — Case 22: an 18-year-old secondary-school student heading her own case has the same $400/mo counted → countable income 124, benefit $185; the same-age dependent student stays exempt (unit Case 4).
- **Care deduction** — Case 18 (`care_expenses` $100/mo for a disabled adult dependent in the unit) vs Case 21 (none): benefit $322 vs $222 (the $100 gap is the deduction).
- Plus 8 boundary cases for `ks_tanf_child_earned_income_exempt` (17 / 18-student / 18-non-student / 19-student / adult / 18-year-old student heading her own case / minor acting in own behalf) and unit cases in `ks_tanf_countable_earned_income.yaml`.
- All 117 KS TANF tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
