### PR TITLE
Use current-year federal EITC for Indiana EITC childless filers

### DIFF
--- a/changelog.d/in-eitc-childless-current.fixed.md
+++ b/changelog.d/in-eitc-childless-current.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the Indiana EITC to use the current-year federal EITC for childless filers as well as filers with children, matching Schedule IN-EIC Section A, which applies the 10% match to all filers.

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/income/in_eitc.yaml
@@ -34,9 +34,9 @@
     in_eitc: 0.09 * 5_980
 
 - name: taxsim_1039_in_eitc_with_child_uses_current_federal_eitc
-  # 2025 Schedule IN-EIC Section B: a filer claiming one or more children takes
-  # 10% of the earned income credit "from your federal income tax return", i.e.
-  # the current-year federal EITC ($4,328 here), not a frozen-IRC recomputation.
+  # 2025 Schedule IN-EIC Section A (applies to all filers): 10% of the earned
+  # income credit "from your federal income tax return", i.e. the current-year
+  # federal EITC ($4,328 here), not a frozen-IRC recomputation.
   # 10% x $4,328 = $432.80. Originating: PolicyEngine/policyengine-taxsim#1039.
   absolute_error_margin: 1
   period: 2025
@@ -51,10 +51,14 @@
   output:
     in_eitc: 433
 
-- name: in_eitc childless 2025 stays on frozen 2023 IRC snapshot
-  # Schedule IN-EIC Section A / IC 6-3-1-11: childless filers remain decoupled
-  # from the federal (ARPA-expanded) EITC and use the frozen Jan 1, 2023 IRC.
-  # 10% x frozen $600 childless max = $60, NOT 10% x current federal $612 = $61.20.
+- name: in_eitc childless 2025 uses current-year federal EITC
+  # Schedule IN-EIC Section A applies to all filers: 10% of "the earned income
+  # credit from your federal income tax return." At $8,000 earnings the 2025
+  # federal childless EITC is phase-in-limited to $612 (7.65% x $8,000), below
+  # the $649 max, so 10% x $612 = $61.20 -- not the frozen 2023 snapshot's
+  # 10% x $600 = $60 (IB92's Jan 1, 2023 freeze applies uniformly and its only
+  # post-2023 effect is inflation indexing, since the ARPA childless expansion
+  # already expired Jan 1, 2022).
   absolute_error_margin: 0.01
   period: 2025
   input:
@@ -65,7 +69,7 @@
     households:
       household: {members: [parent], state_fips: 18}
   output:
-    in_eitc: 60
+    in_eitc: 61.20
 
 - name: Indiana EITC TY 2026 uses the SEA 243 advanced January 1, 2026 IRC snapshot
   period: 2026
@@ -92,14 +96,15 @@
         state_code: IN
   output:
     # TY 2026 onwards Indiana SEA 243 (2025) advances the IRC reference to
-    # January 1, 2026. This with-children filer takes 10% of the current-year
-    # federal EITC per Schedule IN-EIC Section B; under SEA 243 the current and
-    # frozen (2026-01-01) computations coincide, so the credit is $442.70.
+    # January 1, 2026. All filers take 10% of the current-year federal EITC
+    # per Schedule IN-EIC Section A; under SEA 243 the current and frozen
+    # (2026-01-01) computations coincide, so the credit is $442.70.
     in_eitc: 442.70
 
-- name: in_eitc childless 2026 uses the SEA 243 January 1, 2026 IRC snapshot
-  # Childless filers stay on the frozen IRC snapshot; under SEA 243 the 2026
-  # snapshot equals the current federal childless EITC, so 10% x $612 = $61.20.
+- name: in_eitc childless 2026 uses the current-year federal EITC
+  # All filers use the current-year federal EITC (Schedule IN-EIC Section A);
+  # under SEA 243 the 2026 frozen-IRC snapshot equals the current federal
+  # childless EITC, so 10% x $612 = $61.20 either way.
   absolute_error_margin: 0.01
   period: 2026
   input:

--- a/policyengine_us/variables/gov/states/in/tax/income/credits/earned_income_credit/in_eitc.py
+++ b/policyengine_us/variables/gov/states/in/tax/income/credits/earned_income_credit/in_eitc.py
@@ -1,8 +1,4 @@
 from policyengine_us.model_api import *
-from policyengine_us.tools.state_eitc_helpers import (
-    calculate_eitc_demographic_eligibility,
-    calculate_eitc_like_amount,
-)
 
 
 class in_eitc(Variable):
@@ -20,48 +16,23 @@ class in_eitc(Variable):
             federal_eitc = tax_unit("eitc", period)
             return federal_eitc * ip.earned_income.match_rate
         if ip.earned_income.static_conformity_in_effect:
-            # IC 6-3-1-11 (Indiana's IRC definition for IC 6-3.1-21):
-            #   - TY 2023 through 2025: IRC as in effect on January 1, 2023.
-            #   - TY 2026 onward: IRC as in effect on January 1, 2026, per
-            #     Indiana SEA 243 (2025).
-            # The snapshot dates are statutory literals; policyengine-core
-            # parameters do not support date-valued types, so they appear
-            # here rather than in the parameter tree.
-            snapshot_date = "2026-01-01" if period.start.year >= 2026 else "2023-01-01"
-            frozen_eitc = parameters.gov.irs.credits.eitc(snapshot_date)
-            child_count = tax_unit("eitc_child_count", period)
-            demographic_eligible = calculate_eitc_demographic_eligibility(
-                tax_unit, period, frozen_eitc, child_count
-            )
-            filer_identification_eligible = tax_unit(
-                "filer_meets_eitc_identification_requirements", period
-            )
-            investment_income_eligible = (
-                tax_unit("eitc_relevant_investment_income", period)
-                <= frozen_eitc.phase_out.max_investment_income
-            )
-            frozen_federal_eitc = calculate_eitc_like_amount(
-                tax_unit,
-                period,
-                parameters,
-                child_count,
-                demographic_eligible,
-                filer_identification_eligible,
-                separate_filer_eligible=frozen_eitc.eligibility.separate_filer,
-                eitc_parameters=frozen_eitc,
-                investment_income_eligible=investment_income_eligible,
-            )
-            # 2025 Schedule IN-EIC Section B (filers claiming one or more
-            # children) directs the taxpayer to take 10% of the earned income
-            # credit "from your federal income tax return" — i.e. the current-
-            # year federal EITC as claimed, not a frozen-IRC recomputation.
-            # Indiana's decoupling (Section A) targets the childless / ARPA
-            # expansion only, so the frozen federal EITC is retained solely for
-            # childless filers.
-            current_federal_eitc = tax_unit("eitc", period)
-            federal_eitc = where(
-                child_count > 0, current_federal_eitc, frozen_federal_eitc
-            )
+            # Schedule IN-EIC (State Form 49469) Section A applies to every
+            # filer: "Enter the earned income credit from your federal
+            # income tax return," multiplied by 10%. There is no frozen-IRC
+            # recomputation on the form. Section B is a qualifying-child
+            # information schedule (names, SSNs, ages), not a computation
+            # path, so it does not carve out childless filers.
+            #
+            # DOR Information Bulletin #92 describes the IRC section 32
+            # January 1, 2023 conformity freeze (IC 6-3-1-11) uniformly for
+            # "the Indiana EITC," with no childless-specific language. The
+            # ARPA childless EITC expansion expired January 1, 2022, so for
+            # TY2023 onward the freeze's only operative effect is that
+            # Indiana does not automatically adopt post-snapshot federal
+            # EITC changes -- and those changes are inflation indexing only.
+            # The current-year federal EITC therefore satisfies the freeze
+            # for all filers, with or without children.
+            federal_eitc = tax_unit("eitc", period)
             return federal_eitc * ip.earned_income.match_rate
         # if Indiana EITC is decoupled from federal EITC
         fp = parameters(period).gov.irs.credits


### PR DESCRIPTION
## Summary

Follow-up to #8875 / #8831. PR #8875 routed Indiana with-children filers to the current-year federal EITC but kept **childless** filers on a frozen Jan 1, 2023 IRC snapshot, based on a rationale the primary sources contradict. This PR removes the `where(child_count > 0, current, frozen)` split so **all** Indiana filers use the current-year federal EITC.

## Why the split was wrong

- **2025 Schedule IN-EIC (State Form 49469, R25/9-25) Section A** applies to every filer: Line A-1 is "the earned income credit from your federal income tax return," multiplied by 10%. **Section B** is a qualifying-child *information* schedule (names, SSNs, ages), not a computation path — it does not carve out childless filers. #8875 had the Section A / Section B roles reversed.
- **DOR Information Bulletin #92** describes the IRC §32 January 1, 2023 conformity freeze (IC 6-3-1-11) uniformly for "the Indiana EITC," with no childless-specific language.
- The **ARPA childless EITC expansion expired January 1, 2022**, so for TY2023 onward the freeze's only operative effect is that Indiana does not automatically adopt post-snapshot federal EITC changes — and for this window those changes are inflation indexing only, the same indexing #8875 accepted for with-children filers.

## Before / after (childless filer, age 30, $8,000 wages)

| Tax year | `in_eitc` before | `in_eitc` after | Basis |
|---|---|---|---|
| **2025** | $60.00 (10% × frozen 2023 max $600) | **$61.20** | 10% × current federal $612 |
| 2026 | $61.20 | $61.20 (unchanged) | frozen 2026 snapshot already equals current |

**Note on the expected value.** The originating issue suggested the 2025 childless value would become **$64.90** (10% × the indexed $649 max). Recomputing from the model gives **$61.20**: at $8,000 earnings the 2025 federal childless EITC is phase-in-limited to $612 (7.65% × $8,000), which is below the $649 maximum, so the max does not bind at this test household's income. $64.90 would only apply to a childless filer already at or above the max (earnings ≳ $8,484). The test uses the model-computed $61.20, which equals the value the existing (already-passing) 2026 childless test produces for the identical household — a consistency check, since the federal EITC computation is the same in both years for this case.

With-children cases are unchanged ($432.80 → $433 for TY2025; $442.70 for TY2026), as #8875 already routed them to the current-year federal EITC. Their test comments are corrected to cite Section A (all filers) rather than Section B.

## Dead-code check

The frozen-snapshot code path is **not** dead after this change:
- `in_eitc_eligible.py` still computes its own frozen-snapshot `frozen_federal_eitc` for the Indiana EITC *eligibility* test (`frozen_federal_eitc > 0`) — a separate, uniform (no child-count split) computation that this PR leaves untouched.
- The shared helpers `calculate_eitc_demographic_eligibility` and `calculate_eitc_like_amount` remain in active use by CO, DC, IL, and WA credits.
- The `static_conformity_in_effect` gate itself is retained in `in_eitc.py` — it still distinguishes the 2023+ static-conformity regime from the pre-2011 (`not decoupled`) and 2011–2022 (fully-decoupled parameter) branches. Only the frozen *amount recomputation* inside the branch was removed; the unused `state_eitc_helpers` import was dropped accordingly.

## Tests

- Updated `in_eitc.yaml`: childless 2025 → $61.20 (was $60); comments corrected to Section A across all four TY2025/TY2026 cases.
- `changelog.d/in-eitc-childless-current.fixed.md` added.
- **Full Indiana directory: 438 passed** (`policyengine_us/tests/policy/baseline/gov/states/in/`), including `in_eitc.yaml` (7) and `in_eitc_eligible.yaml` (8).
- Regression check on states sharing `state_eitc_helpers.py` — **CO / DC / IL / WA: 81 passed**.
- `ruff format --check` and `ruff check` clean on the edited variable; package smoke-imports.

References: 2025 Schedule IN-EIC (State Form 49469); DOR Information Bulletin #92; IC 6-3-1-11; IC 6-3.1-21; Indiana SEA 243 (2025).

Fixes #8898

🤖 Generated with [Claude Code](https://claude.com/claude-code)
