### PR TITLE
Fix Vermont CDCC: TY2022 AGI cap, low-income credit sunset, and pre-2022 24% nonrefundable credit

### DIFF
--- a/changelog.d/vt-cdcc-fixes.fixed.md
+++ b/changelog.d/vt-cdcc-fixes.fixed.md
@@ -1,0 +1,1 @@
+Apply Vermont's 2022 low-income AGI cap to the child and dependent care credit, end the 50 percent low-income credit after 2021, add the pre-2022 24 percent nonrefundable credit under 32 V.S.A. 5822(d)(1), and correct the state CDCC registry.

--- a/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
@@ -29,6 +29,7 @@ values:
     - me_child_care_credit
     - ny_cdcc
     - vt_low_income_cdcc
+    - vt_nonrefundable_cdcc
   2006-01-01:
     - ca_cdcc
     - co_cdcc
@@ -39,6 +40,7 @@ values:
     - me_child_care_credit
     - ny_cdcc
     - vt_low_income_cdcc
+    - vt_nonrefundable_cdcc
   2013-01-01:
     - ar_cdcc
     - ca_cdcc
@@ -50,6 +52,7 @@ values:
     - me_child_care_credit
     - ny_cdcc
     - vt_low_income_cdcc
+    - vt_nonrefundable_cdcc
   2018-01-01:
     - ar_cdcc
     - ca_cdcc
@@ -65,6 +68,7 @@ values:
     - me_child_care_credit
     - ny_cdcc
     - vt_low_income_cdcc
+    - vt_nonrefundable_cdcc
   2019-01-01:
     - ar_cdcc
     - ca_cdcc
@@ -82,6 +86,7 @@ values:
     - me_child_care_credit
     - ny_cdcc
     - vt_low_income_cdcc
+    - vt_nonrefundable_cdcc
   2020-01-01:
     - ar_cdcc
     - ca_cdcc
@@ -100,6 +105,7 @@ values:
     - ny_cdcc
     - sc_cdcc
     - vt_low_income_cdcc
+    - vt_nonrefundable_cdcc
   2021-01-01:
     - ar_cdcc
     - ca_cdcc
@@ -129,6 +135,7 @@ values:
     - ri_cdcc
     - sc_cdcc
     - vt_low_income_cdcc
+    - vt_nonrefundable_cdcc
   2022-01-01:
     - ar_cdcc
     - ca_cdcc
@@ -159,7 +166,6 @@ values:
     - ri_cdcc
     - sc_cdcc
     - vt_cdcc
-    - vt_low_income_cdcc
     - wi_childcare_expense_credit
   2023-01-01:
     - ar_cdcc
@@ -193,7 +199,6 @@ values:
     - ri_cdcc
     - sc_cdcc
     - vt_cdcc
-    - vt_low_income_cdcc
     - wi_childcare_expense_credit
   2024-01-01:
     - ar_cdcc
@@ -227,7 +232,6 @@ values:
     - ri_cdcc
     - sc_cdcc
     - vt_cdcc
-    - vt_low_income_cdcc
     - wi_childcare_expense_credit
     - wv_cdcc
 

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
@@ -1,0 +1,15 @@
+description: Vermont limits the Child and Dependent Care Credit to filers with adjusted gross income at or below the low-income threshold when this is in effect.
+values:
+  # 2022 Act 138, Sec. 3 retained the 5828c low-income adjusted gross income
+  # cap for 2022; 2023 Act 72, Sec. 14 removed it effective 2023.
+  2022-01-01: true
+  2023-01-01: false
+metadata:
+  unit: bool
+  period: year
+  label: Vermont CDCC income limit in effect
+  reference:
+    - title: 2022 Act 138, Sec. 3 (amending 32 V.S.A. § 5828c)
+      href: https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3
+    - title: 2023 Act 72, Sec. 14 (amending 32 V.S.A. § 5828c)
+      href: https://legislature.vermont.gov/Documents/2024/Docs/ACTS/ACT072/ACT072%20As%20Enacted.pdf#page=14

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/low_income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/low_income/rate.yaml
@@ -1,15 +1,21 @@
-description: Vermont matches this percent of the federal Child and Dependent Care Credit for low-income filers. 
+description: Vermont matches this percent of the federal Child and Dependent Care Credit for low-income filers.
 values:
   2005-01-01: 0.5
+  # 2022 Act 138, Sec. 3 replaced the 50 percent low-income credit with the
+  # 72 percent credit in 32 V.S.A. § 5828c effective 2022.
+  2022-01-01: 0
 metadata:
   unit: /1
+  period: year
   label: Vermont low-income CDCC match
   reference:
+    - title: 2022 Act 138, Sec. 3 (amending 32 V.S.A. § 5828c)
+      href: https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3
     - title: 2021 Form IN-112 Vermont Tax Adjustments and Credits
       href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2021.pdf#page=2
     - title: 2021 Vermont Statutes, Title 32 - Taxation and Finance, Chapter 151 - Income Taxes, §5828c. Low-income child and dependent care credit
       href: https://law.justia.com/codes/vermont/2021/title-32/chapter-151/section-5828c/
     - title: 2020 Form IN-112 Vermont Tax Adjustments and Credits
-      href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2020.pdf#page=2#
+      href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2020.pdf#page=2
     - title: 2020 Vermont Statutes, Title 32 - Taxation and Finance, Chapter 151 - Income Taxes, §5828c. Low-income child and dependent care credit
       href: https://law.justia.com/codes/vermont/2020/title-32/chapter-151/section-5828c/

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/nonrefundable/rate.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/nonrefundable/rate.yaml
@@ -1,0 +1,20 @@
+description: Vermont matches this fraction of the federal Child and Dependent Care Credit under its nonrefundable credit.
+values:
+  # Verified for 2021 via the pre-amendment text struck by 2022 Act 138,
+  # Sec. 2; assumed unchanged back to 2005, matching the low-income credit
+  # parameters.
+  2005-01-01: 0.24
+  # 2022 Act 138, Sec. 2 struck child and dependent care credits from the
+  # 32 V.S.A. § 5822(d)(1) match effective 2022.
+  2022-01-01: 0
+metadata:
+  unit: /1
+  period: year
+  label: Vermont nonrefundable CDCC match
+  reference:
+    - title: 2021 Vermont Statutes, Title 32 - Taxation and Finance, Chapter 151 - Income Taxes, §5822(d)(1)
+      href: https://law.justia.com/codes/vermont/2021/title-32/chapter-151/section-5822/
+    - title: 2022 Act 138, Sec. 2 (amending 32 V.S.A. § 5822(d))
+      href: https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=2
+    - title: 2021 Schedule IN-112, Part II
+      href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2021.pdf#page=2

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/rate.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/rate.yaml
@@ -1,10 +1,17 @@
-description: Vermont matches this percent of the federal Child and Dependent Care Credit. 
+description: Vermont matches this percent of the federal Child and Dependent Care Credit.
 values:
+  # 2022 Act 138, Sec. 3 raised the 5828c match from 50 to 72 percent
+  # effective 2022; before then only the 50 percent low-income credit and
+  # the 24 percent nonrefundable credit applied.
+  2021-01-01: 0
   2022-01-01: 0.72
 metadata:
   unit: /1
+  period: year
   label: Vermont CDCC match
   reference:
+    - title: 2022 Act 138, Sec. 3 (amending 32 V.S.A. § 5828c)
+      href: https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3
     - title: 2022 Form IN-112 Vermont Tax Adjustments and Credits
       href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf#page=2
     - title: 2022 Vermont Statutes, Title 32 - Taxation and Finance, Chapter 151 - Income Taxes, §5828c. Child and dependent care credit

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/non_refundable.yaml
@@ -3,12 +3,20 @@ values:
   2021-01-01:
     - vt_charitable_contribution_credit
     - vt_529_plan_credit
+    - vt_nonrefundable_cdcc
+  # 2022 Act 138, Sec. 2 struck child and dependent care credits from the
+  # 32 V.S.A. § 5822(d)(1) match effective 2022.
+  2022-01-01:
+    - vt_charitable_contribution_credit
+    - vt_529_plan_credit
 metadata:
   unit: list
   label: Vermont non-refundable tax credits
   reference:
   - title: Vermont Statutes Title 32 - Taxation and Finance § 5822-(d)-3
     href: https://law.justia.com/codes/vermont/2022/title-32/chapter-151/section-5822/
+  - title: 2022 Act 138, Sec. 2 (amending 32 V.S.A. § 5822(d))
+    href: https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=2
   - title: 2021 Vermont Income Tax Return Form Line 11-13
     href: https://tax.vermont.gov/sites/tax/files/documents/IN-111-2021.pdf#page=1
   - title: 2022 Vermont Income Tax Return Form Line 11-13

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_cdcc.yaml
@@ -13,3 +13,31 @@
     state_code: VT
   output:
     vt_cdcc: 1440 
+
+- name: Vermont CDCC 2022 above the low-income AGI cap gets no credit, 2022 Act 138 Sec. 3
+  period: 2022
+  input:
+    capped_cdcc: 1_000
+    adjusted_gross_income: 50_000
+    state_code: VT
+  output:
+    vt_cdcc: 0
+
+- name: Vermont CDCC 2022 joint filer at the 40,000 AGI threshold keeps the credit
+  period: 2022
+  input:
+    capped_cdcc: 1_000
+    adjusted_gross_income: 40_000
+    filing_status: JOINT
+    state_code: VT
+  output:
+    vt_cdcc: 720
+
+- name: Vermont CDCC 2023 has no AGI cap, 2023 Act 72 Sec. 14
+  period: 2023
+  input:
+    capped_cdcc: 1_000
+    adjusted_gross_income: 50_000
+    state_code: VT
+  output:
+    vt_cdcc: 720

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_low_income_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_low_income_cdcc.yaml
@@ -24,3 +24,12 @@
     vt_low_income_cdcc_eligible: true
   output:
     vt_low_income_cdcc: 500
+
+- name: Vermont low-income CDCC ends after 2021, replaced by the 72 percent credit
+  period: 2022
+  input:
+    state_code: VT
+    capped_cdcc: 1_000
+    vt_low_income_cdcc_eligible: true
+  output:
+    vt_low_income_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_nonrefundable_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_nonrefundable_cdcc.yaml
@@ -1,0 +1,28 @@
+- name: Vermont 2021 nonrefundable CDCC is 24 percent of the federal credit above the low-income threshold
+  period: 2021
+  input:
+    capped_cdcc: 1_000
+    adjusted_gross_income: 50_000
+    state_code: VT
+  output:
+    vt_nonrefundable_cdcc: 240 # 1,000 * 0.24
+    vt_non_refundable_credits: 240
+
+- name: Vermont 2021 low-income filer takes the 5828c credit in lieu of the nonrefundable credit
+  period: 2021
+  input:
+    capped_cdcc: 1_000
+    adjusted_gross_income: 20_000
+    state_code: VT
+  output:
+    vt_low_income_cdcc: 500 # 1,000 * 0.5
+    vt_nonrefundable_cdcc: 0
+
+- name: Vermont nonrefundable CDCC ends after 2021, 2022 Act 138 Sec. 2
+  period: 2022
+  input:
+    capped_cdcc: 1_000
+    adjusted_gross_income: 50_000
+    state_code: VT
+  output:
+    vt_nonrefundable_cdcc: 0

--- a/policyengine_us/variables/gov/states/vt/tax/income/credits/cdcc/vt_cdcc.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/credits/cdcc/vt_cdcc.py
@@ -8,9 +8,10 @@ class vt_cdcc(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf#page=2"
-        "https://law.justia.com/codes/vermont/2022/title-32/chapter-151/section-5828c/"
-        "https://www.irs.gov/pub/irs-prior/f2441--2022.pdf#page=1"
+        "https://legislature.vermont.gov/statutes/section/32/151/05828c",
+        "https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3",
+        "https://legislature.vermont.gov/Documents/2024/Docs/ACTS/ACT072/ACT072%20As%20Enacted.pdf#page=14",
+        "https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf#page=2",
     )
     defined_for = StateCode.VT
 
@@ -18,4 +19,11 @@ class vt_cdcc(Variable):
         p = parameters(period).gov.states.vt.tax.income.credits.cdcc
         # The form refers to 2022 Form 2441 line 11, which caps the credit at tax liability.
         federal_cdcc = tax_unit("capped_cdcc", period)
+        # 2022 Act 138 raised the 5828c match to 72 percent but retained the
+        # low-income adjusted gross income cap and the certified-facility
+        # requirement for 2022; 2023 Act 72 removed them effective 2023. We
+        # do not track facility certification or in-state care at the moment.
+        if p.income_limit_in_effect:
+            income_eligible = tax_unit("vt_low_income_cdcc_eligible", period)
+            return income_eligible * federal_cdcc * p.rate
         return federal_cdcc * p.rate

--- a/policyengine_us/variables/gov/states/vt/tax/income/credits/cdcc/vt_nonrefundable_cdcc.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/credits/cdcc/vt_nonrefundable_cdcc.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class vt_nonrefundable_cdcc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Vermont nonrefundable child and dependent care credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://law.justia.com/codes/vermont/2021/title-32/chapter-151/section-5822/",
+        "https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=2",
+    )
+    defined_for = StateCode.VT
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.vt.tax.income.credits.cdcc
+        federal_cdcc = tax_unit("capped_cdcc", period)
+        # 32 V.S.A. § 5822(d)(1) matched 24 percent of the federal credit
+        # through 2021; 2022 Act 138 struck the child and dependent care
+        # leg. The § 5828c low-income credit is claimed in lieu of this
+        # credit, and a low-income filer always prefers its larger
+        # refundable match, so income-eligible filers are excluded. We
+        # assume care at a facility qualifying for the § 5828c credit.
+        low_income_eligible = tax_unit("vt_low_income_cdcc_eligible", period)
+        return ~low_income_eligible * federal_cdcc * p.nonrefundable.rate


### PR DESCRIPTION
## Summary

Fixes the three Vermont CDCC divergences confirmed by verbatim reading of the enacted acts (#8879, part of the #8826 state CDCC verification). All three are grounded in the act texts quoted below.

Closes #8879

## Regulatory basis

**[2022 Act 138, Sec. 3](https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3)** amended 32 V.S.A. § 5828c for TY2022 to read:

> "LOW-INCOME CHILD AND DEPENDENT CARE CREDIT — A resident of this State **with federal adjusted gross income less than $30,000.00 (or $40,000.00 for married, filing jointly)** shall be eligible for a refundable credit… equal to ~~50~~ **72** percent of the federal child and dependent care credit… provided in this State in a registered home or licensed facility certified by the Agency of Human Services…"

**[2023 Act 72, Sec. 14](https://legislature.vermont.gov/Documents/2024/Docs/ACTS/ACT072/ACT072%20As%20Enacted.pdf#page=14)** (eff. Jan 1, 2023) rewrote § 5828c without the AGI cap, the certified-facility requirement, or the "low-income" title — matching the [current statute](https://legislature.vermont.gov/statutes/section/32/151/05828c).

**[2022 Act 138, Sec. 2](https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=2)** struck "child care and dependent care credits" from old § 5822(d)(1): "A taxpayer shall be entitled to a credit… of **24 percent** of each of the credits allowed against the taxpayer's federal income tax… and child care and dependent care credits." ([2021 codified text](https://law.justia.com/codes/vermont/2021/title-32/chapter-151/section-5822/))

## Changes

1. **TY2022 AGI cap on `vt_cdcc`.** New `income_limit_in_effect` boolean (true 2022, false 2023+) gates the 72% credit on the existing `vt_low_income_cdcc_eligible` AGI test ($30,000, or $40,000 joint — thresholds unchanged from the prior low-income credit). Previously the model paid 72% to all filers from 2022, over-granting above-threshold TY2022 filers.
2. **Sunset the 50% low-income credit after 2021** (`low_income/rate.yaml` → 0 at 2022-01-01) and remove `vt_low_income_cdcc` from the 2022+ `state_cdccs.yaml` entries, which double-listed both Vermont credits in the `taxsim_state_cdcc` aggregate (0.72 + 0.5 × federal for a low-income filer). Tax liability was unaffected (the refundable-credits list was already year-exclusive); the aggregate was not.
3. **New `vt_nonrefundable_cdcc`** (§ 5822(d)(1)): 24% of the capped federal credit through 2021, ending 2022 per Act 138 Sec. 2. Low-income-eligible filers are excluded — § 5828c is claimed "in lieu of" the 5822(d) credit, and its 50% refundable match always dominates 24% nonrefundable. Registered in `non_refundable.yaml` (2021 entry; new 2022 entry drops it) and in the pre-2022 `state_cdccs.yaml` blocks. Mirrors the sibling `vt_elderly_or_disabled_credit`, the other modeled leg of the same § 5822(d)(1) match. Previously an above-threshold pre-2022 filer received $0 where law gave 24%.
4. Also adds a `2021-01-01: 0` entry to the 72% rate so pre-2022 queries don't back-extrapolate it, fixes `vt_cdcc.py`'s reference tuple (three URLs were concatenated into one string), and adds missing `period:` metadata to the touched parameter files.

## Not modeled (by design)

| What | Source | Why |
|---|---|---|
| Certified-facility requirement (pre-2023 § 5828c; pre-2022 § 5822(d) had none) | Act 138 Sec. 3 | We don't track provider certification at the moment; noted in code comments |
| In-state-care requirement | § 5828c | We don't track where care is provided at the moment |

**Flagged for review:** the 24% § 5822(d)(1) rate is verified for 2021 via Act 138's before-text; continuity back to 2005 (the low-income parameters' start) is assumed and noted in the parameter comment.

## Reproductions

| Scenario | Before | After |
|---|---|---|
| TY2022, AGI $50,000, $1,000 federal CDCC | $720 | **$0** |
| TY2022, joint, AGI $40,000 (at threshold) | $720 | **$720** |
| TY2023, AGI $50,000 | $720 | **$720** (cap removed) |
| TY2021, AGI $50,000 (above low-income threshold) | $0 | **$240** nonrefundable |
| TY2021, AGI $20,000 | $500 low-income credit | **$500** (unchanged; still in lieu of the 24%) |
| Low-income filer's state-CDCC aggregate, TY2022+ | 0.72 + 0.5 × federal | **0.72 × federal** |

## Tests

Seven new/appended cases covering every row above plus the `vt_non_refundable_credits` pickup. Full VT income tax tree passes locally: **168 tests**.

Independent of #8855/#8878 — no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
