### PR TITLE
Use loss-limited net capital gain in Delaware pension exclusion basket

### DIFF
--- a/changelog.d/de-pension-exclusion-loss-limit.fixed.md
+++ b/changelog.d/de-pension-exclusion-loss-limit.fixed.md
@@ -1,0 +1,1 @@
+Use the federally loss-limited net capital gain in the Delaware pension exclusion eligible-income basket.

--- a/changelog.d/fixed/8836.md
+++ b/changelog.d/fixed/8836.md
@@ -1,1 +1,0 @@
-- Use the federally loss-limited net capital gain in the Delaware pension exclusion eligible-income basket.

--- a/changelog.d/fixed/8836.md
+++ b/changelog.d/fixed/8836.md
@@ -1,0 +1,1 @@
+- Use the federally loss-limited net capital gain in the Delaware pension exclusion eligible-income basket.

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/exclusions/pension/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/exclusions/pension/income_sources.yaml
@@ -2,7 +2,7 @@ description: Delaware counts these income sources for the pension exclusion.
 values:
   2021-01-01:
     - dividend_income
-    - capital_gains
+    - loss_limited_net_capital_gains_person
     - taxable_interest_income
     - rental_income
     - taxable_pension_income

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/subtractions/pension_exclusion/de_pension_exclusion.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/subtractions/pension_exclusion/de_pension_exclusion.yaml
@@ -68,11 +68,13 @@
   output:
     de_pension_exclusion: 0
 
-- name: 60+ filer with net capital loss exceeding interest income gets zero exclusion
+- name: 60+ filer with large capital loss keeps full exclusion (interest > cap)
   # PIT-RES 2025 Line 6 defines eligible retirement income as "capital gains
-  # net of capital losses, interest, ..." — losses net against gains within the
-  # basket. Here interest $42,896 + net cap gains -$1,374,932 = -$1,332,036.
-  # The exclusion is min($12,500, max(0, -$1.33M)) = $0, not $12,500.
+  # net of capital losses, interest, ...". The capital-gains figure is the one
+  # that appears on the return, i.e. the federally loss-limited net capital gain
+  # (IRC 1211(b) caps a single filer's net loss at -$3,000; the raw -$1.37M loss
+  # cannot appear on a DE return). Basket = $42,896 interest - $3,000 = $39,896,
+  # well above the $12,500 cap, so the exclusion is $12,500, not $0.
   period: 2025
   input:
     age: 75
@@ -82,4 +84,30 @@
     long_term_capital_gains: 49_197
     state_code: DE
   output:
-    de_pension_exclusion: 0
+    de_pension_exclusion: 12_500
+
+- name: DE 60+ filer with large capital loss keeps full pension exclusion
+  period: 2025
+  input:
+    people:
+      head:
+        age: 75
+        is_tax_unit_head: true
+        taxable_interest_income: 85_793
+        short_term_capital_gains: -2_848_258
+        long_term_capital_gains: 98_394
+      spouse:
+        age: 40
+        is_tax_unit_spouse: true
+        employment_income: 10_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+    households:
+      household:
+        members: [head, spouse]
+        state_code: DE
+  output:
+    # Federal 1211 limits the joint net capital loss to -$3,000, allocated to the
+    # head; basket = $85,793 interest - $3,000 = $82,793 >> $12,500 cap.
+    de_pension_exclusion: [12_500, 0]


### PR DESCRIPTION
## Summary

The Delaware pension exclusion eligible-retirement-income basket
(`de_pension_exclusion_income`, via
`gov.states.de.tax.income.subtractions.exclusions.pension.income_sources`)
summed the **raw, unlimited** `capital_gains` variable (short-term + long-term
net, with no loss limit). A large capital **loss** flowed in at full magnitude,
drove each spouse's basket sharply negative, and `min(cap, max(0, eligible_income))`
in `de_pension_exclusion` then clamped the whole exclusion to **$0** — even for a
60+ filer with far more than $12,500 of otherwise-eligible interest/dividends/pensions.

This PR replaces `capital_gains` with the person-level, federally loss-limited
variable `loss_limited_net_capital_gains_person`.

## Why raw capital gains is wrong here

Delaware taxable income begins with **federal AGI**. By **IRC § 1211(b)** a joint
filer's deductible net capital loss is capped at **−$3,000/year** (excess carries
forward), so no Delaware PIT-RES return ever reflects a multi-million-dollar loss.

The **2025 Form PIT-RES, Line 6 pension-exclusion worksheet** defines eligible
retirement income to include **"capital gains net of capital losses"** — the figure
as it appears on the return, i.e. the federal Schedule D loss-limited net, not the
raw unlimited sum of transactions. Delaware does not decouple from the § 1211 limit.
A capital loss can therefore reduce the basket by at most $3,000 and cannot wipe out
an otherwise-eligible balance exceeding $12,500.

Statutory / form basis:
- **30 Del. C. § 1106(b)(3)** — up to $12,500 exclusion for age 60+ on pensions and
  eligible retirement income (dividends, capital gains, interest, rental income,
  qualified plans).
- **2025 Form PIT-RES, Line 6** worksheet — "capital gains net of capital losses."
- **IRC § 1211(b)** — −$3,000 net capital loss limit for a joint filer.

PR #8502 (issue #8501) fixed only the *bleed* of a negative exclusion into other DE
subtractions; it left the raw, unlimited `capital_gains` in the basket. This PR
addresses that residual.

## Impact (originating TAXSIM case, out2psl/916)

DE joint, primary age 75, spouse age 40, TY 2025: ~$85,793 interest, a large net
capital loss, spouse $10,000 wages.

| System | DE income tax | Head pension exclusion |
|---|---|---|
| PolicyEngine (before) | $3,547.51 | $0 |
| PolicyEngine (after) | **$2,860.25** | **$12,500** |
| TAXSIM-35 | $2,885.17 | $12,500 |
| TaxAct | ≈$2,851 | $12,500 |

§ 1211 limits the joint net capital loss to −$3,000, so the basket
(≈$85,793 interest − $3,000) is well above the $12,500 cap and the filer keeps the
full exclusion.

## Tests

- Corrected the existing `de_pension_exclusion.yaml` test that encoded the buggy
  $0 behavior from a raw −$1.4M loss (a loss that cannot appear on a DE return) to
  the loss-limited treatment (full $12,500 exclusion).
- Added an integration test: DE 60+ filer with a large capital loss and interest
  above the cap → `de_pension_exclusion: [12_500, 0]`.
- `policyengine-core test .../de_pension_exclusion.yaml -c policyengine_us`: 8 passed.

Originating TAXSIM issue: PolicyEngine/policyengine-taxsim#916

Fixes #8836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)