### PR TITLE
Fix MO state-income-tax add-back to respect OBBBA SALT cap phase-down

### DIFF
--- a/changelog.d/mo-salt-addback-phasedown.fixed.md
+++ b/changelog.d/mo-salt-addback-phasedown.fixed.md
@@ -1,0 +1,1 @@
+Limited the Missouri state-income-tax add-back to the federal SALT deduction after the OBBBA cap phase-down.

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_itemized_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_itemized_deductions.yaml
@@ -36,3 +36,18 @@
     state_code: MO
   output:
     mo_itemized_deductions: 1000.00
+
+# MO state-income-tax add-back respects the OBBBA SALT cap phase-down: a
+# high-income MFJ filer whose federal SALT has phased to the $10,000 floor
+# keeps the $50,000 mortgage deduction instead of it being wiped out.
+- name: MO state-income-tax add-back respects the OBBBA SALT cap phase-down
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      head: {age: 45, taxable_interest_income: 789_125.13, deductible_mortgage_interest: 50_000}
+      spouse: {age: 45}
+    tax_units: {tax_unit: {members: [head, spouse]}}
+    households: {household: {members: [head, spouse], state_code: MO}}
+  output:
+    mo_itemized_deductions: 50_000

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.yaml
@@ -39,3 +39,18 @@
     state_code: MO
   output:
     mo_net_state_income_taxes: 6_666.67  # = 10_000 * 2/3
+
+# High earner whose federal SALT deduction has phased down to the $10,000
+# floor under OBBBA: the add-back must be limited to the SALT actually
+# deducted federally, not recomputed against the static $40,000 base cap.
+- name: state-income-tax add-back respects the OBBBA SALT cap phase-down
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      head: {age: 45, taxable_interest_income: 789_125.13, deductible_mortgage_interest: 50_000}
+      spouse: {age: 45}
+    tax_units: {tax_unit: {members: [head, spouse]}}
+    households: {household: {members: [head, spouse], state_code: MO}}
+  output:
+    mo_net_state_income_taxes: 10_000

--- a/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/taxable_income/mo_net_state_income_taxes.py
@@ -15,10 +15,14 @@ class mo_net_state_income_taxes(Variable):
 
     def formula(tax_unit, period, parameters):
         # follows Form MO-A Part II and Part II worksheet logic:
-
-        filing_status = tax_unit("filing_status", period)
-        p = parameters(period).gov.irs.deductions.itemized
-        salt_cap = p.salt_and_real_estate.cap[filing_status]
+        # Missouri adds back the state and local income tax actually included
+        # in the federal itemized SALT deduction. The base is therefore the
+        # federal SALT cap *after* the OBBBA income-based phase-down (the
+        # salt_cap variable), not the static base cap
+        # p.salt_and_real_estate.cap, which would otherwise over-state the
+        # add-back for high earners whose federal SALT has phased down to the
+        # $10,000 floor.
+        salt_cap = tax_unit("salt_cap", period)
 
         uncapped_itax = max_(0, add(tax_unit, period, ["state_withheld_income_tax"]))
         uncapped_ptax = add(tax_unit, period, ["real_estate_taxes"])
@@ -28,4 +32,6 @@ class mo_net_state_income_taxes(Variable):
         mask = uncapped_salt != 0
         ratio[mask] = uncapped_itax[mask] / uncapped_salt[mask]
 
+        # Pro-rate the income-tax share against the SALT actually deducted
+        # federally after the phase-down (MO-A Part 2 worksheet).
         return where(uncapped_salt > salt_cap, salt_cap * ratio, uncapped_itax)


### PR DESCRIPTION
Fixes #8660

## Problem

`mo_net_state_income_taxes` caps the state-income-tax add-back using the **static base** SALT cap (`p.salt_and_real_estate.cap[filing_status]` = $40,000 MFJ), ignoring the OBBBA income-based **phase-down** of that cap toward the $10,000 floor.

For a high-income MO filer whose federal SALT has phased down to $10,000, the old code added back the full uncapped state income tax ($36,172, because $36,172 < the static $40,000), instead of the $10,000 actually deducted federally. Missouri then subtracts that inflated add-back from the federal itemized deductions, wiping out other itemized deductions (mortgage interest) and forcing the MO standard deduction.

Originating TAXSIM comparison: PolicyEngine/policyengine-taxsim#975

## Fix

Per **Form MO-A Part 2**, Missouri adds back the state/local **income** tax included in the federal itemized SALT deduction *after* the cap phase-down. The pro-ration base is now the phased **`salt_cap`** variable (which applies the OBBBA phase-down) rather than the static base-cap parameter. The existing pro-rata worksheet logic (income tax / total SALT, applied to the allowed SALT) is preserved.

`salt_cap` is used rather than `salt_deduction` because `salt_deduction` additionally applies a taxable-income limit that zeroes out on abstract no-income test records; `salt_cap` isolates the phase-down cleanly and preserves all existing unit tests.

## Before / after (MFJ, $789,125 interest, $50,000 mortgage, TY2025)

| | Before | After (correct) |
|---|---|---|
| `mo_net_state_income_taxes` | $36,172 | **$10,000** |
| `mo_itemized_deductions` | $23,827 → standard | **$50,000** |
| `mo_income_tax` | $35,256 | **$34,563** |

The SALT add-back and itemized deduction now match the federal phase-down exactly ($10,000 / $50,000). A small residual (~$176) remains between PE's `mo_income_tax` ($34,563) and the NBER binary / TaxAct figure ($34,387); it stems from downstream MO tax computation unrelated to the SALT add-back, so this PR does not assert that value.

## Tests

- New integration test (the issue record) asserting `mo_itemized_deductions` = $50,000 (2025).
- New `mo_net_state_income_taxes` = $10,000 test for the same phase-down record.
- Full MO baseline sweep: **517 passed** (no regressions; existing pro-rata SALT-cap tests still pass since the phased `salt_cap` equals the pre-OBBBA $10,000 cap for those 2021 records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)