### PR TITLE
Exclude private (IRC 401) employer pensions from OK retirement subtraction before 2022

### DIFF
--- a/changelog.d/fix-ok-401-pension-2021-exclusion.fixed.md
+++ b/changelog.d/fix-ok-401-pension-2021-exclusion.fixed.md
@@ -1,0 +1,1 @@
+Excluded private employer (IRC section 401) pension income from the Oklahoma retirement benefit subtraction before tax year 2022.

--- a/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/private_pension_qualifies.yaml
+++ b/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/private_pension_qualifies.yaml
@@ -1,0 +1,16 @@
+description: Oklahoma includes private employer (IRC section 401) pension income in the retirement benefit subtraction if this is true.
+values:
+  2021-01-01: false
+  2022-01-01: true
+
+metadata:
+  unit: bool
+  period: year
+  label: Oklahoma retirement benefit subtraction includes private employer pensions
+  reference:
+    - title: 2021 Form 511 Schedule 511-A, line 6 Other Retirement Income (IRC section 401 employer plans not listed)
+      href: https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/past-year/2021/511-Pkt-2021.pdf#page=17
+    - title: 2022 Form 511 Schedule 511-A, line 6 Other Retirement Income (IRC section 401 employer plans added)
+      href: https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/past-year/2022/511-Pkt-2022.pdf#page=17
+    - title: 2025 Form 511 Schedule 511-A, line 6 Other Retirement Income
+      href: https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/current/511-Pkt.pdf#page=17

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_pension_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/tax/income/ok_pension_subtraction.yaml
@@ -225,3 +225,83 @@
     # Person2: $45,000 pension, capped at $10,000
     # Total: $10,000 + $10,000 = $20,000
     ok_pension_subtraction: 20_000
+
+# Issue #8830: private employer (IRC 401) pensions were not a qualifying
+# Schedule 511-A line 6 source until tax year 2022.
+- name: OK pension subtraction - 2021 - private (IRC 401) pension does not qualify
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        # Private employer (IRC 401) pension only; not a qualifying source in 2021
+        taxable_private_pension_income: 20_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+        tanf: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: OK
+  output:
+    ok_pension_subtraction: 0
+
+- name: OK pension subtraction - 2022 - private (IRC 401) pension now qualifies
+  absolute_error_margin: 0.01
+  period: 2022
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        taxable_private_pension_income: 20_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+        tanf: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: OK
+  output:
+    # Private pension is a qualifying source from 2022, capped at $10,000
+    ok_pension_subtraction: 10_000
+
+- name: OK pension subtraction - 2021 - government pension still qualifies
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        # Government (non-private) pension remained a qualifying source in 2021
+        taxable_public_pension_income: 8_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+        tanf: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: OK
+  output:
+    ok_pension_subtraction: 8_000

--- a/policyengine_us/variables/gov/states/ok/tax/income/subtractions/ok_pension_subtraction.py
+++ b/policyengine_us/variables/gov/states/ok/tax/income/subtractions/ok_pension_subtraction.py
@@ -33,6 +33,17 @@ class ok_pension_subtraction(Variable):
         # Get pension income for each person in the tax unit
         pensions = tax_unit.members("taxable_pension_income", period)
         p = parameters(period).gov.states.ok.tax.income.agi.subtractions
+        # Before tax year 2022, private employer (IRC section 401) pensions
+        # were not a qualifying source on Schedule 511-A, line 6 (Other
+        # Retirement Income); Oklahoma added IRC section 401 employer plans
+        # starting in 2022. Exclude private pension income from the
+        # subtraction base before then.
+        private_pensions = tax_unit.members("taxable_private_pension_income", period)
+        qualifying_pensions = where(
+            p.private_pension_qualifies,
+            pensions,
+            max_(0, pensions - private_pensions),
+        )
         # Each person can subtract up to the pension limit
         # Sum across all tax unit members
-        return tax_unit.sum(min_(p.pension_limit, pensions))
+        return tax_unit.sum(min_(p.pension_limit, qualifying_pensions))


### PR DESCRIPTION
Fixes #8830.

## Problem
`ok_pension_subtraction` grants Oklahoma's $10,000/person retirement benefit subtraction on **all** `taxable_pension_income` from 2021-01-01. But Oklahoma's Form 511 Schedule 511-A, line 6 ("Other Retirement Income") **did not list IRC §401 employer pension plans until tax year 2022** — so private employer pensions incorrectly received the exclusion in TY2021.

## Fix
- New parameter `gov.states.ok.tax.income.agi.subtractions.private_pension_qualifies` — `false` for 2021, `true` from 2022 (cited to the 2021 vs 2022 Form 511 Schedule 511-A line 6).
- `ok_pension_subtraction` now excludes `taxable_private_pension_income` (non-government/§401 employer pensions) from the subtraction base before 2022; government pensions and other listed sources are unaffected.

PolicyEngine already distinguishes `taxable_private_pension_income` vs `taxable_public_pension_income` (both sum into `taxable_pension_income`), so no new income granularity was needed.

## Tests
- New: 2021 §401 private pension → subtraction `0`; 2022 §401 private pension → `10,000`; 2021 government pension → still `8,000`.
- Existing 8 cases unchanged (they set `taxable_pension_income` directly with private defaulting to 0). 11/11 pass locally.

Surfaced by the taxsim-emulator eCPS comparison (PolicyEngine/policyengine-taxsim#1026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)