### PR TITLE
Backfill state_code enum from state_code_str input

### DIFF
--- a/changelog.d/state-code-str-backfill.fixed.md
+++ b/changelog.d/state-code-str-backfill.fixed.md
@@ -1,0 +1,1 @@
+Backfilled the `state_code` enum from a `state_code_str`-only household input so every state-dependent variable resolves the intended state instead of the California default.

--- a/policyengine_us/system.py
+++ b/policyengine_us/system.py
@@ -12,6 +12,9 @@ from policyengine_core.simulations import (
 from policyengine_us.variables.household.demographic.geographic.state.in_state import (
     create_50_state_variables,
 )
+from policyengine_us.variables.household.demographic.geographic.state_code import (
+    StateCode,
+)
 from policyengine_us.tools.parameters import backdate_parameters
 from policyengine_us.reforms import create_structural_reforms_from_parameters
 from policyengine_core.parameters.operations.homogenize_parameters import (
@@ -118,6 +121,35 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
 system = CountryTaxBenefitSystem()
 
 
+def _backfill_state_code_from_str(simulation):
+    """Backfill the ``state_code`` enum from a ``state_code_str`` input.
+
+    The geography variables derive one-directionally
+    (``state_fips`` -> ``state_name`` -> ``state_code`` -> ``state_code_str``),
+    so a situation that sets only ``state_code_str`` feeds no upstream reader:
+    every variable that reads the ``state_code`` enum silently falls back to
+    its default (``StateCode.CA``) while ``state_code_str`` readers see the
+    intended state (PolicyEngine/policyengine-us#8887).
+
+    Mirror the ``employment_income`` -> ``employment_income_before_lsr`` moves
+    above: when ``state_code`` has no known periods but ``state_code_str``
+    does, encode the strings into ``state_code`` and drop the
+    ``state_code_str`` arrays so derivation is canonical (``state_code_str``
+    re-derives from ``state_code``). An explicitly set ``state_code`` always
+    wins, and datasets are unaffected because they carry ``state_fips`` rather
+    than ``state_code_str``.
+    """
+    state_code = simulation.get_holder("state_code")
+    if state_code.get_known_periods():
+        # An explicit state_code (e.g. from a dataset or situation) wins.
+        return
+    state_code_str = simulation.get_holder("state_code_str")
+    for known_period in state_code_str.get_known_periods():
+        array = state_code_str.get_array(known_period)
+        simulation.set_input("state_code", known_period, StateCode.encode(array))
+        state_code_str.delete_arrays(known_period)
+
+
 class Simulation(CoreSimulation):
     """
     A simulation of the tax-benefit system for the United States,
@@ -189,6 +221,9 @@ class Simulation(CoreSimulation):
                 "long_term_capital_gains_before_response", known_period, array
             )
             cg_holder.delete_arrays(known_period)
+
+        # Geography backfill: state_code_str-only input -> state_code enum.
+        _backfill_state_code_from_str(self)
 
 
 def _resolve_dataset_path(dataset_str):
@@ -358,6 +393,11 @@ class Microsimulation(CoreMicrosimulation):
                 "long_term_capital_gains_before_response", known_period, array
             )
             cg_holder.delete_arrays(known_period)
+
+        # Geography backfill: state_code_str-only input -> state_code enum.
+        # Datasets carry state_fips, so this only fires for situations that
+        # explicitly supply state_code_str.
+        _backfill_state_code_from_str(self)
 
         self.input_variables = [
             variable

--- a/policyengine_us/tests/core/test_state_code_str_backfill.py
+++ b/policyengine_us/tests/core/test_state_code_str_backfill.py
@@ -1,0 +1,156 @@
+"""A situation that sets only ``state_code_str`` must resolve the ``state_code`` enum.
+
+The geography variables derive one-directionally
+(``state_fips`` -> ``state_name`` -> ``state_code`` -> ``state_code_str``), so a
+situation that supplies only ``state_code_str`` used to feed no upstream reader:
+every variable reading the ``state_code`` enum silently fell back to the default,
+``StateCode.CA``, while ``state_code_str`` readers saw the intended state
+(PolicyEngine/policyengine-us#8887).
+
+The ``Simulation``/``Microsimulation`` wrappers now backfill ``state_code`` from
+``state_code_str``, mirroring the ``employment_income`` ->
+``employment_income_before_lsr`` moves. These tests exercise the Python wrapper
+directly because the YAML runner builds simulations without the wrapper and so
+cannot cover the backfill.
+"""
+
+import numpy as np
+import pandas as pd
+
+from policyengine_us import Microsimulation, Simulation
+from policyengine_us.data.dataset_schema import USSingleYearDataset
+
+YEAR = 2026
+
+
+def _single_person_situation(geo_key: str | None = None, geo_value: str = "KS") -> dict:
+    household = {"members": ["person"]}
+    if geo_key is not None:
+        household[geo_key] = {str(YEAR): geo_value}
+    return {
+        "people": {
+            "person": {
+                "age": {str(YEAR): 30},
+                "employment_income": {str(YEAR): 20_000},
+            }
+        },
+        "spm_units": {"spm_unit": {"members": ["person"]}},
+        "tax_units": {"tax_unit": {"members": ["person"]}},
+        "households": {"household": household},
+    }
+
+
+def test_state_code_str_only_resolves_state_code_enum():
+    """state_code_str-only input must set the enum, not leave the CA default."""
+    simulation = Simulation(situation=_single_person_situation("state_code_str", "KS"))
+
+    assert simulation.calculate("state_code", YEAR).decode_to_str()[0] == "KS"
+    assert simulation.calculate("state_code_str", YEAR)[0] == "KS"
+
+
+def test_state_code_str_only_matches_state_code_enum_input():
+    """The SUA/utility chain (a state_code-enum reader) must see the same state.
+
+    ``snap_utility_region`` reads the ``state_code`` enum, so before the fix a
+    ``state_code_str: KS`` household evaluated it under California's region.
+    """
+    via_str = Simulation(situation=_single_person_situation("state_code_str", "KS"))
+    via_enum = Simulation(situation=_single_person_situation("state_code", "KS"))
+
+    assert (
+        via_str.calculate("snap_utility_region", YEAR)[0]
+        == via_enum.calculate("snap_utility_region", YEAR)[0]
+    )
+
+
+def test_state_code_str_only_yields_that_states_income_tax_not_california():
+    """A NY household sent via state_code_str owes NY tax, not California's."""
+    ny_via_str = Simulation(
+        situation=_single_person_situation("state_code_str", "NY")
+    ).calculate("state_income_tax", YEAR)[0]
+    ny_via_enum = Simulation(
+        situation=_single_person_situation("state_code", "NY")
+    ).calculate("state_income_tax", YEAR)[0]
+    ca_via_enum = Simulation(
+        situation=_single_person_situation("state_code", "CA")
+    ).calculate("state_income_tax", YEAR)[0]
+
+    # The string path now equals the enum path for the same state...
+    assert ny_via_str == ny_via_enum
+    # ...and is not the California default that the bug produced.
+    assert ny_via_str != ca_via_enum
+
+
+def test_no_geography_situation_defaults_to_california():
+    """A situation with no geography input must keep the CA default."""
+    simulation = Simulation(situation=_single_person_situation(geo_key=None))
+
+    assert simulation.calculate("state_code", YEAR).decode_to_str()[0] == "CA"
+
+
+def test_explicit_state_code_wins_over_state_code_str():
+    """An explicitly set state_code enum is never overwritten by the backfill."""
+    situation = _single_person_situation("state_code", "NY")
+    situation["households"]["household"]["state_code_str"] = {str(YEAR): "KS"}
+
+    simulation = Simulation(situation=situation)
+
+    assert simulation.calculate("state_code", YEAR).decode_to_str()[0] == "NY"
+
+
+def test_state_code_str_backfill_propagates_across_periods():
+    """Like the income backfill, the geography backfill covers every set period."""
+    situation = _single_person_situation("state_code_str", "NY")
+    # Add a second period of geography (and the inputs it needs).
+    situation["people"]["person"]["age"]["2025"] = 29
+    situation["people"]["person"]["employment_income"]["2025"] = 18_000
+    situation["households"]["household"]["state_code_str"]["2025"] = "NY"
+
+    simulation = Simulation(situation=situation)
+
+    assert simulation.calculate("state_code", 2025).decode_to_str()[0] == "NY"
+    assert simulation.calculate("state_code", 2026).decode_to_str()[0] == "NY"
+
+
+def _state_fips_dataset(state_fips: list[int]) -> USSingleYearDataset:
+    n = len(state_fips)
+    ids = np.arange(1, n + 1)
+    person = pd.DataFrame(
+        {
+            "person_id": ids,
+            "person_household_id": ids,
+            "person_tax_unit_id": ids,
+            "person_spm_unit_id": ids,
+            "person_family_id": ids,
+            "person_marital_unit_id": ids,
+            "age": np.full(n, 40.0),
+            "employment_income": np.full(n, 50_000.0),
+        }
+    )
+    household = pd.DataFrame(
+        {
+            "household_id": ids,
+            "state_fips": np.asarray(state_fips, dtype="int64"),
+            "household_weight": np.full(n, 1.0),
+        }
+    )
+    return USSingleYearDataset(
+        person=person,
+        household=household,
+        tax_unit=pd.DataFrame({"tax_unit_id": ids}),
+        spm_unit=pd.DataFrame({"spm_unit_id": ids}),
+        family=pd.DataFrame({"family_id": ids}),
+        marital_unit=pd.DataFrame({"marital_unit_id": ids}),
+        time_period=2024,
+    )
+
+
+def test_microsimulation_state_fips_dataset_unaffected_by_backfill():
+    """Datasets carry state_fips, so the backfill is a no-op for them.
+
+    The chain state_fips -> state_name -> state_code -> state_code_str must still
+    resolve per household (36 -> NY, 6 -> CA), not collapse to a single state.
+    """
+    simulation = Microsimulation(dataset=_state_fips_dataset([36, 6]))
+
+    assert list(simulation.calculate("state_code_str", 2024)) == ["NY", "CA"]


### PR DESCRIPTION
Fixes #8887.

## Problem

A household situation that sets only `state_code_str` fed no upstream reader of the `state_code` enum. Because the geography variables derive one-directionally (`state_fips` → `state_name` → `state_code` → `state_code_str`), every variable that reads the `state_code` enum silently fell back to its default, `StateCode.CA`, while `state_code_str` readers saw the intended state — so the same household was evaluated as two states at once (state-correct Medicaid next to California-flavored SNAP/CHIP).

This affects the Python/API path, not just the YAML runner: `Simulation` already backfills the five `*_before_lsr`/`_before_response` income inputs, but did nothing for geography.

## Fix

In `policyengine_us/system.py`, a shared helper `_backfill_state_code_from_str` mirrors the existing `employment_income` → `employment_income_before_lsr` move and runs at the end of both `Simulation.__init__` and `Microsimulation.__init__`: when `state_code` has no known periods but `state_code_str` does, it encodes the strings into `state_code` via `StateCode.encode` + `set_input`, then deletes the `state_code_str` arrays so derivation stays canonical (`state_code_str` re-derives from `state_code`).

Safety:
- **An explicitly set `state_code` always wins** — the helper returns early if the `state_code` holder already has known periods.
- **Microsimulation datasets are unaffected** — they carry `state_fips` (integer column), from which the whole chain derives; nothing in the codebase sets `state_code_str` as an input (verified by grep: every occurrence is a formula *reading* it), so the backfill can only fire for user-supplied situations.
- **Propagates across periods** like the income backfill (loops over all known periods).

## Reproduction (sending `KS`)

Before — `state_code_str` input is evaluated under the CA default:

| Input sent | `state_code` | `state_code_str` | `snap_utility_region` |
|---|---|---|---|
| `state_code: KS` | KS | KS | 20 (KS) ✓ |
| `state_code_str: KS` | **CA** | KS | **9 (CA)** ✗ |
| `state_name: KS` | KS | KS | 20 (KS) ✓ |

After — all three inputs agree:

| Input sent | `state_code` | `state_code_str` | `snap_utility_region` |
|---|---|---|---|
| `state_code: KS` | KS | KS | 20 (KS) ✓ |
| `state_code_str: KS` | **KS** | KS | **20 (KS)** ✓ |
| `state_name: KS` | KS | KS | 20 (KS) ✓ |

State income tax at $60k single (the visible symptom): `state_code_str: NY` now yields **$2,643** (matching `state_code: NY`), no longer California's **$1,602.86**. `state_code_str: TX` yields **$0** (no state income tax). A no-geography situation still defaults to CA (`snap_utility_region = 9`).

## Tests

New Python tests in `policyengine_us/tests/core/test_state_code_str_backfill.py` (the YAML runner builds simulations without this wrapper, so it cannot exercise the backfill):

- `state_code_str`-only input resolves the `state_code` enum
- `state_code_str`-only matches the `state_code`-enum input for a `state_code`-enum reader (`snap_utility_region`)
- `state_code_str`-only yields that state's income tax, not California's (NY = enum path ≠ CA)
- no-geography situation still defaults to California
- explicit `state_code` wins over `state_code_str`
- the backfill propagates across periods
- a `state_fips` `Microsimulation` dataset is unaffected (`['NY', 'CA']`)

Test runs (fresh venv, Python 3.14):

```
policyengine_us/tests/core/ ................................ 253 passed
  (includes the 7 new tests + test_county_fips_fallback + all state/plumbing tests)
policyengine_us/tests/microsimulation/test_county_from_dataset.py ... 3 passed
NY YAML: gov/states/ny/tax/income/ny_income_tax.yaml ......... 3 passed
TX YAML: gov/states/tx/ ..................................... 390 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
