### PR TITLE
Add omitted non-age SNAP work registration exemption hooks

### DIFF
--- a/changelog.d/snap-work-registration-exemption-hooks.added.md
+++ b/changelog.d/snap-work-registration-exemption-hooks.added.md
@@ -1,0 +1,1 @@
+SNAP work registration exemption hooks for TANF work requirement compliance, drug/alcohol treatment program participation, and unemployment compensation applicants under 7 CFR 273.7(b)(1).

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_snap_work_registration_exempt_non_age.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_snap_work_registration_exempt_non_age.yaml
@@ -115,9 +115,79 @@
   output:
     is_snap_work_registration_exempt_non_age: true
 
+# --- (iii) Subject to and complying with TANF work requirements ---
+
+- name: Case 9, TANF enrollee complying with TANF work requirements is exempt.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_disabled: false
+        is_complying_with_tanf_work_requirements: true
+    spm_units:
+      spm_unit:
+        members: [person1]
+        is_tanf_enrolled: true
+  output:
+    is_snap_work_registration_exempt_non_age: true
+
+- name: Case 10, complying with TANF work requirements but not enrolled in TANF is not exempt.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_disabled: false
+        is_complying_with_tanf_work_requirements: true
+    spm_units:
+      spm_unit:
+        members: [person1]
+        is_tanf_enrolled: false
+  output:
+    is_snap_work_registration_exempt_non_age: false
+
+- name: Case 11, TANF enrollee not complying with TANF work requirements is not exempt.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        is_disabled: false
+        is_complying_with_tanf_work_requirements: false
+    spm_units:
+      spm_unit:
+        members: [person1]
+        is_tanf_enrolled: true
+  output:
+    is_snap_work_registration_exempt_non_age: false
+
+# --- (v) Applied for but not yet receiving unemployment compensation ---
+
+- name: Case 12, UC applicant not yet receiving UI is exempt.
+  period: 2026-01
+  input:
+    age: 30
+    is_disabled: false
+    unemployment_compensation: 0
+    has_applied_for_unemployment_compensation: true
+  output:
+    is_snap_work_registration_exempt_non_age: true
+
+# --- (vi) Participant in drug/alcohol treatment program ---
+
+- name: Case 13, participant in a drug or alcohol treatment program is exempt.
+  period: 2026-01
+  input:
+    age: 30
+    is_disabled: false
+    is_in_substance_use_treatment_program: true
+  output:
+    is_snap_work_registration_exempt_non_age: true
+
 # --- Non-exempt baseline ---
 
-- name: Case 9, able-bodied adult with no exempting conditions.
+- name: Case 14, able-bodied adult with no exempting conditions.
   period: 2026-01
   input:
     age: 30
@@ -125,5 +195,8 @@
     unemployment_compensation: 0
     is_full_time_college_student: false
     is_part_time_college_student: false
+    is_complying_with_tanf_work_requirements: false
+    has_applied_for_unemployment_compensation: false
+    is_in_substance_use_treatment_program: false
   output:
     is_snap_work_registration_exempt_non_age: false

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/has_applied_for_unemployment_compensation.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/has_applied_for_unemployment_compensation.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class has_applied_for_unemployment_compensation(Variable):
+    value_type = bool
+    entity = Person
+    label = "Has applied for unemployment compensation"
+    documentation = (
+        "Whether this person has applied for unemployment compensation "
+        "but has not yet begun receiving it. "
+        "This is an input variable that the data layer may not yet "
+        "populate; see PolicyEngine/populace#244."
+    )
+    definition_period = MONTH
+    reference = "https://www.law.cornell.edu/cfr/text/7/273.7#b_1_v"

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_complying_with_tanf_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_complying_with_tanf_work_requirements.py
@@ -1,0 +1,16 @@
+from policyengine_us.model_api import *
+
+
+class is_complying_with_tanf_work_requirements(Variable):
+    value_type = bool
+    entity = Person
+    label = "Subject to and complying with TANF work requirements"
+    documentation = (
+        "Whether this person is subject to and complying with the work "
+        "requirements of the Temporary Assistance for Needy Families "
+        "(TANF) program under title IV of the Social Security Act. "
+        "This is an input variable that the data layer may not yet "
+        "populate; see PolicyEngine/populace#244."
+    )
+    definition_period = MONTH
+    reference = "https://www.law.cornell.edu/cfr/text/7/273.7#b_1_iii"

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_substance_use_treatment_program.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_substance_use_treatment_program.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class is_in_substance_use_treatment_program(Variable):
+    value_type = bool
+    entity = Person
+    label = "Regular participant in a drug or alcohol treatment program"
+    documentation = (
+        "Whether this person is a regular participant in a drug addiction "
+        "or alcoholic treatment and rehabilitation program. "
+        "This is an input variable that the data layer may not yet "
+        "populate; see PolicyEngine/populace#244."
+    )
+    definition_period = MONTH
+    reference = "https://www.law.cornell.edu/cfr/text/7/273.7#b_1_vi"

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_registration_exempt_non_age.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_registration_exempt_non_age.py
@@ -13,15 +13,22 @@ class is_snap_work_registration_exempt_non_age(Variable):
 
     def formula(person, period, parameters):
         p = parameters(period).gov.usda.snap.work_requirements.general
-        # 7 CFR 273.7(b)(1) exemptions omitted:
-        # (iii) Subject to and complying with TANF work requirements
-        #       — requires TANF enrollment input variable.
-        # (vi)  Participant in drug/alcohol treatment program
-        #       — requires treatment program input variable.
+        # 7 CFR 273.7(b)(1) exemptions not modeled here:
         # (vii) Working 30+ hours/week or earning federal min wage × 30
         #       — handled separately in ABAWD work activity check.
+        # Age-based exemptions under (b)(1)(i) are handled in the
+        # age-based work registration exemption logic.
         # (ii) Physically or mentally unfit for employment
         is_disabled = person("is_disabled", period)
+        # (iii) Subject to and complying with TANF work requirements.
+        # TANF enrollment is an existing SPM-unit input; person-level
+        # compliance is a documented input the data layer may not yet
+        # populate (PolicyEngine/populace#244). We gate on enrollment
+        # because a person cannot be subject to TANF work requirements
+        # without receiving TANF.
+        complying_with_tanf_work_requirements = person.spm_unit(
+            "is_tanf_enrolled", period
+        ) & person("is_complying_with_tanf_work_requirements", period)
         # (iv) Responsible for care of dependent child under 6
         is_dependent = person("is_tax_unit_dependent", period)
         age = person("monthly_age", period)
@@ -33,17 +40,23 @@ class is_snap_work_registration_exempt_non_age(Variable):
         )
         # (viii) Enrolled at least half-time in school/training/higher ed
         is_student = person("is_snap_higher_ed_student", period)
-        # (v) Receiving unemployment compensation — 7 CFR 273.7(b)(1)(v)
-        # also exempts applicants who have applied but not yet received
-        # UI; we are not tracking that yet.
+        # (v) Receiving unemployment compensation, or has applied for it
+        # but not yet begun receiving it — 7 CFR 273.7(b)(1)(v).
         # Simplification: any UC receipt during the year exempts the person
         # in all months of that year, since survey data lack monthly UC
         # receipt histories.
         receiving_ui = person("unemployment_compensation", period.this_year) > 0
+        applied_for_ui = person("has_applied_for_unemployment_compensation", period)
+        # (vi) Regular participant in a drug addiction or alcoholic
+        # treatment and rehabilitation program — 7 CFR 273.7(b)(1)(vi).
+        in_treatment_program = person("is_in_substance_use_treatment_program", period)
         return (
             is_disabled
+            | complying_with_tanf_work_requirements
             | has_child_under_6
             | has_incapacitated_person
             | is_student
             | receiving_ui
+            | applied_for_ui
+            | in_treatment_program
         )


### PR DESCRIPTION
Fixes #8824

## Summary

`is_snap_work_registration_exempt_non_age` previously omitted three non-age work-registration exemptions under 7 CFR 273.7(b)(1) because the model lacked input variables. This PR adds explicit, documented input hooks for those exemptions so the rules layer exposes the correct input surface, even where the data layer cannot yet populate them (companion data issue: PolicyEngine/populace#244).

## New hooks

| Exemption | Implementation |
|---|---|
| (iii) Subject to and complying with TANF work requirements | New person-level input `is_complying_with_tanf_work_requirements`, gated on the existing SPM-unit input `is_tanf_enrolled` (a person cannot be subject to TANF work requirements without receiving TANF) |
| (v) Applied for but not yet receiving unemployment compensation | New person-level input `has_applied_for_unemployment_compensation`, OR'd with the existing `unemployment_compensation > 0` condition |
| (vi) Regular participant in drug/alcohol treatment program | New person-level input `is_in_substance_use_treatment_program` |

### TANF design note

The repo has `meets_tanf_work_requirements` (SPM-unit level), but it only aggregates two state implementations (DC, MT) and measures modeled TANF compliance, so it would return false for enrollees in the other 49 jurisdictions. Instead, this PR uses a dedicated, documented person-level compliance input combined with the existing `is_tanf_enrolled` input, which keeps the exemption grounded in TANF enrollment data while leaving the compliance signal to the data layer.

## 7 CFR 273.7(b)(1) coverage after this PR

| Paragraph | Exemption | Status |
|---|---|---|
| (i) | Age-based (under 16, 16–17 non-head-of-household, 60+) | Modeled in age-based exemption logic (unchanged) |
| (ii) | Physically or mentally unfit for employment | Modeled via `is_disabled` (unchanged) |
| (iii) | Complying with TANF work requirements | **Now modeled** (new input hook) |
| (iv) | Caring for dependent child under 6 or incapacitated person | Modeled (unchanged) |
| (v) | Receiving UC or applied for UC | Receipt modeled (unchanged); **applicants now modeled** (new input hook) |
| (vi) | Drug/alcohol treatment program participant | **Now modeled** (new input hook) |
| (vii) | Working 30+ hours/week or earning min wage × 30 | Handled separately in ABAWD work activity check (unchanged) |
| (viii) | Enrolled at least half-time in school/training | Modeled via `is_snap_higher_ed_student` (unchanged) |

No exemption paths under 273.7(b)(1) remain unrepresented after this PR.

## Tests

New YAML cases in `is_snap_work_registration_exempt_non_age.yaml`:
- TANF enrolled + complying → exempt
- Complying but not enrolled → not exempt
- Enrolled but not complying → not exempt
- UC applicant with zero UC → exempt
- Treatment program participant → exempt
- Baseline with all new inputs false → not exempt

```
uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements -c policyengine_us
======================== 66 passed, 1 warning in 7.17s =========================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)