### PR TITLE
Fix Vermont retirement-income exemption eligibility gate for Social Security filers

### DIFF
--- a/changelog.d/fix-vt-retirement-exemption-ss-gate.fixed.md
+++ b/changelog.d/fix-vt-retirement-exemption-ss-gate.fixed.md
@@ -1,0 +1,1 @@
+- Fix the Vermont retirement-income exemption eligibility gate to use the Social Security phase-out threshold for Social Security filers.

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/agi/subtractions/vt_retirement_income_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/agi/subtractions/vt_retirement_income_exemption.yaml
@@ -180,3 +180,54 @@
     state_code: VT
   output:
     vt_retirement_income_exemption: 500  # Partial qualified (halfway between $70k and $80k)
+
+# Integration tests: eligibility gate must use the Social Security phase-out
+# threshold (not the CSRS threshold) for Social Security filers in the 2025
+# partial band. Resolves policyengine-taxsim #999 (single) and #1000 (joint).
+- name: VT single SS filer in 2025 partial band gets partial exemption (taxsim #999)
+  absolute_error_margin: 0.1
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 74
+        employment_income: 29_333.33
+        taxable_interest_income: 3.64
+        social_security_retirement: 25_742.70
+        unemployment_compensation: 10_880
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_name: VT
+  output:
+    tax_unit_taxable_social_security: 20_725.08
+    vt_retirement_income_exemption_eligible: true
+    vt_retirement_income_exemption: 8_497.28
+    vt_income_tax: 1_281.20
+
+- name: VT joint SS filers in 2025 partial band get partial exemption (taxsim #1000)
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 77
+        employment_income: 52_380.95
+        taxable_interest_income: 29.15
+        social_security_retirement: 27_581.46
+      person2:
+        age: 77
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_name: VT
+  output:
+    vt_retirement_income_exemption_eligible: true

--- a/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/subtractions/retirement_income_exemption/vt_retirement_income_exemption_eligible.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/subtractions/retirement_income_exemption/vt_retirement_income_exemption_eligible.py
@@ -21,9 +21,7 @@ class vt_retirement_income_exemption_eligible(Variable):
         # or other eligible retirement systems to determine eligibility
         filing_status = tax_unit("filing_status", period)
         agi = tax_unit("adjusted_gross_income", period)
-        p = parameters(
-            period
-        ).gov.states.vt.tax.income.agi.retirement_income_exemption.csrs.reduction
+        p = parameters(period).gov.states.vt.tax.income.agi.retirement_income_exemption
         # One of the retirement income should be greater than 0
         retirement_income = add(
             tax_unit,
@@ -35,8 +33,34 @@ class vt_retirement_income_exemption_eligible(Variable):
             ],
         )
         retirement_income_qualified = retirement_income > 0
+        # Determine which retirement system the filer uses, mirroring the
+        # main exemption formula, so the eligibility gate uses the matching
+        # phase-out threshold (Social Security thresholds differ from CSRS
+        # under 2025 law, S.51).
+        tax_unit_taxable_social_security = tax_unit(
+            "tax_unit_taxable_social_security", period
+        )
+        vt_military_retirement_pay_exclusion = tax_unit(
+            "vt_military_retirement_pay_exclusion", period
+        )
+        vt_csrs_retirement_pay_exclusion = tax_unit(
+            "vt_csrs_retirement_pay_exclusion", period
+        )
+        larger_retirement_income = max_(
+            tax_unit_taxable_social_security,
+            vt_military_retirement_pay_exclusion,
+        )
+        chosen_retirement_income = max_(
+            larger_retirement_income, vt_csrs_retirement_pay_exclusion
+        )
+        use_ss = tax_unit_taxable_social_security == chosen_retirement_income
+        reduction_end = where(
+            use_ss,
+            p.social_security.reduction.end[filing_status],
+            p.csrs.reduction.end[filing_status],
+        )
         # The agi should below threshold
-        agi_qualified = agi < p.end[filing_status]
+        agi_qualified = agi < reduction_end
         # Both qualified then the filer is qualified for vermont retirement
         # income exemption
         return retirement_income_qualified & agi_qualified


### PR DESCRIPTION
## Summary

The Vermont retirement-income exemption eligibility variable `vt_retirement_income_exemption_eligible` tested AGI against the **CSRS** reduction-end threshold for **all** filers, whereas the main exemption formula `vt_retirement_income_exemption` correctly branches on `use_ss` to select the **Social Security** phase-out endpoint. The two were consistent only while the CSRS and Social Security thresholds were identical.

**S.51 (2025)** (32 V.S.A. § 5830e) raised the Social Security thresholds by $5,000 (single: $60k → $65k eligibility end; joint: $75k → $80k), but the CSRS thresholds were left unchanged. As a result, a Social Security filer with AGI between the stale CSRS end and the true Social Security end was gated out of eligibility and received a **$0 exemption**, even though the phase-out formula would have granted a partial exemption.

## Fix

Mirror the `use_ss` branch used by the main formula inside the eligibility gate, so both use the same Social Security reduction-end threshold for Social Security electors. This keeps the gate and the formula consistent and preserves the code's existing model of the two elections' thresholds as independent parameter paths (no YAML changes needed).

## Evidence

- 32 V.S.A. § 5830e(a)(1)(C), (a)(2)(C)
- S.51 (2025), Vermont tax credit package (raises Social Security thresholds by $5,000)
- 2025 Vermont Income Tax Return Booklet, p. 16 — Retirement Income Exemption Worksheet (Schedule **IN-112**, Part I, Line 12)

### Reproduction (taxsim #999, single, age 74, TY2025)

AGI $60,942 sits in the 2025 single partial band ($55k–$65k). Correct SS end = $65,000 → ratio 0.41 → exemption = $20,725.08 × 0.41 = **$8,497.28** (matches filled IN-112 Line 12 = $8,497). Before this fix PE used the stale CSRS end ($60,000), gated the filer out, and returned $0. After the fix PE produces exemption **$8,497.28**, VT income tax **$1,281.20** — matching TaxAct and the worksheet.

## Tests

Adds two integration tests to `vt_retirement_income_exemption.yaml` covering the single (taxsim #999) and joint (taxsim #1000) records. Both pass; neighboring VT tests still pass.

Resolves policyengine-taxsim #999 and #1000.

Fixes #8837

🤖 Generated with [Claude Code](https://claude.com/claude-code)