### PR TITLE
Terminate clean-energy credits under Pub. L. 119-21

### DIFF
--- a/changelog.d/clean-energy-terminations.fixed.md
+++ b/changelog.d/clean-energy-terminations.fixed.md
@@ -1,0 +1,1 @@
+Fixed the residential clean energy credit, energy efficient home improvement credit, and new/used clean vehicle credits to reflect their termination under the One Big Beautiful Bill Act (Pub. L. 119-21).

--- a/policyengine_us/parameters/gov/irs/credits/clean_vehicle/new/eligibility/in_effect.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/clean_vehicle/new/eligibility/in_effect.yaml
@@ -1,0 +1,20 @@
+description: The IRS provides the new clean vehicle credit when this is true.
+values:
+  2023-01-01: true
+  # The statute terminates the credit for vehicles acquired after
+  # September 30, 2025 (an intra-year date). PolicyEngine models annual
+  # periods, so this cutoff is approximated as the credit ending for tax
+  # years after 2025 (2026-01-01), rather than mid-2025. This is not exact:
+  # vehicles acquired in Q4 2025 are treated as eligible here even though
+  # they are not under current law.
+  2026-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: New clean vehicle credit in effect
+  reference:
+    - title: 26 U.S.C. § 30D(h)
+      href: https://www.law.cornell.edu/uscode/text/26/30D#h
+    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70502 (2025) # Terminates the credit for vehicles acquired after September 30, 2025.
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1

--- a/policyengine_us/parameters/gov/irs/credits/clean_vehicle/used/eligibility/in_effect.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/clean_vehicle/used/eligibility/in_effect.yaml
@@ -1,0 +1,20 @@
+description: The IRS provides the used clean vehicle credit when this is true.
+values:
+  2023-01-01: true
+  # The statute terminates the credit for vehicles acquired after
+  # September 30, 2025 (an intra-year date). PolicyEngine models annual
+  # periods, so this cutoff is approximated as the credit ending for tax
+  # years after 2025 (2026-01-01), rather than mid-2025. This is not exact:
+  # vehicles acquired in Q4 2025 are treated as eligible here even though
+  # they are not under current law.
+  2026-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: Used clean vehicle credit in effect
+  reference:
+    - title: 26 U.S.C. § 25E(g)
+      href: https://www.law.cornell.edu/uscode/text/26/25E#g
+    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70501 (2025) # Terminates the credit for vehicles acquired after September 30, 2025.
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1

--- a/policyengine_us/parameters/gov/irs/credits/energy_efficient_home_improvement/in_effect.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/energy_efficient_home_improvement/in_effect.yaml
@@ -15,5 +15,5 @@ metadata:
   reference:
     - title: 26 U.S.C. § 25C(g)
       href: https://www.law.cornell.edu/uscode/text/26/25C#g
-    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70502 (2025) # Terminates the credit for property placed in service after December 31, 2025.
+    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70505 (2025) # Terminates the credit for property placed in service after December 31, 2025.
       href: https://www.congress.gov/bill/119th-congress/house-bill/1

--- a/policyengine_us/parameters/gov/irs/credits/energy_efficient_home_improvement/in_effect.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/energy_efficient_home_improvement/in_effect.yaml
@@ -3,11 +3,17 @@ values:
   2006-01-01: true
   2008-01-01: false
   2009-01-01: true
-  2033-01-01: false
+  2026-01-01: false
   # Pre-Infation Reduction Act law terminated it on 2022-01-01.
   # However, the Inflation Reduction Act extended it retroactively.
+  # One Big Beautiful Bill Act terminates it again for property placed in
+  # service after December 31, 2025. Note: the 25C(h) requirement that
+  # qualified property display a product identification number (PIN) on the
+  # taxpayer's return is not modeled here (see #8703).
 metadata:
   label: Energy efficient home improvement tax credit in effect
   reference:
     - title: 26 U.S.C. § 25C(g)
       href: https://www.law.cornell.edu/uscode/text/26/25C#g
+    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70502 (2025) # Terminates the credit for property placed in service after December 31, 2025.
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1

--- a/policyengine_us/parameters/gov/irs/credits/residential_clean_energy/applicable_percentage.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/residential_clean_energy/applicable_percentage.yaml
@@ -3,9 +3,7 @@ values:
   2017-01-01: 0.3
   2020-01-01: 0.26
   2022-01-01: 0.3
-  2033-01-01: 0.26
-  2034-01-01: 0.22
-  2035-01-01: 0
+  2026-01-01: 0
 metadata:
   unit: /1
   label: Residential Clean Energy Credit applicable percentage
@@ -16,3 +14,5 @@ metadata:
       href: https://www.irs.gov/pub/irs-pdf/f5695.pdf
     - title: Inflation Reduction Act
       href: https://www.democrats.senate.gov/imo/media/doc/inflation_reduction_act_of_2022.pdf#page=351
+    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70521 (2025) # Terminates the credit for expenditures made after December 31, 2025.
+      href: https://www.congress.gov/bill/119th-congress/house-bill/1

--- a/policyengine_us/parameters/gov/irs/credits/residential_clean_energy/applicable_percentage.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/residential_clean_energy/applicable_percentage.yaml
@@ -14,5 +14,5 @@ metadata:
       href: https://www.irs.gov/pub/irs-pdf/f5695.pdf
     - title: Inflation Reduction Act
       href: https://www.democrats.senate.gov/imo/media/doc/inflation_reduction_act_of_2022.pdf#page=351
-    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70521 (2025) # Terminates the credit for expenditures made after December 31, 2025.
+    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70506 (2025) # Terminates the credit for expenditures made after December 31, 2025.
       href: https://www.congress.gov/bill/119th-congress/house-bill/1

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/clean_vehicle/new/new_clean_vehicle_credit_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/clean_vehicle/new/new_clean_vehicle_credit_eligible.yaml
@@ -46,3 +46,25 @@
     adjusted_gross_income: 150_000
   output:
     new_clean_vehicle_credit_eligible: false
+
+- name: Qualifying household is eligible in 2025, before the One Big Beautiful Bill Act termination.
+  period: 2025
+  input:
+    purchased_qualifying_new_clean_vehicle: true
+    new_clean_vehicle_battery_capacity: 4
+    new_clean_vehicle_classification: VAN
+    new_clean_vehicle_msrp: 80_000
+    adjusted_gross_income: 150_000
+  output:
+    new_clean_vehicle_credit_eligible: true
+
+- name: Otherwise-qualifying household is ineligible in 2026, terminated by the One Big Beautiful Bill Act (Pub. L. 119-21).
+  period: 2026
+  input:
+    purchased_qualifying_new_clean_vehicle: true
+    new_clean_vehicle_battery_capacity: 4
+    new_clean_vehicle_classification: VAN
+    new_clean_vehicle_msrp: 80_000
+    adjusted_gross_income: 150_000
+  output:
+    new_clean_vehicle_credit_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/clean_vehicle/used/used_clean_vehicle_credit_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/clean_vehicle/used/used_clean_vehicle_credit_eligible.yaml
@@ -45,3 +45,21 @@
     adjusted_gross_income: 75_001
   output:
     used_clean_vehicle_credit_eligible: false
+
+- name: Qualifying household is eligible in 2025, before the One Big Beautiful Bill Act termination.
+  period: 2025
+  input:
+    purchased_qualifying_used_clean_vehicle: true
+    used_clean_vehicle_sale_price: 25_000
+    adjusted_gross_income: 75_000
+  output:
+    used_clean_vehicle_credit_eligible: true
+
+- name: Otherwise-qualifying household is ineligible in 2026, terminated by the One Big Beautiful Bill Act (Pub. L. 119-21).
+  period: 2026
+  input:
+    purchased_qualifying_used_clean_vehicle: true
+    used_clean_vehicle_sale_price: 25_000
+    adjusted_gross_income: 75_000
+  output:
+    used_clean_vehicle_credit_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/energy_efficient_home_improvement/energy_efficient_home_improvement_credit_potential.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/energy_efficient_home_improvement/energy_efficient_home_improvement_credit_potential.yaml
@@ -43,3 +43,17 @@
     capped_energy_efficient_door_credit: 1
   output:
     energy_efficient_home_improvement_credit_potential: 0
+
+- name: Nonzero in 2025, before the One Big Beautiful Bill Act termination.
+  period: 2025
+  input:
+    capped_energy_efficient_window_credit: 100
+  output:
+    energy_efficient_home_improvement_credit_potential: 100
+
+- name: Terminated in 2026 by the One Big Beautiful Bill Act (Pub. L. 119-21).
+  period: 2026
+  input:
+    capped_energy_efficient_window_credit: 100
+  output:
+    energy_efficient_home_improvement_credit_potential: 0

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/residential_clean_energy/residential_clean_energy_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/residential_clean_energy/residential_clean_energy_credit.yaml
@@ -18,9 +18,8 @@
   output:
     residential_clean_energy_credit_potential: 1_800  # 30% of $6,000.
 
-- name: 26% in 2033.
+- name: Still terminated in 2033 by the One Big Beautiful Bill Act (Pub. L. 119-21).
   period: 2033
-  absolute_error_margin: 0.01
   input:
     qualified_battery_storage_technology_expenditures: 1_000
     geothermal_heat_pump_property_expenditures: 1_000
@@ -31,4 +30,33 @@
     fuel_cell_property_expenditures: 1_100
     fuel_cell_property_capacity: 1
   output:
-    residential_clean_energy_credit_potential: 1_560  # 26% of $6,000.
+    # Prior law phased the rate down to 26% in 2033; the One Big Beautiful
+    # Bill Act (Pub. L. 119-21) instead terminates the credit after 2025,
+    # so the rate remains 0% here.
+    residential_clean_energy_credit_potential: 0
+
+- name: 30% in 2025, before the One Big Beautiful Bill Act termination.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    geothermal_heat_pump_property_expenditures: 1_000
+    small_wind_energy_property_expenditures: 1_000
+    solar_electric_property_expenditures: 1_000
+    solar_water_heating_property_expenditures: 1_000
+    # Fuel cell capped at $1,000 if 1 kW capacity.
+    fuel_cell_property_expenditures: 1_100
+    fuel_cell_property_capacity: 1
+  output:
+    residential_clean_energy_credit_potential: 1_500  # 30% of $5,000.
+
+- name: Terminated in 2026 by the One Big Beautiful Bill Act (Pub. L. 119-21).
+  period: 2026
+  input:
+    geothermal_heat_pump_property_expenditures: 1_000
+    small_wind_energy_property_expenditures: 1_000
+    solar_electric_property_expenditures: 1_000
+    solar_water_heating_property_expenditures: 1_000
+    fuel_cell_property_expenditures: 1_100
+    fuel_cell_property_capacity: 1
+  output:
+    residential_clean_energy_credit_potential: 0

--- a/policyengine_us/variables/gov/irs/credits/clean_vehicle/new/new_clean_vehicle_credit_eligible.py
+++ b/policyengine_us/variables/gov/irs/credits/clean_vehicle/new/new_clean_vehicle_credit_eligible.py
@@ -14,9 +14,15 @@ class new_clean_vehicle_credit_eligible(Variable):
     defined_for = "purchased_qualifying_new_clean_vehicle"
 
     def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.irs.credits.clean_vehicle.new.eligibility
+        # One Big Beautiful Bill Act (Pub. L. 119-21 § 70502) terminates the
+        # credit for vehicles acquired after September 30, 2025. See
+        # in_effect.yaml for the annual-resolution approximation of this
+        # intra-year cutoff.
+        if not p.in_effect:
+            return False
         # Capacity limit applies with and without the Inflation Reduction Act.
         capacity = tax_unit("new_clean_vehicle_battery_capacity", period)
-        p = parameters(period).gov.irs.credits.clean_vehicle.new.eligibility
         meets_capacity_requirement = capacity >= p.min_kwh
         agi = tax_unit("adjusted_gross_income", period)
         filing_status = tax_unit("filing_status", period)

--- a/policyengine_us/variables/gov/irs/credits/clean_vehicle/used/used_clean_vehicle_credit_eligible.py
+++ b/policyengine_us/variables/gov/irs/credits/clean_vehicle/used/used_clean_vehicle_credit_eligible.py
@@ -13,6 +13,12 @@ class used_clean_vehicle_credit_eligible(Variable):
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.irs.credits.clean_vehicle.used
+        # One Big Beautiful Bill Act (Pub. L. 119-21 § 70501) terminates the
+        # credit for vehicles acquired after September 30, 2025. See
+        # eligibility/in_effect.yaml for the annual-resolution approximation
+        # of this intra-year cutoff.
+        if not p.eligibility.in_effect:
+            return False
         # Income eligibility based on lesser of MAGI in current and prior year.
         # Assume AGI in current year for now.
         agi = tax_unit("adjusted_gross_income", period)


### PR DESCRIPTION
## Summary

Applies the One Big Beautiful Bill Act (Pub. L. 119-21, the 2025 reconciliation law) terminations of four clean-energy tax credits.

- **Residential clean energy credit (IRC 25D, § 70506)** — Sets the applicable percentage to `0` for expenditures made after 2025-12-31 and removes the now-dead IRA phasedown entries (2033: 0.26, 2034: 0.22, 2035: 0). The credit's formula already reads `applicable_percentage`, so no code change was needed.
- **Energy efficient home improvement credit (IRC 25C, § 70505)** — Turns off `in_effect` at 2026-01-01 (property placed in service after 2025-12-31). The formula already gates on `in_effect`, so no code change was needed. The **25C(h) product-identification-number (PIN) requirement remains unmodeled** — see #8703.
- **New and used clean vehicle credits (IRC 30D/25E, §§ 70502/70501)** — Adds `eligibility/in_effect` parameters under `clean_vehicle/new/` and `clean_vehicle/used/` and gates the two eligibility variables (`new_clean_vehicle_credit_eligible`, `used_clean_vehicle_credit_eligible`) on them. Because the downstream credit, credit-limit, and potential variables are all `defined_for` the eligibility variables, gating eligibility to `False` zeroes the entire credit chain — no hardcoded values in formulas.

### Clean vehicle acquisition-date caveat

The statute terminates the vehicle credits for vehicles **acquired after September 30, 2025** (an intra-year date, confirmed against 26 U.S.C. §§ 25E(g), 30D(h)). PolicyEngine models annual periods, so this cutoff is approximated as the credit ending for tax years after 2025 (`2026-01-01`), rather than mid-2025. This is documented in both `in_effect.yaml` files and the two formula comments. It is not exact: vehicles acquired in Q4 2025 are treated as eligible here even though they are not under current law. Representing the intra-2025 cutoff exactly would require an acquisition-date input at sub-annual resolution (the adapter/design ask in #8760).

## Tests

Added YAML tests asserting each credit is nonzero in 2025 and zero in 2026 (residential clean energy potential, EEHIC potential, and new/used clean vehicle eligibility), and updated the stale residential-clean-energy 2033 phasedown test (previously asserted 26%, now 0). Added `changelog.d/clean-energy-terminations.fixed.md`.

Ran locally against Python 3.14 (`policyengine-core test ... -c policyengine_us`):

- `residential_clean_energy`: **5 passed**
- `energy_efficient_home_improvement`: **44 passed**
- `clean_vehicle`: **30 passed**

Parameter tree loads cleanly; boundary values verified: 25D applicable percentage 0.3 (2025) → 0 (2026); 25C `in_effect` True (2025) → False (2026); new/used vehicle `eligibility.in_effect` True (2025) → False (2026).

Fixes #8694
Addresses #8703 (PIN requirement unmodeled)
Addresses #8760 (acquisition-date sunset approximated at annual resolution; adapter/design ask open)
