### PR TITLE
Fix partner-impact Slack notice crashing when a PR changes more than 20 partner files

### DIFF
--- a/.github/workflows/partner-api-impact-notice.yaml
+++ b/.github/workflows/partner-api-impact-notice.yaml
@@ -62,10 +62,16 @@ jobs:
           fi
 
           file_count=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d' | wc -l | tr -d ' ')
-          file_list=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d' | head -20 | sed 's/^/- /')
+          # awk reads all input, so the producer never gets SIGPIPE (head -20
+          # exits after 20 lines, which fails the pipeline under pipefail
+          # whenever more than 20 partner files change).
+          file_list=$(printf '%s\n' "${CHANGED_FILES}" | awk 'NF && ++n <= 20 { print "- " $0 }')
 
           if [ "${file_count}" -gt 20 ]; then
+            files_heading="Showing first 20:"
             file_list=$(printf '%s\n- ...and %d more. See the PR file diff for the full list.' "${file_list}" $((file_count - 20)))
+          else
+            files_heading="Changed files:"
           fi
 
           payload=$(
@@ -73,6 +79,7 @@ jobs:
               --arg author "${PR_AUTHOR}" \
               --arg count "${file_count}" \
               --arg files "${file_list}" \
+              --arg heading "${files_heading}" \
               --arg number "${PR_NUMBER}" \
               --arg title "${PR_TITLE}" \
               --arg url "${PR_URL}" \
@@ -82,7 +89,7 @@ jobs:
                   "PR: <" + $url + "|#" + $number + " " + $title + ">\n" +
                   "Author: " + $author + "\n" +
                   "Changed partner files: " + $count + "\n" +
-                  "Showing first 20:\n" + $files + "\n\n" +
+                  $heading + "\n" + $files + "\n\n" +
                   "Please review whether this changes partner-facing API behavior before merge."
                 )
               }'

--- a/changelog.d/fix-partner-notice-truncation.fixed.md
+++ b/changelog.d/fix-partner-notice-truncation.fixed.md
@@ -1,0 +1,1 @@
+Fix the partner API impact Slack notification job crashing on pull requests that change more than 20 partner test files.


### PR DESCRIPTION
## Summary

The `partner-api-impact-notice.yaml` workflow (Slack notice when partner contract tests change) crashes on any PR that changes more than 20 partner files — first triggered by #8890 (172 changed partner files), which consequently got **no Slack notice**.

## Root cause

```bash
file_list=$(printf '%s\n' "${CHANGED_FILES}" | sed '/^$/d' | head -20 | sed 's/^/- /')
```

`head -20` exits after emitting 20 lines, closing the pipe's read end. GNU sed flushes its output in ~4KB chunks, so with enough files its next `write()` hits the closed pipe. The Actions runner ignores SIGPIPE, so sed gets EPIPE, prints `sed: couldn't write 114 items to stdout: Broken pipe`, and exits 4 — which `set -euo pipefail` promotes to a job failure. Reproduced deterministically: a producer still writing after the consumer exits fails with 141/4 under `pipefail`; the awk form below cannot fail this way because awk always reads to EOF.

## Fix

- Replace the `head -20` pipeline with `awk 'NF && ++n <= 20 { print "- " $0 }'` — identical output (blank lines dropped, first 20 files, `- ` prefix), but the consumer reads all input, so no producer ever receives SIGPIPE.
- Make the list heading accurate: `Showing first 20:` only when the list is actually truncated, `Changed files:` otherwise.

Message rendering dry-run against #8890's real 172-file list produces the expected notice (`Changed partner files: 172`, first 20 listed, `...and 152 more`).

Note: this workflow runs on `pull_request_target`, so the fix only takes effect after merging to `main`; #8890's red check clears on its next event after that.

## Test plan

- [x] YAML parses (PyYAML)
- [x] awk filter verified on blank-line and 172-line inputs
- [x] Full fixed step dry-run rendered the exact Slack payload for #8890
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
