### PR TITLE
Reinstate California's non-MAGI Medi-Cal asset limit effective 2026

### DIFF
--- a/changelog.d/ca-nonmagi-asset-limit-2026.fixed.md
+++ b/changelog.d/ca-nonmagi-asset-limit-2026.fixed.md
@@ -1,0 +1,1 @@
+Reinstate California's non-MAGI Medi-Cal asset limit effective January 1, 2026 ($130,000 for an individual, $195,000 for a couple), per DHCS ACWDL 25-14.

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/couple.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/couple.yaml
@@ -8,6 +8,10 @@ metadata:
   reference:
     - title: "Medicaid Eligibility and Enrollment Policies for Seniors and People with Disabilities (Non-MAGI) During the Unwinding | KFF (June 2024)"
       href: https://www.kff.org/report-section/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey-appendix-tables/
+    - title: "Asset Limit Changes for Non-MAGI Medi-Cal | California DHCS (asset limit reinstated at $130,000 plus $65,000 per additional household member effective January 1, 2026)"
+      href: https://www.dhcs.ca.gov/services/medi-cal/eligibility/Pages/Asset-Limit-Changes-for-Non-MAGI-Medi-Cal.aspx
+    - title: "California DHCS All County Welfare Directors Letter 25-14 (reinstatement of the non-MAGI Medi-Cal asset limit)"
+      href: https://www.dhcs.ca.gov/services/medi-cal/eligibility/letters/Documents/25-14.pdf
 
 AL:
   2015-01-01: 3_000
@@ -21,6 +25,7 @@ AR:
 CA:
   2015-01-01: 3_000
   2024-01-01: .inf
+  2026-01-01: 195_000
 CO:
   2015-01-01: 3_000
 CT:

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/individual.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/individual.yaml
@@ -8,6 +8,10 @@ metadata:
   reference:
     - title: "Medicaid Eligibility and Enrollment Policies for Seniors and People with Disabilities (Non-MAGI) During the Unwinding | KFF (June 2024)"
       href: https://www.kff.org/report-section/medicaid-eligibility-and-enrollment-policies-for-seniors-and-people-with-disabilities-non-magi-during-the-unwinding-appendix/
+    - title: "Asset Limit Changes for Non-MAGI Medi-Cal | California DHCS (asset limit reinstated at $130,000 for an individual effective January 1, 2026)"
+      href: https://www.dhcs.ca.gov/services/medi-cal/eligibility/Pages/Asset-Limit-Changes-for-Non-MAGI-Medi-Cal.aspx
+    - title: "California DHCS All County Welfare Directors Letter 25-14 (reinstatement of the non-MAGI Medi-Cal asset limit)"
+      href: https://www.dhcs.ca.gov/services/medi-cal/eligibility/letters/Documents/25-14.pdf
 
 AL:
   2015-01-01: 2_000
@@ -21,6 +25,7 @@ AR:
 CA:
   2015-01-01: 2_000
   2024-01-01: .inf
+  2026-01-01: 130_000
 CO:
   2015-01-01: 2_000
 CT:

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_optional_senior_or_disabled_asset_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_optional_senior_or_disabled_asset_eligible.yaml
@@ -22,3 +22,65 @@
     state_code: CA
   output:
     is_optional_senior_or_disabled_asset_eligible: true
+
+- name: high assets, still eligible for Medicaid in CA in 2025
+  period: 2025
+  input:
+    ssi_countable_resources: 1_000_000
+    state_code: CA
+  output:
+    is_optional_senior_or_disabled_asset_eligible: true
+
+- name: assets below the reinstated CA limit in 2026, eligible
+  period: 2026
+  input:
+    ssi_countable_resources: 100_000
+    state_code: CA
+  output:
+    is_optional_senior_or_disabled_asset_eligible: true
+
+- name: assets above the reinstated CA limit in 2026, ineligible
+  period: 2026
+  input:
+    ssi_countable_resources: 150_000
+    state_code: CA
+  output:
+    is_optional_senior_or_disabled_asset_eligible: false
+
+- name: joint filers below the reinstated CA couple limit in 2026, eligible
+  period: 2026
+  input:
+    people:
+      person1:
+        ssi_countable_resources: 90_000
+      person2:
+        ssi_countable_resources: 90_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CA
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+  output:
+    is_optional_senior_or_disabled_asset_eligible: [true, true]
+
+- name: joint filers above the reinstated CA couple limit in 2026, ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        ssi_countable_resources: 100_000
+      person2:
+        ssi_countable_resources: 100_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: CA
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+  output:
+    is_optional_senior_or_disabled_asset_eligible: [false, false]


### PR DESCRIPTION
## Summary

California DHCS reinstates the non-MAGI Medi-Cal asset limit on January 1, 2026, at **$130,000 for an individual** plus $65,000 per additional household member (**$195,000 for a couple**). PolicyEngine previously modeled CA as having no asset limit indefinitely after the January 2024 elimination, so 2026+ simulations overstated senior/disabled-pathway Medicaid eligibility for high-asset California households.

## Changes

- `senior_or_disabled/assets/limit/individual.yaml`: add `CA: 2026-01-01: 130_000`
- `senior_or_disabled/assets/limit/couple.yaml`: add `CA: 2026-01-01: 195_000`
- Both parameters gain references to the DHCS asset-limit page and All County Welfare Directors Letter (ACWDL) 25-14
- Tests: CA 2025 unlimited still eligible; 2026 individual below/above $130k; 2026 joint couple below/above $195k

## Sources

- DHCS, Asset Limit Changes for Non-MAGI Medi-Cal: https://www.dhcs.ca.gov/services/medi-cal/eligibility/Pages/Asset-Limit-Changes-for-Non-MAGI-Medi-Cal.aspx ("Effective January 1, 2026, the asset limit for Non-MAGI Medi-Cal programs will be reinstated at $130,000 for a household of one and $65,000 for each additional household member")
- DHCS ACWDL 25-14 (implementation guidance): https://www.dhcs.ca.gov/services/medi-cal/eligibility/letters/Documents/25-14.pdf

Note: per ACWDL 25-18, asset transfers made while the limit was eliminated (2024–2025) are not penalized; this PR only reinstates the limit level, which matches how `is_optional_senior_or_disabled_asset_eligible` consumes it.

Found while triaging PolicyBench reference values (PolicyEngine/policybench#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
