### PR TITLE
Add Schedule D capital gain distributions memo variable

### DIFF
--- a/changelog.d/schedule-d-capital-gain-distributions.added.md
+++ b/changelog.d/schedule-d-capital-gain-distributions.added.md
@@ -1,0 +1,1 @@
+Add schedule_d_capital_gain_distributions (memo component of long_term_capital_gains for Schedule D line 13 amounts) and capital_gain_distributions (total across both reporting routes).

--- a/policyengine_us/tests/policy/baseline/gov/irs/integration/capital_gain_distributions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/integration/capital_gain_distributions.yaml
@@ -1,0 +1,59 @@
+- name: Case 1, capital gain distributions total both reporting routes.
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 50
+        long_term_capital_gains: 8_000
+        schedule_d_capital_gain_distributions: 3_000
+        non_sch_d_capital_gains: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    capital_gain_distributions: 3_000
+
+- name: Case 2, Schedule D distributions are a memo and do not double count in AGI.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 50
+        employment_income: 60_000
+        long_term_capital_gains: 8_000
+        schedule_d_capital_gain_distributions: 3_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    # 60,000 wages + 8,000 LTCG; the 3,000 memo component adds nothing.
+    adjusted_gross_income: 68_000
+
+- name: Case 3, non-Schedule-D route only.
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 70
+        non_sch_d_capital_gains: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    capital_gain_distributions: 2_000

--- a/policyengine_us/variables/household/income/person/capital_gains/capital_gain_distributions.py
+++ b/policyengine_us/variables/household/income/person/capital_gains/capital_gain_distributions.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class capital_gain_distributions(Variable):
+    value_type = float
+    entity = Person
+    label = "capital gain distributions"
+    unit = USD
+    documentation = "Total capital gain distributions received, whether reported on Schedule D line 13 or directly on Form 1040 line 7 without a Schedule D."
+    definition_period = YEAR
+    reference = dict(
+        title="26 U.S. Code § 852(b)(3) - capital gain dividends",
+        href="https://www.law.cornell.edu/uscode/text/26/852",
+    )
+    adds = [
+        "schedule_d_capital_gain_distributions",
+        "non_sch_d_capital_gains",
+    ]

--- a/policyengine_us/variables/household/income/person/capital_gains/schedule_d_capital_gain_distributions.py
+++ b/policyengine_us/variables/household/income/person/capital_gains/schedule_d_capital_gain_distributions.py
@@ -1,0 +1,14 @@
+from policyengine_us.model_api import *
+
+
+class schedule_d_capital_gain_distributions(Variable):
+    value_type = float
+    entity = Person
+    label = "Schedule D capital gain distributions"
+    unit = USD
+    documentation = "Capital gain distributions from regulated investment companies and REITs reported on Schedule D line 13. Memo component of long_term_capital_gains — already included there, so it does not separately enter gross income."
+    definition_period = YEAR
+    reference = dict(
+        title="2024 Instructions for Schedule D (Form 1040), line 13",
+        href="https://www.irs.gov/instructions/i1040sd",
+    )


### PR DESCRIPTION
## Summary

Adds two variables:

- `schedule_d_capital_gain_distributions` — input memo for the Schedule D line 13 amount. It is a component of `long_term_capital_gains` (already included there), so it does not separately enter gross income — Case 2 in the tests pins AGI unchanged.
- `capital_gain_distributions` — adds-total across both reporting routes (line 13 + the non-Schedule-D Form 1040 line 7 route, `non_sch_d_capital_gains`).

## Why

Reforms that treat fund distributions differently from other realized gains — the GROWTH Act (H.R. 2089 / S. 1839) defers tax on automatically reinvested RIC capital gain dividends — need a variable to act on, and the populace imputation (PolicyEngine/populace#274) needs an engine-known column to fill. Default 0 → zero behavior change for every existing dataset.

Companion to #8839 (which wires the non-Schedule-D route into AGI/NII).

🤖 Generated with [Claude Code](https://claude.com/claude-code)