### PR TITLE
Wire Maryland county income tax into household tax and SALT aggregates

### DIFF
--- a/changelog.d/md-local-income-tax-aggregation.added.md
+++ b/changelog.d/md-local-income-tax-aggregation.added.md
@@ -1,0 +1,1 @@
+Wire Maryland county income tax into the household tax and SALT aggregates, adding the local earned income credit and local poverty level credit.

--- a/policyengine_us/parameters/gov/states/household/state_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_income_tax_before_refundable_credits.yaml
@@ -21,6 +21,7 @@ values:
     - me_income_tax_before_refundable_credits
     - ma_income_tax_before_refundable_credits
     - md_income_tax_before_refundable_credits
+    - md_local_income_tax_before_refundable_credits
     - mi_income_tax_before_refundable_credits
     - mn_income_tax_before_refundable_credits
     - mo_income_tax_before_refundable_credits

--- a/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/local/rate_multiplier.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/credits/eitc/local/rate_multiplier.yaml
@@ -1,0 +1,12 @@
+description: Maryland multiplies the federal earned income credit by this multiple of the applicable county income tax rate to compute the local earned income credit.
+values:
+  2021-01-01: 10
+metadata:
+  unit: /1
+  period: year
+  label: MD local EITC county rate multiplier
+  reference:
+    - title: Md. Code, Tax-Gen. § 10-704(d)
+      href: https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-704&enactments=false
+    - title: "Maryland 2025 Resident Tax Forms and Instructions - Local Earned Income Credit Worksheet (19B)"
+      href: "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=26"

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -1488,6 +1488,18 @@ programs:
     parameter_prefix: gov.local.ca.sf.caap
     notes: General Assistance and PAES grant tiers modeled; CALM/SSIP tiers and activity-qualification gates not yet modeled
 
+  - id: md_local_income_tax
+    name: MD local income tax
+    full_name: Maryland County and Baltimore City Income Tax
+    category: Taxes
+    agency: Local
+    status: complete
+    coverage: Maryland
+    variable: md_local_income_tax_before_refundable_credits
+    parameter_prefix: gov.local.md
+    verified_start_year: 2021
+    notes: County piggyback income tax on Maryland taxable income, less the local earned income credit and local poverty level credit; optional county refundable local EITCs are not modeled (Montgomery County's match is modeled separately as md_montgomery_eitc)
+
   - id: nyc_income_tax
     name: NYC income tax
     full_name: New York City Income Tax

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/credits/md_local_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/credits/md_local_eitc.yaml
@@ -1,0 +1,46 @@
+- name: Baltimore City filer, local EITC below local tax (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    eitc: 3_000
+    md_local_income_tax_before_credits: 2_000
+  output:
+    # 3,000 * 10 * 0.032 = 960
+    md_local_eitc: 960
+
+- name: Baltimore City filer, local EITC capped at local tax (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    eitc: 3_000
+    md_local_income_tax_before_credits: 500
+  output:
+    # min(3,000 * 10 * 0.032, 500) = 500
+    md_local_eitc: 500
+
+- name: Anne Arundel County filer uses the lowest marginal rate (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: ANNE_ARUNDEL_COUNTY_MD
+    eitc: 1_000
+    md_local_income_tax_before_credits: 10_000
+  output:
+    # 1,000 * 10 * 0.027 = 270
+    md_local_eitc: 270
+
+- name: No federal EITC yields no local EITC (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    eitc: 0
+    md_local_income_tax_before_credits: 2_000
+  output:
+    md_local_eitc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/credits/md_local_poverty_line_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/credits/md_local_poverty_line_credit.yaml
@@ -1,0 +1,41 @@
+- name: Eligible Baltimore City filer receives rate times earnings (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    is_eligible_md_poverty_line_credit: true
+    employment_income: 10_000
+    eitc: 0
+    md_local_income_tax_before_credits: 400
+  output:
+    # 10,000 * 0.032 = 320 < 400 remaining tax
+    md_local_poverty_line_credit: 320
+
+- name: Credit capped at local tax remaining after local EITC (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    is_eligible_md_poverty_line_credit: true
+    employment_income: 10_000
+    eitc: 50
+    md_local_income_tax_before_credits: 200
+  output:
+    # Local EITC: min(50 * 10 * 0.032, 200) = 16
+    # Credit: min(10,000 * 0.032, 200 - 16) = 184
+    md_local_poverty_line_credit: 184
+
+- name: Ineligible filer receives no credit (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    is_eligible_md_poverty_line_credit: false
+    employment_income: 10_000
+    eitc: 0
+    md_local_income_tax_before_credits: 400
+  output:
+    md_local_poverty_line_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_applicable_local_tax_rate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_applicable_local_tax_rate.yaml
@@ -1,0 +1,50 @@
+- name: Baltimore City uses its flat rate (2025)
+  period: 2025
+  absolute_error_margin: 0.0001
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+  output:
+    md_applicable_local_tax_rate: 0.032
+
+- name: Anne Arundel County uses its lowest marginal rate (2025)
+  period: 2025
+  absolute_error_margin: 0.0001
+  input:
+    state_code_str: MD
+    county_str: ANNE_ARUNDEL_COUNTY_MD
+  output:
+    md_applicable_local_tax_rate: 0.027
+
+- name: Frederick County single filer with $30,000 taxable income (2025)
+  period: 2025
+  absolute_error_margin: 0.0001
+  input:
+    state_code_str: MD
+    county_str: FREDERICK_COUNTY_MD
+    filing_status: SINGLE
+    md_taxable_income: 30_000
+  output:
+    md_applicable_local_tax_rate: 0.0275
+
+- name: Frederick County joint filers with $120,000 taxable income (2025)
+  period: 2025
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      head:
+        age: 40
+      spouse:
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+        md_taxable_income: 120_000
+    households:
+      household:
+        members: [head, spouse]
+        state_code_str: MD
+        county_str: FREDERICK_COUNTY_MD
+  output:
+    md_applicable_local_tax_rate: 0.0296

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_local_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_local_income_tax_before_refundable_credits.yaml
@@ -1,0 +1,36 @@
+- name: Local tax less local credits (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    md_local_income_tax_before_credits: 1_600
+    md_local_eitc: 300
+    md_local_poverty_line_credit: 100
+  output:
+    md_local_income_tax_before_refundable_credits: 1_200
+
+- name: Baltimore City single filer without credits (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    md_taxable_income: 50_000
+    eitc: 0
+  output:
+    # 50,000 * 0.032 = 1,600, no local credits
+    md_local_income_tax_before_refundable_credits: 1_600
+
+- name: Local EITC zeroes out local tax for a low-income family (2025)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    state_code_str: MD
+    county_str: BALTIMORE_CITY_MD
+    md_taxable_income: 14_000
+    eitc: 5_000
+  output:
+    # Local tax: 14,000 * 0.032 = 448
+    # Local EITC: min(5,000 * 10 * 0.032 = 1,600, 448) = 448
+    md_local_income_tax_before_refundable_credits: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_local_income_tax_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_local_income_tax_integration.yaml
@@ -1,0 +1,25 @@
+- name: Baltimore City county tax reaches the household tax aggregate (2026)
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    people:
+      person:
+        age: 40
+        employment_income: 97_140
+    tax_units:
+      tax_unit:
+        members: [person]
+    spm_units:
+      spm_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code_str: MD
+        county_str: BALTIMORE_CITY_MD
+  output:
+    # 3.2% * 90,540 MD taxable income = 2,897.28, no local credits
+    md_local_income_tax_before_refundable_credits: 2_897.28
+    # 4,248.15 MD state income tax + 2,897.28 local income tax
+    household_state_tax_before_refundable_credits: 7_145.43
+    household_tax: 27_117.44

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/md_withheld_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/md_withheld_income_tax.yaml
@@ -5,18 +5,24 @@
     adjusted_gross_income_person: 5_000
     filing_status: JOINT
     state_code: MD
+    county_str: BALTIMORE_CITY_MD
   output:
-    md_withheld_income_tax: 76
+    # State: single rates on (5,000 - 2,350 standard deduction) = 76
+    # Local: 3.2% Baltimore City rate * 2,650 = 84.80
+    md_withheld_income_tax: 160.8
 
-- name: Changing the filing status should not change the output 
+- name: Changing the filing status should not change the output
   period: 2021
   absolute_error_margin: 0.01
   input:
     adjusted_gross_income_person: 5_000
     filing_status: SURVIVING_SPOUSE
     state_code: MD
+    county_str: BALTIMORE_CITY_MD
   output:
-    md_withheld_income_tax: 76
+    # State: single rates on (5,000 - 2,350 standard deduction) = 76
+    # Local: 3.2% Baltimore City rate * 2,650 = 84.80
+    md_withheld_income_tax: 160.8
 
 - name: Capped at 0
   period: 2021

--- a/policyengine_us/variables/gov/states/md/tax/income/local/credits/md_local_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/credits/md_local_eitc.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class md_local_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD local earned income credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = (
+        "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-704&enactments=false",
+        "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=26",
+    )
+
+    def formula(tax_unit, period, parameters):
+        # § 10-704(d): the credit against the county income tax equals the
+        # lesser of the federal earned income credit multiplied by 10 times
+        # the applicable county income tax rate, or the county income tax.
+        p = parameters(period).gov.states.md.tax.income.credits.eitc.local
+        federal_eitc = tax_unit("eitc", period)
+        rate = tax_unit("md_applicable_local_tax_rate", period)
+        uncapped = federal_eitc * p.rate_multiplier * rate
+        local_tax = tax_unit("md_local_income_tax_before_credits", period)
+        return min_(uncapped, local_tax)

--- a/policyengine_us/variables/gov/states/md/tax/income/local/credits/md_local_poverty_line_credit.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/credits/md_local_poverty_line_credit.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class md_local_poverty_line_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD local poverty line credit"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = (
+        "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-709&enactments=false",
+        "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=26",
+    )
+
+    def formula(tax_unit, period, parameters):
+        # § 10-709(d): the credit against the county income tax equals the
+        # lesser of the county income tax after subtracting the local earned
+        # income credit, or the county income tax rate multiplied by the
+        # eligible low income taxpayer's earned income.
+        eligible = tax_unit("is_eligible_md_poverty_line_credit", period)
+        earnings = tax_unit("tax_unit_earned_income", period)
+        rate = tax_unit("md_applicable_local_tax_rate", period)
+        earnings_portion = earnings * rate
+        local_tax = tax_unit("md_local_income_tax_before_credits", period)
+        local_eitc = tax_unit("md_local_eitc", period)
+        remaining_tax = max_(local_tax - local_eitc, 0)
+        return eligible * min_(earnings_portion, remaining_tax)

--- a/policyengine_us/variables/gov/states/md/tax/income/local/md_applicable_local_tax_rate.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/md_applicable_local_tax_rate.py
@@ -1,0 +1,43 @@
+from policyengine_us.model_api import *
+
+
+class md_applicable_local_tax_rate(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD applicable local income tax rate"
+    unit = "/1"
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = (
+        "https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gtg&section=10-704&enactments=false",
+        "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=26",
+    )
+
+    def formula(tax_unit, period, parameters):
+        county = tax_unit.household("county_str", period)
+
+        # Guard against non-MD counties in microsimulation:
+        # defined_for masks results but doesn't prevent formula execution.
+        in_md = tax_unit.household("state_code_str", period) == "MD"
+        safe_county = where(in_md, county, "ALLEGANY_COUNTY_MD")
+
+        p = parameters(period).gov.local.md
+        flat_rate = p.flat_rate[safe_county]
+
+        # Anne Arundel County imposes its tax on a marginal-rate basis, so
+        # § 10-704(d)(2) applies its lowest marginal rate.
+        is_anne_arundel = county == "ANNE_ARUNDEL_COUNTY_MD"
+        anne_arundel_rate = p.anne_arundel_county.tax.income.single.rates[0]
+
+        # Frederick County applies a fixed rate by bracket, so the rate
+        # applicable to the taxpayer's income level and filing status
+        # applies.
+        is_frederick = county == "FREDERICK_COUNTY_MD"
+        frederick_rate = tax_unit("md_frederick_county_tax_rate", period)
+
+        rate = select(
+            [is_anne_arundel, is_frederick],
+            [anne_arundel_rate, frederick_rate],
+            default=flat_rate,
+        )
+        return rate * in_md

--- a/policyengine_us/variables/gov/states/md/tax/income/local/md_frederick_county_tax.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/md_frederick_county_tax.py
@@ -11,49 +11,8 @@ class md_frederick_county_tax(Variable):
     reference = "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=25"
 
     def formula(tax_unit, period, parameters):
-        county = tax_unit.household("county_str", period)
-        is_frederick = county == "FREDERICK_COUNTY_MD"
-
-        filing_status = tax_unit("filing_status", period)
-        filing_statuses = filing_status.possible_values
         taxable_income = tax_unit("md_taxable_income", period)
-
-        p = parameters(period).gov.local.md.frederick_county.tax.income
-
-        # Filing status conditions
-        is_single = filing_status == filing_statuses.SINGLE
-        is_joint = filing_status == filing_statuses.JOINT
-        is_separate = filing_status == filing_statuses.SEPARATE
-        is_head_of_household = filing_status == filing_statuses.HEAD_OF_HOUSEHOLD
-        is_surviving_spouse = filing_status == filing_statuses.SURVIVING_SPOUSE
-
-        # Frederick County uses fixed-rate-by-bracket (NOT marginal rates)
-        # The entire income is multiplied by the single rate for the bracket
-        single_rate = p.single.calc(taxable_income, right=True)
-        joint_rate = p.joint.calc(taxable_income, right=True)
-        separate_rate = p.separate.calc(taxable_income, right=True)
-        head_of_household_rate = p.head_of_household.calc(taxable_income, right=True)
-        surviving_spouse_rate = p.surviving_spouse.calc(taxable_income, right=True)
-
-        # Select rate based on filing status
-        rate = select(
-            [
-                is_single,
-                is_joint,
-                is_separate,
-                is_head_of_household,
-                is_surviving_spouse,
-            ],
-            [
-                single_rate,
-                joint_rate,
-                separate_rate,
-                head_of_household_rate,
-                surviving_spouse_rate,
-            ],
-        )
-
-        # Fixed rate: entire income * bracket rate
-        tax = taxable_income * rate
-
-        return where(is_frederick, tax, 0)
+        # Fixed rate: entire income * bracket rate.
+        # The rate is zero outside Frederick County.
+        rate = tax_unit("md_frederick_county_tax_rate", period)
+        return taxable_income * rate

--- a/policyengine_us/variables/gov/states/md/tax/income/local/md_frederick_county_tax_rate.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/md_frederick_county_tax_rate.py
@@ -1,0 +1,48 @@
+from policyengine_us.model_api import *
+
+
+class md_frederick_county_tax_rate(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD Frederick County local income tax rate"
+    unit = "/1"
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=25"
+
+    def formula(tax_unit, period, parameters):
+        county = tax_unit.household("county_str", period)
+        is_frederick = county == "FREDERICK_COUNTY_MD"
+
+        filing_status = tax_unit("filing_status", period)
+        filing_statuses = filing_status.possible_values
+        taxable_income = tax_unit("md_taxable_income", period)
+
+        p = parameters(period).gov.local.md.frederick_county.tax.income
+
+        # Frederick County uses fixed-rate-by-bracket (NOT marginal rates):
+        # the entire income is taxed at the single rate for its bracket.
+        single_rate = p.single.calc(taxable_income, right=True)
+        joint_rate = p.joint.calc(taxable_income, right=True)
+        separate_rate = p.separate.calc(taxable_income, right=True)
+        head_of_household_rate = p.head_of_household.calc(taxable_income, right=True)
+        surviving_spouse_rate = p.surviving_spouse.calc(taxable_income, right=True)
+
+        rate = select(
+            [
+                filing_status == filing_statuses.SINGLE,
+                filing_status == filing_statuses.JOINT,
+                filing_status == filing_statuses.SEPARATE,
+                filing_status == filing_statuses.HEAD_OF_HOUSEHOLD,
+                filing_status == filing_statuses.SURVIVING_SPOUSE,
+            ],
+            [
+                single_rate,
+                joint_rate,
+                separate_rate,
+                head_of_household_rate,
+                surviving_spouse_rate,
+            ],
+        )
+
+        return where(is_frederick, rate, 0)

--- a/policyengine_us/variables/gov/states/md/tax/income/local/md_local_income_tax_before_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/md_local_income_tax_before_refundable_credits.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class md_local_income_tax_before_refundable_credits(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "MD local income tax before refundable credits"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = "https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=26"
+    adds = ["md_local_income_tax_before_credits"]
+    subtracts = ["md_local_eitc", "md_local_poverty_line_credit"]

--- a/policyengine_us/variables/gov/states/md/tax/income/md_withheld_income_tax.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/md_withheld_income_tax.py
@@ -15,4 +15,29 @@ class md_withheld_income_tax(Variable):
         # We apply the maximum standard deduction amount
         standard_deduction = p.deductions.standard.max["SINGLE"]
         reduced_agi = max_(agi - standard_deduction, 0)
-        return p.rates.single.calc(reduced_agi)
+        state_withheld = p.rates.single.calc(reduced_agi)
+        # Maryland employers withhold county income tax together with the
+        # state tax (Form 502 line 41 reports combined Maryland and local
+        # withholding), so the estimate includes the county component.
+        county = person.household("county_str", period)
+        # Guard against non-MD counties in microsimulation:
+        # defined_for masks results but doesn't prevent formula execution.
+        in_md = person.household("state_code_str", period) == "MD"
+        safe_county = where(in_md, county, "ALLEGANY_COUNTY_MD")
+        p_local = parameters(period).gov.local.md
+        flat_rate_withheld = p_local.flat_rate[safe_county] * reduced_agi
+        is_anne_arundel = county == "ANNE_ARUNDEL_COUNTY_MD"
+        anne_arundel_withheld = p_local.anne_arundel_county.tax.income.single.calc(
+            reduced_agi
+        )
+        is_frederick = county == "FREDERICK_COUNTY_MD"
+        frederick_withheld = (
+            p_local.frederick_county.tax.income.single.calc(reduced_agi, right=True)
+            * reduced_agi
+        )
+        local_withheld = select(
+            [is_anne_arundel, is_frederick],
+            [anne_arundel_withheld, frederick_withheld],
+            default=flat_rate_withheld,
+        )
+        return state_withheld + local_withheld * in_md


### PR DESCRIPTION
Fixes #5157

## Problem

`md_local_income_tax_before_credits` (Anne Arundel + Frederick + flat-rate county taxes) is computed but never aggregated: Maryland county piggyback income tax reaches neither `household_tax` nor the SALT deduction. A Baltimore City single filer with $97,140 in wages (2026) owes $2,897.28 of county tax (3.2% × $90,540 MD taxable income) that appears nowhere in net income. #5159 attempted this in 2024 and went stale; this PR follows the guidance from that review.

## What this does

**Household aggregate (net income, poverty, distributional results):**
- Adds `md_local_income_tax_before_refundable_credits` = county tax − local EITC − local poverty level credit, and routes it into `gov.states.household.state_income_tax_before_refundable_credits` — the same route `nyc_income_tax_before_refundable_credits` uses, since both are locally-set taxes administered on the state return.

**Local credits (both previously unmodeled):**
- `md_local_eitc` (Tax-Gen § 10-704(d)): the lesser of federal EITC × 10 × the applicable county rate, or the county tax. Per the statute and the 2025 booklet worksheet 19B, the applicable rate is the lowest marginal rate for Anne Arundel County (.0270, the only marginal-rate county) and the taxpayer's bracket rate for Frederick County.
- `md_local_poverty_line_credit` (§ 10-709(d)): the lesser of the county rate × earned income, or the county tax remaining after the local EITC; reuses `is_eligible_md_poverty_line_credit` from the state credit.
- `md_applicable_local_tax_rate` implements the § 10-704(d) "applicable county income tax rate", and `md_frederick_county_tax_rate` is extracted from `md_frederick_county_tax` so the tax and the credits share one rate definition.

**SALT deduction:**
- Extends `md_withheld_income_tax` with the county component. Maryland employers withhold state and county tax together (Form 502 line 41 reports combined "Maryland and local tax withheld"), and `state_and_local_sales_or_income_tax` already consumes `state_withheld_income_tax`.
- Deliberately does *not* add MD to `local_income_tax`: that creates a genuine dependency cycle (`local_income_tax` → SALT → `tax_unit_itemizes` → `md_deductions` → `md_taxable_income` → county tax), because Maryland allows itemizing only when the filer itemized federally — NYC escapes this because NY's itemization choice is decoupled from the federal one. This is the withheld-variable approach requested in the #5159 review.

**Registry:** adds an `md_local_income_tax` entry to `programs.yaml` (Taxes / Local), mirroring `nyc_income_tax`.

## Results (Baltimore City single filer, $97,140 wages, 2026)

| Variable | Before | After |
|---|---|---|
| `md_local_income_tax_before_refundable_credits` | — | $2,897.28 |
| `household_state_tax_before_refundable_credits` | $4,248.15 | $7,145.43 |
| `household_tax` | $24,220.16 | $27,117.44 |
| `state_and_local_sales_or_income_tax` | $4,428.65 | $7,447.53 |

A low-income example: Baltimore City filer with $14,000 MD taxable income and $5,000 federal EITC owes $448 of county tax before credits; the local EITC (capped at the tax) zeroes it out, so wiring the gross tax without the credits would have overtaxed exactly the households the credit protects.

## Not modeled (out of scope)

- Optional county **refundable** local EITCs (§ 10-704(f): refund of federal EITC × 5 × county rate in excess of county tax, county opt-in). Montgomery County's 100% match is already modeled as `md_montgomery_eitc` in the state refundable credits list and is unchanged here (no double-count).
- Separate-jurisdiction spouses (Form 502 "separate jurisdictions" ratio rule).

## Tests

- New YAML unit tests for the applicable rate (flat / Anne Arundel lowest-marginal / Frederick single & joint brackets), local EITC (uncapped, capped, zero), poverty level credit (uncapped, capped after EITC, ineligible), and the before-refundable-credits composition including the low-income zero-out case.
- Household integration test: county tax flows into `household_tax` for a Baltimore City filer.
- Existing 24 Maryland county test files pass unchanged (the Frederick refactor is behavior-preserving).
- The two `md_withheld_income_tax.yaml` cases now pin an explicit county and expect the combined state + local estimate (previously state-only for a county-unspecified household).
- Vectorized mixed-state smoke (MD flat/Anne Arundel/Frederick + NY/TX/CA in one simulation): county guards hold, non-MD households unaffected, and Anne Arundel's marginal liability matches hand computation to the cent.
