### PR TITLE
Document SNAP work requirement modeling simplifications and fix mislabeled HR1 parameter

### DIFF
--- a/changelog.d/snap-work-requirements-documentation.changed.md
+++ b/changelog.d/snap-work-requirements-documentation.changed.md
@@ -1,0 +1,1 @@
+Document SNAP work requirement modeling simplifications (ABAWD 3-in-36 time limit, voluntary quit, annual hours and unemployment compensation proxies) and correct the mislabeled HR1 ABAWD in-effect parameter.

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/in_effect.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/in_effect.yaml
@@ -1,4 +1,4 @@
-description: The Department of Agriculture removes the exemption from Able-Bodied Adult Without Dependents (ABAWD) work requirements for homeless individuals or veterans under the Supplemental Nutrition Assistance Program, if this is true.
+description: The HR1 changes to Able-Bodied Adult Without Dependents (ABAWD) work requirements under the Supplemental Nutrition Assistance Program are in effect when this is true, including the higher exempted age threshold, the lower dependent child age threshold, the removal of the exemptions for homeless individuals and veterans, and the addition of the exemptions for Indians, Urban Indians, and California Indians.
 
 values:
   0000-01-01: false
@@ -7,7 +7,7 @@ values:
 metadata:
   unit: bool
   period: year
-  label: SNAP ABAWD work requirement exemption removed for homeless or veterans
+  label: SNAP ABAWD HR1 work requirement changes in effect
   reference:
     - title: Public Law 119-21, Section 10102(a) - Modifications to SNAP ABAWD Requirements
       href: https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=81

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_registration_exempt_non_age.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_work_registration_exempt_non_age.py
@@ -36,6 +36,9 @@ class is_snap_work_registration_exempt_non_age(Variable):
         # (v) Receiving unemployment compensation — 7 CFR 273.7(b)(1)(v)
         # also exempts applicants who have applied but not yet received
         # UI; we are not tracking that yet.
+        # Simplification: any UC receipt during the year exempts the person
+        # in all months of that year, since survey data lack monthly UC
+        # receipt histories.
         receiving_ui = person("unemployment_compensation", period.this_year) > 0
         return (
             is_disabled

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
@@ -6,6 +6,23 @@ class meets_snap_abawd_work_requirements(Variable):
     entity = Person
     label = "Person is eligible for SNAP benefits via Able-Bodied Adult Without Dependents (ABAWD) work requirements"
     definition_period = MONTH
+    documentation = (
+        "Whether the person meets the Able-Bodied Adult Without Dependents "
+        "(ABAWD) work requirements or is exempt from them. Modeling "
+        "simplification (3-in-36 time limit): under 7 CFR 273.24(b), a "
+        "noncompliant ABAWD loses eligibility only after receiving benefits "
+        "for 3 countable months within a 36-month period; eligibility can be "
+        "regained by working 80 hours in a 30-day period (273.24(d)), and "
+        "individuals who regain and then lose work qualify for one additional "
+        "3-consecutive-month allotment per 36-month period (273.24(e)). The "
+        "model does not track month-counting histories, so it treats "
+        "noncompliance as immediate monthly ineligibility. This is a "
+        "steady-state assumption: it is accurate for ABAWDs who have already "
+        "exhausted their 3 countable months, but overstates ineligibility "
+        "for new noncompliance spells. The overstatement is largest in "
+        "FY2026, when HR1 (P.L. 119-21) restarts time-limit clocks for newly "
+        "covered populations."
+    )
     reference = (
         "https://www.law.cornell.edu/cfr/text/7/273.24",
         "https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=81",
@@ -23,7 +40,10 @@ class meets_snap_abawd_work_requirements(Variable):
             p.age_threshold.exempted.calc(age),
             p_pre.age_threshold.exempted.calc(age),
         )
-        # Work activity
+        # Work activity — 7 CFR 273.24(a)(1) defines compliance monthly
+        # (20 hours per week averaged monthly, i.e., 80 hours per month).
+        # Annual average weekly hours are used as a proxy since survey
+        # data lack monthly work histories.
         weekly_hours_worked = person("weekly_hours_worked_before_lsr", period.this_year)
         is_working = weekly_hours_worked >= p.weekly_hours_threshold
         # (B) Disability — 7 U.S.C. 2015(o)(3)(B)

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_general_work_requirements.py
@@ -6,11 +6,21 @@ class meets_snap_general_work_requirements(Variable):
     entity = Person
     label = "Person is eligible for SNAP benefits via general work requirements"
     definition_period = MONTH
+    documentation = (
+        "Whether the person meets the SNAP general work requirements or is "
+        "exempt from them. Non-modeled provision: voluntary quit and reduced "
+        "work effort disqualifications (7 CFR 273.7(j)) are not modeled, "
+        "because job-separation events are unobservable in cross-sectional "
+        "survey data."
+    )
     reference = "https://www.law.cornell.edu/cfr/text/7/273.7"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.usda.snap.work_requirements.general
         age = person("monthly_age", period)
+        # 7 CFR 273.7(b)(1)(vii) exempts persons working 30 or more hours
+        # per week, determined monthly. Annual average weekly hours are
+        # used as a proxy since survey data lack monthly work histories.
         weekly_hours_worked = person("weekly_hours_worked_before_lsr", period.this_year)
         # Exemptions under 7 CFR 273.7(b)(1):
         # Under 16 or 60 years of age or older are exempted


### PR DESCRIPTION
Fixes #8866

Documentation/metadata-only PR — no behavior changes.

## Changes

1. **ABAWD 3-in-36 time limit** (`meets_snap_abawd_work_requirements.py`): adds a `documentation` attribute explaining that 7 CFR 273.24(b) disqualifies an ABAWD only after 3 countable months in 36, with regaining provisions (80 hours in 30 days, 273.24(d)) and one bonus 3-consecutive-month allotment (273.24(e)). The model treats noncompliance as immediate monthly ineligibility — a steady-state assumption that overstates ineligibility for new spells, largest in FY2026 as HR1 restarts time-limit clocks.
2. **Voluntary quit / reduced work effort** (`meets_snap_general_work_requirements.py`): adds a `documentation` attribute noting that 7 CFR 273.7(j) disqualifications are not modeled, since job-separation events are unobservable in cross-sectional survey data.
3. **Mislabeled HR1 parameter** (`gov/usda/snap/work_requirements/abawd/in_effect.yaml`): the description and label said it "removes the exemption ... for homeless individuals or veterans," but it gates all HR1 ABAWD changes (higher exempted age threshold, lower dependent-child age threshold, exemption removals and additions). Rewritten accurately; references kept.
4. **Annual hours proxy**: comments in both work requirement variables where `weekly_hours_worked_before_lsr` is read over `period.this_year`, noting the annual-average proxy for what is legally a monthly determination (20 hrs/week averaged monthly / 80 hrs/month per 7 CFR 273.24(a)(1); 30 hrs/week per 273.7(b)(1)(vii)).
5. **Annual UC receipt** (`is_snap_work_registration_exempt_non_age.py`): comment noting that annual unemployment compensation receipt exempting all months of the year is a simplification.

The optional parameterized grace-months fraction from the issue is deliberately excluded to keep this PR docs-only; it can follow in a separate PR if wanted.

## Testing

`policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements -c policyengine_us` — 61 passed, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)