### PR TITLE
Add SNAP ABAWD discretionary exemption hook

### DIFF
--- a/changelog.d/snap-abawd-discretionary-exemptions.added.md
+++ b/changelog.d/snap-abawd-discretionary-exemptions.added.md
@@ -1,0 +1,1 @@
+Added SNAP ABAWD discretionary exemption hook: parameter for the exemption share of covered individuals under 7 U.S.C. 2015(o)(6) and a person-level input ORed into the ABAWD time limit exceptions.

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/discretionary_exemption_rate.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/discretionary_exemption_rate.yaml
@@ -1,0 +1,33 @@
+description: States may exempt individuals from the Able-Bodied Adult Without Dependents (ABAWD) time limit up to this monthly average share of covered individuals under the Supplemental Nutrition Assistance Program.
+
+values:
+  # 15% for FY1998-2019 — 7 U.S.C. 2015(o)(6)(C)-(D), added by the
+  # Balanced Budget Act of 1997 (P.L. 105-33).
+  1997-10-01: 0.15
+  # 12% for FY2020-2023 — 7 U.S.C. 2015(o)(6)(E), Agriculture Improvement
+  # Act of 2018 (P.L. 115-334, Section 4005).
+  2019-10-01: 0.12
+  # 8% for FY2024 and each subsequent fiscal year — 7 U.S.C. 2015(o)(6)(F),
+  # Fiscal Responsibility Act of 2023 (P.L. 118-5, Section 312).
+  # OBBBA (P.L. 119-21, Section 10102) did not amend 2015(o)(6).
+  2023-10-01: 0.08
+
+metadata:
+  unit: /1
+  period: year
+  label: SNAP ABAWD discretionary exemption rate
+  # Discretionary exemptions are assigned by state caseworkers and are
+  # unobservable in survey data; like takeup, they are assigned during
+  # microdata construction rather than at simulation time.
+  economy: false
+  reference:
+    - title: 7 U.S.C. 2015(o)(6) - Exemptions from the ABAWD time limit
+      href: https://www.law.cornell.edu/uscode/text/7/2015#o_6
+    - title: 7 C.F.R. § 273.24(g) - Discretionary exemptions
+      href: https://www.law.cornell.edu/cfr/text/7/273.24#g
+    - title: Fiscal Responsibility Act of 2023 (P.L. 118-5), Section 312
+      href: https://www.congress.gov/118/plaws/publ5/PLAW-118publ5.pdf
+    - title: Agriculture Improvement Act of 2018 (P.L. 115-334), Section 4005
+      href: https://www.congress.gov/115/plaws/publ334/PLAW-115publ334.pdf
+    - title: Balanced Budget Act of 1997 (P.L. 105-33), Section 1001
+      href: https://www.congress.gov/105/plaws/publ33/PLAW-105publ33.pdf

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
@@ -461,3 +461,42 @@
     state_code: CA
   output:
     meets_snap_abawd_work_requirements: false
+
+# =====================================================
+# State discretionary exemptions — 7 U.S.C. 2015(o)(6),
+# 7 CFR 273.24(g). Assigned at data-construction time.
+# =====================================================
+
+- name: Case 33, discretionary-exempt noncompliant ABAWD meets requirement.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    is_snap_abawd_discretionary_exempt: true
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 34, identical non-exempt person does NOT meet requirement.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    is_snap_abawd_discretionary_exempt: false
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: false
+
+- name: Case 35, pre-HR1 discretionary exemption also applies.
+  period: 2022
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    is_snap_abawd_discretionary_exempt: true
+  output:
+    meets_snap_abawd_work_requirements: true

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_abawd_discretionary_exempt.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_abawd_discretionary_exempt.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class is_snap_abawd_discretionary_exempt(Variable):
+    value_type = bool
+    entity = Person
+    label = "Exempt from the SNAP ABAWD time limit via a state discretionary exemption"
+    documentation = (
+        "State agencies may exempt individuals from the Able-Bodied Adult "
+        "Without Dependents (ABAWD) time limit up to a monthly average share "
+        "of covered individuals under 7 U.S.C. 2015(o)(6) (8 percent from "
+        "fiscal year 2024, previously 15 and then 12 percent). These "
+        "exemptions are individually assigned by state caseworkers and are "
+        "unobservable in survey data, so this input defaults to false and is "
+        "intended to be assigned at data-construction time (e.g., in "
+        "populace) among covered individuals."
+    )
+    definition_period = YEAR
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/7/2015#o_6",
+        "https://www.law.cornell.edu/cfr/text/7/273.24#g",
+    )

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.py
@@ -45,6 +45,9 @@ class meets_snap_abawd_work_requirements(Variable):
         is_pregnant = person("is_pregnant", period)
         # (F)-(G) Indian, Urban Indian, or California Indian.
         is_indian_exempt = person("is_snap_abawd_indian_exempt", period)
+        # State discretionary exemption — 7 U.S.C. 2015(o)(6).
+        # Assigned at data-construction time among covered individuals.
+        is_discretionary_exempt = person("is_snap_abawd_discretionary_exempt", period)
         # TODO: HI/AK delayed adoption (2025-11-01) to be handled
         # in a follow-up PR via state-level hr1_in_effect parameters.
         base_conditions = (
@@ -54,6 +57,7 @@ class meets_snap_abawd_work_requirements(Variable):
             | exempt_parent
             | work_reg_exempt
             | is_pregnant
+            | is_discretionary_exempt
         )
         # Pre-HR1 exemptions: homeless, veteran
         is_homeless = person.household("is_homeless", period)


### PR DESCRIPTION
Fixes #8867

## Summary

States may exempt individuals from the ABAWD time limit up to a monthly average share of covered individuals — 7 U.S.C. 2015(o)(6), 7 CFR 273.24(g). OBBBA (P.L. 119-21 §10102) did NOT amend (o)(6); it only amends (o)(3), (o)(4)(A)(ii) and inserts (o)(7). This PR adds the rules parameter and the person-level hook:

- **`gov/usda/snap/work_requirements/abawd/discretionary_exemption_rate`** — dated values verified against the current U.S. Code text of 2015(o)(6)(C)–(F) at uscode.house.gov:
  - `1997-10-01: 0.15` — 15% for FY1998–2019 ((o)(6)(C)–(D), Balanced Budget Act of 1997, P.L. 105-33)
  - `2019-10-01: 0.12` — 12% for FY2020–2023 ((o)(6)(E), Agriculture Improvement Act of 2018, P.L. 115-334 §4005)
  - `2023-10-01: 0.08` — 8% for FY2024 and each subsequent fiscal year ((o)(6)(F), Fiscal Responsibility Act of 2023, P.L. 118-5 §312)

  Marked `economy: false`: like takeup, caseworker-assigned exemptions are unobservable in survey data and are assigned during microdata construction, not simulation time.
- **`is_snap_abawd_discretionary_exempt`** — person-level boolean input defaulting to false, ORed into the ABAWD exception conditions in `meets_snap_abawd_work_requirements` (applies both pre- and post-HR1, since (o)(6) predates and survives HR1).

## Carryover context (documented, not modeled)

7 U.S.C. 2015(o)(6)(J) (added by FRA 2023): from FY2024 onward, a state may carry unused exemptions forward only to the subsequent fiscal year — no indefinite accumulation. This affects how many exemptions a state has available in a given year, which is an assignment-time (data-layer) concern, not a rules-engine mechanic.

## Data dependency

Assignment of exemptions among covered individuals (up to the parameter's share) is data-layer work in populace; this PR only provides the parameter and the hook.

## Tests

`uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements -c policyengine_us`

```
64 passed, 1 warning in 7.23s
```

New cases: discretionary-exempt noncompliant ABAWD meets the requirement (post-HR1 and pre-HR1); identical non-exempt person does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)