### PR TITLE
Apply the IRC § 21(e)(2)/(4) filing-status rules to Wisconsin, New York, and Hawaii CDCC provisions

### DIFF
--- a/changelog.d/fix-state-cdcc-filing-status.fixed.md
+++ b/changelog.d/fix-state-cdcc-filing-status.fixed.md
@@ -1,0 +1,1 @@
+Apply the IRC § 21(e)(2) joint-return rule and § 21(e)(4) separated-taxpayer exception to the Wisconsin childcare expense credit (2024+) and subtraction, the New York CDCC, and the Hawaii CDCC, and restrict Hawaii's deemed earned income floor to a spouse who is a student or incapable of self-care.

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_eligible.yaml
@@ -13,3 +13,34 @@
     state_code: HI
   output:
     hi_cdcc_eligible: true
+
+- name: Separate filer with a qualifying individual is not eligible, HRS 235-55.6(e)(2)
+  period: 2022
+  input:
+    count_cdcc_eligible: 1
+    filing_status: SEPARATE
+    state_code: HI
+  output:
+    hi_cdcc_eligible: false
+
+- name: Separated filer maintaining a home for a qualifying individual is eligible, HRS 235-55.6(e)(4)
+  period: 2022
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 35
+        is_separated: true
+      person2:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SEPARATE
+        count_cdcc_eligible: 1
+    households:
+      household:
+        members: [person1, person2]
+        state_code: HI
+  output:
+    hi_cdcc_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_income_floor_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_income_floor_eligible.yaml
@@ -3,10 +3,12 @@
   input:
     people:
       head:
-        is_disabled: true
+        is_tax_unit_head: true
+        is_incapable_of_self_care: true
         is_full_time_student: false
       spouse:
-        is_disabled: false
+        is_tax_unit_spouse: true
+        is_incapable_of_self_care: false
         is_full_time_student: false
     tax_units:
       tax_unit:
@@ -24,10 +26,12 @@
   input:
     people:
       head:
-        is_disabled: true
+        is_tax_unit_head: true
+        is_incapable_of_self_care: true
         is_full_time_student: true
       spouse:
-        is_disabled: false
+        is_tax_unit_spouse: true
+        is_incapable_of_self_care: false
         is_full_time_student: true
     tax_units:
       tax_unit:
@@ -45,11 +49,53 @@
   input:
     people:
       head:
-        is_disabled: false
+        is_tax_unit_head: true
+        is_incapable_of_self_care: false
         is_full_time_student: false
       spouse:
-        is_disabled: false
+        is_tax_unit_spouse: true
+        is_incapable_of_self_care: false
         is_full_time_student: false
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        count_cdcc_eligible: 1
+    households:
+      household:
+        members: [head, spouse]
+        state_code: HI
+  output:
+    hi_cdcc_income_floor_eligible: [false, false]
+
+- name: Single filer incapable of self-care is not floor eligible, HRS 235-55.6(d)(2) deems income only for a spouse.
+  period: 2022
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        age: 40
+        is_incapable_of_self_care: true
+    tax_units:
+      tax_unit:
+        members: [head]
+        count_cdcc_eligible: 1
+    households:
+      household:
+        members: [head]
+        state_code: HI
+  output:
+    hi_cdcc_income_floor_eligible: false
+
+- name: Disabled spouse who is capable of self-care is not floor eligible.
+  period: 2022
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+      spouse:
+        is_tax_unit_spouse: true
+        is_disabled: true
+        is_incapable_of_self_care: false
     tax_units:
       tax_unit:
         members: [head, spouse]

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_integration.yaml
@@ -4,13 +4,13 @@
     people:
       head:
         is_tax_unit_head: true
-        is_disabled: false
+        is_incapable_of_self_care: false
         is_full_time_student: false
         earned_income: 20_000
         dependent_care_employer_benefits: 1_000
       spouse:
         is_tax_unit_spouse: true
-        is_disabled: false
+        is_incapable_of_self_care: false
         is_full_time_student: false
         earned_income: 30_000
         dependent_care_employer_benefits: 2_000
@@ -37,7 +37,7 @@
     people:
       head:
         is_tax_unit_head: true
-        is_disabled: false
+        is_incapable_of_self_care: false
         is_full_time_student: false
         earned_income: 20_000
         dependent_care_employer_benefits: 1_000
@@ -64,13 +64,13 @@
     people:
       head:
         is_tax_unit_head: true
-        is_disabled: false
+        is_incapable_of_self_care: false
         is_full_time_student: false
         earned_income: 20_000
         dependent_care_employer_benefits: 1_000
       spouse:
         is_tax_unit_spouse: true
-        is_disabled: true
+        is_incapable_of_self_care: true
         is_full_time_student: false
         earned_income: 0
         dependent_care_employer_benefits: 0
@@ -97,13 +97,13 @@
     people:
       head:
         is_tax_unit_head: true
-        is_disabled: false
+        is_incapable_of_self_care: false
         is_full_time_student: false
         earned_income: 20_000
         dependent_care_employer_benefits: 5_000
       spouse:
         is_tax_unit_spouse: true
-        is_disabled: true
+        is_incapable_of_self_care: true
         is_full_time_student: false
         earned_income: 0
         dependent_care_employer_benefits: 0
@@ -122,4 +122,27 @@
     hi_cdcc_income_floor_eligible: [false, true]
     hi_cdcc_min_head_spouse_earned: 2_400
     hi_dependent_care_benefits: 0
+    hi_cdcc: 0
+
+- name: integration test 5, separate filer is not eligible, HRS 235-55.6(e)(2)
+  period: 2022
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        earned_income: 20_000
+        dependent_care_employer_benefits: 1_000
+    tax_units:
+      tax_unit:
+        hi_agi: 19_000
+        filing_status: SEPARATE
+        tax_unit_childcare_expenses: 4_000
+        members: [head]
+        count_cdcc_eligible: 2
+    households:
+      household:
+        members: [head]
+        state_code: HI
+  output:
+    hi_cdcc_eligible: false
     hi_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_min_head_spouse_earned.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_min_head_spouse_earned.yaml
@@ -113,18 +113,18 @@
   output:
     hi_cdcc_min_head_spouse_earned: 10_000
 
-- name: single, one eligible, one child, income below floor
+- name: single, one child, income below floor, HRS 235-55.6(d)(2) floor never applies to a single filer
   period: 2022
   input:
     people:
       head:
-        is_tax_unit_head_or_spouse: true
+        is_tax_unit_head: true
+        age: 30
         earned_income: 200
-        hi_cdcc_income_floor_eligible: 2_400
+        is_incapable_of_self_care: true
       child:
-        is_tax_unit_head_or_spouse: false
+        age: 10
         earned_income: 100
-        hi_cdcc_income_floor_eligible: 2_400
     tax_units:
       tax_unit:
         members: [head, child]
@@ -133,7 +133,8 @@
         members: [head, child]
         state_code: HI
   output:
-    hi_cdcc_min_head_spouse_earned: 2_400
+    hi_cdcc_income_floor_eligible: [false, false]
+    hi_cdcc_min_head_spouse_earned: 200
 
 - name: married, one eligible, both income below floor
   period: 2022

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/tax/income/credits/ny_cdcc.yaml
@@ -7,3 +7,38 @@
     employment_income: 10_000
   output:
     ny_cdcc: 3_850 # From the tax form IT-216.
+
+- name: Separate filer with qualifying individuals gets no credit, IT-216 applies IRC 21(e)(2).
+  period: 2022
+  input:
+    count_cdcc_eligible: 3
+    cdcc_relevant_expenses: 10_000
+    state_code: NY
+    employment_income: 10_000
+    filing_status: SEPARATE
+  output:
+    ny_cdcc: 0
+
+- name: Separated filer maintaining a home for a qualifying child keeps the credit, IRC 21(e)(4).
+  period: 2022
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 35
+        is_separated: true
+        employment_income: 10_000
+      person2:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SEPARATE
+        count_cdcc_eligible: 3
+        cdcc_relevant_expenses: 10_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NY
+  output:
+    ny_cdcc: 3_850

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/credits/pa_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/credits/pa_cdcc.yaml
@@ -30,3 +30,52 @@
     cdcc_potential: 1_000
   output:
     pa_cdcc: 1_000
+
+- name: Separate filer gets no credit because the federal potential credit is zero, IRC 21(e)(2)
+  period: 2023
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 35
+        employment_income: 45_000
+      person2:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SEPARATE
+        tax_unit_childcare_expenses: 3_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: PA
+  output:
+    cdcc_potential: 0
+    pa_cdcc: 0
+
+- name: Separated filer maintaining a home for a qualifying child keeps the credit, IRC 21(e)(4)
+  period: 2023
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 35
+        employment_income: 45_000
+        is_separated: true
+      person2:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SEPARATE
+        tax_unit_childcare_expenses: 3_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: PA
+  output:
+    # cdcc_relevant_expenses = min(3000, 3000 cap, 45000 earned) = 3000
+    # cdcc_rate at 45k AGI = 20% floor; potential = 600; PA match 100% in 2023
+    cdcc_potential: 600
+    pa_cdcc: 600

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_credit.yaml
@@ -124,3 +124,58 @@
         members: [head, child]
   output:
     wi_childcare_expense_credit_potential: 2_000 # min(12000, 10000) * 0.20 * 1.0
+
+- name: WI CDCC 2024 separate filer is not eligible per Wis. Stat. 71.07(9g)(c)4.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        age: 35
+        employment_income: 60_000
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: SEPARATE
+        tax_unit_childcare_expenses: 2_000
+        adjusted_gross_income: 60_000
+    households:
+      household:
+        members: [head, child]
+        state_code: WI
+    spm_units:
+      spm_unit:
+        members: [head, child]
+  output:
+    wi_childcare_expense_credit_potential: 0
+
+- name: WI CDCC 2024 separated filer maintaining a home for a qualifying child keeps the credit, IRC 21(e)(4)
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        age: 35
+        employment_income: 60_000
+        is_separated: true
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: SEPARATE
+        tax_unit_childcare_expenses: 2_000
+        adjusted_gross_income: 60_000
+    households:
+      household:
+        members: [head, child]
+        state_code: WI
+    spm_units:
+      spm_unit:
+        members: [head, child]
+  output:
+    wi_childcare_expense_credit_potential: 400 # 2000 * 0.20 * 1.0

--- a/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wi/tax/income/wi_childcare_expense_subtraction.yaml
@@ -30,3 +30,40 @@
     state_code: WI
   output:
     wi_childcare_expense_subtraction: 2_000
+
+- name: WI childcare_expense_subtraction separate filer is not eligible per Wis. Stat. 71.05(6)(b)43.e.
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    tax_unit_childcare_expenses: 2_000
+    count_cdcc_eligible: 1
+    min_head_spouse_earned: 3_000
+    filing_status: SEPARATE
+    state_code: WI
+  output:
+    wi_childcare_expense_subtraction: 0
+
+- name: WI childcare_expense_subtraction separated filer maintaining a home for a qualifying child keeps the subtraction, IRC 21(e)(4)
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        age: 35
+        is_separated: true
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: SEPARATE
+        tax_unit_childcare_expenses: 2_000
+        count_cdcc_eligible: 1
+        min_head_spouse_earned: 3_000
+    households:
+      household:
+        members: [head, child]
+        state_code: WI
+  output:
+    wi_childcare_expense_subtraction: 2_000

--- a/policyengine_us/variables/gov/states/hi/tax/income/credits/cdcc/dependent_care_benefit/hi_cdcc_income_floor_eligible.py
+++ b/policyengine_us/variables/gov/states/hi/tax/income/credits/cdcc/dependent_care_benefit/hi_cdcc_income_floor_eligible.py
@@ -6,14 +6,20 @@ class hi_cdcc_income_floor_eligible(Variable):
     entity = Person
     label = "Hawaii income floor eligible"
     defined_for = StateCode.HI
-    unit = USD
     definition_period = YEAR
     reference = (
+        "https://files.hawaii.gov/tax/legal/hrs/hrs_235.pdf#page=47",
         "https://files.hawaii.gov/tax/forms/2022/n11ins.pdf#page=28",
-        "https://files.hawaii.gov/tax/forms/2022/n11ins.pdf#page=29",
-        "https://files.hawaii.gov/tax/legal/hrs/hrs_235.pdf#page=41",
         "https://files.hawaii.gov/tax/forms/2022/schx_i.pdf#page=2",
     )
 
     def formula(person, period, parameters):
-        return person("is_disabled", period) | person("is_full_time_student", period)
+        # HRS §235-55.6(d)(2) deems earned income only for a spouse who is a
+        # student or incapable of caring for oneself, so the floor requires a
+        # married couple and never applies to a single filer's own earnings.
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        married = person.tax_unit("tax_unit_married", period)
+        student_or_incapable = person("is_full_time_student", period) | person(
+            "is_incapable_of_self_care", period
+        )
+        return head_or_spouse & married & student_or_incapable

--- a/policyengine_us/variables/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_eligible.py
+++ b/policyengine_us/variables/gov/states/hi/tax/income/credits/cdcc/hi_cdcc_eligible.py
@@ -8,9 +8,14 @@ class hi_cdcc_eligible(Variable):
     defined_for = StateCode.HI
     definition_period = YEAR
     reference = (
-        "https://law.justia.com/codes/hawaii/title-14/chapter-235/section-235-55-6/"
+        "https://law.justia.com/codes/hawaii/title-14/chapter-235/section-235-55-6/",
+        "https://files.hawaii.gov/tax/legal/hrs/hrs_235.pdf#page=47",
     )
 
     def formula(tax_unit, period, parameters):
         count_cdcc_eligible = tax_unit("count_cdcc_eligible", period)
-        return count_cdcc_eligible > 0
+        # HRS §235-55.6(e)(2): a married taxpayer may claim the credit only
+        # on a joint return, unless (e)(4) treats them as unmarried — the
+        # same special rules as IRC §21(e)(2) and (4).
+        filing_status_eligible = tax_unit("cdcc_filing_status_eligible", period)
+        return (count_cdcc_eligible > 0) & filing_status_eligible

--- a/policyengine_us/variables/gov/states/ny/tax/income/credits/cdcc/ny_cdcc.py
+++ b/policyengine_us/variables/gov/states/ny/tax/income/credits/cdcc/ny_cdcc.py
@@ -7,11 +7,18 @@ class ny_cdcc(Variable):
     label = "NY CDCC"
     unit = USD
     definition_period = YEAR
-    reference = "https://www.nysenate.gov/legislation/laws/TAX/606"  # (c)
+    reference = (
+        "https://www.nysenate.gov/legislation/laws/TAX/606",  # (c)
+        "https://www.tax.ny.gov/pdf/current_forms/it/it216i.pdf#page=1",
+    )
     defined_for = StateCode.NY
 
     def formula(tax_unit, period, parameters):
         cdcc_max = tax_unit("ny_cdcc_max", period)
         expenses = tax_unit("cdcc_relevant_expenses", period)
         cdcc_rate = tax_unit("ny_cdcc_rate", period) * tax_unit("cdcc_rate", period)
-        return min_(cdcc_max, expenses * cdcc_rate)
+        # Form IT-216 requires qualifying for the federal credit and applies
+        # the IRC §21(e)(2) and (4) special rules, so a married filer must
+        # file jointly unless treated as unmarried.
+        eligible = tax_unit("cdcc_filing_status_eligible", period)
+        return eligible * min_(cdcc_max, expenses * cdcc_rate)

--- a/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit_potential.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/credits/childcare_expense/wi_childcare_expense_credit_potential.py
@@ -35,7 +35,11 @@ class wi_childcare_expense_credit_potential(Variable):
                 tax_unit("min_head_spouse_earned", period),
             )
             cdcc_rate = tax_unit("cdcc_rate", period)
-            return wi_relevant_expenses * cdcc_rate * p_wi.fraction
+            # §71.07(9g)(c)4.: a claimant is subject to the special rules in
+            # IRC §21(e)(2) and (4), so a married claimant must file jointly
+            # unless treated as unmarried.
+            eligible = tax_unit("cdcc_filing_status_eligible", period)
+            return eligible * wi_relevant_expenses * cdcc_rate * p_wi.fraction
         else:
             # Pre-2024: Wisconsin matches the potential federal credit
             us_cdcc = tax_unit("cdcc_potential", period)

--- a/policyengine_us/variables/gov/states/wi/tax/income/subtractions/wi_childcare_expense_subtraction.py
+++ b/policyengine_us/variables/gov/states/wi/tax/income/subtractions/wi_childcare_expense_subtraction.py
@@ -8,8 +8,9 @@ class wi_childcare_expense_subtraction(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://www.revenue.wi.gov/TaxForms2021/2021-ScheduleSB.pdf"
-        "https://www.revenue.wi.gov/TaxForms2021/2021-ScheduleSB-inst.pdf#page=7"
+        "https://docs.legis.wisconsin.gov/statutes/statutes/71/i/05/6/b/43",
+        "https://www.revenue.wi.gov/TaxForms2021/2021-ScheduleSB.pdf",
+        "https://www.revenue.wi.gov/TaxForms2021/2021-ScheduleSB-inst.pdf#page=7",
     )
     defined_for = StateCode.WI
 
@@ -24,4 +25,11 @@ class wi_childcare_expense_subtraction(Variable):
             uncapped_expenses,
             count_eligible * subtraction.childcare_expense.max_amount,
         )
-        return min_(capped_expenses, tax_unit("min_head_spouse_earned", period))
+        earnings_capped_expenses = min_(
+            capped_expenses, tax_unit("min_head_spouse_earned", period)
+        )
+        # §71.05(6)(b)43.e.: a claimant is subject to the special rules in
+        # IRC §21(e)(2) and (4), so a married claimant must file jointly
+        # unless treated as unmarried.
+        eligible = tax_unit("cdcc_filing_status_eligible", period)
+        return eligible * earnings_capped_expenses


### PR DESCRIPTION
## Summary

Fixes the three state CDCC bugs confirmed by the statute verification in #8826: Wisconsin, New York, and Hawaii pay their child and dependent care provisions to married-filing-separately filers whose statutes deny them, and Hawaii additionally over-applies its deemed earned income floor. All three are pre-existing gaps — these code paths bypass the federal variables that #8704 gated — surfaced by the post-#8704 state-coupling audit.

Addresses the WI, NY, and HI items in #8826.

## Wisconsin — 2024+ credit and subtraction miss the § 21(e)(2)/(4) gate

Wis. Stat. [§ 71.07(9g)(c)4.](https://docs.legis.wisconsin.gov/statutes/statutes/71/i/07/9g) and [§ 71.05(6)(b)43.e.](https://docs.legis.wisconsin.gov/statutes/statutes/71/i/05/6/b/43) each provide that a claimant "is subject to the special rules in 26 USC 21 (e)(2) and (4)". 2023 Act 101 replaced only the § 21(c) expense cap with Wisconsin's own $10,000 limit — the rest of § 21, including the joint-return requirement, is imported, and the [2024 Schedule WI-2441 instructions](https://www.revenue.wi.gov/TaxForms2024/2024-ScheduleWI-2441-Inst.pdf#page=1) limit eligibility to single/HoH/MFJ filers.

The model's pre-2024 path multiplies the federal `cdcc_potential` and inherited the gate from #8704, but the 2024+ standalone branch of `wi_childcare_expense_credit_potential` and the `wi_childcare_expense_subtraction` compute from WI's own caps with the ungated `cdcc_rate`. Both now multiply by `cdcc_filing_status_eligible`. Also repairs the subtraction's reference metadata (two URLs were concatenated into one string) and adds the statute link.

## New York — replica credit misses the filing-status gate

`ny_cdcc` rebuilds the federal credit from components (`cdcc_relevant_expenses` × `ny_cdcc_rate` × `cdcc_rate`) without the gate, so an MFS filer kept a NY credit that § 21(e)(2) denies. The [IT-216 instructions](https://www.tax.ny.gov/pdf/current_forms/it/it216i.pdf#page=1) require qualifying for the federal credit and state the married-filing-separately rule with the considered-unmarried exception (living apart the last six months, qualifying person in the home more than half the year, over half the cost of keeping up the home) — § 21(e)(2)/(4) exactly. `ny_cdcc` now multiplies by `cdcc_filing_status_eligible`; `nyc_cdcc` reads `ny_cdcc` and inherits the fix.

## Hawaii — missing joint-return gate; deeming over-applied; wrong disability standard

[HRS § 235-55.6](https://files.hawaii.gov/tax/legal/hrs/hrs_235.pdf#page=47):

- **(e)(2)**: "If the taxpayer is married at the close of the taxable year, the credit shall be allowed … only if the taxpayer and the taxpayer's spouse file a joint return", with the (e)(4) living-apart exception. `hi_cdcc_eligible` only checked `count_cdcc_eligible > 0`; it now also requires `cdcc_filing_status_eligible` (HI's qualifying-individual definition tracks federal § 21(b)(1)/(e)(5), so the federal gate is exact).
- **(d)(2)**: deems earned income only for "a spouse who is a student or a qualified individual described in subsection (b)(1)(C)" — spouse-only, on a married return. `hi_cdcc_income_floor_eligible` was person-level (`is_disabled | is_full_time_student`) with no marriage requirement, so a single disabled filer's $0 earnings were floored to $2,400, manufacturing a credit HRS gives as $0. It now mirrors the federal `cdcc_income_floor_eligible`: head/spouse, married, student or incapable of self-care.
- **Disability standard**: HRS says "incapable of caring for oneself" — the variable now uses `is_incapable_of_self_care` (which HI's qualifying-individual count already used via the federal chain) instead of the broader `is_disabled`.

Confirmed correct and unchanged: HI's $2,400/$4,800 floor amounts ((d)(2)(A)/(B) $200/$400 monthly) and the two-incapacitated-spouses-count-as-one inheritance.

## Reproductions (before → after)

| Scenario | Before | After |
|---|---|---|
| WI 2024, MFS filer, one child, $2,000 expenses | $400 | **$0** |
| WI 2021 subtraction, MFS filer | $2,000 | **$0** |
| NY 2022, MFS filer, three children, $10,000 expenses | $3,850 | **$0** |
| HI 2022, MFS filer with qualifying individuals | positive | **$0** |
| HI single filer incapable of self-care, $200 earnings | floored to $2,400 | **$200** |
| Each state, separated filer maintaining a home for a qualifying child (§ 21(e)(4)) | — | **credit preserved** |

## Tests

- WI credit (2024 branch), WI subtraction, NY, and HI each gain an MFS → $0 case and a separated-filer § 21(e)(4) carve-out case.
- PA gains the end-to-end MFS regression test deferred from #8704 (PA statute verification confirmed Act 53 couples to § 21, including the joint-return rule and the (e)(4)-mirror exception).
- HI floor tests rewritten with explicit head/spouse roles and `is_incapable_of_self_care`; new regressions for the single-filer and disabled-but-capable-spouse cases; the HI integration suite swaps to the correct disability variable with expectations unchanged and adds a SEPARATE case.
- Ran locally: HI CDCC tree, WI credit/subtraction/credit-order, PA, and the full federal `gov/irs/credits/cdcc` tree — **132 passed**. NY suites left to CI (locally slow per #8114; the NY change is a single multiplicative gate).

## Out of scope (tracked in #8826)

The SC § 21(e)(4) decision item, the VA/ID/OR/MN/WI expense-base conformity gap, and the AR/VT/MD tangential flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
