### PR TITLE
Model California county and litigation-reinstated statewide SNAP ABAWD waivers

### DIFF
--- a/changelog.d/snap-abawd-ca-statewide-waivers.added.md
+++ b/changelog.d/snap-abawd-ca-statewide-waivers.added.md
@@ -1,0 +1,1 @@
+Add California county-level SNAP ABAWD time limit waivers (CDSS ACL 25-79 and ACL 26-15) and litigation-reinstated statewide waivers for CA, DC, IL, and NV following Rhode Island State Council of Churches v. Rollins.

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
@@ -10,8 +10,16 @@
 # From 2025-11-01 through 2026-10-31, FNS approved Alaska's good faith
 # exemption waiver under P.L. 119-21 (OBBBA) section 10102, covering the same
 # 29 boroughs and census areas (all except the Municipality of Anchorage).
+# From 2025-11-01 through 2026-10-31, FNS approved California's request to
+# waive the time limit in seven counties under the post-OBBBA over-10-percent
+# unemployment criterion of 7 U.S.C. 2015(o)(4)(A)(i) and 7 CFR 273.24(f):
+# Colusa, Imperial, and Tulare (approved October 23, 2025, announced in CDSS
+# ACL 25-79), and Alpine, Merced, Monterey, and Plumas (modification approved
+# February 10, 2026, retroactively effective November 1, 2025, announced in
+# CDSS ACL 26-15).
 # Waivers in effect before 2024-11-01 (in Alaska and elsewhere), and after
-# the documented 2026-10-31 Alaska approval end date, are not modeled.
+# the documented 2026-10-31 Alaska and California approval end dates, are
+# not modeled. Statewide waivers are modeled separately in waived_states.
 description: The Department of Agriculture waives the Able-Bodied Adult Without Dependents (ABAWD) time limit under the Supplemental Nutrition Assistance Program for residents of areas with these county FIPS codes.
 
 values:
@@ -47,6 +55,43 @@ values:
     - "02275" # Wrangell City and Borough, AK
     - "02282" # Yakutat City and Borough, AK
     - "02290" # Yukon-Koyukuk Census Area, AK
+  2025-11-01:
+    - "02013" # Aleutians East Borough, AK
+    - "02016" # Aleutians West Census Area, AK
+    - "02050" # Bethel Census Area, AK
+    - "02060" # Bristol Bay Borough, AK
+    - "02063" # Chugach Census Area, AK
+    - "02066" # Copper River Census Area, AK
+    - "02068" # Denali Borough, AK
+    - "02070" # Dillingham Census Area, AK
+    - "02090" # Fairbanks North Star Borough, AK
+    - "02100" # Haines Borough, AK
+    - "02105" # Hoonah-Angoon Census Area, AK
+    - "02110" # Juneau City and Borough, AK
+    - "02122" # Kenai Peninsula Borough, AK
+    - "02130" # Ketchikan Gateway Borough, AK
+    - "02150" # Kodiak Island Borough, AK
+    - "02158" # Kusilvak Census Area, AK
+    - "02164" # Lake and Peninsula Borough, AK
+    - "02170" # Matanuska-Susitna Borough, AK
+    - "02180" # Nome Census Area, AK
+    - "02185" # North Slope Borough, AK
+    - "02188" # Northwest Arctic Borough, AK
+    - "02195" # Petersburg Borough, AK
+    - "02198" # Prince of Wales-Hyder Census Area, AK
+    - "02220" # Sitka City and Borough, AK
+    - "02230" # Skagway Municipality, AK
+    - "02240" # Southeast Fairbanks Census Area, AK
+    - "02275" # Wrangell City and Borough, AK
+    - "02282" # Yakutat City and Borough, AK
+    - "02290" # Yukon-Koyukuk Census Area, AK
+    - "06003" # Alpine County, CA
+    - "06011" # Colusa County, CA
+    - "06025" # Imperial County, CA
+    - "06047" # Merced County, CA
+    - "06053" # Monterey County, CA
+    - "06063" # Plumas County, CA
+    - "06107" # Tulare County, CA
   2026-11-01:
     []
 
@@ -67,3 +112,7 @@ metadata:
       href: https://www.fns.usda.gov/snap/obbb-ABAWD-Waivers-Implementation-Memo
     - title: State of Alaska Department of Health, H.R. 1 - AK Impacts (good faith exemption waiver, November 1, 2025 - October 31, 2026)
       href: https://health.alaska.gov/en/education/hr-1-ak-impacts/
+    - title: CDSS All County Letter No. 25-79 (November 7, 2025) - CalFresh One-Year ABAWD Time Limit Waiver for Colusa, Imperial, and Tulare Counties
+      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf
+    - title: CDSS All County Letter No. 26-15 (February 26, 2026) - CalFresh One-Year ABAWD Time Limit Waiver for Alpine, Merced, Monterey, and Plumas Counties
+      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
@@ -105,7 +105,7 @@ metadata:
     - title: 7 CFR 273.24(f) - Waivers
       href: https://www.law.cornell.edu/cfr/text/7/273.24#f
     - title: USDA FNS Alaska FY 2025 ABAWD Waiver Response (September 20, 2024)
-      href: https://www.fna.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf
+      href: https://www.fna.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf#page=4
     - title: Public Law 119-21, Section 10102 - Modifications to SNAP ABAWD Requirements
       href: https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=81
     - title: USDA FNS ABAWD Waivers Implementation Memorandum (October 3, 2025)
@@ -113,6 +113,6 @@ metadata:
     - title: State of Alaska Department of Health, H.R. 1 - AK Impacts (good faith exemption waiver, November 1, 2025 - October 31, 2026)
       href: https://health.alaska.gov/en/education/hr-1-ak-impacts/
     - title: CDSS All County Letter No. 25-79 (November 7, 2025) - CalFresh One-Year ABAWD Time Limit Waiver for Colusa, Imperial, and Tulare Counties
-      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf
+      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf#page=6
     - title: CDSS All County Letter No. 26-15 (February 26, 2026) - CalFresh One-Year ABAWD Time Limit Waiver for Alpine, Merced, Monterey, and Plumas Counties
-      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf
+      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf#page=6

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
@@ -105,7 +105,7 @@ metadata:
     - title: 7 CFR 273.24(f) - Waivers
       href: https://www.law.cornell.edu/cfr/text/7/273.24#f
     - title: USDA FNS Alaska FY 2025 ABAWD Waiver Response (September 20, 2024)
-      href: https://www.fna.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf#page=4
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf#page=4
     - title: Public Law 119-21, Section 10102 - Modifications to SNAP ABAWD Requirements
       href: https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=81
     - title: USDA FNS ABAWD Waivers Implementation Memorandum (October 3, 2025)

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_county_fips.yaml
@@ -113,6 +113,6 @@ metadata:
     - title: State of Alaska Department of Health, H.R. 1 - AK Impacts (good faith exemption waiver, November 1, 2025 - October 31, 2026)
       href: https://health.alaska.gov/en/education/hr-1-ak-impacts/
     - title: CDSS All County Letter No. 25-79 (November 7, 2025) - CalFresh One-Year ABAWD Time Limit Waiver for Colusa, Imperial, and Tulare Counties
-      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf#page=6
+      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf#page=5
     - title: CDSS All County Letter No. 26-15 (February 26, 2026) - CalFresh One-Year ABAWD Time Limit Waiver for Alpine, Merced, Monterey, and Plumas Counties
       href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf#page=6

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
@@ -1,0 +1,101 @@
+# State codes of states with an approved USDA FNS statewide waiver of the
+# SNAP ABAWD time limit under 7 U.S.C. 2015(o)(4) and 7 CFR 273.24(f).
+#
+# Only waivers verified as STATEWIDE from FNS FY2025 waiver response letters
+# are encoded here:
+# - CA: statewide, 2024-11-01 through 2025-10-31 (FNS response,
+#   Aug 12, 2024), replaced by a statewide waiver effective 2025-02-01
+#   (FNS response, Jan 15, 2025).
+# - IL: statewide, 2024-11-01 through 2025-10-31 (FNS response,
+#   Aug 19, 2024), replaced by a statewide waiver effective 2025-02-01
+#   through 2026-01-31 (FNS response, partially approving 12 of the
+#   requested 24 months).
+# - NV: statewide since 2024-07-01; the FNS response of Mar 14, 2025,
+#   effective 2025-02-01 through 2026-01-31, replaced the prior statewide
+#   waiver (partially approving 12 of the requested 24 months). Modeled from
+#   2024-11-01, in line with this parameter's overall modeling start date.
+# - DC: districtwide, 2024-12-01 through 2025-11-30 (FNS response,
+#   Apr 26, 2024), replaced by a districtwide waiver effective 2025-01-01
+#   (FNS response, Jan 13, 2025).
+#
+# In November 2025, USDA terminated waivers approved under the
+# "lack of sufficient jobs" criterion, which P.L. 119-21 (OBBBA)
+# section 10102 repealed. After Rhode Island State Council of Churches v.
+# Rollins (D.R.I., No. 1:25-cv-00569, TRO issued 2025-10-31), USDA's
+# February 26, 2026 guidance kept the terminated waivers in effect through
+# their original expiration dates. Per that guidance's expiration table (as
+# reported by Ballotpedia's OBBBA implementation tracker; USDA has not
+# published the table on a stable public page): CT and KY through 2025-11-30;
+# DC, NM, and OR through 2025-12-31; CA, IL, NV, NJ, and WA through
+# 2026-01-31; MI, NY, and RI through 2026-02-28; MN, MT, and ND through
+# 2026-06-30.
+#
+# Known limitations:
+# - Twelve of the sixteen reinstated waivers were PARTIAL-state waivers per
+#   the FNS FY2025 response letters (CT: 68 towns; KY: 117 counties; MI: 80
+#   counties, 3 cities, 10 reservations; MN: 17 counties, 9 reservations;
+#   MT: 6 reservation areas; NJ: 20 counties; NM: 29 counties,
+#   18 reservations; NY: 61 counties; OR: 30 counties, 7 reservation areas;
+#   RI: 9 towns; WA: 38 counties, 1 reservation area; ND: partial per the
+#   FY2025 quarterly status reports). Sub-state coverage would require
+#   county FIPS (or sub-county) encoding and is not modeled here.
+# - The CA and DC FNS approval letters run through 2027-01-31 and 2026-12-31
+#   respectively, but the USDA February 26, 2026 guidance table lists their
+#   reinstated expirations as 2026-01-31 and 2025-12-31; this parameter
+#   follows the guidance table, which governs post-litigation administration
+#   (CDSS implemented the time limit statewide on 2026-06-01 per ACL 25-93).
+# - Statewide waivers in effect before 2024-11-01 are not modeled.
+# - Guam and the U.S. Virgin Islands held territory-wide waivers but are not
+#   modeled by PolicyEngine US.
+description: The Department of Agriculture waives the Able-Bodied Adult Without Dependents (ABAWD) time limit under the Supplemental Nutrition Assistance Program statewide in these states.
+
+values:
+  2018-01-01:
+    []
+  2024-11-01:
+    - CA
+    - IL
+    - NV
+  2024-12-01:
+    - CA
+    - DC
+    - IL
+    - NV
+  # DC districtwide waiver expired 2025-12-31.
+  2026-01-01:
+    - CA
+    - IL
+    - NV
+  # CA, IL, and NV statewide waivers expired 2026-01-31.
+  2026-02-01:
+    []
+
+metadata:
+  label: SNAP ABAWD time limit statewide waived states
+  period: month
+  unit: list
+  reference:
+    - title: 7 U.S.C. 2015(o)(4) - ABAWD Time Limit Waivers
+      href: https://www.law.cornell.edu/uscode/text/7/2015#o_4
+    - title: 7 CFR 273.24(f) - Waivers
+      href: https://www.law.cornell.edu/cfr/text/7/273.24#f
+    - title: USDA FNS California Statewide ABAWD Waiver Response, FY 2025 (effective 2024-11-01)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025.pdf
+    - title: USDA FNS California Statewide ABAWD Waiver Response, January 15, 2025 (effective 2025-02-01)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025-b.pdf
+    - title: USDA FNS Illinois Statewide ABAWD Waiver Response, FY 2025 (effective 2024-11-01)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025.pdf
+    - title: USDA FNS Illinois Statewide ABAWD Waiver Response (effective 2025-02-01 through 2026-01-31)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025-b.pdf
+    - title: USDA FNS Nevada Statewide ABAWD Waiver Response (effective 2025-02-01 through 2026-01-31)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/nv-abawd-response-fy2025.pdf
+    - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, FY 2025 (effective 2024-12-01)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf
+    - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, January 13, 2025 (effective 2025-01-01)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025-b.pdf
+    - title: Rhode Island State Council of Churches v. Rollins, D.R.I. No. 1:25-cv-00569, Temporary Restraining Order (November 1, 2025)
+      href: https://democracyforward.org/wp-content/uploads/2025/11/RH-State-Council-of-Churchs-v.-Rollins-SNAP-TRO-11.1.25.pdf
+    - title: Ballotpedia, USDA guidance in response to litigation reinstates SNAP benefits for some ABAWDs (reporting the USDA February 26, 2026 guidance expiration table)
+      href: https://news.ballotpedia.org/2026/04/02/usda-guidance-in-response-to-litigation-reinstates-snap-benefits-for-some-abawds/
+    - title: USDA FNS FY 2025 Quarter 2 ABAWD Waiver Status Report (statewide vs. partial waiver classification)
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
@@ -80,22 +80,22 @@ metadata:
     - title: 7 CFR 273.24(f) - Waivers
       href: https://www.law.cornell.edu/cfr/text/7/273.24#f
     - title: USDA FNS California Statewide ABAWD Waiver Response, FY 2025 (effective 2024-11-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025.pdf#page=3
     - title: USDA FNS California Statewide ABAWD Waiver Response, January 15, 2025 (effective 2025-02-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025-b.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025-b.pdf#page=3
     - title: USDA FNS Illinois Statewide ABAWD Waiver Response, FY 2025 (effective 2024-11-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025.pdf#page=3
     - title: USDA FNS Illinois Statewide ABAWD Waiver Response (effective 2025-02-01 through 2026-01-31)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025-b.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025-b.pdf#page=4
     - title: USDA FNS Nevada Statewide ABAWD Waiver Response (effective 2025-02-01 through 2026-01-31)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/nv-abawd-response-fy2025.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/nv-abawd-response-fy2025.pdf#page=4
     - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, FY 2025 (effective 2024-12-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf#page=3
     - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, January 13, 2025 (effective 2025-01-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025-b.pdf
-    - title: Rhode Island State Council of Churches v. Rollins, D.R.I. No. 1:25-cv-00569, Temporary Restraining Order (November 1, 2025)
-      href: https://democracyforward.org/wp-content/uploads/2025/11/RH-State-Council-of-Churchs-v.-Rollins-SNAP-TRO-11.1.25.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025-b.pdf#page=3
+    - title: USDA FNS Supplemental Nutrition Assistance Program Time Limit Waiver Status Update Memorandum (February 26, 2026)
+      href: https://drive.google.com/uc?export=download&id=1G7TGS7MYfPZ_JGBrc7jb82Fs-BwEow1y#page=2
     - title: Ballotpedia, USDA guidance in response to litigation reinstates SNAP benefits for some ABAWDs (reporting the USDA February 26, 2026 guidance expiration table)
       href: https://news.ballotpedia.org/2026/04/02/usda-guidance-in-response-to-litigation-reinstates-snap-benefits-for-some-abawds/
     - title: USDA FNS FY 2025 Quarter 2 ABAWD Waiver Status Report (statewide vs. partial waiver classification)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf
+      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf#page=1

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
@@ -19,9 +19,10 @@
 #   start date. The replacement FY2025 waiver (FNS response, Oct 2, 2024)
 #   covers 61 of 62 counties from 2025-03-01, so New York is a
 #   partial-waiver state from that date (see known limitations).
-# - DC: districtwide, 2024-12-01 through 2025-11-30 (FNS response,
-#   Apr 26, 2024), replaced by a districtwide waiver effective 2025-01-01
-#   (FNS response, Jan 13, 2025).
+# - DC: initial districtwide waiver effective 2024-12-01 (FNS response,
+#   Apr 26, 2024, originally through 2025-11-30); a superseding districtwide
+#   waiver approved Jan 13, 2025 took effect 2025-01-01; the reinstated
+#   expiration is 2025-12-31 per Appendix A of the memorandum.
 #
 # In November 2025, USDA terminated waivers approved under the
 # "lack of sufficient jobs" criterion, which P.L. 119-21 (OBBBA)
@@ -105,30 +106,32 @@ metadata:
     - title: 7 CFR 273.24(f) - Waivers
       href: https://www.law.cornell.edu/cfr/text/7/273.24#f
     - title: USDA FNS California Statewide ABAWD Waiver Response, FY 2025 (effective 2024-11-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025.pdf#page=3
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/ca-abawd-response-fy2025.pdf#page=3
     - title: USDA FNS California Statewide ABAWD Waiver Response, January 15, 2025 (effective 2025-02-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025-b.pdf#page=3
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/ca-abawd-response-fy2025-b.pdf#page=3
     - title: USDA FNS Illinois Statewide ABAWD Waiver Response, FY 2025 (effective 2024-11-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025.pdf#page=3
-    - title: USDA FNS Illinois Statewide ABAWD Waiver Response (effective 2025-02-01 through 2026-01-31)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025-b.pdf#page=4
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/il-abawd-response-fy2025.pdf#page=3
+    - title: USDA FNS Illinois Statewide ABAWD Waiver Response, March 14, 2025 (effective 2025-02-01 through 2026-01-31)
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/il-abawd-response-fy2025-b.pdf#page=4
     - title: USDA FNS Nevada Statewide ABAWD Waiver Response (effective 2025-02-01 through 2026-01-31)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/nv-abawd-response-fy2025.pdf#page=4
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/nv-abawd-response-fy2025.pdf#page=4
     - title: USDA FNS New York Statewide ABAWD Waiver Response, FY 2024 (statewide, effective 2024-03-01 through 2025-02-28)
       href: https://www.fns.usda.gov/sites/default/files/resource-files/ny-abawd-response-fy2024.pdf#page=3
     - title: USDA FNS New York ABAWD Waiver Response, October 2, 2024 (61 counties, effective 2025-03-01 through 2026-02-28)
       href: https://www.fns.usda.gov/sites/default/files/resource-files/ny-abawd-response-fy2025.pdf#page=4
     - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, FY 2025 (effective 2024-12-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf#page=3
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf#page=3
     - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, January 13, 2025 (effective 2025-01-01)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025-b.pdf#page=3
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/dc-abawd-response-fy2025-b.pdf#page=3
     - title: USDA SNAP Waiver of the Time Limit - Status Update Memorandum, February 26, 2026 (Appendix A, time limit waiver expiration dates)
       href: https://www.usda.gov/sites/default/files/guidance-documents/fna.obbb-time-limit-waivers-reinstatement.pdf#page=2
     - title: USDA Food and Nutrition Administration, SNAP Waiver of the Time Limit - Status Update (landing page for the February 26, 2026 memorandum)
       href: https://www.fns.usda.gov/snap/work-requirements/policies/waiver-reinstatement
-    - title: Ballotpedia, USDA guidance in response to litigation reinstates SNAP benefits for some ABAWDs (secondary reporting of the February 26, 2026 memorandum)
+    - title: Ballotpedia, USDA guidance in response to litigation reinstates SNAP benefits for some ABAWDs (secondary reporting of the February 26, 2026 memorandum) — where dates differ, the primary USDA memorandum governs
       href: https://news.ballotpedia.org/2026/04/02/usda-guidance-in-response-to-litigation-reinstates-snap-benefits-for-some-abawds/
     - title: USDA FNS FY 2025 Quarter 2 ABAWD Waiver Status Report (waivers as of 2025-01-01; NY then statewide under its FY2024 waiver)
-      href: https://fns-prod.azureedge.us/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf#page=1
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf#page=1
     - title: USDA FNS FY 2025 Quarter 4 ABAWD Waiver Status Report (waivers as of 2025-07-01; NY classified as a partial waiver)
       href: https://www.fns.usda.gov/sites/default/files/resource-files/FY25-Quarter-4-ABAWD-Waiver-Status.pdf#page=1
+    - title: CDSS All County Letter No. 25-93 - CalFresh Statewide ABAWD Time Limit Implementation (June 1, 2026)
+      href: https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-93.pdf

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
@@ -22,11 +22,12 @@
 # "lack of sufficient jobs" criterion, which P.L. 119-21 (OBBBA)
 # section 10102 repealed. After Rhode Island State Council of Churches v.
 # Rollins (D.R.I., No. 1:25-cv-00569, TRO issued 2025-10-31), USDA's
-# February 26, 2026 guidance kept the terminated waivers in effect through
-# their original expiration dates. Per that guidance's expiration table (as
-# reported by Ballotpedia's OBBBA implementation tracker; USDA has not
-# published the table on a stable public page): CT and KY through 2025-11-30;
-# DC, NM, and OR through 2025-12-31; CA, IL, NV, NJ, and WA through
+# February 26, 2026 status update memorandum ("Waiver of the Time Limit -
+# Status Update," published on the USDA guidance portal and linked from the
+# FNA SNAP waiver reinstatement page) kept the terminated waivers in effect
+# through their original expiration dates. Per Appendix A of that
+# memorandum: CT and KY through 2025-11-30; DC, NM, OR, and the U.S. Virgin
+# Islands through 2025-12-31; CA, IL, NV, NJ, WA, and Guam through
 # 2026-01-31; MI, NY, and RI through 2026-02-28; MN, MT, and ND through
 # 2026-06-30.
 #
@@ -40,10 +41,11 @@
 #   FY2025 quarterly status reports). Sub-state coverage would require
 #   county FIPS (or sub-county) encoding and is not modeled here.
 # - The CA and DC FNS approval letters run through 2027-01-31 and 2026-12-31
-#   respectively, but the USDA February 26, 2026 guidance table lists their
-#   reinstated expirations as 2026-01-31 and 2025-12-31; this parameter
-#   follows the guidance table, which governs post-litigation administration
-#   (CDSS implemented the time limit statewide on 2026-06-01 per ACL 25-93).
+#   respectively, but Appendix A of the USDA February 26, 2026 memorandum
+#   lists their reinstated expirations as 2026-01-31 and 2025-12-31; this
+#   parameter follows the memorandum, which governs post-litigation
+#   administration (CDSS implemented the time limit statewide on 2026-06-01
+#   per ACL 25-93).
 # - Statewide waivers in effect before 2024-11-01 are not modeled.
 # - Guam and the U.S. Virgin Islands held territory-wide waivers but are not
 #   modeled by PolicyEngine US.
@@ -93,9 +95,11 @@ metadata:
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf#page=3
     - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, January 13, 2025 (effective 2025-01-01)
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025-b.pdf#page=3
-    - title: USDA FNS Supplemental Nutrition Assistance Program Time Limit Waiver Status Update Memorandum (February 26, 2026)
-      href: https://drive.google.com/uc?export=download&id=1G7TGS7MYfPZ_JGBrc7jb82Fs-BwEow1y#page=2
-    - title: Ballotpedia, USDA guidance in response to litigation reinstates SNAP benefits for some ABAWDs (reporting the USDA February 26, 2026 guidance expiration table)
+    - title: USDA SNAP Waiver of the Time Limit - Status Update Memorandum, February 26, 2026 (Appendix A, time limit waiver expiration dates)
+      href: https://www.usda.gov/sites/default/files/guidance-documents/fna.obbb-time-limit-waivers-reinstatement.pdf#page=2
+    - title: USDA Food and Nutrition Administration, SNAP Waiver of the Time Limit - Status Update (landing page for the February 26, 2026 memorandum)
+      href: https://www.fna.usda.gov/snap/work-requirements/policies/waiver-reinstatement
+    - title: Ballotpedia, USDA guidance in response to litigation reinstates SNAP benefits for some ABAWDs (secondary reporting of the February 26, 2026 memorandum)
       href: https://news.ballotpedia.org/2026/04/02/usda-guidance-in-response-to-litigation-reinstates-snap-benefits-for-some-abawds/
     - title: USDA FNS FY 2025 Quarter 2 ABAWD Waiver Status Report (statewide vs. partial waiver classification)
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf#page=1

--- a/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/work_requirements/abawd/waived_states.yaml
@@ -1,8 +1,8 @@
 # State codes of states with an approved USDA FNS statewide waiver of the
 # SNAP ABAWD time limit under 7 U.S.C. 2015(o)(4) and 7 CFR 273.24(f).
 #
-# Only waivers verified as STATEWIDE from FNS FY2025 waiver response letters
-# are encoded here:
+# Only waivers verified as STATEWIDE from FNS waiver response letters are
+# encoded here:
 # - CA: statewide, 2024-11-01 through 2025-10-31 (FNS response,
 #   Aug 12, 2024), replaced by a statewide waiver effective 2025-02-01
 #   (FNS response, Jan 15, 2025).
@@ -14,6 +14,11 @@
 #   effective 2025-02-01 through 2026-01-31, replaced the prior statewide
 #   waiver (partially approving 12 of the requested 24 months). Modeled from
 #   2024-11-01, in line with this parameter's overall modeling start date.
+# - NY: statewide, 2024-03-01 through 2025-02-28 (FNS FY2024 response).
+#   Modeled from 2024-11-01, in line with this parameter's overall modeling
+#   start date. The replacement FY2025 waiver (FNS response, Oct 2, 2024)
+#   covers 61 of 62 counties from 2025-03-01, so New York is a
+#   partial-waiver state from that date (see known limitations).
 # - DC: districtwide, 2024-12-01 through 2025-11-30 (FNS response,
 #   Apr 26, 2024), replaced by a districtwide waiver effective 2025-01-01
 #   (FNS response, Jan 13, 2025).
@@ -40,12 +45,21 @@
 #   RI: 9 towns; WA: 38 counties, 1 reservation area; ND: partial per the
 #   FY2025 quarterly status reports). Sub-state coverage would require
 #   county FIPS (or sub-county) encoding and is not modeled here.
+# - New York's classification changed mid-window: the FY 2025 Q2 status
+#   report (waivers as of 2025-01-01) lists NY among the seven STATEWIDE
+#   jurisdictions because its FY2024 statewide waiver (encoded above) ran
+#   through 2025-02-28, while the FY 2025 Q4 status report (waivers as of
+#   2025-07-01) lists NY as PARTIAL under its 61-county FY2025 waiver
+#   (effective 2025-03-01 through 2026-02-28). The waiver USDA terminated
+#   and litigation reinstated through 2026-02-28 was therefore the partial
+#   61-county waiver, which is not modeled here.
 # - The CA and DC FNS approval letters run through 2027-01-31 and 2026-12-31
 #   respectively, but Appendix A of the USDA February 26, 2026 memorandum
 #   lists their reinstated expirations as 2026-01-31 and 2025-12-31; this
 #   parameter follows the memorandum, which governs post-litigation
 #   administration (CDSS implemented the time limit statewide on 2026-06-01
-#   per ACL 25-93).
+#   per ACL 25-93). The DC Appendix A date of 2025-12-31 likewise differs
+#   from the Apr 26, 2024 letter's original 2025-11-30 expiration.
 # - Statewide waivers in effect before 2024-11-01 are not modeled.
 # - Guam and the U.S. Virgin Islands held territory-wide waivers but are not
 #   modeled by PolicyEngine US.
@@ -58,7 +72,16 @@ values:
     - CA
     - IL
     - NV
+    - NY
   2024-12-01:
+    - CA
+    - DC
+    - IL
+    - NV
+    - NY
+  # NY statewide waiver expired 2025-02-28; from 2025-03-01 New York held
+  # a 61-county partial waiver, which is not modeled.
+  2025-03-01:
     - CA
     - DC
     - IL
@@ -91,6 +114,10 @@ metadata:
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025-b.pdf#page=4
     - title: USDA FNS Nevada Statewide ABAWD Waiver Response (effective 2025-02-01 through 2026-01-31)
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/nv-abawd-response-fy2025.pdf#page=4
+    - title: USDA FNS New York Statewide ABAWD Waiver Response, FY 2024 (statewide, effective 2024-03-01 through 2025-02-28)
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/ny-abawd-response-fy2024.pdf#page=3
+    - title: USDA FNS New York ABAWD Waiver Response, October 2, 2024 (61 counties, effective 2025-03-01 through 2026-02-28)
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/ny-abawd-response-fy2025.pdf#page=4
     - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, FY 2025 (effective 2024-12-01)
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf#page=3
     - title: USDA FNS District of Columbia Districtwide ABAWD Waiver Response, January 13, 2025 (effective 2025-01-01)
@@ -98,8 +125,10 @@ metadata:
     - title: USDA SNAP Waiver of the Time Limit - Status Update Memorandum, February 26, 2026 (Appendix A, time limit waiver expiration dates)
       href: https://www.usda.gov/sites/default/files/guidance-documents/fna.obbb-time-limit-waivers-reinstatement.pdf#page=2
     - title: USDA Food and Nutrition Administration, SNAP Waiver of the Time Limit - Status Update (landing page for the February 26, 2026 memorandum)
-      href: https://www.fna.usda.gov/snap/work-requirements/policies/waiver-reinstatement
+      href: https://www.fns.usda.gov/snap/work-requirements/policies/waiver-reinstatement
     - title: Ballotpedia, USDA guidance in response to litigation reinstates SNAP benefits for some ABAWDs (secondary reporting of the February 26, 2026 memorandum)
       href: https://news.ballotpedia.org/2026/04/02/usda-guidance-in-response-to-litigation-reinstates-snap-benefits-for-some-abawds/
-    - title: USDA FNS FY 2025 Quarter 2 ABAWD Waiver Status Report (statewide vs. partial waiver classification)
+    - title: USDA FNS FY 2025 Quarter 2 ABAWD Waiver Status Report (waivers as of 2025-01-01; NY then statewide under its FY2024 waiver)
       href: https://fns-prod.azureedge.us/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf#page=1
+    - title: USDA FNS FY 2025 Quarter 4 ABAWD Waiver Status Report (waivers as of 2025-07-01; NY classified as a partial waiver)
+      href: https://www.fns.usda.gov/sites/default/files/resource-files/FY25-Quarter-4-ABAWD-Waiver-Status.pdf#page=1

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
@@ -2,6 +2,11 @@
 # From 2024-11-01, FNS waived the ABAWD time limit in every Alaska
 # borough and census area except the Municipality of Anchorage
 # (FIPS 02020).
+# From 2025-11-01 through 2026-10-31, FNS waived the time limit in seven
+# California counties (CDSS ACL 25-79 and ACL 26-15).
+# Statewide waivers (CA, DC, IL, NV) are modeled in waived_states,
+# including the period litigation kept them in effect (Rhode Island State
+# Council of Churches v. Rollins, D.R.I. No. 1:25-cv-00569).
 
 - name: Case 1, post-HR1 AK resident of waived borough (Fairbanks North Star) meets ABAWD requirements via area waiver.
   period: 2026-01
@@ -76,6 +81,185 @@
     is_disabled: false
     state_code: AK
     county_fips: "02090"
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+# California county waivers (CDSS ACL 25-79, ACL 26-15): Colusa, Imperial,
+# Tulare, Alpine, Merced, Monterey, and Plumas counties, 2025-11-01 through
+# 2026-10-31. California applies pre-HR1 ABAWD rules until 2026-06-01
+# (ACL 25-93), so the waiver is tested in both branches.
+
+- name: Case 7, CA resident of waived Tulare County (2026-03, after the statewide waiver expired) is exempt via the county waiver under pre-HR1 rules.
+  period: 2026-03
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
+    county_fips:
+      2026: "06107"
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 8, CA resident of non-waived Los Angeles County (2026-03) is not exempt via any waiver.
+  period: 2026-03
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
+    county_fips:
+      2026: "06037"
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+- name: Case 9, CA resident of waived Tulare County (2026-07, after CA adopts HR1 rules on 2026-06-01) remains exempt via the county waiver under the post-HR1 branch.
+  period: 2026-07
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
+    county_fips:
+      2026: "06107"
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 10, CA household without county geography (2025-12) is exempt via the litigation-reinstated statewide waiver under pre-HR1 rules.
+  period: 2025-12
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: CA
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+# Litigation-reinstated statewide waivers (Rhode Island State Council of
+# Churches v. Rollins; USDA February 26, 2026 guidance): CA, IL, and NV
+# through 2026-01-31; DC through 2025-12-31.
+
+- name: Case 11, NV resident (2026-01) is exempt via the statewide waiver under the post-HR1 branch.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: NV
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 12, NV resident (2026-02) is no longer exempt after the statewide waiver expires on 2026-01-31.
+  period: 2026-02
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: NV
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+- name: Case 13, DC resident (2025-12) is exempt via the districtwide waiver.
+  period: 2025-12
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: DC
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 14, DC resident (2026-01) is no longer exempt after the districtwide waiver expires on 2025-12-31.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: DC
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+- name: Case 15, IL resident (2025-06, before HR1 takes effect) is exempt via the statewide waiver under the pre-HR1 branch.
+  period: 2025-06
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: IL
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+# Documented limitation: 12 of the 16 litigation-reinstated waivers were
+# partial-state waivers (e.g., NY covered 61 of 62 counties) and are not
+# modeled; see waived_states.yaml.
+
+- name: Case 16, NY resident (2026-02) is not exempt because NY's litigation-reinstated waiver was partial-state and is not modeled.
+  period: 2026-02
+  absolute_error_margin: 0.1
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: NY
   output:
     is_in_snap_abawd_waived_area: false
     meets_snap_abawd_work_requirements: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
@@ -260,10 +260,14 @@
 - name: Case 17, NY resident (2025-01) is exempt via the FY2024 statewide waiver under pre-HR1 rules.
   period: 2025-01
   input:
-    age: 30
-    weekly_hours_worked_before_lsr: 1
-    is_disabled: false
-    state_code: NY
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: NY
   output:
     is_in_snap_abawd_waived_area: true
     meets_snap_abawd_work_requirements: true
@@ -319,3 +323,118 @@
   output:
     is_in_snap_abawd_waived_area: false
     meets_snap_abawd_work_requirements: false
+
+# Statewide waiver expiry (2026-01-31) with no county geography: after the
+# CA and IL statewide waivers expire, a household with no county FIPS has no
+# remaining waiver (only the seven CA counties stay waived through
+# 2026-10-31).
+
+- name: Case 21, CA household without county geography (2026-02, after the statewide waiver expired) is not exempt.
+  period: 2026-02
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+- name: Case 22, IL resident (2026-02, after the statewide waiver expired on 2026-01-31) is not exempt.
+  period: 2026-02
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: IL
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+# CA county waiver (ACL 26-15) retroactive window: the Monterey County
+# modification was approved 2026-02-10 but is retroactively effective
+# 2025-11-01, so the waiver applies from the start of the window.
+
+- name: Case 23, CA resident of waived Monterey County (2025-11, retroactive ACL 26-15 window) is exempt via the county waiver.
+  period: 2025-11
+  input:
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: CA
+    county_fips:
+      2025: "06053"
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 24, CA resident of waived Monterey County (2026-03, after the statewide waiver expired) is exempt via the county waiver alone.
+  period: 2026-03
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
+    county_fips:
+      2026: "06053"
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+# County-not-waived but state-waived: Los Angeles County (06037) is not in
+# the seven-county list, but the statewide waiver is still active in
+# 2025-12, so the OR of county and state coverage is true.
+
+- name: Case 25, CA resident of non-waived Los Angeles County (2025-12) is exempt via the still-active statewide waiver.
+  period: 2025-12
+  input:
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: CA
+    county_fips:
+      2025: "06037"
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+# Alaska county block split (2025-11-01 good faith exemption waiver under
+# P.L. 119-21 section 10102): the waived-borough list continues after the
+# 2025-11-01 renewal, so Fairbanks remains waived.
+
+- name: Case 26, AK resident of waived Fairbanks North Star Borough (2025-11, after the good faith exemption waiver renewal) is exempt via the area waiver.
+  period: 2025-11
+  input:
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: AK
+    county_fips:
+      2025: "02090"
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
@@ -92,7 +92,6 @@
 
 - name: Case 7, CA resident of waived Tulare County (2026-03, after the statewide waiver expired) is exempt via the county waiver under pre-HR1 rules.
   period: 2026-03
-  absolute_error_margin: 0.1
   input:
     age:
       2026: 30
@@ -110,7 +109,6 @@
 
 - name: Case 8, CA resident of non-waived Los Angeles County (2026-03) is not exempt via any waiver.
   period: 2026-03
-  absolute_error_margin: 0.1
   input:
     age:
       2026: 30
@@ -128,7 +126,6 @@
 
 - name: Case 9, CA resident of waived Tulare County (2026-07, after CA adopts HR1 rules on 2026-06-01) remains exempt via the county waiver under the post-HR1 branch.
   period: 2026-07
-  absolute_error_margin: 0.1
   input:
     age:
       2026: 30
@@ -146,7 +143,6 @@
 
 - name: Case 10, CA household without county geography (2025-12) is exempt via the litigation-reinstated statewide waiver under pre-HR1 rules.
   period: 2025-12
-  absolute_error_margin: 0.1
   input:
     age:
       2025: 30
@@ -166,7 +162,6 @@
 
 - name: Case 11, NV resident (2026-01) is exempt via the statewide waiver under the post-HR1 branch.
   period: 2026-01
-  absolute_error_margin: 0.1
   input:
     age:
       2026: 30
@@ -182,7 +177,6 @@
 
 - name: Case 12, NV resident (2026-02) is no longer exempt after the statewide waiver expires on 2026-01-31.
   period: 2026-02
-  absolute_error_margin: 0.1
   input:
     age:
       2026: 30
@@ -198,7 +192,6 @@
 
 - name: Case 13, DC resident (2025-12) is exempt via the districtwide waiver.
   period: 2025-12
-  absolute_error_margin: 0.1
   input:
     age:
       2025: 30
@@ -214,7 +207,6 @@
 
 - name: Case 14, DC resident (2026-01) is no longer exempt after the districtwide waiver expires on 2025-12-31.
   period: 2026-01
-  absolute_error_margin: 0.1
   input:
     age:
       2026: 30
@@ -230,7 +222,6 @@
 
 - name: Case 15, IL resident (2025-06, before HR1 takes effect) is exempt via the statewide waiver under the pre-HR1 branch.
   period: 2025-06
-  absolute_error_margin: 0.1
   input:
     age:
       2025: 30
@@ -250,7 +241,6 @@
 
 - name: Case 16, NY resident (2026-02) is not exempt because NY's litigation-reinstated waiver was partial-state and is not modeled.
   period: 2026-02
-  absolute_error_margin: 0.1
   input:
     age:
       2026: 30

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.yaml
@@ -4,9 +4,10 @@
 # (FIPS 02020).
 # From 2025-11-01 through 2026-10-31, FNS waived the time limit in seven
 # California counties (CDSS ACL 25-79 and ACL 26-15).
-# Statewide waivers (CA, DC, IL, NV) are modeled in waived_states,
-# including the period litigation kept them in effect (Rhode Island State
-# Council of Churches v. Rollins, D.R.I. No. 1:25-cv-00569).
+# Statewide waivers (CA, DC, IL, NV, and NY through 2025-02-28) are
+# modeled in waived_states, including the period litigation kept them in
+# effect (Rhode Island State Council of Churches v. Rollins, D.R.I.
+# No. 1:25-cv-00569).
 
 - name: Case 1, post-HR1 AK resident of waived borough (Fairbanks North Star) meets ABAWD requirements via area waiver.
   period: 2026-01
@@ -236,8 +237,10 @@
     meets_snap_abawd_work_requirements: true
 
 # Documented limitation: 12 of the 16 litigation-reinstated waivers were
-# partial-state waivers (e.g., NY covered 61 of 62 counties) and are not
-# modeled; see waived_states.yaml.
+# partial-state waivers (e.g., NY covered 61 of 62 counties from
+# 2025-03-01) and are not modeled; see waived_states.yaml. New York's
+# earlier FY2024 waiver (2024-03-01 through 2025-02-28) WAS statewide and
+# is modeled from 2024-11-01.
 
 - name: Case 16, NY resident (2026-02) is not exempt because NY's litigation-reinstated waiver was partial-state and is not modeled.
   period: 2026-02
@@ -250,6 +253,69 @@
       2026: false
     state_code:
       2026: NY
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+- name: Case 17, NY resident (2025-01) is exempt via the FY2024 statewide waiver under pre-HR1 rules.
+  period: 2025-01
+  input:
+    age: 30
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: NY
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 18, NY resident (2025-03) is not exempt after the FY2024 statewide waiver expires on 2025-02-28 (the 61-county FY2025 waiver is not modeled).
+  period: 2025-03
+  input:
+    age:
+      2025: 30
+    weekly_hours_worked_before_lsr:
+      2025: 1
+    is_disabled:
+      2025: false
+    state_code:
+      2025: NY
+  output:
+    is_in_snap_abawd_waived_area: false
+    meets_snap_abawd_work_requirements: false
+
+# CA county waiver window edges: the county list applies from 2025-11-01
+# through 2026-10-31 only.
+
+- name: Case 19, CA resident of waived Imperial County (2026-04, after the statewide waiver expired) is exempt via the county waiver.
+  period: 2026-04
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
+    county_fips:
+      2026: "06025"
+  output:
+    is_in_snap_abawd_waived_area: true
+    meets_snap_abawd_work_requirements: true
+
+- name: Case 20, CA resident of Tulare County (2026-11, after the county waiver approval end date) is no longer exempt.
+  period: 2026-11
+  input:
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
+    county_fips:
+      2026: "06107"
   output:
     is_in_snap_abawd_waived_area: false
     meets_snap_abawd_work_requirements: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
@@ -33,6 +33,8 @@
   output:
     meets_snap_abawd_work_requirements: true
 
+# state_code defaults to CA, which holds a statewide waiver from
+# 2024-11-01 (see waived_states.yaml), so a non-waived state is set.
 - name: Case 4, pre-HR1 age 54 NOT exempt.
   period: 2024
   absolute_error_margin: 0.1
@@ -40,6 +42,7 @@
     age: 54
     weekly_hours_worked_before_lsr: 1
     is_disabled: false
+    state_code: TX
   output:
     meets_snap_abawd_work_requirements: false
 
@@ -366,6 +369,8 @@
   output:
     meets_snap_abawd_work_requirements: true
 
+# state_code defaults to CA, which holds a statewide waiver from
+# 2024-11-01 (see waived_states.yaml), so a non-waived state is set.
 - name: Case 25, pre-HR1 Indian exemption input does not change ABAWD rules.
   period: 2024
   input:
@@ -373,6 +378,7 @@
     weekly_hours_worked_before_lsr: 1
     is_disabled: false
     is_snap_abawd_indian_exempt: true
+    state_code: TX
   output:
     meets_snap_abawd_work_requirements: false
 
@@ -464,14 +470,20 @@
     # age-exempt (pre-HR1 threshold is under 18).
     meets_snap_abawd_work_requirements: [false, true]
 
-- name: Case 32, CA pre-HR1 non-exempt person fails.
-  period: 2026-01
+# In 2026-01 the litigation-reinstated CA statewide waiver still applies
+# (through 2026-01-31), so the non-exempt case is tested in 2026-03.
+- name: Case 32, CA pre-HR1 non-exempt person fails after the statewide waiver expires.
+  period: 2026-03
   absolute_error_margin: 0.1
   input:
-    age: 30
-    weekly_hours_worked_before_lsr: 1
-    is_disabled: false
-    state_code: CA
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
   output:
     meets_snap_abawd_work_requirements: false
 

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
@@ -410,38 +410,58 @@
 # California delayed adoption — ACL 25-93
 # =====================================================
 
+# In 2026-01 the litigation-reinstated CA statewide waiver still applies
+# (through 2026-01-31), so the exempt cases below (28-30) are tested in
+# 2026-03, after it expires, to confirm the pre-HR1 personal exemptions
+# still hold on their own. The same 2026-03 period is used for the
+# non-exempt cases (31-32) so all CA delayed-adoption cases share the
+# post-statewide-waiver window.
 - name: Case 28, CA pre-HR1 age 55 still exempt.
-  period: 2026-01
+  period: 2026-03
   absolute_error_margin: 0.1
   input:
-    age: 55
-    weekly_hours_worked_before_lsr: 1
-    is_disabled: false
-    state_code: CA
+    age:
+      2026: 55
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    state_code:
+      2026: CA
   output:
     meets_snap_abawd_work_requirements: true
 
 - name: Case 29, CA pre-HR1 homeless still exempt.
-  period: 2026-01
+  period: 2026-03
   absolute_error_margin: 0.1
   input:
-    age: 30
-    weekly_hours_worked_before_lsr: 1
-    is_disabled: false
-    is_homeless: true
-    state_code: CA
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    is_homeless:
+      2026: true
+    state_code:
+      2026: CA
   output:
     meets_snap_abawd_work_requirements: true
 
 - name: Case 30, CA pre-HR1 veteran still exempt.
-  period: 2026-01
+  period: 2026-03
   absolute_error_margin: 0.1
   input:
-    age: 30
-    weekly_hours_worked_before_lsr: 1
-    is_disabled: false
-    is_veteran: true
-    state_code: CA
+    age:
+      2026: 30
+    weekly_hours_worked_before_lsr:
+      2026: 1
+    is_disabled:
+      2026: false
+    is_veteran:
+      2026: true
+    state_code:
+      2026: CA
   output:
     meets_snap_abawd_work_requirements: true
 
@@ -478,8 +498,6 @@
     # age-exempt (pre-HR1 threshold is under 18).
     meets_snap_abawd_work_requirements: [false, true]
 
-# In 2026-01 the litigation-reinstated CA statewide waiver still applies
-# (through 2026-01-31), so non-exempt cases are tested in 2026-03.
 - name: Case 32, CA pre-HR1 non-exempt person fails after the statewide waiver expires.
   period: 2026-03
   absolute_error_margin: 0.1

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
@@ -445,24 +445,32 @@
   output:
     meets_snap_abawd_work_requirements: true
 
-- name: Case 31, CA pre-HR1 non-age-exempt parent is not ABAWD-exempt at this layer.
-  period: 2026-01
+- name: Case 31, CA pre-HR1 non-age-exempt parent is not ABAWD-exempt at this layer after the statewide waiver expires.
+  period: 2026-03
   absolute_error_margin: 0.1
   input:
     people:
       person1:
-        age: 30
-        weekly_hours_worked_before_lsr: 1
-        is_disabled: false
-        is_parent: true
+        age:
+          2026: 30
+        weekly_hours_worked_before_lsr:
+          2026: 1
+        is_disabled:
+          2026: false
+        is_parent:
+          2026: true
       person2:
-        age: 15
-        is_disabled: false
-        is_tax_unit_dependent: true
+        age:
+          2026: 15
+        is_disabled:
+          2026: false
+        is_tax_unit_dependent:
+          2026: true
     households:
       household:
         members: [person1, person2]
-        state_code: CA
+        state_code:
+          2026: CA
   output:
     # The child-under-18 exemption (CA pre-HR1) is applied upstream in
     # meets_snap_work_requirements_person, not in this variable, so person1
@@ -471,7 +479,7 @@
     meets_snap_abawd_work_requirements: [false, true]
 
 # In 2026-01 the litigation-reinstated CA statewide waiver still applies
-# (through 2026-01-31), so the non-exempt case is tested in 2026-03.
+# (through 2026-01-31), so non-exempt cases are tested in 2026-03.
 - name: Case 32, CA pre-HR1 non-exempt person fails after the statewide waiver expires.
   period: 2026-03
   absolute_error_margin: 0.1

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.py
@@ -10,17 +10,26 @@ class is_in_snap_abawd_waived_area(Variable):
         "https://www.law.cornell.edu/uscode/text/7/2015#o_4",
         "https://www.law.cornell.edu/cfr/text/7/273.24#f",
         "https://www.fna.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf",
+        "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf",
+        "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf",
     )
     documentation = (
         "Whether the person lives in an area where the USDA Food and "
         "Nutrition Service has waived the SNAP ABAWD time limit under "
         "7 U.S.C. 2015(o)(4) and 7 CFR 273.24(f). Waived areas are "
-        "identified by county FIPS code. When a dataset does not include "
-        "county geography, county_fips defaults to an empty string and "
-        "this variable returns False, so no area waiver applies."
+        "identified by county FIPS code (sub-state waivers) or by state "
+        "code (statewide waivers, including waivers litigation kept in "
+        "effect after Rhode Island State Council of Churches v. Rollins, "
+        "D.R.I. No. 1:25-cv-00569). When a dataset does not include county "
+        "geography, county_fips defaults to an empty string and no "
+        "county-level waiver applies; statewide waivers still apply via "
+        "state_code."
     )
 
     def formula(person, period, parameters):
         p = parameters(period).gov.usda.snap.work_requirements.abawd
         county_fips = person.household("county_fips", period.this_year)
-        return np.isin(county_fips, p.waived_county_fips)
+        state_code = person.household("state_code_str", period.this_year)
+        in_waived_county = np.isin(county_fips, p.waived_county_fips)
+        in_waived_state = np.isin(state_code, p.waived_states)
+        return in_waived_county | in_waived_state

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.py
@@ -9,7 +9,7 @@ class is_in_snap_abawd_waived_area(Variable):
     reference = (
         "https://www.law.cornell.edu/uscode/text/7/2015#o_4",
         "https://www.law.cornell.edu/cfr/text/7/273.24#f",
-        "https://www.fna.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf#page=4",
+        "https://www.fns.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf#page=4",
         "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf#page=6",
         "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf#page=6",
     )

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_in_snap_abawd_waived_area.py
@@ -9,9 +9,9 @@ class is_in_snap_abawd_waived_area(Variable):
     reference = (
         "https://www.law.cornell.edu/uscode/text/7/2015#o_4",
         "https://www.law.cornell.edu/cfr/text/7/273.24#f",
-        "https://www.fna.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf",
-        "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf",
-        "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf",
+        "https://www.fna.usda.gov/sites/default/files/resource-files/ak-abawd-response-fy2025.pdf#page=4",
+        "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf#page=6",
+        "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf#page=6",
     )
     documentation = (
         "Whether the person lives in an area where the USDA Food and "


### PR DESCRIPTION
Fixes #8868

> [!IMPORTANT]
> **Stacked on #8860** — review only the commits after that branch point; merge #8860 first. This branch builds on `snap-abawd-ak-borough-waivers` and extends its waived-area mechanism.

## Summary

Extends the SNAP ABAWD waived-area mechanism from #8860 with two additions:

1. **California county waivers** (7 U.S.C. 2015(o)(4)(A)(i), 7 CFR 273.24(f)): adds seven CA counties to `gov.usda.snap.work_requirements.abawd.waived_county_fips` effective 2025-11-01 through 2026-10-31 — Colusa (06011), Imperial (06025), Tulare (06107), Alpine (06003), Merced (06047), Monterey (06053), and Plumas (06063). The 2025-11-01 dated entry retains all 29 Alaska boroughs/census areas (the AK good-faith exemption runs through 2026-10-31), and the combined list ends 2026-11-01.
2. **Litigation-reinstated statewide waivers**: new dated list parameter `gov.usda.snap.work_requirements.abawd.waived_states` covering the statewide waivers USDA terminated in November 2025 and — after *Rhode Island State Council of Churches v. Rollins* (D.R.I. No. 1:25-cv-00569, TRO 2025-10-31) — kept in effect through their original expiration dates per USDA's February 26, 2026 guidance. `is_in_snap_abawd_waived_area` now returns true when the household's state is in this list, in addition to the county FIPS check. Because the waiver sits in `base_conditions` of `meets_snap_abawd_work_requirements`, it applies under both the pre-HR1 and post-HR1 branches (tested in both).

## Source provenance (per parameter value)

### `waived_county_fips` — CA counties, 2025-11-01 → 2026-10-31 (primary sources, verified)

| Counties | Source | Basis |
|---|---|---|
| Colusa, Imperial, Tulare | [CDSS ACL 25-79](https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-79.pdf) (Nov 7, 2025) with attached FNS approval (Oct 23, 2025) | 12-month average unemployment >10% (13.0% / 18.7% / 10.4%, Jul 2024–Jun 2025 BLS data) |
| Alpine, Merced, Monterey, Plumas | [CDSS ACL 26-15](https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2026/26-15.pdf) (Feb 26, 2026) with attached FNS modification approval (Feb 10, 2026) | 3-month average unemployment >10%; retroactively effective Nov 1, 2025 |

Both FNS enclosures state implementation 2025-11-01 and expiration 2026-10-31. I read both ACL PDFs directly, including the FNS waiver-response enclosures.

### `waived_states` — statewide waivers (primary sources for scope and windows; guidance table for reinstated expirations)

Verified STATEWIDE from FNS FY2025 waiver response letters (fns-prod.azureedge.us):

| State | Verified window | Sources |
|---|---|---|
| CA | statewide 2024-11-01 → 2025-10-31, replaced by statewide waiver effective 2025-02-01 ([response a](https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025.pdf), [response b](https://fns-prod.azureedge.us/sites/default/files/resource-files/ca-abawd-response-fy2025-b.pdf)) | reinstated expiration 2026-01-31 per USDA guidance table |
| IL | statewide 2024-11-01 → 2025-10-31, replaced by statewide waiver 2025-02-01 → 2026-01-31 ([a](https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025.pdf), [b](https://fns-prod.azureedge.us/sites/default/files/resource-files/il-abawd-response-fy2025-b.pdf)) | FNS partially approved 12 of 24 requested months |
| NV | statewide since 2024-07-01; replacement statewide waiver 2025-02-01 → 2026-01-31 ([response](https://fns-prod.azureedge.us/sites/default/files/resource-files/nv-abawd-response-fy2025.pdf)) | modeled from 2024-11-01 (parameter's modeling start) |
| DC | districtwide 2024-12-01 → 2025-11-30, replaced by districtwide waiver effective 2025-01-01 ([a](https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025.pdf), [b](https://fns-prod.azureedge.us/sites/default/files/resource-files/dc-abawd-response-fy2025-b.pdf)) | reinstated expiration 2025-12-31 per USDA guidance table |

Resulting dated values: `[CA, IL, NV]` from 2024-11-01 → `[CA, DC, IL, NV]` from 2024-12-01 → `[CA, IL, NV]` from 2026-01-01 (DC expired) → `[]` from 2026-02-01.

**What I could NOT verify from primary sources, and how it is handled:**

- **The USDA Feb 26, 2026 guidance expiration table itself.** USDA has not published it on a stable public page; the expiration cohorts (CT, KY → 2025-11-30; DC, NM, OR → 2025-12-31; CA, IL, NV, NJ, WA → 2026-01-31; MI, NY, RI → 2026-02-28; MN, MT, ND → 2026-06-30) come from [Ballotpedia's OBBBA implementation tracker report of the guidance](https://news.ballotpedia.org/2026/04/02/usda-guidance-in-response-to-litigation-reinstates-snap-benefits-for-some-abawds/) (its table renders as an image; the accompanying text confirms the guidance reinstated the 18 terminated waivers through original expirations). Labeled as such in the parameter references.
- **12 of the 16 reinstated waivers were PARTIAL-state, not statewide**, per the FNS FY2025 response letters I read: CT (68 towns), KY (117 counties), MI (80 counties + 3 cities + 10 reservations), MN (17 counties + 9 reservations), MT (6 reservation areas), NJ (20 counties), NM (29 counties + 18 reservations), NY (61 of 62 counties), OR (30 counties + 7 reservation areas), RI (9 towns), WA (38 counties + 1 reservation area), plus ND (partial per the [FY25 Q2 waiver status report](https://fns-prod.azureedge.us/sites/default/files/resource-files/FY25-Quarter-2-ABAWD-Waiver-Status-Revised.pdf); its response letter was not retrievable). These are **not modeled** — sub-state coverage would need county FIPS (or sub-county, for towns/reservations) encoding. Documented in the parameter header, and pinned by a test (NY resident in 2026-02 is not exempt).
- **CA/DC approval-letter vs guidance-table end dates.** The CA replacement approval letter runs through 2027-01-31 and the DC letter through 2026-12-31, but the USDA guidance table lists 2026-01-31 and 2025-12-31 respectively. The parameter follows the guidance table (which governs post-litigation administration; CDSS implemented the time limit statewide 2026-06-01 per ACL 25-93). The discrepancy is documented in the parameter header.
- **Waivers before 2024-11-01** (e.g., NV's statewide waiver from 2024-07-01) are outside this parameter's modeling window, consistent with #8860.

## Interaction with HR1 (pre/post composition)

`is_snap_abawd_hr1_in_effect` for CA is false until 2026-06-01 (ACL 25-93). The waiver is part of `base_conditions`, so it exempts in both branches:
- pre-HR1 branch: IL 2025-06 (Case 15), CA 2025-12 (Case 10), Tulare County 2026-03 (Case 7)
- post-HR1 branch: NV 2026-01 (Case 11), DC 2025-12 (Case 13), Tulare County 2026-07 after CA adopts HR1 (Case 9)

Because `state_code` defaults to `CA`, three pre-existing tests in `meets_snap_abawd_work_requirements.yaml` began picking up the CA statewide waiver; they were adjusted minimally while preserving intent (Cases 4 and 25 now pin `state_code: TX`; Case 32 moved from 2026-01 to 2026-03, after the CA statewide waiver expires but still pre-HR1 for CA).

## Tests

```
uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements -c policyengine_us
======================== 77 passed, 1 warning in 7.82s =========================
```

Broader regression runs (both clean):

```
uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/usda -c policyengine_us
================== 481 passed, 1 warning in 152.41s (0:02:32) ==================

uv run policyengine-core test policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility -c policyengine_us  # consumes meets_snap_abawd_work_requirements
uv run policyengine-core test policyengine_us/tests/policy/baseline/partners -c policyengine_us
================== 191 passed, 1 warning in 128.33s (0:02:08) ==================
```

Note on test conventions: year-defined inputs (`state_code`, `age`, etc.) are keyed by year (e.g. `state_code: {2026: NV}`) in the new cases because their test periods are non-January months; unkeyed year inputs at such periods fail to build in the YAML test runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
