### PR TITLE
Use current-year federal EITC for Indiana EITC with-children filers

### DIFF
--- a/changelog.d/in-eitc-current-federal.fixed.md
+++ b/changelog.d/in-eitc-current-federal.fixed.md
@@ -1,0 +1,1 @@
+Compute the Indiana EITC for filers with children from the current-year federal EITC, per Schedule IN-EIC Section B, instead of a frozen 2023 IRC snapshot.

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_eitc.yaml
@@ -33,19 +33,39 @@
   output:
     in_eitc: 0.09 * 5_980
 
-- name: in_eitc unit test 4
+- name: taxsim_1039_in_eitc_with_child_uses_current_federal_eitc
+  # 2025 Schedule IN-EIC Section B: a filer claiming one or more children takes
+  # 10% of the earned income credit "from your federal income tax return", i.e.
+  # the current-year federal EITC ($4,328 here), not a frozen-IRC recomputation.
+  # 10% x $4,328 = $432.80. Originating: PolicyEngine/policyengine-taxsim#1039.
+  absolute_error_margin: 1
+  period: 2025
+  input:
+    people:
+      parent: {age: 35, employment_income: 15_714}
+      child: {age: 10}
+    tax_units:
+      tax_unit: {members: [parent, child]}
+    households:
+      household: {members: [parent, child], state_fips: 18}
+  output:
+    in_eitc: 433
+
+- name: in_eitc childless 2025 stays on frozen 2023 IRC snapshot
+  # Schedule IN-EIC Section A / IC 6-3-1-11: childless filers remain decoupled
+  # from the federal (ARPA-expanded) EITC and use the frozen Jan 1, 2023 IRC.
+  # 10% x frozen $600 childless max = $60, NOT 10% x current federal $612 = $61.20.
   absolute_error_margin: 0.01
   period: 2025
   input:
-    state_code: IN
-    eitc: 0
-    in_eitc_eligible: true
-    filing_status: HEAD_OF_HOUSEHOLD
-    eitc_child_count: 1
-    filer_adjusted_earnings: 10_000
-    adjusted_gross_income: 10_000
+    people:
+      parent: {age: 30, employment_income: 8_000}
+    tax_units:
+      tax_unit: {members: [parent]}
+    households:
+      household: {members: [parent], state_fips: 18}
   output:
-    in_eitc: 340
+    in_eitc: 60
 
 - name: Indiana EITC TY 2026 uses the SEA 243 advanced January 1, 2026 IRC snapshot
   period: 2026
@@ -72,8 +92,22 @@
         state_code: IN
   output:
     # TY 2026 onwards Indiana SEA 243 (2025) advances the IRC reference to
-    # January 1, 2026. The static_conformity_in_effect parameter is true;
-    # the year-conditional snapshot logic picks "2026-01-01" instead of
-    # "2023-01-01". A positive credit confirms the post-SEA 243 frozen-IRC
-    # code path is exercised.
+    # January 1, 2026. This with-children filer takes 10% of the current-year
+    # federal EITC per Schedule IN-EIC Section B; under SEA 243 the current and
+    # frozen (2026-01-01) computations coincide, so the credit is $442.70.
     in_eitc: 442.70
+
+- name: in_eitc childless 2026 uses the SEA 243 January 1, 2026 IRC snapshot
+  # Childless filers stay on the frozen IRC snapshot; under SEA 243 the 2026
+  # snapshot equals the current federal childless EITC, so 10% x $612 = $61.20.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      parent: {age: 30, employment_income: 8_000}
+    tax_units:
+      tax_unit: {members: [parent]}
+    households:
+      household: {members: [parent], state_fips: 18}
+  output:
+    in_eitc: 61.20

--- a/policyengine_us/variables/gov/states/in/tax/income/credits/earned_income_credit/in_eitc.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/credits/earned_income_credit/in_eitc.py
@@ -51,7 +51,18 @@ class in_eitc(Variable):
                 eitc_parameters=frozen_eitc,
                 investment_income_eligible=investment_income_eligible,
             )
-            return frozen_federal_eitc * ip.earned_income.match_rate
+            # 2025 Schedule IN-EIC Section B (filers claiming one or more
+            # children) directs the taxpayer to take 10% of the earned income
+            # credit "from your federal income tax return" — i.e. the current-
+            # year federal EITC as claimed, not a frozen-IRC recomputation.
+            # Indiana's decoupling (Section A) targets the childless / ARPA
+            # expansion only, so the frozen federal EITC is retained solely for
+            # childless filers.
+            current_federal_eitc = tax_unit("eitc", period)
+            federal_eitc = where(
+                child_count > 0, current_federal_eitc, frozen_federal_eitc
+            )
+            return federal_eitc * ip.earned_income.match_rate
         # if Indiana EITC is decoupled from federal EITC
         fp = parameters(period).gov.irs.credits
         # ... cap child count


### PR DESCRIPTION
## Summary

For **with-children** Indiana filers, `in_eitc` was computing 10% of a **frozen (Jan 1, 2023 IRC) federal EITC** instead of 10% of the **current-year** federal EITC actually claimed. For TY2025 this understated Indiana's EIC by the 2023-to-2025 inflation adjustment.

## Root cause

The `static_conformity_in_effect` branch (TY2023-2025) recomputed a frozen federal EITC from the `2023-01-01` IRC snapshot and multiplied by the 10% match rate for **all** filers. The frozen 2023 base for 1 child ($3,995 max) is smaller than the current 2025 EITC ($4,328) purely due to inflation indexing, producing $399.50 instead of $432.80.

## Statutory basis

**2025 Schedule IN-EIC, Section B** ("Complete if you claimed one or more children on your federal Schedule EIC"):
- Line A-1: *"Enter the earned income credit **from your federal income tax return**."*
- *"Enter your Indiana earned income credit. **Multiply Line A-1 by 10% (.10)**."*

So filers with children take **10% of the current-year federal EITC as claimed** — there is no instruction to recompute it under a frozen IRC. Indiana's EITC decoupling (IC 6-3.1-21 / IC 6-3-1-11) targeted the **childless** ARPA expansion (Schedule IN-EIC Section A), so the frozen snapshot is retained **only for childless filers**.

## Fix

In the `static_conformity_in_effect` branch, select the current-year federal EITC (`tax_unit("eitc", period)`) for filers with children, keeping the frozen federal EITC for childless filers.

## Before / after (originating taxsim #1039 — IN HoH, age 35, 1 child, $15,714 wages)

| | value |
|---|---|
| Federal EITC (2025) | $4,328 |
| PE `in_eitc` **before** | $399.50 (10% x frozen 2023 max $3,995) |
| PE `in_eitc` **after** | **$432.80 → $433** (10% x current federal EITC) |
| Schedule IN-EIC / TaxAct / TAXSIM | $432.80 → $433 |

## Tests

Added/updated `in_eitc.yaml`:
- With-children 2025 uses current federal EITC → $433 (integration test from the issue).
- Childless 2025 stays on the frozen 2023 snapshot → $60 (10% x frozen $600), NOT $61.20 (10% x current $612) — confirms childless decoupling is preserved.
- Childless 2026 uses the SEA 243 January 1, 2026 snapshot → $61.20.
- With-children 2026 (SEA 243) → $442.70 (comment updated).

All 438 Indiana state tests pass.

Originating: PolicyEngine/policyengine-taxsim#1039
References: 2025 Schedule IN-EIC; 2025 IT-40 Instruction Booklet p.30; IC 6-3.1-21.

Fixes #8831

🤖 Generated with [Claude Code](https://claude.com/claude-code)