### PR TITLE
Fix CA AMT: don't add back acquisition home mortgage interest (Schedule P Line 4)

### DIFF
--- a/changelog.d/ca-amt-nonacquisition-interest.fixed.md
+++ b/changelog.d/ca-amt-nonacquisition-interest.fixed.md
@@ -1,0 +1,1 @@
+California AMT (Schedule P Line 4) no longer adds back acquisition home mortgage interest, matching the federal AMT treatment.

--- a/policyengine_us/parameters/gov/states/ca/tax/income/amt/amti/sources.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/amt/amti/sources.yaml
@@ -3,7 +3,10 @@ values:
    2021-01-01:
      - medical_expense_deduction # line 2 Medical and dental expenses
      - real_estate_taxes # line 3 Personal property taxes and real property taxes
-     - mortgage_interest # line 4 Certain interest on a home mortgage
+     # Line 4 (certain interest on a home mortgage) adds back only non-acquisition
+     # (home-equity) mortgage interest not used to buy, build, or improve the home,
+     # mirroring federal Form 6251. PolicyEngine's deductible_mortgage_interest is
+     # entirely acquisition interest, so there is no line 4 add-back.
      - misc_deduction # line 5 Miscellaneous itemized deductions
 
 

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/alternative_minimum_tax/ca_amt.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/alternative_minimum_tax/ca_amt.yaml
@@ -41,3 +41,14 @@
     ca_income_tax_before_credits: 55_000
   output:
     ca_amt: 0
+
+- name: CA AMT does not add back acquisition home mortgage interest
+  period: 2025
+  input:
+    people:
+      head: {age: 45, taxable_interest_income: 168_340.64, deductible_mortgage_interest: 50_000}
+      spouse: {age: 45}
+    tax_units: {tax_unit: {members: [head, spouse]}}
+    households: {household: {members: [head, spouse], state_code: CA}}
+  output:
+    ca_amt: 0


### PR DESCRIPTION
## Summary

California's AMT (`ca_amti_adjustments`) added back the **full** home mortgage interest deduction via the `mortgage_interest` entry in the AMTI sources list. **Schedule P (540), Part I, Line 4** adds back only *non-acquisition* mortgage interest — *"Certain interest on a home mortgage **not used to buy, build, or improve your home**."* This mirrors federal Form 6251 line 2e (IRC §56(b)(1)(C)/(e)): acquisition mortgage interest is **not** added back for AMT.

PolicyEngine's federal AMT already excludes acquisition interest — its add-back list (`itemized_deductions_add_back`) is only `salt_deduction` and `misc_deduction`, with no mortgage interest, because `deductible_mortgage_interest` represents entirely acquisition (debt-capped) interest and PE models no separate non-acquisition/home-equity amount. CA was internally inconsistent with the federal treatment it mirrors, creating a phantom CA AMT.

The fix removes `mortgage_interest` from the CA AMTI sources list so CA conforms to the federal AMT.

## Before / after

CA MFJ, \$168,340.64 interest, \$50,000 acquisition mortgage, TY2025:

| | Before (PE) | After (this PR) | Correct (NBER binary / TaxAct) |
|---|---|---|---|
| `ca_amti_adjustments` | \$50,000 | **\$0** | \$0 |
| `ca_amt` | \$2,391.80 | **\$0** | \$0 |
| `ca_income_tax` | \$6,321.16 | **\$3,929.35** | \$3,929 |

## Legal basis

- CA Schedule P (540), Part I, Line 4 (2025)
- IRC §56(b)(1)(C) / §56(e) (qualified housing interest)

## Testing

Added an integration test to `ca_amt.yaml`. All 18 CA AMT tests pass. Existing `ca_amti_adjustments` tests set `mortgage_interest: 0`, so they are unaffected.

Originating TAXSIM comparison: PolicyEngine/policyengine-taxsim#973

Fixes #8658

🤖 Generated with [Claude Code](https://claude.com/claude-code)