### PR TITLE
Count disabled adult dependents in state EITC qualifying-child rebuilds

### DIFF
--- a/changelog.d/state-eitc-disabled-exception.fixed.md
+++ b/changelog.d/state-eitc-disabled-exception.fixed.md
@@ -1,0 +1,1 @@
+Counted permanently and totally disabled adult dependents as qualifying children in the California, DC, Illinois, Colorado, Washington, and Minnesota EITC-style credits that rebuild the qualifying-child count directly.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_is_qualifying_child_for_caleitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/tax/income/credits/earned_income/ca_is_qualifying_child_for_caleitc.yaml
@@ -1,0 +1,63 @@
+# CalEITC follows the federal EITC qualifying-child rules (RTC 17052).
+# IRC 152(c)(3)(B) waives the age test for permanently and totally disabled
+# dependents, so such a dependent is a CalEITC qualifying child at any age.
+
+- name: Child under the age test is a CalEITC qualifying child.
+  period: 2026
+  input:
+    people:
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+    households:
+      household:
+        members: [child]
+        state_code: CA
+  output:
+    ca_is_qualifying_child_for_caleitc: true
+
+- name: Disabled adult dependent is a CalEITC qualifying child.
+  period: 2026
+  input:
+    people:
+      disabled_adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_permanently_and_totally_disabled: true
+        has_tin: true
+    households:
+      household:
+        members: [disabled_adult]
+        state_code: CA
+  output:
+    ca_is_qualifying_child_for_caleitc: true
+
+- name: Non-disabled adult dependent over the age test is not a CalEITC qualifying child.
+  period: 2026
+  input:
+    people:
+      adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_permanently_and_totally_disabled: false
+    households:
+      household:
+        members: [adult]
+        state_code: CA
+  output:
+    ca_is_qualifying_child_for_caleitc: false
+
+- name: Disabled non-dependent adult is not a CalEITC qualifying child.
+  period: 2026
+  input:
+    people:
+      disabled_nondependent:
+        age: 29
+        is_tax_unit_dependent: false
+        is_permanently_and_totally_disabled: true
+    households:
+      household:
+        members: [disabled_nondependent]
+        state_code: CA
+  output:
+    ca_is_qualifying_child_for_caleitc: false

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/eitc/co_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/eitc/co_eitc.yaml
@@ -327,3 +327,37 @@
         state_code: CO
   output:
     co_eitc: 324.5
+
+- name: Colorado EITC counts a disabled adult dependent as a qualifying child (IRC 152(c)(3)(B))
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 45
+        employment_income: 10_000
+        is_tax_unit_head: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+      disabled_adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_permanently_and_totally_disabled: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, disabled_adult]
+        filing_status: HEAD_OF_HOUSEHOLD
+    spm_units:
+      spm_unit:
+        members: [head, disabled_adult]
+    households:
+      household:
+        members: [head, disabled_adult]
+        state_code: CO
+  output:
+    # The permanently and totally disabled adult dependent is a qualifying
+    # child under IRC 152(c)(3)(B), so the CO EITC pays its match on the
+    # 1-child federal-style EITC rather than the childless amount.
+    co_eitc: 1_700

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_eitc_with_qualifying_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_eitc_with_qualifying_child.yaml
@@ -56,3 +56,39 @@
         state_code: DC
   output:
     dc_eitc_with_qualifying_child: 3_400
+
+- name: DC EITC with qualifying child counts a disabled adult dependent (IRC 152(c)(3)(B))
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 45
+        employment_income: 10_000
+        is_tax_unit_head: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+      disabled_adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_permanently_and_totally_disabled: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, disabled_adult]
+        filing_status: HEAD_OF_HOUSEHOLD
+    spm_units:
+      spm_unit:
+        members: [head, disabled_adult]
+    households:
+      household:
+        members: [head, disabled_adult]
+        state_code: DC
+  output:
+    # The permanently and totally disabled adult dependent is a qualifying
+    # child under IRC 152(c)(3)(B), so the DC EITC uses the with-children
+    # match ($3,400 = 100% of the 1-child federal-like EITC at $10k earnings)
+    # and the childless schedule returns zero.
+    dc_eitc_with_qualifying_child: 3_400
+    dc_eitc_without_qualifying_child: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_eitc.yaml
@@ -140,3 +140,37 @@
   output:
     # Below the IL childless minimum age of 18; not eligible.
     il_eitc: 0
+
+- name: Illinois EITC counts a disabled adult dependent as a qualifying child (IRC 152(c)(3)(B))
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 45
+        employment_income: 10_000
+        is_tax_unit_head: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+      disabled_adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_permanently_and_totally_disabled: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, disabled_adult]
+        filing_status: HEAD_OF_HOUSEHOLD
+    spm_units:
+      spm_unit:
+        members: [head, disabled_adult]
+    households:
+      household:
+        members: [head, disabled_adult]
+        state_code: IL
+  output:
+    # The permanently and totally disabled adult dependent is a qualifying
+    # child under IRC 152(c)(3)(B), so the IL EIC reflects the 1-child federal
+    # EITC (rather than the childless schedule) times the IL match.
+    il_eitc: 680

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
@@ -422,3 +422,69 @@
         state_code: MN
   output:
     mn_child_and_working_families_credits: 1_163.2
+
+- name: MN qualifying older child bonus counts a disabled adult dependent (M1DQC step 4 / IRC 152(c)(3)(B))
+  # Schedule M1DQC steps 3-4: a dependent who is permanently and totally
+  # disabled and aged 18 or older is checked as a qualifying older child
+  # (row 11) without the full-time-student test that non-disabled 18+ children
+  # must meet. This adds the 1-qualifying-older-child WFC bonus ($1,000 in 2025).
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 45
+        is_full_time_student: false
+      disabled_adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_full_time_student: false
+        is_permanently_and_totally_disabled: true
+    tax_units:
+      tax_unit:
+        members: [person1, disabled_adult]
+        ctc_qualifying_children: 0
+        mn_wfc_eligible: true
+        filer_adjusted_earnings: 10_000
+        adjusted_gross_income: 10_000
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, disabled_adult]
+        state_code: MN
+  output:
+    # WFC base: min($10,000, $9,480) * 0.04 = $379.20
+    # Qualifying older child bonus (1 child): $1,000
+    # No CTC (the disabled adult is over the CTC age limit), no phase-out
+    # below the $37,910 joint threshold: $379.20 + $1,000 = $1,379.20.
+    mn_child_and_working_families_credits: 1_379.2
+
+- name: MN qualifying older child bonus excludes a non-disabled 18+ dependent who is not a full-time student
+  # The same 29-year-old dependent without the disability flag and not a
+  # full-time student is not a qualifying older child (M1DQC step 6-8), so
+  # only the WFC base applies with no bonus.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 45
+        is_full_time_student: false
+      adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_full_time_student: false
+        is_permanently_and_totally_disabled: false
+    tax_units:
+      tax_unit:
+        members: [person1, adult]
+        ctc_qualifying_children: 0
+        mn_wfc_eligible: true
+        filer_adjusted_earnings: 10_000
+        adjusted_gross_income: 10_000
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, adult]
+        state_code: MN
+  output:
+    # WFC base only: min($10,000, $9,480) * 0.04 = $379.20, no older-child bonus.
+    mn_child_and_working_families_credits: 379.2

--- a/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.yaml
@@ -622,3 +622,39 @@
     # at $3,816; ESSB 6346 multiplies it by 12 for tax years 2029 onward.
     wa_working_families_tax_credit_maximum_qualifying_income: 45_792
     wa_working_families_tax_credit: 277.02
+
+- name: WA WFTC counts a disabled adult dependent as a qualifying child (IRC 152(c)(3)(B) via frozen 2022 EITC)
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 45
+        employment_income: 10_000
+        is_tax_unit_head: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+      disabled_adult:
+        age: 29
+        is_tax_unit_dependent: true
+        is_permanently_and_totally_disabled: true
+        has_tin: true
+        ssn_card_type: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, disabled_adult]
+        filing_status: HEAD_OF_HOUSEHOLD
+        would_file_taxes_voluntarily: true
+        takes_up_eitc: true
+    spm_units:
+      spm_unit:
+        members: [head, disabled_adult]
+    households:
+      household:
+        members: [head, disabled_adult]
+        state_code: WA
+  output:
+    # RCW 82.08.0206 pins the WFTC to the federal EITC rules as in effect on
+    # June 9, 2022, which include IRC 152(c)(3)(B). The disabled adult
+    # dependent is a qualifying child, so the WFTC pays the 1-child amount.
+    wa_working_families_tax_credit: 660

--- a/policyengine_us/variables/gov/states/ca/tax/income/credits/earned_income/ca_is_qualifying_child_for_caleitc.py
+++ b/policyengine_us/variables/gov/states/ca/tax/income/credits/earned_income/ca_is_qualifying_child_for_caleitc.py
@@ -6,9 +6,20 @@ class ca_is_qualifying_child_for_caleitc(Variable):
     entity = Person
     label = "Child qualifies for CalEITC"
     definition_period = YEAR
-    reference = "https://www.ftb.ca.gov/file/personal/credits/EITC-calculator/Help/QualifyingChildren"
+    reference = (
+        "https://www.ftb.ca.gov/file/personal/credits/EITC-calculator/Help/QualifyingChildren",
+        # RTC 17052 conforms CalEITC to the IRC 32 qualifying-child definition.
+        "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=RTC&sectionNum=17052",
+        # IRC 152(c)(3)(B) waives the qualifying-child age test for permanently and totally disabled individuals.
+        "https://www.law.cornell.edu/uscode/text/26/152#c_3_B",
+    )
     defined_for = StateCode.CA
 
     def formula(person, period, parameters):
-        # CalEITC uses federal EITC rules regarding qualifying children
-        return person("is_qualifying_child_dependent", period)
+        # CalEITC uses federal EITC rules regarding qualifying children.
+        # IRC 152(c)(3)(B) waives the age test for a permanently and totally
+        # disabled dependent, so such a dependent qualifies at any age.
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
+        )
+        return person("is_qualifying_child_dependent", period) | is_disabled_dependent

--- a/policyengine_us/variables/gov/states/co/tax/income/credits/eitc/co_eitc.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/credits/eitc/co_eitc.py
@@ -10,7 +10,13 @@ class co_eitc(Variable):
     label = "Colorado EITC"
     unit = USD
     definition_period = YEAR
-    reference = "https://leg.colorado.gov/sites/default/files/te19_colorado_earned_income_tax_credit.pdf"
+    reference = (
+        "https://leg.colorado.gov/sites/default/files/te19_colorado_earned_income_tax_credit.pdf",
+        # C.R.S. 39-22-123.5 pays a percentage of the federal IRC 32 credit.
+        "https://leg.colorado.gov/sites/default/files/images/olls/crs2023-title-39.pdf",
+        # IRC 152(c)(3)(B) waives the qualifying-child age test for permanently and totally disabled individuals.
+        "https://www.law.cornell.edu/uscode/text/26/152#c_3_B",
+    )
     defined_for = StateCode.CO
 
     def formula(tax_unit, period, parameters):
@@ -26,9 +32,14 @@ class co_eitc(Variable):
         filer_has_federal_identification = (
             tax_unit.sum(is_head_or_spouse & ~federal_identification) == 0
         )
-        qualifying_child_with_tin = (
-            person("is_qualifying_child_dependent", period) & has_tin
+        # IRC 152(c)(3)(B) waives the age test for a permanently and totally
+        # disabled dependent, matching the federal eitc_child_count.
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
         )
+        qualifying_child_with_tin = (
+            person("is_qualifying_child_dependent", period) | is_disabled_dependent
+        ) & has_tin
         child_count_with_tin = tax_unit.sum(qualifying_child_with_tin)
         federal_eitc_parameters = parameters(period).gov.irs.credits.eitc
         student = person("is_full_time_student", period)

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/eitc/dc_eitc_with_qualifying_child.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/eitc/dc_eitc_with_qualifying_child.py
@@ -11,7 +11,9 @@ class dc_eitc_with_qualifying_child(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.04"  # (f)
+        "https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.04",  # (f)
+        # IRC 152(c)(3)(B) waives the qualifying-child age test for permanently and totally disabled individuals.
+        "https://www.law.cornell.edu/uscode/text/26/152#c_3_B",
     )
     defined_for = StateCode.DC
 
@@ -21,7 +23,14 @@ class dc_eitc_with_qualifying_child(Variable):
         person = tax_unit.members
         has_tin = person("has_tin", period)
         is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
-        qualifying_child = person("is_qualifying_child_dependent", period) & has_tin
+        # IRC 152(c)(3)(B) waives the age test for a permanently and totally
+        # disabled dependent, matching the federal eitc_child_count.
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
+        )
+        qualifying_child = (
+            person("is_qualifying_child_dependent", period) | is_disabled_dependent
+        ) & has_tin
         child_count = tax_unit.sum(qualifying_child)
         filer_has_tin = tax_unit.sum(is_head_or_spouse & ~has_tin) == 0
         federal_like_eitc = calculate_eitc_like_amount(

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/eitc/dc_eitc_without_qualifying_child.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/eitc/dc_eitc_without_qualifying_child.py
@@ -12,7 +12,9 @@ class dc_eitc_without_qualifying_child(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.04"  # (f)
+        "https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.04",  # (f)
+        # IRC 152(c)(3)(B) waives the qualifying-child age test for permanently and totally disabled individuals.
+        "https://www.law.cornell.edu/uscode/text/26/152#c_3_B",
     )
     defined_for = StateCode.DC
 
@@ -27,9 +29,16 @@ class dc_eitc_without_qualifying_child(Variable):
         min_age = parameters.gov.irs.credits.eitc.eligibility.age.min(period)
         max_age = parameters.gov.irs.credits.eitc.eligibility.age.max(period)
         age_eligible = is_head_or_spouse & (age >= min_age) & (age <= max_age)
-        no_qualifying_child = (
-            tax_unit.sum(person("is_qualifying_child_dependent", period) & has_tin) == 0
+        # IRC 152(c)(3)(B) waives the age test for a permanently and totally
+        # disabled dependent, so such a dependent is a qualifying child and
+        # routes the unit to the with-children schedule.
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
         )
+        qualifying_child = (
+            person("is_qualifying_child_dependent", period) | is_disabled_dependent
+        ) & has_tin
+        no_qualifying_child = tax_unit.sum(qualifying_child) == 0
         us_eligible = (
             filer_has_tin
             & no_qualifying_child

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_eitc.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_eitc.py
@@ -10,7 +10,13 @@ class il_eitc(Variable):
     label = "IL EITC"
     unit = USD
     definition_period = YEAR
-    reference = "https://www2.illinois.gov/rev/programs/EIC/Pages/default.aspx"
+    reference = (
+        "https://www2.illinois.gov/rev/programs/EIC/Pages/default.aspx",
+        # 35 ILCS 5/212 bases the IL EIC on the federal IRC 32 credit.
+        "https://www.ilga.gov/legislation/ilcs/fulltext.asp?DocName=003500050K212",
+        # IRC 152(c)(3)(B) waives the qualifying-child age test for permanently and totally disabled individuals.
+        "https://www.law.cornell.edu/uscode/text/26/152#c_3_B",
+    )
     defined_for = StateCode.IL
 
     def formula(tax_unit, period, parameters):
@@ -18,7 +24,14 @@ class il_eitc(Variable):
         age = person("age", period)
         has_tin = person("has_tin", period)
         is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
-        qualifying_child = person("is_qualifying_child_dependent", period) & has_tin
+        # IRC 152(c)(3)(B) waives the age test for a permanently and totally
+        # disabled dependent, matching the federal eitc_child_count.
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
+        )
+        qualifying_child = (
+            person("is_qualifying_child_dependent", period) | is_disabled_dependent
+        ) & has_tin
         child_count = tax_unit.sum(qualifying_child)
         filer_has_tin = tax_unit.sum(is_head_or_spouse & ~has_tin) == 0
         p = parameters(period).gov.states.il.tax.income.credits.eitc

--- a/policyengine_us/variables/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.py
+++ b/policyengine_us/variables/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.py
@@ -33,13 +33,25 @@ class mn_child_and_working_families_credits(Variable):
         earnings = tax_unit("filer_adjusted_earnings", period)
         base_wfc_credit = p.wfc.phase_in.calc(earnings)
         person = tax_unit.members
-        qualifying_child = person("is_qualifying_child_dependent", period)
+        # Minn. Stat. 290.0671, subd. 1a defines a qualifying older child as
+        # an IRC 32(c) qualifying child that attained at least age 18; the
+        # IRC 32(c)(3) definition incorporates IRC 152(c)(3)(B), which waives
+        # the age (and student) test for permanently and totally disabled
+        # individuals. Schedule M1DQC step 4 routes a disabled dependent aged
+        # 18 or older directly to the qualifying-older-child row (row 11)
+        # without the full-time-student test.
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
+        )
+        qualifying_child = (
+            person("is_qualifying_child_dependent", period) | is_disabled_dependent
+        )
         age = person("age", period)
         full_time_student = person("is_full_time_student", period)
         qualifying_older_child = (
             qualifying_child
             & (age > p.wfc.additional.age_threshold)
-            & full_time_student
+            & (full_time_student | is_disabled_dependent)
         )
         qualifying_older_children = tax_unit.sum(qualifying_older_child)
         additional_wfc_credit = p.wfc.additional.amount.calc(qualifying_older_children)

--- a/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.py
+++ b/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit.py
@@ -15,6 +15,10 @@ class wa_working_families_tax_credit(Variable):
     reference = (
         "https://app.leg.wa.gov/RCW/default.aspx?cite=82.08.0206",
         "https://lawfilesext.leg.wa.gov/biennium/2025-26/Pdf/Bills/Senate%20Passed%20Legislature/6346-S.PL.pdf#page=61",
+        # IRC 152(c)(3)(B), included in the federal EITC rules as in effect on
+        # June 9, 2022, waives the qualifying-child age test for permanently
+        # and totally disabled individuals.
+        "https://www.law.cornell.edu/uscode/text/26/152#c_3_B",
     )
     defined_for = StateCode.WA
 
@@ -31,8 +35,15 @@ class wa_working_families_tax_credit(Variable):
         person = tax_unit.members
         has_tin = person("has_tin", period)
         is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        # IRC 152(c)(3)(B) (part of the frozen 2022-06-09 federal EITC rules)
+        # waives the age test for a permanently and totally disabled
+        # dependent, matching the federal eitc_child_count.
+        is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
+            "is_permanently_and_totally_disabled", period
+        )
         child_count = tax_unit.sum(
-            person("is_qualifying_child_dependent", period) & has_tin
+            (person("is_qualifying_child_dependent", period) | is_disabled_dependent)
+            & has_tin
         )
         filer_has_tin = tax_unit.sum(is_head_or_spouse & ~has_tin) == 0
         federal_identification_eligible = tax_unit(

--- a/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit_age_expansion_eligible.py
+++ b/policyengine_us/variables/gov/states/wa/tax/income/credits/wa_working_families_tax_credit_age_expansion_eligible.py
@@ -38,9 +38,12 @@ class wa_working_families_tax_credit_age_expansion_eligible(Variable):
         is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
         has_tin = person("has_tin", period)
         filers_have_tin = tax_unit.sum(is_head_or_spouse & ~has_tin) == 0
-        child_count = tax_unit.sum(
-            person("is_qualifying_child_dependent", period) & has_tin
-        )
+        # ESSB 6346 Sec. 901(2)(a)(ii)(D) is the childless-by-age expansion
+        # path: it covers filers who would qualify for the EITC except for
+        # age. Because it does not depend on qualifying children, no child
+        # count (and therefore no IRC 152(c)(3)(B) disabled-dependent test) is
+        # needed here; the disabled-dependent handling lives in the main
+        # wa_working_families_tax_credit child_count.
         # RCW 82.08.0206(2)(d) pins WFTC to the federal EITC rules as in
         # effect on June 9, 2022; this snapshot date is a statutory literal.
         frozen_eitc = parameters.gov.irs.credits.eitc("2022-06-09")


### PR DESCRIPTION
## Summary

Fixes #8896. PR #8895 added the IRC 152(c)(3)(B) permanently-and-totally-disabled exception to the federal `eitc_child_count`, so disabled adult dependents count as EITC qualifying children. State credits that instead **rebuild** the qualifying-child count directly from `is_qualifying_child_dependent` — to swap the federal SSN requirement for ITIN-inclusive `has_tin` — still applied only the age/student test. This mirrors the #8895 pattern inside each rebuild while keeping each state's TIN handling:

```python
is_disabled_dependent = person("is_tax_unit_dependent", period) & person(
    "is_permanently_and_totally_disabled", period
)
qualifying_child = (
    person("is_qualifying_child_dependent", period) | is_disabled_dependent
) & has_tin
```

`is_permanently_and_totally_disabled` is not populated in the CPS microdata, so this affects household-level (app/API) results, not microsimulation aggregates.

## Per-state changes

| State | File(s) | Legal basis | What changed |
|-------|---------|-------------|--------------|
| CA | `ca_is_qualifying_child_for_caleitc.py` | RTC 17052 → IRC 32/152(c)(3)(B) | Disabled adult dependent now qualifies as a CalEITC qualifying child at any age. (Consumed by `ca_yctc`; `ca_eitc` already routed through the fixed federal `eitc_child_count`.) |
| DC | `dc_eitc_with_qualifying_child.py`, `dc_eitc_without_qualifying_child.py` | D.C. Code 47-1806.04(f) | Disabled adult dependent counts toward the with-children match and routes the unit off the childless schedule. Also fixed both `reference` tuples, which were bare parenthesized strings (trailing `# (f)` comment) rather than tuples. |
| IL | `il_eitc.py` | 35 ILCS 5/212 | Disabled adult dependent counts toward the IL EIC child count. |
| CO | `co_eitc.py` | C.R.S. 39-22-123.5 | Disabled adult dependent counts toward the ITIN-inclusive `child_count_with_tin`. |
| WA | `wa_working_families_tax_credit.py` | RCW 82.08.0206 (federal EITC as of 2022-06-09) | Disabled adult dependent counts toward the state-only/ITIN `child_count`. The frozen 2022 federal law includes 152(c)(3)(B). |
| WA | `wa_working_families_tax_credit_age_expansion_eligible.py` | ESSB 6346 Sec. 901 | Removed the unused `child_count` (dead code on `main`). The childless-by-age expansion path does not depend on qualifying children, so no disabled-dependent test belongs here. |
| MN | `mn_child_and_working_families_credits.py` | Minn. Stat. 290.0671 subd. 1a; Schedule M1DQC | **Verified change (see below):** the qualifying-older-child WFC bonus now includes a permanently and totally disabled dependent aged 18+ without the full-time-student test. |

## MN verification

Verified against the 2023 **Schedule M1DQC** (Dependents and Qualifying Children) and Minn. Stat. 290.0671/290.0661 before changing MN.

- Minn. Stat. 290.0671 subd. 1a defines a qualifying older child as "a qualifying child, as defined in section 32(c) of the Internal Revenue Code, that attained at least the age of 18 in the taxable year." IRC 32(c)(3) incorporates the IRC 152(c) qualifying-child definition, which includes the 152(c)(3)(B) disability waiver of the age test.
- Schedule M1DQC's step table makes this explicit. **Step 3:** "Were they permanently and totally disabled in [year]?" → if yes, check row 9. **Step 4:** "Were they under age 18 at the end of [year]? … If no and you checked the box in row 9, check the box in row 11 [qualifying older child] and stop here." So a disabled dependent aged 18+ is a qualifying older child **without** reaching the full-time-student test (steps 6–8) that non-disabled 18+ children must pass.

The MN CTC (`mn_child_and_working_families_credits_ctc_eligible_child`) is unaffected: Minn. Stat. 290.0661 excludes children who "attained the age of 18 or greater," and M1DQC step 4 stops a disabled 18+ dependent at the older-child row (row 11), not the CTC row (row 10). So the disabled adult does not gain a CTC amount — only the WFC older-child bonus. This matches the code, which leaves the age-limited CTC-eligible-child variable untouched.

MN change encoded as: `qualifying_older_child = qualifying_child & (age > threshold) & (full_time_student | is_disabled_dependent)`, with `qualifying_child` now including the disabled dependent.

## Tests

Added a disabled-adult-dependent case (age 29, `is_tax_unit_dependent: true`, `is_permanently_and_totally_disabled: true`, with TIN) to each changed state, mirroring the federal `eitc_child_count` cases 4–5. Each disabled-dependent credit matches the corresponding existing ITIN-1-child scenario at the same income, confirming the dependent is now counted exactly like a qualifying child:

- CA `ca_is_qualifying_child_for_caleitc.yaml` (new file): qualifying-child flag true for the disabled adult, false for a non-disabled adult dependent and for a disabled non-dependent.
- DC: with-children credit = $3,400, childless credit = $0.
- IL: $680. CO: $1,700. WA: $660 (all equal to their existing ITIN-1-child cases).
- MN: $1,379.20 (WFC base $379.20 + $1,000 older-child bonus); contrast case with a non-disabled non-student 18+ dependent stays at $379.20.

Ran each touched state's credit test directory in full plus the federal regression:

- CA `earned_income` 32, `young_child` 9
- DC EITC 13
- IL `credits` 29
- CO `eitc` 18
- WA `credits` 25
- MN `credits` 65
- federal `eitc_child_count` 5 (no regression)

`ruff format` / `ruff check` clean on all changed `.py` files; `git diff --check` clean.
