### PR TITLE
Fix AZ property tax credit table selection for married couples

### DIFF
--- a/changelog.d/az-ptc-cohabitating-default.fixed.md
+++ b/changelog.d/az-ptc-cohabitating-default.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Arizona property tax credit (Form 140PTC) to use the Table 2 (cohabitating) schedule for married couples living together per ARS 43-1072(B)(2).

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_property_tax_credit.yaml
@@ -69,3 +69,14 @@
     rent: 1_000
   output:
     az_property_tax_credit: 0
+
+- name: AZ property tax credit uses the cohabitating (Table 2) schedule for a married couple
+  period: 2025
+  input:
+    people:
+      head: {age: 75, taxable_interest_income: 3_637.87, rent: 9_059.32}
+      spouse: {age: 75}
+    tax_units: {tax_unit: {members: [head, spouse]}}
+    households: {household: {members: [head, spouse], state_code: AZ}}
+  output:
+    az_property_tax_credit: 323

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/property_tax_credit/az_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/property_tax_credit/az_property_tax_credit.py
@@ -14,7 +14,13 @@ class az_property_tax_credit(Variable):
         p = parameters(period).gov.states.az.tax.income.credits.property_tax
         income = tax_unit("az_property_tax_credit_income", period)
 
-        cohabitating = tax_unit("cohabitating_spouses", period)
+        # ARS 43-1072(A)(3): a claimant who "lived with a spouse or one or
+        # more persons" uses the Table 2 (cohabitating) schedule. A married
+        # couple filing jointly lives together, so treat them as cohabitating
+        # regardless of the (default-False) cohabitating_spouses input.
+        cohabitating = tax_unit("cohabitating_spouses", period) | tax_unit(
+            "tax_unit_married", period
+        )
 
         cap = where(
             cohabitating,


### PR DESCRIPTION
## Summary

`az_property_tax_credit` (Form 140PTC) selected the Table 1 (living-alone) schedule for married couples, roughly quartering the credit. It relied on `cohabitating_spouses`, a no-formula input defaulting to `False`, so a married-filing-jointly couple living together was treated as not cohabitating.

Per **ARS §43-1072(A)(3)**, a claimant who "lived with a spouse or one or more persons" uses the **Table 2** schedule (**§43-1072(B)(2)**); only a claimant who "did not live with a spouse or any other persons" uses Table 1. A married couple living together falls under Table 2.

## Fix

Treat the tax unit as cohabitating when it is married (`tax_unit_married`), in addition to the existing `cohabitating_spouses` flag. This is a **local** fix in `az_property_tax_credit` rather than changing the global `cohabitating_spouses` default, which also feeds Social Security taxability, Medicaid household size/income, and the NJ property tax credit.

## Impact

AZ MFJ, both age 75, $3,638 household income, $9,059 rent, TY2025:

| | Table | `az_property_tax_credit` |
|---|---|---|
| Before | Table 1 (living alone) | **$78** |
| After | Table 2 (cohabitating) | **$323** |

$323 matches the ARS §43-1072(B)(2) table (household income $3,551–3,700 → $323), PE's own Table 2 parameter, and the reporter's filled 2025 Form 140PTC.

## Tests

Added the issue's integration test to `az_property_tax_credit.yaml`. Full AZ baseline sweep: 468 passed.

Originating TAXSIM comparison: PolicyEngine/policyengine-taxsim#983

Fixes #8649

🤖 Generated with [Claude Code](https://claude.com/claude-code)