### PR TITLE
Support qualifying work-program participation in SNAP ABAWD work requirement

### DIFF
--- a/changelog.d/snap-abawd-work-program-hours.added.md
+++ b/changelog.d/snap-abawd-work-program-hours.added.md
@@ -1,0 +1,1 @@
+SNAP ABAWD work requirement support for qualifying work-program hours and workfare participation under 7 CFR 273.24(a)(1).

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
@@ -556,3 +556,64 @@
       2025: TX
   output:
     meets_snap_abawd_work_requirements: false
+
+# Work program and workfare participation —
+# 7 U.S.C. 2015(o)(2); 7 CFR 273.24(a)(1)
+# =====================================================
+
+# --- 273.24(a)(1)(ii): Work program participation 20+ hrs ---
+
+- name: Case 39, work program participation of 20 hrs meets requirement.
+  period: 2022
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 0
+    weekly_snap_work_program_hours: 20
+    is_disabled: false
+  output:
+    meets_snap_abawd_work_requirements: true
+
+# --- 273.24(a)(1)(iii): Combination of work and work program hours ---
+
+- name: Case 40, combined work and work program hours of 20 meet requirement.
+  period: 2022
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 10
+    weekly_snap_work_program_hours: 10
+    is_disabled: false
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 41, combined work and work program hours below 20 fail.
+  period: 2022
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 10
+    weekly_snap_work_program_hours: 9
+    is_disabled: false
+  output:
+    meets_snap_abawd_work_requirements: false
+
+# --- 273.24(a)(1)(iv): Workfare participation ---
+
+- name: Case 42, workfare participant meets requirement regardless of hours.
+  period: 2022
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 0
+    is_snap_workfare_participant: true
+    is_disabled: false
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 43, post-HR1 work program participation of 20 hrs meets requirement.
+  period: 2027
+  absolute_error_margin: 0.1
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 0
+    weekly_snap_work_program_hours: 20
+    is_disabled: false
+  output:
+    meets_snap_abawd_work_requirements: true

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_workfare_participant.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_workfare_participant.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class is_snap_workfare_participant(Variable):
+    value_type = bool
+    entity = Person
+    label = "participates in and complies with a SNAP workfare program"
+    documentation = (
+        "Whether the person participates in and complies with the "
+        "requirements of a workfare program under 7 CFR 273.7(m) or a "
+        "comparable state or local program. Workfare participation "
+        "satisfies the SNAP ABAWD work requirement regardless of the "
+        "number of hours, since workfare hours are set by dividing the "
+        "household benefit by the minimum wage (7 U.S.C. 2015(o)(2)(C); "
+        "7 CFR 273.24(a)(1)(iv)). Survey data does not capture this "
+        "input, so it defaults to false; see PolicyEngine/populace#249 "
+        "for the companion data issue."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/7/2015#o_2_C",
+        "https://www.law.cornell.edu/cfr/text/7/273.24#a_1_iv",
+    )

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
@@ -40,12 +40,23 @@ class meets_snap_abawd_work_requirements(Variable):
             p.age_threshold.exempted.calc(age),
             p_pre.age_threshold.exempted.calc(age),
         )
-        # Work activity — 7 CFR 273.24(a)(1) defines compliance monthly
-        # (20 hours per week averaged monthly, i.e., 80 hours per month).
-        # Annual average weekly hours are used as a proxy since survey
+        # Work activity — 7 U.S.C. 2015(o)(2); 7 CFR 273.24(a)(1):
+        # (i) work 20+ hours per week, (ii) participate in and comply
+        # with a qualifying work program 20+ hours per week, or
+        # (iii) any combination of work and work program participation
+        # totaling 20+ hours per week. Compliance is defined monthly
+        # (20 hours per week averaged monthly, i.e., 80 hours per month);
+        # annual average weekly hours are used as a proxy since survey
         # data lack monthly work histories.
         weekly_hours_worked = person("weekly_hours_worked_before_lsr", period.this_year)
-        is_working = weekly_hours_worked >= p.weekly_hours_threshold
+        work_program_hours = person("weekly_snap_work_program_hours", period.this_year)
+        combined_weekly_hours = weekly_hours_worked + work_program_hours
+        meets_hours_threshold = combined_weekly_hours >= p.weekly_hours_threshold
+        # (iv) participate in and comply with a workfare program under
+        # 7 CFR 273.7(m), which satisfies the requirement regardless of
+        # hours.
+        is_workfare_participant = person("is_snap_workfare_participant", period)
+        is_working = meets_hours_threshold | is_workfare_participant
         # (B) Disability — 7 U.S.C. 2015(o)(3)(B)
         is_disabled = person("is_disabled", period)
         # (C) Parent with qualifying child — 7 U.S.C. 2015(o)(3)(C)

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
@@ -55,7 +55,9 @@ class meets_snap_abawd_work_requirements(Variable):
         # (iv) participate in and comply with a workfare program under
         # 7 CFR 273.7(m), which satisfies the requirement regardless of
         # hours.
-        is_workfare_participant = person("is_snap_workfare_participant", period)
+        is_workfare_participant = person(
+            "is_snap_workfare_participant", period.this_year
+        )
         is_working = meets_hours_threshold | is_workfare_participant
         # (B) Disability — 7 U.S.C. 2015(o)(3)(B)
         is_disabled = person("is_disabled", period)

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/weekly_snap_work_program_hours.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/weekly_snap_work_program_hours.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class weekly_snap_work_program_hours(Variable):
+    value_type = float
+    entity = Person
+    label = "average weekly hours of participation in a SNAP qualifying work program"
+    unit = "hour"
+    documentation = (
+        "Average weekly hours of participation in and compliance with a "
+        "work program qualifying under the SNAP ABAWD work requirement, "
+        "such as a SNAP Employment and Training program, a program under "
+        "the Workforce Innovation and Opportunity Act, or a program under "
+        "section 236 of the Trade Act of 1974 (7 U.S.C. 2015(o)(1)(B); "
+        "7 CFR 273.24(a)(3)). These hours count toward the 20-hour weekly "
+        "ABAWD work-activity threshold, alone or combined with hours of "
+        "employment (7 CFR 273.24(a)(1)(i)-(iii)). Survey data does not "
+        "capture this input, so it defaults to zero; see "
+        "PolicyEngine/populace#249 for the companion data issue."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/7/2015#o_2",
+        "https://www.law.cornell.edu/cfr/text/7/273.24#a_1",
+    )


### PR DESCRIPTION
Fixes #8823

## Summary

`meets_snap_abawd_work_requirements` previously treated ABAWD work activity as employment hours only (`weekly_hours_worked_before_lsr >= 20`). Under 7 U.S.C. 2015(o)(2) and 7 CFR 273.24(a)(1), an ABAWD also fulfills the work requirement by:

- (ii) participating in and complying with a qualifying work program (SNAP E&T, WIOA, Trade Act) for 20+ hours per week;
- (iii) any combination of work and qualifying work-program participation totaling 20+ hours per week; or
- (iv) participating in and complying with a workfare program under 7 CFR 273.7(m), regardless of hours.

This PR adds two person-level input variables and updates the ABAWD formula so the work-activity condition is satisfied when combined employment plus qualifying work-program hours meet the 20-hour threshold, or when the person participates in workfare.

## Design rationale

- **Hours input (`weekly_snap_work_program_hours`) rather than a boolean**: 7 CFR 273.24(a)(1)(iii) allows any *combination* of work and work-program hours to meet the threshold, which a boolean cannot represent. An hours input composes naturally with `weekly_hours_worked_before_lsr` (same YEAR definition period and hour unit) and keeps the threshold comparison in one place against the existing `gov.usda.snap.work_requirements.abawd.weekly_hours_threshold` parameter.
- **Separate boolean (`is_snap_workfare_participant`) for workfare**: under 7 CFR 273.24(a)(1)(iv), workfare satisfies the requirement regardless of hours (workfare hours are derived from the benefit divided by minimum wage), so it cannot be folded into the hours input without distorting the rule.
- **General work registration unchanged**: `meets_snap_general_work_requirements` (7 CFR 273.7) is untouched, preserving the legal distinction between general work-registration compliance and ABAWD qualifying activity under 7 CFR 273.24. Note: the issue references an existing `is_snap_work_program_participant` variable, but no such variable exists in the codebase — the general formula uses hours and exemptions only — so this PR adds the ABAWD-specific inputs directly.
- **Minimal diff**: the edit is confined to the work-activity condition since parallel PRs are editing other parts of this formula (state effective dates, area waivers).

## Data layer

Survey data does not capture work-program or workfare participation, so both inputs default to zero/false, preserving current behavior for all existing data. Companion data issue: PolicyEngine/populace#249. The variable documentation states this assumption explicitly.

## Tests

New YAML cases 33-37 in `meets_snap_abawd_work_requirements.yaml`:
- Work-program participation of 20 hrs with no employment meets the rule (pre- and post-HR1);
- Combined 10 work + 10 program hours meets the rule;
- Combined 10 + 9 hours fails;
- Workfare participation meets the rule with zero hours;
- Existing cases 6-7 continue to cover employment-hours-only compliance.

```
$ uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements -c policyengine_us
collected 66 items
...
======================== 66 passed, 1 warning in 7.61s =========================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)