### PR TITLE
Fix 2020 unemployment exclusion boundary at $150,000 AGI

### DIFF
--- a/changelog.d/ui-exclusion-boundary.fixed.md
+++ b/changelog.d/ui-exclusion-boundary.fixed.md
@@ -1,0 +1,1 @@
+Fixed the 2020 unemployment compensation exclusion to require AGI strictly below $150,000.

--- a/policyengine_us/tests/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/unemployment_insurance/tax_unit_taxable_unemployment_compensation.yaml
+++ b/policyengine_us/tests/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/unemployment_insurance/tax_unit_taxable_unemployment_compensation.yaml
@@ -1,0 +1,62 @@
+# 26 USC 85(c)(1) excludes up to $10,200 of 2020 unemployment compensation
+# only if AGI (determined without regard to unemployment compensation) is
+# strictly less than $150,000.
+- name: No exclusion in 2020 when AGI over UC equals the $150,000 cutoff exactly
+  period: 2020
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 155_000
+        unemployment_compensation: 5_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    marital_units:
+      marital_unit:
+        members: [head]
+    families:
+      family:
+        members: [head]
+    spm_units:
+      spm_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: TX
+  output:
+    # AGI over UC = 155,000 - 5,000 = 150,000, not below the cutoff,
+    # so all unemployment compensation is taxable.
+    tax_unit_taxable_unemployment_compensation: 5_000
+
+- name: Full exclusion in 2020 when AGI over UC is one dollar below the cutoff
+  period: 2020
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 154_999
+        unemployment_compensation: 5_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+    marital_units:
+      marital_unit:
+        members: [head]
+    families:
+      family:
+        members: [head]
+    spm_units:
+      spm_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: TX
+  output:
+    # AGI over UC = 154,999 - 5,000 = 149,999, below the $150,000 cutoff,
+    # so unemployment compensation up to $10,200 is excluded.
+    tax_unit_taxable_unemployment_compensation: 0

--- a/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/unemployment_insurance/tax_unit_taxable_unemployment_compensation.py
+++ b/policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/unemployment_insurance/tax_unit_taxable_unemployment_compensation.py
@@ -17,7 +17,7 @@ class tax_unit_taxable_unemployment_compensation(Variable):
         agi_over_uc = agi - uc_amount
         filing_status = tax_unit("filing_status", period)
         uc_excluded = where(
-            agi_over_uc <= ui.exemption.cutoff[filing_status],
+            agi_over_uc < ui.exemption.cutoff[filing_status],
             min_(uc_amount, ui.exemption.amount),
             0,
         )


### PR DESCRIPTION
## Summary

26 USC 85(c)(1) excludes up to $10,200 of tax-year-2020 unemployment compensation only when adjusted gross income (determined without regard to that unemployment compensation) is **strictly less than** $150,000. A taxpayer at exactly $150,000 receives no exclusion.

`tax_unit_taxable_unemployment_compensation` compared `agi_over_uc <= ui.exemption.cutoff[filing_status]`, which granted the exclusion at exactly the $150,000 cutoff. This changes the comparison to `<` so the exclusion is denied at the boundary, matching the statute.

The exemption cutoff parameter is `150_000` for 2020 only (`0` in all other years), and the exemption amount is likewise nonzero only in 2020, so this change affects the tax-year-2020 exclusion exclusively.

## Changes

- `policyengine_us/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/unemployment_insurance/tax_unit_taxable_unemployment_compensation.py`: `<=` → `<` against the exemption cutoff.
- Added `tax_unit_taxable_unemployment_compensation.yaml` boundary regression tests in the matching `unemployment_insurance` tests directory.
- Added changelog fragment `changelog.d/ui-exclusion-boundary.fixed.md`.

## Tests

Two new boundary cases (single filer, 2020, $5,000 unemployment compensation):

| Employment income | AGI over UC | Expected taxable UC | Rationale |
|---|---|---|---|
| $155,000 | $150,000 (= cutoff) | $5,000 (no exclusion) | AGI over UC not below $150,000 |
| $154,999 | $149,999 (< cutoff) | $0 (full exclusion) | AGI over UC below $150,000 |

```
$ python -m policyengine_core.scripts.policyengine_command test \
    policyengine_us/tests/variables/gov/irs/income/taxable_income/adjusted_gross_income/irs_gross_income/unemployment_insurance \
    -c policyengine_us
============================= test session starts ==============================
collected 5 items
.../unemployment_insurance/tax_unit_taxable_unemployment_compensation.yaml ..
.../unemployment_insurance/taxable_unemployment_compensation.yaml ...
========================= 5 passed, 1 warning in 2.04s =========================
```

The full `unemployment_insurance` test directory passes (5/5), including the pre-existing `taxable_unemployment_compensation.yaml` allocation tests, confirming no regression.

Fixes #8877

🤖 Generated with [Claude Code](https://claude.com/claude-code)
