### PR TITLE
Update NY TANF earned income disregard to 62/63/64% (2023-2025)

### DIFF
--- a/changelog.d/fix-ny-tanf-earned-income-disregard.fixed.md
+++ b/changelog.d/fix-ny-tanf-earned-income-disregard.fixed.md
@@ -1,0 +1,1 @@
+Updated the New York TANF earned income disregard to 62% (2023-06-01), 63% (2024-06-01), and 64% (2025-06-01) per the annual OTDA administrative directives.

--- a/policyengine_us/parameters/gov/states/ny/otda/tanf/income/earned_income_deduction/percent.yaml
+++ b/policyengine_us/parameters/gov/states/ny/otda/tanf/income/earned_income_deduction/percent.yaml
@@ -11,8 +11,17 @@ metadata:
       href: https://otda.ny.gov/policy/gis/2022/22DC052.pdf#page=2
     - title: 22-ADM-11 Section IV(B) Earned Income Disregard
       href: https://otda.ny.gov/policy/directives/2022/ADM/22-ADM-11.pdf#page=3
+    - title: 23-ADM-04 Earned Income Disregard (62%, effective 2023-06-01)
+      href: https://otda.ny.gov/policy/directives/2023/ADM/23-ADM-04.pdf
+    - title: 24-ADM-04 Earned Income Disregard (63%, effective 2024-06-01)
+      href: https://otda.ny.gov/policy/directives/2024/ADM/24-ADM-04.pdf
+    - title: 25-ADM-04 Earned Income Disregard (64%, effective 2025-06-01)
+      href: https://otda.ny.gov/policy/directives/2025/ADM/25-ADM-04.pdf
 
 values:
   1998-01-01: 0.42
   2022-06-01: 0.55
   2022-10-01: 0.50
+  2023-06-01: 0.62
+  2024-06-01: 0.63
+  2025-06-01: 0.64

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/otda/tanf/ny_tanf_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/otda/tanf/ny_tanf_countable_earned_income.yaml
@@ -64,3 +64,37 @@
     # $1,000 - $90 = $910
     # $910 × 0.58 = $527.80
     ny_tanf_countable_earned_income: 527.8
+
+# Issue #8835: annual June-1 earned income disregard increases
+# (62% from 2023-06-01, 63% from 2024-06-01, 64% from 2025-06-01).
+# Tested at January periods, which are in effect for each rate:
+# 2024-01 -> 62%, 2025-01 -> 63%, 2026-01 -> 64%.
+- name: Case 7, earned income disregard is 62% (effective 2023-06-01).
+  period: 2024-01
+  input:
+    state_code: NY
+    tanf_gross_earned_income: 500
+  output:
+    # $500 × (1 - 0.62) = $190
+    # $190 - $150 = $40
+    ny_tanf_countable_earned_income: 40
+
+- name: Case 8, earned income disregard is 63% (effective 2024-06-01).
+  period: 2025-01
+  input:
+    state_code: NY
+    tanf_gross_earned_income: 1_000
+  output:
+    # $1,000 × (1 - 0.63) = $370
+    # $370 - $150 = $220
+    ny_tanf_countable_earned_income: 220
+
+- name: Case 9, earned income disregard is 64% (effective 2025-06-01).
+  period: 2026-01
+  input:
+    state_code: NY
+    tanf_gross_earned_income: 1_000
+  output:
+    # $1,000 × (1 - 0.64) = $360
+    # $360 - $150 = $210
+    ny_tanf_countable_earned_income: 210


### PR DESCRIPTION
Fixes #8835.

## Problem
`gov.states.ny.otda.tanf.income.earned_income_deduction.percent` was stuck at **50%** (2022-10-01). New York OTDA resets the TANF/Family Assistance regular earned income disregard **every June 1**, and it has risen since:

| Effective | Rate | Directive |
|---|---|---|
| 2023-06-01 | 62% | 23-ADM-04 |
| 2024-06-01 | 63% | 24-ADM-04 |
| 2025-06-01 | 64% | 25-ADM-04 |

(The issue's "62% for the 2024-2026 state plan" reflects the value current when the plan was drafted; the annual ADM directives are the operative source.)

## Fix
Added the three June-1 values (0.62 / 0.63 / 0.64) with the numbered OTDA directive citations. This is separate from the $150 flat general work disregard, which PE already carries.

## Tests
Added cases locking 62% (2024-01), 63% (2025-01), and 64% (2026-01). 9/9 pass. (January test periods are used because mid-year MONTH periods trip a framework quirk with the YEAR-level `state_code` input; each January still lands on the intended rate.)

Surfaced by the Axiom oracle comparison (axiom-oracles `ny-tanf-ecps`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)