### PR TITLE
Fix CTC value and EITC disabled dependent child count

### DIFF
--- a/changelog.d/fix-ctc-value-eitc-disabled.fixed.md
+++ b/changelog.d/fix-ctc-value-eitc-disabled.fixed.md
@@ -1,0 +1,1 @@
+Fixed the reported federal Child Tax Credit value and EITC child count for permanently disabled adult dependents.

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable/ctc_value.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable/ctc_value.yaml
@@ -82,3 +82,25 @@
     refundable_ctc: 4_000
     non_refundable_ctc: 0
     ctc_value: 4_000
+
+- name: Case 5, actual CTC value is capped by liability plus refundable credit.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    ctc: 4_400
+    ctc_limiting_tax_liability: 853.67
+    ctc_phase_in: 5_735
+    refundable_ctc: 3_400
+  output:
+    ctc_value: 4_253.67
+
+- name: Case 6, other dependent credit is valuable even with no CTC phase-in.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    ctc: 500
+    ctc_limiting_tax_liability: 10_133.92
+    ctc_phase_in: 0
+    refundable_ctc: 0
+  output:
+    ctc_value: 500

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/earned_income/eitc_child_count.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/earned_income/eitc_child_count.yaml
@@ -51,3 +51,37 @@
         members: [person1, person2, person3]
   output:
     eitc_child_count: 1
+
+- name: Case 4, disabled adult dependent meets the EITC child count.
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head_or_spouse: true
+        meets_eitc_identification_requirements: true
+      person2:
+        is_permanently_and_totally_disabled: true
+        is_tax_unit_dependent: true
+        meets_eitc_identification_requirements: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    eitc_child_count: 1
+
+- name: Case 5, disabled non-dependent does not meet the EITC child count.
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head_or_spouse: true
+        meets_eitc_identification_requirements: true
+      person2:
+        is_permanently_and_totally_disabled: true
+        is_tax_unit_dependent: false
+        meets_eitc_identification_requirements: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    eitc_child_count: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/integration.yaml
@@ -67,7 +67,7 @@
         members: [person1, person2, person3, person4]
         state_fips: 40
   output:
-    ctc_value: 0
+    ctc_value: 93.26
     ctc: 4_000
     ok_federal_ctc: 93.26
     # Only match 5% of the actual federal CTC allowed.

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_child_care_child_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_child_care_child_tax_credit.yaml
@@ -167,7 +167,7 @@
         members: [head, child1, child2]
         state_code: OK
   output:
-    ctc_value: 0
+    ctc_value: 4_400
     ok_federal_ctc: 2_799
     ok_child_care_child_tax_credit: 140
     taxsim_ok_child_tax_credit_component: 140

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/composition/tax_credits/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/composition/tax_credits/federal.yaml
@@ -201,7 +201,7 @@
         eitc: 4427.0
         eitc_eligible: true
         ctc: 2200.0
-        ctc_value: 2200.0
+        ctc_value: 1700.0
         refundable_ctc: 1700.0
         cdcc: 0.0
         adjusted_gross_income: 20000.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/tax_credits/cdcc/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/tax_credits/cdcc/federal.yaml
@@ -212,7 +212,7 @@
         eitc: 4427.0
         eitc_eligible: true
         ctc: 2200.0
-        ctc_value: 1875.0
+        ctc_value: 1700.0
         refundable_ctc: 1700.0
         cdcc: 0.0
         adjusted_gross_income: 15000.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/tax_credits/eitc/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/tax_credits/eitc/federal.yaml
@@ -63,7 +63,7 @@
         eitc: 4427.0
         eitc_eligible: true
         ctc: 2200.0
-        ctc_value: 2200.0
+        ctc_value: 1700.0
         refundable_ctc: 1700.0
         cdcc: 0.0
         adjusted_gross_income: 31060.0
@@ -133,7 +133,7 @@
         eitc: 4427.0
         eitc_eligible: true
         ctc: 2200.0
-        ctc_value: 2200.0
+        ctc_value: 1700.0
         refundable_ctc: 1700.0
         cdcc: 0.0
         adjusted_gross_income: 31160.0
@@ -203,7 +203,7 @@
         eitc: 4267.2
         eitc_eligible: true
         ctc: 2200.0
-        ctc_value: 2200.0
+        ctc_value: 1700.0
         refundable_ctc: 1700.0
         cdcc: 0.0
         adjusted_gross_income: 32160.0
@@ -274,7 +274,7 @@
         eitc: 4260.97
         eitc_eligible: true
         ctc: 2200.0
-        ctc_value: 2200.0
+        ctc_value: 1700.0
         refundable_ctc: 1700.0
         cdcc: 0.0
         adjusted_gross_income: 32199.0
@@ -345,7 +345,7 @@
         eitc: 4260.65
         eitc_eligible: true
         ctc: 2200.0
-        ctc_value: 2200.0
+        ctc_value: 1700.1
         refundable_ctc: 1700.0
         cdcc: 0.0
         adjusted_gross_income: 32201.0
@@ -415,7 +415,7 @@
         eitc: 4427.0
         eitc_eligible: true
         ctc: 500.0
-        ctc_value: 500.0
+        ctc_value: 0.0
         refundable_ctc: 0.0
         cdcc: 0.0
         adjusted_gross_income: 20000.0
@@ -485,7 +485,7 @@
         eitc: 521.71
         eitc_eligible: true
         ctc: 500.0
-        ctc_value: 500.0
+        ctc_value: 0.0
         refundable_ctc: 0.0
         cdcc: 0.0
         adjusted_gross_income: 20000.0
@@ -555,7 +555,7 @@
         eitc: 4427.0
         eitc_eligible: true
         ctc: 500.0
-        ctc_value: 500.0
+        ctc_value: 0.0
         refundable_ctc: 0.0
         cdcc: 0.0
         adjusted_gross_income: 20000.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
@@ -194,7 +194,7 @@
       tax_unit:
         co_ctc: 0.0
         co_eitc: 0.0
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     spm_units:
       spm_unit:
@@ -391,7 +391,7 @@
       tax_unit:
         co_ctc: 0.0
         co_eitc: 0.0
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     spm_units:
       spm_unit:
@@ -591,7 +591,7 @@
       tax_unit:
         co_ctc: 0.0
         co_eitc: 0.0
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     spm_units:
       spm_unit:
@@ -876,7 +876,7 @@
       tax_unit:
         co_ctc: 0.0
         co_eitc: 0.0
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     spm_units:
       spm_unit:
@@ -1077,7 +1077,7 @@
       tax_unit:
         co_ctc: 0.0
         co_eitc: 0.0
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     spm_units:
       spm_unit:

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
@@ -175,7 +175,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 17036.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         il_ctc: 0.0
         il_eitc: 0.0
@@ -433,7 +433,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 17036.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         il_ctc: 0.0
         il_eitc: 0.0
@@ -679,7 +679,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 17036.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         il_ctc: 0.0
         il_eitc: 0.0
@@ -928,7 +928,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 17036.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         il_ctc: 0.0
         il_eitc: 0.0
@@ -1181,7 +1181,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 17036.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         il_ctc: 0.0
         il_eitc: 0.0
@@ -1438,7 +1438,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 17036.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         il_ctc: 0.0
         il_eitc: 0.0
@@ -1683,7 +1683,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 17036.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         il_ctc: 0.0
         il_eitc: 0.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
@@ -161,7 +161,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 14531.4
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         ma_child_and_family_credit: 0.0
         ma_eitc: 0.0
@@ -401,7 +401,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 14531.4
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         ma_child_and_family_credit: 0.0
         ma_eitc: 0.0
@@ -638,7 +638,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 14531.4
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         ma_child_and_family_credit: 0.0
         ma_eitc: 0.0
@@ -878,7 +878,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 14531.4
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         ma_child_and_family_credit: 0.0
         ma_eitc: 0.0
@@ -1119,7 +1119,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 14531.4
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
         ma_child_and_family_credit: 0.0
         ma_eitc: 0.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
@@ -147,7 +147,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 11228.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -327,7 +327,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 11228.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -510,7 +510,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 11228.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -694,7 +694,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 11228.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -873,7 +873,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 11228.81
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
@@ -166,7 +166,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 15935.95
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -418,7 +418,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 15935.95
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -678,7 +678,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 27263.95
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -917,7 +917,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 15935.95
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -1168,7 +1168,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 15935.95
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -1424,7 +1424,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 15935.95
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:
@@ -1679,7 +1679,7 @@
     tax_units:
       tax_unit:
         aca_ptc: 27263.95
-        ctc_value: 4400.0
+        ctc_value: 3400.0
         eitc: 3769.5
     people:
       head:

--- a/policyengine_us/variables/gov/irs/credits/ctc/ctc_value.py
+++ b/policyengine_us/variables/gov/irs/credits/ctc/ctc_value.py
@@ -11,8 +11,6 @@ class ctc_value(Variable):
 
     def formula(tax_unit, period, parameters):
         ctc = tax_unit("ctc", period)
-        p = parameters(period).gov.irs.credits.ctc.refundable
-        if not p.fully_refundable:
-            phase_in = tax_unit("ctc_phase_in", period)
-            return min_(ctc, phase_in)
-        return ctc
+        limiting_tax = tax_unit("ctc_limiting_tax_liability", period)
+        refundable_ctc = tax_unit("refundable_ctc", period)
+        return min_(ctc, limiting_tax + refundable_ctc)

--- a/policyengine_us/variables/gov/irs/credits/earned_income/eitc_child_count.py
+++ b/policyengine_us/variables/gov/irs/credits/earned_income/eitc_child_count.py
@@ -11,11 +11,18 @@ class eitc_child_count(Variable):
     reference = (
         # IRC 32(c)(3)(D)(i) specifies qualifying children need a taxpayer identification number.
         "https://www.law.cornell.edu/uscode/text/26/32#c_3_D_i",
+        # IRC 152(c)(3)(B) waives the qualifying-child age test for permanently and totally disabled individuals.
+        "https://www.law.cornell.edu/uscode/text/26/152#c_3_B",
     )
 
     def formula(tax_unit, period, parameters):
         person = tax_unit.members
-        is_child = person("is_qualifying_child_dependent", period)
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
+        )
+        is_child = (
+            person("is_qualifying_child_dependent", period) | is_disabled_dependent
+        )
         meets_eitc_identification_requirements = person(
             "meets_eitc_identification_requirements", period
         )


### PR DESCRIPTION
## Summary

- calculate `ctc_value` as the actual allowed CTC value capped by tax liability plus refundable CTC
- include permanently and totally disabled tax-unit dependents in `eitc_child_count`
- add regression cases for the Axiom/TaxCalc oracle mismatches
- repin 41 downstream `ctc_value` assertions that encoded the old `min(ctc, ctc_phase_in)` behavior (analytics-coverage signatures for CO/IL/MA/NC/TX, EITC/CDCC/composition edge cases, OK integration tests); the OK integration case now matches `ok_federal_ctc` (93.26), which already modeled the liability-capped federal CTC

Closes #8893
Closes #8894

## Tests

- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/credits/ctc/refundable/ctc_value.yaml -c policyengine_us`
- `uv run python -m policyengine_core.scripts.policyengine_command test policyengine_us/tests/policy/baseline/gov/irs/credits/earned_income/eitc_child_count.yaml -c policyengine_us`
- ran all 26 test files that reference `ctc_value` or set `is_permanently_and_totally_disabled` (partners analytics coverage, my_friend_ben, NY/OK/KS/PA state tests): 152 passed
- `uv run ruff format` / `uv run ruff check` on the changed variables
- `git diff --check`
