### PR TITLE
Fix Saver's Credit AGI thresholds for 2024-2026

### DIFF
--- a/changelog.d/savers-credit-thresholds.fixed.md
+++ b/changelog.d/savers-credit-thresholds.fixed.md
@@ -1,0 +1,1 @@
+- Added Saver's Credit joint AGI rate thresholds for 2024, 2025, and 2026 from IRS Notices 2023-75, 2024-80, and 2025-67.

--- a/policyengine_us/parameters/gov/irs/credits/retirement_saving/rate/joint.yaml
+++ b/policyengine_us/parameters/gov/irs/credits/retirement_saving/rate/joint.yaml
@@ -2,10 +2,10 @@ description: IRS multiplies the qualified contributions by the following rate fo
 metadata:
   type: single_amount
   threshold_unit: currency-USD
-  ramount_unit: /1
+  amount_unit: /1
   period: year
   label: Saver's Credit joint rate
-  reference: 
+  reference:
     - title: 26 U.S. Code § 25B(b)(1)
       href: https://www.law.cornell.edu/uscode/text/26/25B#b
     - title: IRS | Retirement Savings Contributions Credit (Saver's Credit)
@@ -14,6 +14,12 @@ metadata:
       href: https://www.irs.gov/pub/irs-pdf/f8880.pdf#page=1
     - title: 2018 Form 8880
       href: https://www.irs.gov/pub/irs-prior/f8880--2018.pdf#page=1
+    - title: IRS Notice 2023-75, 2024 Amounts Relating to Retirement Plans and IRAs (25B(b)(1)(A)-(D) joint amounts $46,000/$50,000/$76,500)
+      href: https://www.irs.gov/pub/irs-drop/n-23-75.pdf#page=3
+    - title: IRS Notice 2024-80, 2025 Amounts Relating to Retirement Plans and IRAs (25B(b)(1)(A)-(D) joint amounts $47,500/$51,000/$79,000)
+      href: https://www.irs.gov/pub/irs-drop/n-24-80.pdf#page=3
+    - title: IRS Notice 2025-67, 2026 Amounts Relating to Retirement Plans and IRAs (25B(b)(1)(A)-(D) joint amounts $48,500/$52,500/$80,500)
+      href: https://www.irs.gov/pub/irs-drop/n-25-67.pdf#page=3
 
 brackets:
   - threshold:
@@ -28,11 +34,9 @@ brackets:
         2021-01-01: 39_500
         2022-01-01: 41_000
         2023-01-01: 43_500
-      uprating:
-        parameter: gov.irs.uprating
-        rounding:
-          type: nearest
-          interval: 500
+        2024-01-01: 46_000
+        2025-01-01: 47_500
+        2026-01-01: 48_500
     amount:
       2018-01-01: 0.2
   - threshold:
@@ -43,11 +47,9 @@ brackets:
         2021-01-01: 43_000
         2022-01-01: 44_000
         2023-01-01: 47_500
-      uprating:
-        parameter: gov.irs.uprating
-        rounding:
-          type: nearest
-          interval: 500
+        2024-01-01: 50_000
+        2025-01-01: 51_000
+        2026-01-01: 52_500
     amount:
       2018-01-01: 0.1
   - threshold:
@@ -58,10 +60,8 @@ brackets:
         2021-01-01: 66_000
         2022-01-01: 68_000
         2023-01-01: 73_000
-      uprating:
-        parameter: gov.irs.uprating
-        rounding:
-          type: nearest
-          interval: 500
+        2024-01-01: 76_500
+        2025-01-01: 79_000
+        2026-01-01: 80_500
     amount:
       2018-01-01: 0

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/retirement_saving/savers_credit_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/retirement_saving/savers_credit_person.yaml
@@ -133,3 +133,127 @@
         adjusted_gross_income: 39_000
   output:
     savers_credit_person: [0, 0]
+
+- name: Case 1, 2024 joint filer just below the 50%-to-20% rate bracket boundary.
+  # 2024 joint 50%/20% boundary is $46,000 (IRS Notice 2023-75).
+  # AGI of $45,999 is below the threshold, so the 50% rate applies.
+  # Credit: 0.5 * $2,000 = $1,000.
+  period: 2024
+  input:
+    people:
+      person1:
+        savers_credit_eligible_person: true
+        traditional_ira_contributions_desired: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: JOINT
+        adjusted_gross_income: 45_999
+  output:
+    savers_credit_person: [1_000]
+
+- name: Case 2, 2024 joint filer exactly at the 50%-to-20% rate bracket boundary.
+  # 2024 joint 50%/20% boundary is $46,000 (IRS Notice 2023-75).
+  # AGI of $46,000 is at-or-above the threshold, so the 20% rate applies.
+  # Credit: 0.2 * $2,000 = $400.
+  period: 2024
+  input:
+    people:
+      person1:
+        savers_credit_eligible_person: true
+        traditional_ira_contributions_desired: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: JOINT
+        adjusted_gross_income: 46_000
+  output:
+    savers_credit_person: [400]
+
+- name: Case 3, 2025 joint filer just below the 20%-to-10% rate bracket boundary.
+  # 2025 joint 20%/10% boundary is $51,000 (IRS Notice 2024-80).
+  # AGI of $50,999 is below the threshold, so the 20% rate applies.
+  # Credit: 0.2 * $2,000 = $400.
+  period: 2025
+  input:
+    people:
+      person1:
+        savers_credit_eligible_person: true
+        traditional_ira_contributions_desired: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: JOINT
+        adjusted_gross_income: 50_999
+  output:
+    savers_credit_person: [400]
+
+- name: Case 4, 2025 joint filer exactly at the 20%-to-10% rate bracket boundary.
+  # 2025 joint 20%/10% boundary is $51,000 (IRS Notice 2024-80).
+  # AGI of $51,000 is at-or-above the threshold, so the 10% rate applies.
+  # Credit: 0.1 * $2,000 = $200.
+  period: 2025
+  input:
+    people:
+      person1:
+        savers_credit_eligible_person: true
+        traditional_ira_contributions_desired: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: JOINT
+        adjusted_gross_income: 51_000
+  output:
+    savers_credit_person: [200]
+
+- name: Case 5, 2025 head of household filer at the credit phase-out limit.
+  # 2025 HoH full phase-out limit is $59,250 (0.75 x joint $79,000, IRS Notice 2024-80).
+  # AGI at-or-above this threshold receives a 0% rate (no credit).
+  period: 2025
+  input:
+    people:
+      person1:
+        savers_credit_eligible_person: true
+        traditional_ira_contributions_desired: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: HEAD_OF_HOUSEHOLD
+        adjusted_gross_income: 59_250
+  output:
+    savers_credit_person: [0]
+
+- name: Case 6, 2026 joint filer just below the 10%-to-0% phase-out boundary.
+  # 2026 joint full phase-out limit is $80,500 (IRS Notice 2025-67).
+  # AGI of $80,499 is below the threshold, so the 10% rate still applies.
+  # Credit: 0.1 * $2,000 = $200.
+  period: 2026
+  input:
+    people:
+      person1:
+        savers_credit_eligible_person: true
+        traditional_ira_contributions_desired: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: JOINT
+        adjusted_gross_income: 80_499
+  output:
+    savers_credit_person: [200]
+
+- name: Case 7, 2026 joint filer at the full phase-out limit.
+  # 2026 joint full phase-out limit is $80,500 (IRS Notice 2025-67).
+  # AGI at-or-above this threshold receives a 0% rate (no credit).
+  period: 2026
+  input:
+    people:
+      person1:
+        savers_credit_eligible_person: true
+        traditional_ira_contributions_desired: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: JOINT
+        adjusted_gross_income: 80_500
+  output:
+    savers_credit_person: [0]


### PR DESCRIPTION
Fixes #8889

## Problem

The joint AGI rate thresholds for the Retirement Savings Contributions Credit (Saver's Credit, IRC §25B / Form 8880) in `gov/irs/credits/retirement_saving/rate/joint.yaml` had explicit entries only through `2023-01-01`. The brackets carried a `uprating: gov.irs.uprating` clause with `rounding` to the nearest 500, but `gov.irs.uprating` is a flat index (value `1` from 2010 on), so it produces **no growth**. As a result, 2024, 2025, and 2026 all resolved to the 2023 thresholds (43,500 / 47,500 / 73,000). CPI uprating would not reproduce the published figures anyway, because the IRS publishes rounded statutory amounts.

## Fix

Added explicit joint §25B(b)(1)(A)/(B)/(C)-(D) thresholds for 2024-2026 and removed the (non-functional) uprating/rounding clause from each bracket.

### Verified values and sources

The Saver's Credit AGI thresholds are **not** in the Rev. Proc. inflation-adjustment series (Rev. Proc. 2023-34 / 2024-40 / 2025-32) — I confirmed §25B is absent from the Rev. Proc. 2023-34 table of contents. They are published in the separate annual IRS **Notice** on retirement-plan dollar limits. I extracted the exact figures from each Notice PDF (via `pdftotext`), and each Notice restates the prior year's value as its "increased from" baseline, giving an internal cross-check across all three documents.

| Tax year | §25B(b)(1)(A) — 50%→20% | §25B(b)(1)(B) — 20%→10% | §25B(b)(1)(C)-(D) — phase-out | Source (joint figures on p. 3) |
|---|---|---|---|---|
| 2024 | 46,000 | 50,000 | 76,500 | [IRS Notice 2023-75](https://www.irs.gov/pub/irs-drop/n-23-75.pdf#page=3) |
| 2025 | 47,500 | 51,000 | 79,000 | [IRS Notice 2024-80](https://www.irs.gov/pub/irs-drop/n-24-80.pdf#page=3) |
| 2026 | 48,500 | 52,500 | 80,500 | [IRS Notice 2025-67](https://www.irs.gov/pub/irs-drop/n-25-67.pdf#page=3) |

All three years — including 2026 — are verified from the authoritative IRS Notice PDFs. (The issue's cited "Rev. Proc. 2023-34 §2.19 / Rev. Proc. 2024-40" are the correct *year* but the wrong *document type*; the actual §25B source is the retirement-plan-limits Notice.)

### Single / head-of-household check

The formula divides AGI by `rate.threshold_adjustment[filing_status]` (single = 0.5, HoH = 0.75) before applying the joint brackets, so `threshold_adjustment.yaml` needs no change — but I verified it reproduces the published single/HoH values exactly once the joint thresholds are corrected:

| Year | Filing status | Derived (joint × adj.) | Published (IRS Notice) | Match |
|---|---|---|---|---|
| 2024 | HoH (×0.75) | 34,500 / 37,500 / 57,375 | 34,500 / 37,500 / 57,375 | ✅ |
| 2024 | Single/Other (×0.5) | 23,000 / 25,000 / 38,250 | 23,000 / 25,000 / 38,250 | ✅ |
| 2025 | HoH | 35,625 / 38,250 / 59,250 | 35,625 / 38,250 / 59,250 | ✅ |
| 2025 | Single/Other | 23,750 / 25,500 / 39,500 | 23,750 / 25,500 / 39,500 | ✅ |
| 2026 | HoH | 36,375 / 39,375 / 60,375 | 36,375 / 39,375 / 60,375 | ✅ |
| 2026 | Single/Other | 24,250 / 26,250 / 40,250 | 24,250 / 26,250 / 40,250 | ✅ |

## Tests

Added 7 cases to `savers_credit_person.yaml` exercising bracket boundaries (a $2,000 contributor just below vs. exactly at each threshold, receiving different credit rates):

- **Cases 1-2 (2024):** joint AGI 45,999 → 50% ($1,000) vs. 46,000 → 20% ($400)
- **Cases 3-4 (2025):** joint AGI 50,999 → 20% ($400) vs. 51,000 → 10% ($200)
- **Case 5 (2025):** HoH AGI 59,250 → 0% (at phase-out limit)
- **Cases 6-7 (2026):** joint AGI 80,499 → 10% ($200) vs. 80,500 → 0% (at phase-out limit)

`single_amount` brackets use at-or-above semantics, matching the statutory rule that reaching the limit drops you to the next (lower) tier.

Full `retirement_saving` policy test directory (19 tests) and the `retirement_savings` variables tests (2 tests) pass.

Also fixed a metadata typo in `joint.yaml`: `ramount_unit` → `amount_unit`.
