### PR TITLE
Correct Georgia parent/caretaker Medicaid income limit to 0.33 FPL from 2024

### DIFF
--- a/changelog.d/fix-ga-parent-medicaid-income-limit.fixed.md
+++ b/changelog.d/fix-ga-parent-medicaid-income-limit.fixed.md
@@ -1,0 +1,1 @@
+Corrected the Georgia parent/caretaker Medicaid income limit to 0.33 FPL (28% dollar-based standard plus the 5% MAGI disregard) from 2024.

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
@@ -5,6 +5,8 @@ metadata:
   breakdown:
   - state_code
   reference:
+    - title: MACPAC Exhibit 36, Medicaid Income Eligibility Levels as a Percentage of the FPL (July 2024) - Georgia parents/caretakers 28% + 5% MAGI disregard
+      href: https://www.macpac.gov/wp-content/uploads/2024/12/EXHIBIT-36.-Medicaid-Income-Eligibility-Levels-as-a-Percentage-of-the-FPL-for-Non-Aged-Non-Disabled-Non-Pregnant-Adults-July-2024.pdf
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=33
     - title: medicaidscreener.com
@@ -50,6 +52,8 @@ FL:
   2021-01-01: 0.32
 GA:
   2018-01-01: 0.39
+  # 28% FPL parent/caretaker standard + 5% MAGI disregard (MACPAC July 2024)
+  2024-01-01: 0.33
 HI:
   2018-01-01: 1.10
   2021-01-01: 1.10

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/parent/medicaid_parent_income_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/parent/medicaid_parent_income_limit.yaml
@@ -79,3 +79,33 @@
   output:
     medicaid_parent_income_limit: 0.460322
   absolute_error_margin: 0.0001
+
+# Issue #8834: Georgia's dollar-based parent/caretaker standard is ~28% FPL,
+# or 0.33 including the 5% MAGI disregard (MACPAC July 2024).
+- name: Case 6, Georgia parent limit before the dollar-standard correction.
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+    households:
+      household:
+        members: [person1]
+        state_code: GA
+  output:
+    medicaid_parent_income_limit: 0.39
+  absolute_error_margin: 0.0001
+
+- name: Case 7, Georgia parent limit is 0.33 FPL (28% + 5% MAGI disregard).
+  period: 2024
+  input:
+    people:
+      person1:
+        age: 30
+    households:
+      household:
+        members: [person1]
+        state_code: GA
+  output:
+    medicaid_parent_income_limit: 0.33
+  absolute_error_margin: 0.0001


### PR DESCRIPTION
Fixes #8834.

## Problem
`gov.hhs.medicaid.eligibility.categories.parent.income_limit.GA` = 0.39 FPL (2018 vintage). Georgia's parent/caretaker-relative (Section 1931) standard is a **frozen dollar amount ≈ 28% FPL**, or **0.33 including the 5% MAGI disregard**. The other GA categories in the same table already match Georgia's current published limits once the 5% disregard is included (infant 2.10, ages 1-5 1.54, ages 6-18 1.38, pregnant 2.25), so the parent row was the only stale entry.

## Fix
Added `GA: 2024-01-01: 0.33` (keeping the 2018 value for prior years, consistent with the frozen-dollar standard drifting down over time as FPL rises). Cited to **MACPAC Exhibit 36 (July 2024)** — Georgia parents/caretakers 28% + the note that effective limits are 5 percentage points higher due to the general MAGI disregard.

## Tests
Added `medicaid_parent_income_limit` cases: GA = 0.39 at 2023, 0.33 at 2024. 7/7 pass; the 30 `is_medicaid_eligible` tests still pass (the GA case there is at 2022, unaffected).

Note: because it's a frozen-dollar standard, 0.33 is a 2024 approximation that should ideally be re-verified as FPL rises.

Surfaced by the Axiom oracle comparison (axiom-oracles `ga-health-thresholds`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)