### PR TITLE
Add SNAP work requirement state coverage tests and limitation diagnostics

### DIFF
--- a/changelog.d/snap-work-requirements-coverage-diagnostics.added.md
+++ b/changelog.d/snap-work-requirements-coverage-diagnostics.added.md
@@ -1,0 +1,1 @@
+Added a SNAP work requirements state coverage document and coverage tests for HR1 ABAWD effective dates across states.

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/README.md
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/README.md
@@ -1,0 +1,62 @@
+# SNAP work requirements coverage
+
+This document records which SNAP work-requirement rules are modeled in
+PolicyEngine US, which are partially modeled, and which are pending, on a
+rule-by-rule and state-by-state basis. It covers general work registration
+(7 CFR 273.7), the Able-Bodied Adult Without Dependents (ABAWD) time limit
+(7 CFR 273.24), and the HR1/OBBBA changes (P.L. 119-21, Section 10102(a),
+effective 2025-07-04).
+
+Maintenance: this document and the accompanying coverage tests
+(`policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/state_coverage.yaml`)
+must be updated as the child issues of
+[#8820](https://github.com/PolicyEngine/policyengine-us/issues/8820)
+([#8821](https://github.com/PolicyEngine/policyengine-us/issues/8821)–[#8824](https://github.com/PolicyEngine/policyengine-us/issues/8824))
+land.
+
+## Rule-by-rule coverage
+
+| Rule | Status | Notes |
+| --- | --- | --- |
+| General work registration age exemptions (under 16, 60 and older) — 7 CFR 273.7(b)(1)(i) | Modeled | `meets_snap_general_work_requirements` |
+| General work registration 30-hour weekly work threshold — 7 CFR 273.7(b)(1)(vii) | Modeled | `gov.usda.snap.work_requirements.general.weekly_hours_threshold` |
+| General exemptions: disability, care of child under 6, care of incapacitated person — 7 CFR 273.7(b)(1)(ii), (iv) | Modeled | Shared between general and ABAWD checks |
+| Non-age work registration exemptions: student enrollment, unemployment compensation receipt — 7 CFR 273.7(b)(1)(v), (viii) | Modeled | `is_snap_work_registration_exempt_non_age` |
+| Non-age work registration exemptions: TANF-complying, drug or alcohol treatment participants, unemployment compensation applicants not yet receiving — 7 CFR 273.7(b)(1)(iii), (v), (vi) | Pending | [#8824](https://github.com/PolicyEngine/policyengine-us/issues/8824); requires additional input variables |
+| ABAWD 20-hour weekly work threshold — 7 CFR 273.24(a)(1)(i) | Modeled | `meets_snap_abawd_work_requirements` |
+| ABAWD age exemption brackets, including the HR1 change of the upper bound from 55 to 65 — 7 U.S.C. 2015(o)(3)(A) | Modeled | `gov.usda.snap.work_requirements.abawd.age_threshold.exempted` |
+| ABAWD dependent-child age threshold, including the HR1 change from 18 to 14 — 7 U.S.C. 2015(o)(3)(C) | Modeled | `gov.usda.snap.work_requirements.abawd.age_threshold.dependent` |
+| Removal of pre-HR1 homeless and veteran ABAWD exemptions | Modeled | Applied where HR1 is in effect via `is_snap_abawd_hr1_in_effect` |
+| Pregnancy exemption — 7 U.S.C. 2015(o)(3)(E) | Modeled | Uses the `is_pregnant` input variable |
+| Indian, Urban Indian, and California Indian ABAWD exemption — 7 U.S.C. 2015(o)(3)(F)-(G) | Partially modeled | `is_snap_abawd_indian_exempt` is consumed by the ABAWD formula but is an input variable with no formula; it defaults to false unless supplied |
+| Qualifying work-program participation or hours counting toward the ABAWD requirement | Pending | [#8823](https://github.com/PolicyEngine/policyengine-us/issues/8823); only employment hours (`weekly_hours_worked_before_lsr`) are counted |
+
+## State-by-state HR1 ABAWD effective dates
+
+`is_snap_abawd_hr1_in_effect` determines whether the HR1 ABAWD changes apply
+to a person, based on their state.
+
+| State(s) | Model behavior | Actual policy | Status |
+| --- | --- | --- | --- |
+| All states except CA, HI, AK | HR1 in effect from 2025-07-04 (`gov.usda.snap.work_requirements.abawd.in_effect`) | Federal effective date 2025-07-04 | Modeled |
+| CA | HR1 in effect from 2026-06-01 (`gov.states.ca.cdss.snap.work_requirements.abawd.hr1_in_effect`, per ACL 25-93) | Delayed implementation to 2026-06-01 | Modeled |
+| HI, AK | HR1 applied at the federal 2025-07-04 date | Delayed implementation to 2025-11-01 | Pending [#8821](https://github.com/PolicyEngine/policyengine-us/issues/8821); the `gov.usda.snap.work_requirements.abawd.exempt_states` parameter exists but is not consumed by any formula |
+| AK boroughs with high-unemployment waivers | No sub-state waiver geography | Borough-level ABAWD waivers | Pending [#8822](https://github.com/PolicyEngine/policyengine-us/issues/8822) |
+
+## Data-dependent input limitations
+
+Several exemption paths depend on input variables that standard survey
+microdata do not carry, so household-level results are only as precise as the
+supplied inputs:
+
+- `weekly_hours_worked_before_lsr`: hours worked; drives both the 30-hour
+  general and 20-hour ABAWD thresholds.
+- `is_snap_abawd_indian_exempt`: no survey source; defaults to false.
+- `is_pregnant`: no survey source; defaults to false.
+- `is_incapable_of_self_care`: care-of-incapacitated-person exemption.
+- `is_homeless` and `is_veteran`: pre-HR1 ABAWD exemptions.
+- `is_snap_higher_ed_student` and `unemployment_compensation`: non-age work
+  registration exemptions.
+
+Population-level data parity is tracked separately in
+[PolicyEngine/populace#248](https://github.com/PolicyEngine/populace/issues/248).

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/state_coverage.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/state_coverage.yaml
@@ -1,0 +1,51 @@
+# State-by-state coverage of HR1 (P.L. 119-21) ABAWD effective dates.
+# See policyengine_us/parameters/gov/usda/snap/work_requirements/README.md
+# for the full coverage table.
+# Federal effective date: 2025-07-04; CA delays to 2026-06-01 per ACL 25-93.
+# HI/AK delayed adoption (2025-11-01) is not yet modeled — tracked in
+# https://github.com/PolicyEngine/policyengine-us/issues/8821 — so no HI/AK
+# cases are asserted here until that lands.
+# AK borough-level waivers are tracked in
+# https://github.com/PolicyEngine/policyengine-us/issues/8822.
+# state_code is a yearly variable, so non-January test months key it to the
+# calendar year explicitly.
+
+- name: Default-rule state (TX), month before federal HR1 effective date, HR1 not in effect.
+  period: 2025-06
+  input:
+    state_code:
+      2025: TX
+  output:
+    is_snap_abawd_hr1_in_effect: false
+
+- name: Default-rule state (TX), first full month after federal HR1 effective date, HR1 in effect.
+  period: 2025-08
+  input:
+    state_code:
+      2025: TX
+  output:
+    is_snap_abawd_hr1_in_effect: true
+
+- name: Second default-rule state (NY), first full month after federal HR1 effective date, HR1 in effect.
+  period: 2025-08
+  input:
+    state_code:
+      2025: NY
+  output:
+    is_snap_abawd_hr1_in_effect: true
+
+- name: CA, month before state adoption date, HR1 not in effect despite federal date having passed.
+  period: 2026-05
+  input:
+    state_code:
+      2026: CA
+  output:
+    is_snap_abawd_hr1_in_effect: false
+
+- name: CA, at state adoption date of 2026-06-01, HR1 in effect.
+  period: 2026-06
+  input:
+    state_code:
+      2026: CA
+  output:
+    is_snap_abawd_hr1_in_effect: true


### PR DESCRIPTION
Fixes #8825

## Summary

Adds a lightweight, inspectable coverage artifact for SNAP OBBBA work-requirement state coverage, per #8825 (child of tracker #8820). No formula or parameter logic is changed — this PR only documents and tests the current state of the model.

- **`policyengine_us/parameters/gov/usda/snap/work_requirements/README.md`**: rule-by-rule and state-by-state coverage tables covering general work registration (7 CFR 273.7), the ABAWD time limit (7 CFR 273.24), and the HR1/OBBBA changes (P.L. 119-21, effective 2025-07-04). It records:
  - Modeled rules: 30-hour general and 20-hour ABAWD thresholds, HR1 age and dependent-child threshold changes, removal of pre-HR1 homeless/veteran exemptions, pregnancy exemption, and California's delayed HR1 implementation (2026-06-01 per ACL 25-93).
  - Partially modeled: the Indian/Urban Indian/California Indian ABAWD exemption is consumed by the formula but is an input variable with no formula (defaults to false unless supplied).
  - Pending gaps with issue links: HI/AK delayed adoption and the unconsumed `exempt_states` parameter (#8821), Alaska borough-level waivers (#8822), qualifying work-program hours (#8823), and omitted non-age work-registration exemptions (#8824).
  - Data-dependent input limitations (hours worked, pregnancy, Indian status, etc.), with a pointer to PolicyEngine/populace#248.
  - A note that the artifact must be updated as child issues #8821–#8824 land.
- **`policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/state_coverage.yaml`**: coverage tests of `is_snap_abawd_hr1_in_effect` for default-rule states (TX, NY) before and after the federal 2025-07-04 effective date, and California before and at its 2026-06-01 adoption date. HI/AK cases are intentionally not asserted (current behavior is a known gap being fixed in the #8821 PR); they are documented in the README instead.

## Test output

```
uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements -c policyengine_us
======================== 66 passed, 1 warning in 8.19s =========================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)