### PR TITLE
Include 5-year-olds in the Head Start age range

### DIFF
--- a/changelog.d/head-start-age-window.fixed.md
+++ b/changelog.d/head-start-age-window.fixed.md
@@ -1,0 +1,1 @@
+Include 5-year-olds in the Head Start age range, matching 45 CFR 1302.12(b), which covers children from age 3 up to compulsory school age.

--- a/policyengine_us/parameters/gov/hhs/head_start/age_range.yaml
+++ b/policyengine_us/parameters/gov/hhs/head_start/age_range.yaml
@@ -10,7 +10,7 @@ brackets:
     amount:
       2021-09-01: true
   - threshold:
-      2021-09-01: 5
+      2021-09-01: 6
     amount:
       2021-09-01: false
 

--- a/policyengine_us/tests/policy/baseline/gov/hhs/head_start/is_head_start_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/head_start/is_head_start_eligible.yaml
@@ -19,7 +19,7 @@
 - name: Not Head Start eligible 3
   period: 2021
   input:
-    age: 5
+    age: 6
     is_head_start_categorically_eligible: false
     is_head_start_income_eligible: true
   output:
@@ -48,6 +48,15 @@
   input:
     age: 4
     is_head_start_categorically_eligible: true
+    is_head_start_income_eligible: true
+  output:
+    is_head_start_eligible: true
+
+- name: Head Start eligible 4
+  period: 2021
+  input:
+    age: 5
+    is_head_start_categorically_eligible: false
     is_head_start_income_eligible: true
   output:
     is_head_start_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/childcare/head_start/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/childcare/head_start/federal.yaml
@@ -171,7 +171,7 @@
       head:
         head_start: 0.0
       child1:
-        head_start: 0.0
+        head_start: 12320.27
 - name: head_start_low_income_age_4 (federal)
   period: 2026
   absolute_error_margin: 0.1
@@ -483,7 +483,7 @@
       head:
         head_start: 0.0
       child1:
-        head_start: 0.0
+        head_start: 12320.27
 - name: head_start_size_3_single_parent_2_children (federal)
   period: 2026
   absolute_error_margin: 0.1


### PR DESCRIPTION
## Summary

45 CFR 1302.12(b) makes a child eligible for Head Start preschool if they are "at least three years old or, turn three years old by the date used to determine eligibility for public school" and "no older than the age required to attend school" — i.e., Head Start serves ages 3–5, up to compulsory school age. ACF describes the program as serving "children ages 3 to 5," and the parameter's own cited source (Atlanta Fed Policy Rules Database §2.1.8) uses ages 3–5.

PolicyEngine's `age_range` scale cut off at age 5 (`threshold: 5 → false` fires at age ≥ 5), so the effective window was ages 3–4 only. Income- and categorically-eligible 5-year-olds were wrongly excluded.

## Changes

- `gov/hhs/head_start/age_range.yaml`: raise the upper threshold from 5 to 6 (ages 3, 4, 5 eligible; 6+ excluded — 6 is the modal compulsory-attendance age and matches the program's 3–5 window without over-including 6-year-olds)
- `is_head_start_eligible.yaml`: the age-5 case that encoded the bug now expects eligible; the age-6 boundary case expects ineligible

Early Head Start is unaffected (separate under-3 rule, verified consistent).

## ⚠️ Partner contract tests

This change is partner-facing: two `analytics_coverage` cases flip from $0 to ~$12,320 for age-5 children (`head_start_child_age_5_age_out`, `head_start_size_2_single_parent_1_child` in `partners/.../childcare/head_start/federal.yaml`). Their expected outputs are updated in this PR after running the repo's partner-edit gate with Max (approved 2026-07-02); team/partner notification is in progress on Slack. All 78 partner childcare tests, 36 Head Start unit tests, and the partner signature suites pass locally.

## Sources

- 45 CFR 1302.12(b): https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-12-determining-verifying-documenting-eligibility
- Atlanta Fed Policy Rules Database §2.1.8 (already cited in the parameter): Head Start ages 3–5

Found while triaging PolicyBench reference values (PolicyEngine/policybench#91): two income-eligible age-5 children (MT and NJ households) were scored as ineligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
