### PR TITLE
Apply New Jersey's filing-threshold tax floor before refundable credits

### DIFF
--- a/changelog.d/nj-filing-threshold-floor.fixed.md
+++ b/changelog.d/nj-filing-threshold-floor.fixed.md
@@ -1,0 +1,1 @@
+Apply New Jersey's filing-threshold tax floor (N.J.S.A. 54A:2-4) to New Jersey income tax before refundable credits, which previously bypassed it.

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.yaml
@@ -1,0 +1,50 @@
+- name: Below the SINGLE filing threshold, pre-refundable-credit tax is zero
+  period: 2022
+  input:
+    state_code: NJ
+    nj_agi: 9_999
+    filing_status: SINGLE
+    nj_main_income_tax: 140
+  output:
+    nj_income_tax_before_refundable_credits: 0
+
+- name: AGI exactly at the SINGLE filing threshold is still inside the no-tax zone
+  period: 2022
+  input:
+    state_code: NJ
+    nj_agi: 10_000
+    filing_status: SINGLE
+    nj_main_income_tax: 140
+  output:
+    nj_income_tax_before_refundable_credits: 0
+
+- name: One dollar above the SINGLE filing threshold falls through to the schedule
+  period: 2022
+  input:
+    state_code: NJ
+    nj_agi: 10_001
+    filing_status: SINGLE
+    nj_main_income_tax: 140
+    nj_non_refundable_credits: 40
+  output:
+    nj_income_tax_before_refundable_credits: 100
+
+- name: Below the JOINT filing threshold, pre-refundable-credit tax is zero
+  period: 2022
+  input:
+    state_code: NJ
+    nj_agi: 19_999
+    filing_status: JOINT
+    nj_main_income_tax: 280
+  output:
+    nj_income_tax_before_refundable_credits: 0
+
+- name: Single filer with gross income below the threshold owes no tax end to end
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: NJ
+    filing_status: SINGLE
+    self_employment_income: 5_800
+  output:
+    nj_income_tax_before_refundable_credits: 0

--- a/policyengine_us/variables/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.py
@@ -8,9 +8,18 @@ class nj_income_tax_before_refundable_credits(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.NJ
+    reference = (
+        "https://law.justia.com/codes/new-jersey/title-54a/section-54a-2-4/",
+        "https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf#page=5",
+    )
 
     def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.nj.tax.income
         main_income_tax = tax_unit("nj_main_income_tax", period)
         non_refundable_credits = tax_unit("nj_non_refundable_credits", period)
-
-        return max_(main_income_tax - non_refundable_credits, 0)
+        tax = max_(main_income_tax - non_refundable_credits, 0)
+        # N.J.S.A. 54A:2-4 imposes no tax on filers with gross income at or
+        # below the filing threshold.
+        agi = tax_unit("nj_agi", period)
+        filing_status = tax_unit("filing_status", period)
+        return where(agi <= p.filing_threshold[filing_status], 0, tax)


### PR DESCRIPTION
## Summary

N.J.S.A. 54A:2-4 ("Minimum taxable income") provides that a filer with gross income at or below the filing threshold — $10,000 for single/married-filing-separately, $20,000 for joint/head-of-household/surviving-spouse — owes no New Jersey income tax. PolicyEngine has the correct `filing_threshold` parameter and applies it in `nj_income_tax`, but nothing consumes that variable: the `state_income_tax` rollup routes through `nj_income_tax_before_refundable_credits`, which had no threshold gate. A below-threshold filer therefore showed positive bracket-schedule tax on the benchmarked path (e.g., NJ gross income of $5,838.53 → $67.74 instead of $0).

## Changes

- `nj_income_tax_before_refundable_credits.py`: apply the N.J.S.A. 54A:2-4 floor (zero tax when `nj_agi` ≤ `filing_threshold[filing_status]`), matching the gate already in `nj_income_tax`, and add statute/instructions references
- New tests: below/at/above the single threshold, below the joint threshold, and an end-to-end case (single, $5,800 self-employment income → $0)

The existing gate in `nj_income_tax` is kept: it preserves the input-override semantics its tests assert, and the two gates use the same condition.

## Sources

- N.J.S.A. 54A:2-4: https://law.justia.com/codes/new-jersey/title-54a/section-54a-2-4/ ("a taxpayer shall not be subject to tax under this act" at or below the thresholds)
- 2025 NJ-1040 instructions, Filing Requirements (p. 3): https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf

All 549 NJ YAML tests pass. No partner contract tests include NJ households.

Found while triaging PolicyBench reference values (PolicyEngine/policybench#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
