### PR TITLE
Add North Dakota to the CCDF coverage list

### DIFF
--- a/changelog.d/nd-ccdf-coverage.fixed.md
+++ b/changelog.d/nd-ccdf-coverage.fixed.md
@@ -1,0 +1,1 @@
+Added North Dakota to the CCDF coverage list, matching its existing state implementation entry.

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -460,7 +460,7 @@ programs:
     category: Benefits
     agency: HHS
     status: partial
-    coverage: AK, AR, AL, AZ, CA, CO, CT, DE, DC, FL, GA, HI, IA, ID, IL, IN, KS, KY, LA, MA, MD, ME, MI, MN, MO, MS, NC, NE, NH, NJ, PA, RI, SC, TX, VA, VT, WA, WV
+    coverage: AK, AR, AL, AZ, CA, CO, CT, DE, DC, FL, GA, HI, IA, ID, IL, IN, KS, KY, LA, MA, MD, ME, MI, MN, MO, MS, NC, ND, NE, NH, NJ, PA, RI, SC, TX, VA, VT, WA, WV
     state_implementations:
       - state: AK
         status: complete


### PR DESCRIPTION
The #8709 ND CCAP merge added the state_implementations entry but not the matching entry in the CCDF coverage string, so coverage metadata understates the program's footprint. One-line fix plus changelog fragment. Found by a coverage-vs-implementations set comparison during #8665/#8662 review.