### PR TITLE
Add explicit indexed values to NE, ME, RI, NY parameters frozen by misplaced uprating (#8905)

### DIFF
--- a/changelog.d/state-indexed-frozen-parameters.fixed.md
+++ b/changelog.d/state-indexed-frozen-parameters.fixed.md
@@ -1,0 +1,1 @@
+- Added explicit 2026 values to Nebraska, Maine, and Rhode Island income tax parameters, and 2024-2025 values to New York's itemized deduction phase-out threshold, that had been frozen by a misplaced uprating block (#8905).

--- a/policyengine_us/parameters/gov/states/me/tax/income/deductions/personal_exemption/phaseout/start.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/deductions/personal_exemption/phaseout/start.yaml
@@ -18,6 +18,9 @@ metadata:
       href: https://legislature.maine.gov/statutes/36/title36sec5126-A.html
     - title: 2025 Instructions for Form 1040ME - Worksheet for Phaseout of Personal Exemption Deduction Amount, Line 2
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf#page=6
+    # 2026 phase-out thresholds from MRS 2026 Estimated Tax Worksheet, Line 6b (Phaseout of Personal Exemption Deduction Amount Worksheet, rev. Dec. 2025).
+    - title: 2026 Maine Estimated Tax Worksheet, Line 6b - Phaseout of Personal Exemption Deduction Amount Worksheet
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/26_1040es_pers_exempt_phaseout_wksht.pdf
   breakdown:
     - filing_status
 SINGLE:
@@ -27,6 +30,7 @@ SINGLE:
     2023-01-01: 305_150
     2024-01-01: 323_900
     2025-01-01: 333_450
+    2026-01-01: 341_000
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -39,6 +43,7 @@ SEPARATE:
     2023-01-01: 183_050
     2024-01-01: 194_325
     2025-01-01: 200_050
+    2026-01-01: 204_575
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -51,6 +56,7 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 335_650
     2024-01-01: 356_300
     2025-01-01: 366_750
+    2026-01-01: 375_050
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -63,6 +69,7 @@ JOINT:
     2023-01-01: 366_100
     2024-01-01: 388_650
     2025-01-01: 400_100
+    2026-01-01: 409_150
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -75,6 +82,7 @@ SURVIVING_SPOUSE:
     2023-01-01: 366_100
     2024-01-01: 388_650
     2025-01-01: 400_100
+    2026-01-01: 409_150
   uprating:
     parameter: gov.irs.uprating
     rounding:

--- a/policyengine_us/parameters/gov/states/me/tax/income/deductions/phase_out/start.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/deductions/phase_out/start.yaml
@@ -12,6 +12,9 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_1040me_sched_2%20_ff.pdf#page=1
     - title: 2025 Instructions for Form 1040ME - Worksheet for Standard/Itemized Deductions, Line 2
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf#page=5
+    # 2026 phase-out thresholds from MRS 2026 Estimated Tax Worksheet, Line 6a (Phaseout of Itemized/Standard Deductions Worksheet, rev. Dec. 2025).
+    - title: 2026 Maine Estimated Tax Worksheet, Line 6a - Phaseout of Itemized/Standard Deductions Worksheet
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/26_item_stand_%20ded_phaseout_wksht_0.pdf
     - title: Maine form 1040 Schedule 2 (2023)
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_2_ff_0.pdf#page=1
     - title: Maine form 1040 Schedule 2 (2022)
@@ -41,6 +44,7 @@ SINGLE:
     2023-01-01: 91_500
     2024-01-01: 97_150
     2025-01-01: 100_000
+    2026-01-01: 102_250
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -57,6 +61,7 @@ SEPARATE:
     2023-01-01: 91_500
     2024-01-01: 97_150
     2025-01-01: 100_000
+    2026-01-01: 102_250
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -73,6 +78,7 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 137_300
     2024-01-01: 145_750
     2025-01-01: 150_000
+    2026-01-01: 153_400
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -89,6 +95,7 @@ JOINT:
     2023-01-01: 183_050
     2024-01-01: 194_300
     2025-01-01: 200_050
+    2026-01-01: 204_550
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -105,6 +112,7 @@ SURVIVING_SPOUSE:
     2023-01-01: 183_050
     2024-01-01: 194_300
     2025-01-01: 200_050
+    2026-01-01: 204_550
   uprating:
     parameter: gov.irs.uprating
     rounding:

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/head_of_household.yaml
@@ -22,6 +22,8 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf
+    - title: Maine 2026 Individual Income Tax Rate Schedules (Maine Revenue Services, rev. May 5, 2026)
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/2026-05/ind_tax_rate_sched_2026_rev.pdf#page=1
 
 brackets:
   - threshold:
@@ -36,6 +38,7 @@ brackets:
         2023-01-01: 36_750
         2024-01-01: 39_050
         2025-01-01: 40_200
+        2026-01-01: 41_100
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -51,6 +54,7 @@ brackets:
         2023-01-01: 87_100
         2024-01-01: 92_450
         2025-01-01: 95_150
+        2026-01-01: 97_300
       uprating:
         parameter: gov.irs.uprating
         rounding:

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/joint.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/joint.yaml
@@ -22,6 +22,8 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf
+    - title: Maine 2026 Individual Income Tax Rate Schedules (Maine Revenue Services, rev. May 5, 2026)
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/2026-05/ind_tax_rate_sched_2026_rev.pdf#page=1
 brackets:
   - threshold:
       2017-01-01: 0
@@ -35,6 +37,7 @@ brackets:
         2023-01-01: 49_050
         2024-01-01: 52_100
         2025-01-01: 53_600
+        2026-01-01: 54_850
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -50,6 +53,7 @@ brackets:
         2023-01-01: 116_100
         2024-01-01: 123_250
         2025-01-01: 126_900
+        2026-01-01: 129_750
       uprating:
         parameter: gov.irs.uprating
         rounding:

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/separate.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/separate.yaml
@@ -22,6 +22,8 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf
+    - title: Maine 2026 Individual Income Tax Rate Schedules (Maine Revenue Services, rev. May 5, 2026)
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/2026-05/ind_tax_rate_sched_2026_rev.pdf#page=1
 brackets:
   - threshold:
       2017-01-01: 0
@@ -35,6 +37,7 @@ brackets:
         2023-01-01: 24_500
         2024-01-01: 26_050
         2025-01-01: 26_800
+        2026-01-01: 27_400
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -50,6 +53,7 @@ brackets:
         2023-01-01: 58_050
         2024-01-01: 61_600
         2025-01-01: 63_450
+        2026-01-01: 64_850
       uprating:
         parameter: gov.irs.uprating
         rounding:

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/single.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/single.yaml
@@ -22,6 +22,8 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf
+    - title: Maine 2026 Individual Income Tax Rate Schedules (Maine Revenue Services, rev. May 5, 2026)
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/2026-05/ind_tax_rate_sched_2026_rev.pdf#page=1
 brackets:
   - threshold:
       2017-01-01: 0
@@ -35,6 +37,7 @@ brackets:
         2023-01-01: 24_500
         2024-01-01: 26_050
         2025-01-01: 26_800
+        2026-01-01: 27_400
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -50,6 +53,7 @@ brackets:
         2023-01-01: 58_050
         2024-01-01: 61_600
         2025-01-01: 63_450
+        2026-01-01: 64_850
       uprating:
         parameter: gov.irs.uprating
         rounding:

--- a/policyengine_us/parameters/gov/states/me/tax/income/main/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/main/surviving_spouse.yaml
@@ -22,6 +22,8 @@ metadata:
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2024.pdf
     - title: Maine 2025 Individual Income Tax Rate Schedules
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/ind_tax_rate_sched_2025.pdf
+    - title: Maine 2026 Individual Income Tax Rate Schedules (Maine Revenue Services, rev. May 5, 2026)
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/2026-05/ind_tax_rate_sched_2026_rev.pdf#page=1
 brackets:
   - threshold:
       2017-01-01: 0
@@ -35,6 +37,7 @@ brackets:
         2023-01-01: 49_050
         2024-01-01: 52_100
         2025-01-01: 53_600
+        2026-01-01: 54_850
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -50,6 +53,7 @@ brackets:
         2023-01-01: 116_100
         2024-01-01: 123_250
         2025-01-01: 126_900
+        2026-01-01: 129_750
       uprating:
         parameter: gov.irs.uprating
         rounding:

--- a/policyengine_us/parameters/gov/states/ne/tax/income/rates/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/rates/head_of_household.yaml
@@ -11,6 +11,7 @@ brackets:
         2023-01-01: 6_900
         2024-01-01: 7_270
         2025-01-01: 7_510
+        2026-01-01: 7_700
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -25,6 +26,7 @@ brackets:
         2023-01-01: 35_480
         2024-01-01: 37_400
         2025-01-01: 38_590
+        2026-01-01: 39_620
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -41,6 +43,7 @@ brackets:
         2023-01-01: 52_980
         2024-01-01: 55_850
         2025-01-01: 57_630
+        2026-01-01: 59_160
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -77,3 +80,6 @@ metadata:
     href: https://revenue.nebraska.gov/sites/default/files/doc/research/chronology/4-607table1_0.pdf
   - title: 2025 Nebraska Individual Income Tax Booklet, Tax Table
     href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_Individual_Income_Tax_Booklet.pdf#page=49
+  # 2026 filing brackets from the DOR 2026 Estimated Income Tax Rate Schedule (Form 1040N-ES, 8-014-2025 Rev. 11-2025), page 5.
+  - title: 2026 Nebraska Estimated Income Tax Rate Schedule (Form 1040N-ES)
+    href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_1040N-ES.pdf#page=5

--- a/policyengine_us/parameters/gov/states/ne/tax/income/rates/joint.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/rates/joint.yaml
@@ -11,6 +11,7 @@ brackets:
         2023-01-01: 7_390
         2024-01-01: 7_790
         2025-01-01: 8_040
+        2026-01-01: 8_250
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -25,6 +26,7 @@ brackets:
         2023-01-01: 44_350
         2024-01-01: 46_760
         2025-01-01: 48_250
+        2026-01-01: 49_530
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -41,6 +43,7 @@ brackets:
         2023-01-01: 71_460
         2024-01-01: 75_340
         2025-01-01: 77_730
+        2026-01-01: 79_800
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -77,3 +80,6 @@ metadata:
     href: https://revenue.nebraska.gov/sites/default/files/doc/research/chronology/4-607table1_0.pdf
   - title: 2025 Nebraska Individual Income Tax Booklet, Tax Table
     href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_Individual_Income_Tax_Booklet.pdf#page=49
+  # 2026 filing brackets from the DOR 2026 Estimated Income Tax Rate Schedule (Form 1040N-ES, 8-014-2025 Rev. 11-2025), page 5.
+  - title: 2026 Nebraska Estimated Income Tax Rate Schedule (Form 1040N-ES)
+    href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_1040N-ES.pdf#page=5

--- a/policyengine_us/parameters/gov/states/ne/tax/income/rates/separate.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/rates/separate.yaml
@@ -11,6 +11,7 @@ brackets:
         2023-01-01: 3_700
         2024-01-01: 3_900
         2025-01-01: 4_030
+        2026-01-01: 4_130
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -25,6 +26,7 @@ brackets:
         2023-01-01: 22_170
         2024-01-01: 23_370
         2025-01-01: 24_120
+        2026-01-01: 24_760
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -41,6 +43,7 @@ brackets:
         2023-01-01: 35_730
         2024-01-01: 37_670
         2025-01-01: 38_870
+        2026-01-01: 39_900
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -77,3 +80,6 @@ metadata:
     href: https://revenue.nebraska.gov/sites/default/files/doc/research/chronology/4-607table1_0.pdf
   - title: 2025 Nebraska Individual Income Tax Booklet, Tax Table
     href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_Individual_Income_Tax_Booklet.pdf#page=49
+  # 2026 filing brackets from the DOR 2026 Estimated Income Tax Rate Schedule (Form 1040N-ES, 8-014-2025 Rev. 11-2025), page 5.
+  - title: 2026 Nebraska Estimated Income Tax Rate Schedule (Form 1040N-ES)
+    href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_1040N-ES.pdf#page=5

--- a/policyengine_us/parameters/gov/states/ne/tax/income/rates/single.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/rates/single.yaml
@@ -11,6 +11,7 @@ brackets:
         2023-01-01: 3_700
         2024-01-01: 3_900
         2025-01-01: 4_030
+        2026-01-01: 4_130
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -25,6 +26,7 @@ brackets:
         2023-01-01: 22_170
         2024-01-01: 23_370
         2025-01-01: 24_120
+        2026-01-01: 24_760
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -41,6 +43,7 @@ brackets:
         2023-01-01: 35_730
         2024-01-01: 37_670
         2025-01-01: 38_870
+        2026-01-01: 39_900
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -77,3 +80,6 @@ metadata:
     href: https://revenue.nebraska.gov/sites/default/files/doc/research/chronology/4-607table1_0.pdf
   - title: 2025 Nebraska Individual Income Tax Booklet, Tax Table
     href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_Individual_Income_Tax_Booklet.pdf#page=49
+  # 2026 filing brackets from the DOR 2026 Estimated Income Tax Rate Schedule (Form 1040N-ES, 8-014-2025 Rev. 11-2025), page 5.
+  - title: 2026 Nebraska Estimated Income Tax Rate Schedule (Form 1040N-ES)
+    href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_1040N-ES.pdf#page=5

--- a/policyengine_us/parameters/gov/states/ne/tax/income/rates/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/rates/surviving_spouse.yaml
@@ -11,6 +11,7 @@ brackets:
         2023-01-01: 7_390
         2024-01-01: 7_790
         2025-01-01: 8_040
+        2026-01-01: 8_250
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -25,6 +26,7 @@ brackets:
         2023-01-01: 44_350
         2024-01-01: 46_760
         2025-01-01: 48_250
+        2026-01-01: 49_530
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -41,6 +43,7 @@ brackets:
         2023-01-01: 71_460
         2024-01-01: 75_340
         2025-01-01: 77_730
+        2026-01-01: 79_800
       uprating:
         parameter: gov.irs.uprating
         rounding:
@@ -75,3 +78,6 @@ metadata:
     href: https://revenue.nebraska.gov/sites/default/files/doc/research/chronology/4-607table1_0.pdf
   - title: 2025 Nebraska Individual Income Tax Booklet, Tax Table
     href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_Individual_Income_Tax_Booklet.pdf#page=49
+  # 2026 filing brackets from the DOR 2026 Estimated Income Tax Rate Schedule (Form 1040N-ES, 8-014-2025 Rev. 11-2025), page 5.
+  - title: 2026 Nebraska Estimated Income Tax Rate Schedule (Form 1040N-ES)
+    href: https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_1040N-ES.pdf#page=5

--- a/policyengine_us/parameters/gov/states/ny/tax/income/deductions/itemized/phase_out/start.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/deductions/itemized/phase_out/start.yaml
@@ -4,7 +4,9 @@ SINGLE:
     2021-01-01: 282_400
     2022-01-01: 290_850
     2023-01-01: 313_200
-  uprating: 
+    2024-01-01: 330_200
+    2025-01-01: 340_700
+  uprating:
     parameter: gov.irs.uprating
     rounding:
       type: nearest
@@ -14,7 +16,9 @@ JOINT:
     2021-01-01: 338_850
     2022-01-01: 349_000
     2023-01-01: 375_850
-  uprating: 
+    2024-01-01: 396_250
+    2025-01-01: 408_850
+  uprating:
     parameter: gov.irs.uprating
     rounding:
       type: nearest
@@ -24,7 +28,9 @@ SURVIVING_SPOUSE:
     2021-01-01: 338_850
     2022-01-01: 349_000
     2023-01-01: 375_850
-  uprating: 
+    2024-01-01: 396_250
+    2025-01-01: 408_850
+  uprating:
     parameter: gov.irs.uprating
     rounding:
       type: nearest
@@ -34,7 +40,9 @@ SEPARATE:
     2021-01-01: 169_400
     2022-01-01: 174_500
     2023-01-01: 187_900
-  uprating: 
+    2024-01-01: 198_100
+    2025-01-01: 204_400
+  uprating:
     parameter: gov.irs.uprating
     rounding:
       type: nearest
@@ -44,7 +52,9 @@ HEAD_OF_HOUSEHOLD:
     2021-01-01: 310_600
     2022-01-01: 319_950
     2023-01-01: 344_500
-  uprating: 
+    2024-01-01: 363_250
+    2025-01-01: 374_800
+  uprating:
     parameter: gov.irs.uprating
     rounding:
       type: nearest
@@ -70,5 +80,8 @@ metadata:
       href: https://www.tax.ny.gov/pdf/2022/inc/it196i_2022.pdf#page=18
     - title: 2023 NY Form IT-196 Instructions Line 40
       href: https://www.tax.ny.gov/pdf/2023/printable-pdfs/inc/it196i-2023.pdf#page=25
-    - title: 2025 Form IT-201-I Instructions
-      href: https://www.tax.ny.gov/pdf/current_forms/it/it201i.pdf#page=14
+    # 2024 and 2025 applicable amounts (NY itemized deduction limitation) from Form IT-196-I, "Table 1" (Line 41 instructions).
+    - title: 2024 NY Form IT-196 Instructions, Table 1 (applicable amount)
+      href: https://www.tax.ny.gov/pdf/2024/inc/it196i_2024.pdf#page=19
+    - title: 2025 NY Form IT-196 Instructions, Table 1 (applicable amount)
+      href: https://www.tax.ny.gov/pdf/current_forms/it/it196i.pdf#page=19

--- a/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/amount.yaml
@@ -10,6 +10,9 @@ metadata:
   reference:
   - title: Rhode Island RI-1040 Instructions 2025
     href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=4
+  # 2026 standard deduction amounts from RI Division of Taxation Advisory ADV 2025-22 (Nov. 3, 2025), page 1.
+  - title: Rhode Island Division of Taxation, ADV 2025-22 - Inflation-adjusted amounts set for Tax Year 2026
+    href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=1
   - title: Rhode Island Department of Revenue, Division of Taxation, Inflation-adjusted amounts set for tax year 2023.
     href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2022-12/ADV_2022_40_Inflation_Adjustments.pdf#page=1
   - title: Rhode Island tax rate schedule and worksheets 2021
@@ -22,6 +25,7 @@ SINGLE:
     2023-01-01: 10_000
     2024-01-01: 10_550
     2025-01-01: 10_900
+    2026-01-01: 11_200
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -34,6 +38,7 @@ JOINT:
     2023-01-01: 20_050
     2024-01-01: 21_150
     2025-01-01: 21_800
+    2026-01-01: 22_400
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -46,6 +51,7 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 15_050
     2024-01-01: 15_850
     2025-01-01: 16_350
+    2026-01-01: 16_800
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -58,6 +64,7 @@ SEPARATE:
     2023-01-01: 10_025
     2024-01-01: 10_575
     2025-01-01: 10_900
+    2026-01-01: 11_200
   uprating:
     parameter: gov.irs.uprating
     rounding:
@@ -70,6 +77,7 @@ SURVIVING_SPOUSE:
     2023-01-01: 20_050
     2024-01-01: 21_150
     2025-01-01: 21_800
+    2026-01-01: 22_400
   uprating:
     parameter: gov.irs.uprating
     rounding:

--- a/policyengine_us/tests/core/test_state_indexed_frozen_parameters.py
+++ b/policyengine_us/tests/core/test_state_indexed_frozen_parameters.py
@@ -1,0 +1,147 @@
+"""Pin state parameters that were frozen by a misplaced (sibling-of-``values``)
+``uprating:`` block, to explicit values from official published sources.
+
+These parameters previously stopped at their last hand-entered year because the
+``uprating:`` block sat beside ``values:`` (not under ``metadata:``) and was
+silently discarded by the loader (see policyengine-us #8905). The fix adds
+explicit dated entries from each state's official annual release. Several of the
+parameters are not (currently) reachable through a household calculation -- e.g.
+New York's itemized-deduction ``phase_out.start`` is not referenced by any
+formula -- so they are pinned here rather than in a YAML household test.
+
+Sources (one per state; see the parameter YAML ``reference`` blocks for the rest):
+  * NE -- 2026 Nebraska Estimated Income Tax Rate Schedule (Form 1040N-ES,
+    8-014-2025 Rev. 11-2025), page 5.
+  * ME -- Maine Revenue Services 2026 Individual Income Tax Rate Schedules
+    (rev. May 5, 2026) and the 2026 Estimated Tax Worksheet phase-out worksheets
+    (rev. Dec. 2025).
+  * RI -- RI Division of Taxation Advisory ADV 2025-22 (Nov. 3, 2025).
+  * NY -- Form IT-196-I "Table 1" applicable amounts, tax years 2024 and 2025.
+"""
+
+import pytest
+
+from policyengine_us import CountryTaxBenefitSystem
+
+SYSTEM = CountryTaxBenefitSystem()
+
+
+def _p(date):
+    return SYSTEM.parameters(date)
+
+
+# --- Nebraska: 2026 indexed bracket thresholds (Neb. Rev. Stat. 77-2715.03) ----
+# brackets[1..3] map to the 3.51%/4.55%/4.55% breakpoints in the 2026 schedule.
+NE_2026 = {
+    "single": (4_130, 24_760, 39_900),
+    "separate": (4_130, 24_760, 39_900),
+    "head_of_household": (7_700, 39_620, 59_160),
+    "joint": (8_250, 49_530, 79_800),
+    "surviving_spouse": (8_250, 49_530, 79_800),
+}
+
+
+@pytest.mark.parametrize("status,thresholds", NE_2026.items())
+def test_ne_2026_income_tax_brackets(status, thresholds):
+    # Access the raw parameter tree (not parameters(date)) so the bracket scale is
+    # not collapsed to an instant, then evaluate each threshold at the 2026 date.
+    rates = getattr(SYSTEM.parameters.gov.states.ne.tax.income.rates, status)
+    got = tuple(rates.brackets[i].threshold("2026-01-01") for i in (1, 2, 3))
+    assert got == thresholds
+
+
+# --- Maine: 2026 indexed rate-schedule thresholds (36 M.R.S. 5111 / 5403) ------
+# brackets[1] = 6.75% start, brackets[2] = 7.15% start.
+ME_MAIN_2026 = {
+    "single": (27_400, 64_850),
+    "separate": (27_400, 64_850),
+    "head_of_household": (41_100, 97_300),
+    "joint": (54_850, 129_750),
+    "surviving_spouse": (54_850, 129_750),
+}
+
+
+@pytest.mark.parametrize("status,thresholds", ME_MAIN_2026.items())
+def test_me_2026_income_tax_brackets(status, thresholds):
+    main = getattr(SYSTEM.parameters.gov.states.me.tax.income.main, status)
+    got = tuple(main.brackets[i].threshold("2026-01-01") for i in (1, 2))
+    assert got == thresholds
+
+
+# --- Maine: 2026 standard/itemized deduction phase-out start (36 M.R.S. 5124-C/5125)
+ME_DED_PHASEOUT_2026 = {
+    "SINGLE": 102_250,
+    "SEPARATE": 102_250,
+    "HEAD_OF_HOUSEHOLD": 153_400,
+    "JOINT": 204_550,
+    "SURVIVING_SPOUSE": 204_550,
+}
+
+
+@pytest.mark.parametrize("status,value", ME_DED_PHASEOUT_2026.items())
+def test_me_2026_deduction_phaseout_start(status, value):
+    start = _p("2026-01-01").gov.states.me.tax.income.deductions.phase_out.start
+    assert start[status] == value
+
+
+# --- Maine: 2026 personal exemption phase-out start (36 M.R.S. 5126-A / 5403) ---
+ME_PE_PHASEOUT_2026 = {
+    "SINGLE": 341_000,
+    "SEPARATE": 204_575,
+    "HEAD_OF_HOUSEHOLD": 375_050,
+    "JOINT": 409_150,
+    "SURVIVING_SPOUSE": 409_150,
+}
+
+
+@pytest.mark.parametrize("status,value", ME_PE_PHASEOUT_2026.items())
+def test_me_2026_personal_exemption_phaseout_start(status, value):
+    node = _p(
+        "2026-01-01"
+    ).gov.states.me.tax.income.deductions.personal_exemption.phaseout.start
+    assert node[status] == value
+
+
+# --- Rhode Island: 2026 standard deduction (R.I. Gen. Laws 44-30-2.6) ----------
+RI_STD_2026 = {
+    "SINGLE": 11_200,
+    "JOINT": 22_400,
+    "HEAD_OF_HOUSEHOLD": 16_800,
+    "SEPARATE": 11_200,
+    "SURVIVING_SPOUSE": 22_400,
+}
+
+
+@pytest.mark.parametrize("status,value", RI_STD_2026.items())
+def test_ri_2026_standard_deduction(status, value):
+    amount = _p("2026-01-01").gov.states.ri.tax.income.deductions.standard.amount
+    assert amount[status] == value
+
+
+# --- New York: 2024 and 2025 itemized-deduction phase-out applicable amount ----
+# NY Tax Law 615 conforms to the pre-TCJA federal 26 U.S.C. 68 applicable amount,
+# which NY continues to inflation-adjust. This parameter is not currently consumed
+# by any formula, so it is pinned here rather than in a household test.
+NY_ITEMIZED_START = {
+    "2024-01-01": {
+        "SINGLE": 330_200,
+        "JOINT": 396_250,
+        "SURVIVING_SPOUSE": 396_250,
+        "SEPARATE": 198_100,
+        "HEAD_OF_HOUSEHOLD": 363_250,
+    },
+    "2025-01-01": {
+        "SINGLE": 340_700,
+        "JOINT": 408_850,
+        "SURVIVING_SPOUSE": 408_850,
+        "SEPARATE": 204_400,
+        "HEAD_OF_HOUSEHOLD": 374_800,
+    },
+}
+
+
+@pytest.mark.parametrize("date", list(NY_ITEMIZED_START))
+def test_ny_itemized_phase_out_start(date):
+    node = _p(date).gov.states.ny.tax.income.deductions.itemized.phase_out.start
+    for status, value in NY_ITEMIZED_START[date].items():
+        assert node[status] == value, f"{status} @ {date}"

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/main/me_income_tax_rates_2026.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/main/me_income_tax_rates_2026.yaml
@@ -1,0 +1,44 @@
+# 2026 Maine bracket thresholds, from the Maine Revenue Services 2026 Individual
+# Income Tax Rate Schedules (rev. May 5, 2026).
+# https://www.maine.gov/revenue/sites/maine.gov.revenue/files/2026-05/ind_tax_rate_sched_2026_rev.pdf
+# Expected values are the exact marginal-rate tax; the published schedule states a
+# whole-dollar base tax (e.g. $1,589 = 5.8% x 27,400 rounded), while PolicyEngine
+# integrates the exact bracket, so results differ from the printed base by cents.
+# The point of these tests is to pin the 2026 first/second bracket thresholds.
+
+# Single 2026: 0-27,400 @ 5.8%; 27,400-64,850 @ 6.75%; 64,850+ @ 7.15%.
+- name: ME 2026 single income tax before credits pins the 2026 indexed brackets
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    filing_status: SINGLE
+    me_taxable_income: 40_000
+    state_code: ME
+  output:
+    # 5.8% x 27,400 + 6.75% x (40,000 - 27,400) = 1,589.20 + 850.50 = 2,439.70
+    me_income_tax_before_credits: 2_439.70
+
+# Married filing jointly 2026: 0-54,850 @ 5.8%; 54,850-129,750 @ 6.75%; 129,750+ @ 7.15%.
+- name: ME 2026 joint income tax before credits pins the 2026 indexed brackets
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    filing_status: JOINT
+    me_taxable_income: 140_000
+    state_code: ME
+  output:
+    # 5.8% x 54,850 + 6.75% x (129,750 - 54,850) + 7.15% x (140,000 - 129,750)
+    # = 3,181.30 + 5,055.75 + 732.875 = 8,969.925
+    me_income_tax_before_credits: 8_969.93
+
+# Head of household 2026: 0-41,100 @ 5.8%; 41,100-97,300 @ 6.75%; 97,300+ @ 7.15%.
+- name: ME 2026 head of household income tax before credits pins the 2026 indexed brackets
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    filing_status: HEAD_OF_HOUSEHOLD
+    me_taxable_income: 50_000
+    state_code: ME
+  output:
+    # 5.8% x 41,100 + 6.75% x (50,000 - 41,100) = 2,383.80 + 600.75 = 2,984.55
+    me_income_tax_before_credits: 2_984.55

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/me_income_tax_before_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/me_income_tax_before_credits.yaml
@@ -177,7 +177,10 @@
     filing_status: SINGLE
     state_code: ME
   output:
-    me_income_tax_before_credits: 89_291.6
+    # 2026 brackets (27,400 / 64,850): 5.8% x 27,400 + 6.75% x (64,850 - 27,400)
+    # + 7.15% x (1,200,000 - 64,850) = 85,280.30, plus 2% surcharge x 200,000 = 4,000.
+    # (Was 89,291.60 while the brackets were frozen at their 2025 values; #8905.)
+    me_income_tax_before_credits: 89_280.3
 
 - name: Joint filer 2026 me_income_tax_before_credits includes the surcharge.
   period: 2026

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/rates/ne_income_tax_rates_2026.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/tax/income/rates/ne_income_tax_rates_2026.yaml
@@ -1,0 +1,41 @@
+# 2026 Nebraska bracket thresholds, from the DOR 2026 Nebraska Estimated Income Tax
+# Rate Schedule (Form 1040N-ES, 8-014-2025 Rev. 11-2025), page 5.
+# https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_1040N-ES.pdf#page=5
+# Single 2026 schedule: 0-4,130 @ 2.46%; 4,130-24,760 @ 3.51% (base 101.60);
+# 24,760-39,900 @ 4.55% (base 825.71); 39,900+ @ 4.55% (base 1,514.58).
+- name: NE 2026 single income tax before credits pins the 2026 indexed brackets
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    filing_status: SINGLE
+    ne_taxable_income: 30_000
+    state_code: NE
+  output:
+    # 825.71 + 4.55% x (30,000 - 24,760) = 1,064.13
+    ne_income_tax_before_credits: 1_064.13
+
+# Married filing jointly 2026 schedule: 0-8,250 @ 2.46%; 8,250-49,530 @ 3.51%
+# (base 202.95); 49,530-79,800 @ 4.55% (base 1,651.88); 79,800+ @ 4.55%.
+- name: NE 2026 joint income tax before credits pins the 2026 indexed brackets
+  absolute_error_margin: 0.02
+  period: 2026
+  input:
+    filing_status: JOINT
+    ne_taxable_income: 60_000
+    state_code: NE
+  output:
+    # 1,651.88 + 4.55% x (60,000 - 49,530) = 2,128.27
+    ne_income_tax_before_credits: 2_128.27
+
+# Head of household 2026 schedule: 0-7,700 @ 2.46%; 7,700-39,620 @ 3.51%
+# (base 189.42); 39,620-59,160 @ 4.55% (base 1,309.81); 59,160+ @ 4.55%.
+- name: NE 2026 head of household income tax before credits pins the 2026 indexed brackets
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    filing_status: HEAD_OF_HOUSEHOLD
+    ne_taxable_income: 50_000
+    state_code: NE
+  output:
+    # 1,309.81 + 4.55% x (50,000 - 39,620) = 1,782.10
+    ne_income_tax_before_credits: 1_782.10

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/deductions/standard/ri_standard_deduction_2026.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/deductions/standard/ri_standard_deduction_2026.yaml
@@ -1,0 +1,42 @@
+# 2026 Rhode Island standard deduction amounts, from RI Division of Taxation
+# Advisory ADV 2025-22, "Inflation-adjusted amounts set for Tax Year 2026"
+# (November 3, 2025), page 1.
+# https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf
+# AGI is kept well below the phase-out range ($261,000 for 2026) so the applicable
+# percentage is 1.0 and the standard deduction equals the full indexed amount.
+
+- name: RI 2026 single standard deduction pins the ADV 2025-22 amount
+  period: 2026
+  input:
+    filing_status: SINGLE
+    employment_income: 20_000
+    state_code: RI
+  output:
+    ri_standard_deduction: 11_200
+
+- name: RI 2026 joint standard deduction pins the ADV 2025-22 amount
+  period: 2026
+  input:
+    filing_status: JOINT
+    employment_income: 20_000
+    state_code: RI
+  output:
+    ri_standard_deduction: 22_400
+
+- name: RI 2026 head of household standard deduction pins the ADV 2025-22 amount
+  period: 2026
+  input:
+    filing_status: HEAD_OF_HOUSEHOLD
+    employment_income: 20_000
+    state_code: RI
+  output:
+    ri_standard_deduction: 16_800
+
+- name: RI 2026 separate standard deduction pins the ADV 2025-22 amount
+  period: 2026
+  input:
+    filing_status: SEPARATE
+    employment_income: 20_000
+    state_code: RI
+  output:
+    ri_standard_deduction: 11_200


### PR DESCRIPTION
Addresses #8905.

## What this does

The parameters below carried an `uprating:` block written as a **sibling of `values:`** (rather than nested under `metadata:`), which the loader silently discards — freezing them at their last hand-entered year despite statutory annual indexing. This PR adds **explicit dated entries from official published sources** for every published year that was missing, placed **above** the existing `uprating:` block (left untouched, so a sibling PR relocating those blocks does not collide — see the note at the bottom).

This is the "official values" layer only. It does not change `uprating:` placement.

## Value-source table

### Nebraska — Neb. Rev. Stat. § 77-2715.03 (2026 added; last explicit was 2025)
Source: [2026 Nebraska Estimated Income Tax Rate Schedule (Form 1040N-ES, 8-014-2025 Rev. 11-2025), p. 5](https://revenue.nebraska.gov/sites/default/files/doc/tax-forms/2025/f_1040N-ES.pdf#page=5). Bracket thresholds map to `brackets[1..3].threshold`.

| Filing status | bracket 1 | bracket 2 | bracket 3 |
|---|---|---|---|
| Single / Married filing separately | 4,130 | 24,760 | 39,900 |
| Head of household | 7,700 | 39,620 | 59,160 |
| Married filing jointly / Surviving spouse | 8,250 | 49,530 | 79,800 |

### Maine — 36 M.R.S. § 5111 / § 5403 (2026 added; last explicit was 2025)
Rate schedule source: [Maine 2026 Individual Income Tax Rate Schedules (MRS, rev. May 5, 2026)](https://www.maine.gov/revenue/sites/maine.gov.revenue/files/2026-05/ind_tax_rate_sched_2026_rev.pdf). `brackets[1]` = 6.75% start, `brackets[2]` = 7.15% start.

| Filing status | bracket 1 | bracket 2 |
|---|---|---|
| Single / Married filing separately | 27,400 | 64,850 |
| Head of household | 41,100 | 97,300 |
| Married filing jointly / Surviving spouse | 54,850 | 129,750 |

Phase-out starts (2026), from the [MRS 2026 Estimated Tax Worksheets (rev. Dec. 2025)](https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/26_1040es_pers_exempt_phaseout_wksht.pdf):

| Parameter | Single | Separate | HoH | Joint | Surviving |
|---|---|---|---|---|---|
| Standard/itemized deduction phase-out start | 102,250 | 102,250 | 153,400 | 204,550 | 204,550 |
| Personal exemption phase-out start | 341,000 | 204,575 | 375,050 | 409,150 | 409,150 |

### Rhode Island — R.I. Gen. Laws § 44-30-2.6 (2026 added; last explicit was 2025)
Source: [RI Division of Taxation Advisory ADV 2025-22 (Nov. 3, 2025), p. 1](https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=1).

| Standard deduction | Single | Joint | HoH | Separate | Surviving |
|---|---|---|---|---|---|
| 2026 | 11,200 | 22,400 | 16,800 | 11,200 | 22,400 |

### New York — Tax Law § 615 (conforms to pre-TCJA 26 U.S.C. § 68); 2024 + 2025 added (last explicit was 2023)
NY continues to inflation-index the § 68 applicable amount, so values are **added** (the block is not removed). Sources: Form IT-196-I "Table 1" (Line 41 instructions) for [2024](https://www.tax.ny.gov/pdf/2024/inc/it196i_2024.pdf#page=19) and [2025](https://www.tax.ny.gov/pdf/current_forms/it/it196i.pdf#page=19). Series: single 313,200 (2023) → 330,200 (2024) → 340,700 (2025).

| Itemized phase-out start | Single | Joint | Surviving | Separate | HoH |
|---|---|---|---|---|---|
| 2024 | 330,200 | 396,250 | 396,250 | 198,100 | 363,250 |
| 2025 | 340,700 | 408,850 | 408,850 | 204,400 | 374,800 |

## Cross-checks (secondary source)

[Tax Foundation, State Individual Income Tax Rates and Brackets, 2026](https://taxfoundation.org/data/all/state/state-income-tax-rates-2026/) agrees with the primary sources: NE single 4,130/24,760 and MFJ 8,250/49,530; ME single 27,400/64,850 and MFJ 54,850/129,750; RI standard deduction 11,200 (single) / 22,400 (joint). No disagreements.

## Target files intentionally NOT changed, and why

- **NE 2027** — indexed off CPI through August 2026, not published until ~Sept 2026. 2027 legitimately still holds the 2026 value for now.
- **ME sales-tax fairness credit base + reduction start; ME pension-exclusion phase-out start** — 2026 figures not yet published (the May-2026 MRS release omits STFC; Schedule PTFC/STFC and general instructions for 2026 are not posted; the pension phase-out was enacted for 2025 with no 2026 worksheet yet). Left at last published year.
- **RI Social Security limit + taxable retirement income limit** — publish on a one-year lag; ADV 2025-22 shows only 2024/2025 for these (both already present). 2026 will appear in the Nov-2026 advisory.
- **RI child tax credit phase-out threshold + increment** — a **future TY2027 program** (2026 R.I. H 7127); the files hold only a 2027 base value, so there are no 2024–2026 figures to backfill (the credit does not exist those years). Skipped, as #8905 anticipated.

## Note on NY parameter usage

`gov.states.ny.tax.income.deductions.itemized.phase_out.start` is **not currently referenced by any formula** (only DC's namesake parameter is consumed). The values are still corrected and are pinned by a Python test; a household test is not possible until a formula wires it up. Flagging in case a follow-up should wire or remove it.

## Tests

- Household YAML tests for the newly-added NE, ME, and RI 2026 values (expected tax derived from the official rate schedules).
- `tests/core/test_state_indexed_frozen_parameters.py` — pins every added value (including NY's) against the official figure.
- Updated one stale ME test (`me_income_tax_before_credits.yaml`, single filer > $1M) whose 2026 expectation had baked in the frozen brackets (89,291.60 → 89,280.30).

## Coordination

A sibling PR is relocating the `uprating:` blocks to `metadata:`. For NE/ME/RI, values were inserted strictly **above** the untouched `uprating:` lines. In the **NY** file only, adding values normalized a trailing space on each per-status `uprating:` line (`  uprating: ` → `  uprating:`) — no semantic change, but it touches the lines being relocated, so expect a trivial whitespace conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
