### PR TITLE
Fix AR TEA below-trigger payment and AL TANF work expense rate; verify MT TANF standards

### DIFF
--- a/changelog.d/tanf-review-mt-ar-al.fixed.md
+++ b/changelog.d/tanf-review-mt-ar-al.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Arkansas TEA below-trigger payment to pay the full flat grant per TEA Policy Manual 2362 and raised the Alabama TANF work expense deduction to the 30 percent promulgated in Ala. Admin. Code r. 660-2-2-.30.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+      - Arkansas TEA below-trigger payment now pays the full maximum grant for the family size (per TEA Manual Section 2362), rather than subtracting countable income.
+      - Alabama TANF earned-income work expense deduction updated from 20% to 30% of gross earnings (per Ala. Admin. Code r. 660-2-2-.30, effective 2022-05-15).

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,5 +1,0 @@
-- bump: patch
-  changes:
-    fixed:
-      - Arkansas TEA below-trigger payment now pays the full maximum grant for the family size (per TEA Manual Section 2362), rather than subtracting countable income.
-      - Alabama TANF earned-income work expense deduction updated from 20% to 30% of gross earnings (per Ala. Admin. Code r. 660-2-2-.30, effective 2022-05-15).

--- a/policyengine_us/parameters/gov/states/al/dhs/tanf/income/work_expense_rate.yaml
+++ b/policyengine_us/parameters/gov/states/al/dhs/tanf/income/work_expense_rate.yaml
@@ -1,12 +1,15 @@
-description: Alabama deducts this share of miscellaneous expenses from earned income under the Temporary Assistance for Needy Families program.
+description: Alabama deducts this share of gross earnings as work expenses from earned income under the Temporary Assistance for Needy Families program.
 
 values:
   2002-01-01: 0.2
+  2022-05-15: 0.3
 
 metadata:
   unit: /1
   period: month
   label: Alabama TANF work expense deduction rate
   reference:
-    - title: Alabama DHR Public Assistance Payment Manual - Section 3215.B Work Expenses
+    - title: Ala. Admin. Code r. 660-2-2-.30(2)(b) - Income (deduct the first 30% of gross earnings), effective 05/15/2022
+      href: https://admincode.legislature.state.al.us/api/chapter/660-2-2
+    - title: Alabama DHR Public Assistance Payment Manual - Section 3215.B Work Expenses (prior 20% rate)
       href: https://dhr.alabama.gov/wp-content/uploads/2022/04/Appendix-N-Sec-2-Public-Assistance-Payment-Manual.pdf#page=37

--- a/policyengine_us/parameters/gov/states/mt/dhs/tanf/income_standards/benefit_fpg_rate.yaml
+++ b/policyengine_us/parameters/gov/states/mt/dhs/tanf/income_standards/benefit_fpg_rate.yaml
@@ -8,9 +8,9 @@ metadata:
   period: month
   label: Montana TANF benefit standard FPG rate
   reference:
+    - title: TANF 001 Monthly Income Standards (eff. 07/01/2025) - Benefit Standards based on 30% of 2023 FPL
+      href: https://dphhs.mt.gov/assets/hcsd/tanfmanual/TANF001.pdf#page=2
     - title: Temporary Assistance for Needy Families (TANF) State Plan #25 - Income Standards
       href: https://dphhs.mt.gov/assets/hcsd/TANF/TANFStatePlan.pdf#page=10
-    - title: TANF 001 Monthly Income Standards
-      href: https://dphhs.mt.gov/assets/hcsd/tanfmanual/TANF001.pdf#page=2
     - title: Mont. Admin. r. 37.78.420 - TANF CASH ASSISTANCE; INCOME STANDARDS
       href: https://www.law.cornell.edu/regulations/montana/Mont-Admin-r-37.78.420

--- a/policyengine_us/parameters/gov/states/mt/dhs/tanf/income_standards/payment_fpg_rate.yaml
+++ b/policyengine_us/parameters/gov/states/mt/dhs/tanf/income_standards/payment_fpg_rate.yaml
@@ -9,9 +9,9 @@ metadata:
   period: month
   label: Montana TANF payment standard FPG rate
   reference:
+    - title: TANF 001 Monthly Income Standards (eff. 07/01/2025) - Payment Standards based on 35% of 2023 FPL
+      href: https://dphhs.mt.gov/assets/hcsd/tanfmanual/TANF001.pdf#page=2
     - title: Temporary Assistance for Needy Families (TANF) State Plan #25 - Income Standards
       href: https://dphhs.mt.gov/assets/hcsd/TANF/TANFStatePlan.pdf#page=10
-    - title: TANF 001 Monthly Income Standards
-      href: https://dphhs.mt.gov/assets/hcsd/tanfmanual/TANF001.pdf#page=2
     - title: Mont. Admin. r. 37.78.420 - TANF CASH ASSISTANCE; INCOME STANDARDS
       href: https://www.law.cornell.edu/regulations/montana/Mont-Admin-r-37.78.420

--- a/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/al_tanf.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/al_tanf.yaml
@@ -1,6 +1,9 @@
 # Unit tests for Alabama TANF benefit amount
-# Reference: https://dhr.alabama.gov/wp-content/uploads/2022/04/Appendix-N-Sec-2-Public-Assistance-Payment-Manual.pdf#page=37
+# Reference: Ala. Admin. Code r. 660-2-2 (Income r. .30, effective 05/15/2022;
+# Payment Standard r. .31; Grant Computation r. .32)
+# https://admincode.legislature.state.al.us/api/chapter/660-2-2
 # Benefit = max(payment_standard - countable_income, 0)
+# Work expense deduction: the first 30% of gross earnings
 # Payment standards: $264 (1), $304 (2), $344 (3), $392 (4), $440 (5), $488 (6), etc.
 
 - name: Case 1, no income - full benefit.
@@ -43,11 +46,11 @@
         state_code: AL
   output:
     # Monthly employment: $200
-    # Work expense deduction (20%): $200 * 0.20 = $40
-    # Countable earned: $200 - $40 = $160
+    # Work expense deduction (30%): $200 * 0.30 = $60
+    # Countable earned: $200 - $60 = $140
     # Payment standard (2 persons): $304
-    # Benefit: $304 - $160 = $144
-    al_tanf: 144
+    # Benefit: $304 - $140 = $164
+    al_tanf: 164
 
 - name: Case 3, income exceeds threshold - zero benefit.
   period: 2024-01
@@ -67,8 +70,8 @@
         state_code: AL
   output:
     # Monthly employment: $1,000
-    # Work expense deduction (20%): $1,000 * 0.20 = $200
-    # Countable earned: $1,000 - $200 = $800
+    # Work expense deduction (30%): $1,000 * 0.30 = $300
+    # Countable earned: $1,000 - $300 = $700
     # Payment standard (2 persons): $304
     # Ineligible: countable > payment standard
     # Benefit: $0
@@ -94,11 +97,11 @@
         state_code: AL
   output:
     # Monthly employment: $250
-    # Work expense deduction (20%): $250 * 0.20 = $50
-    # Countable earned: $250 - $50 = $200
+    # Work expense deduction (30%): $250 * 0.30 = $75
+    # Countable earned: $250 - $75 = $175
     # Payment standard (3 persons): $344
-    # Benefit: $344 - $200 = $144
-    al_tanf: 144
+    # Benefit: $344 - $175 = $169
+    al_tanf: 169
 
 - name: Case 5, family of 4 full benefit.
   period: 2024-01
@@ -149,11 +152,11 @@
         state_code: AL
   output:
     # Monthly employment: $300
-    # Work expense deduction (20%): $300 * 0.20 = $60
-    # Countable earned: $300 - $60 = $240
+    # Work expense deduction (30%): $300 * 0.30 = $90
+    # Countable earned: $300 - $90 = $210
     # Payment standard (5 persons): $440
-    # Benefit: $440 - $240 = $200
-    al_tanf: 200
+    # Benefit: $440 - $210 = $230
+    al_tanf: 230
 
 - name: Case 7, self-employment income.
   period: 2024-01
@@ -173,11 +176,11 @@
         state_code: AL
   output:
     # Monthly self-employment: $300
-    # Work expense deduction (20%): $300 * 0.20 = $60
-    # Countable earned: $300 - $60 = $240
+    # Work expense deduction (30%): $300 * 0.30 = $90
+    # Countable earned: $300 - $90 = $210
     # Payment standard (2 persons): $304
-    # Benefit: $304 - $240 = $64
-    al_tanf: 64
+    # Benefit: $304 - $210 = $94
+    al_tanf: 94
 
 - name: Case 8, unearned income.
   period: 2024-01
@@ -222,13 +225,13 @@
         state_code: AL
   output:
     # Monthly employment: $500
-    # Work expense deduction (20%): $500 * 0.20 = $100
-    # After work expense: $400
+    # Work expense deduction (30%): $500 * 0.30 = $150
+    # After work expense: $350
     # Childcare deduction: $300
-    # Countable earned: max($400 - $300, 0) = $100
+    # Countable earned: max($350 - $300, 0) = $50
     # Payment standard (2 persons): $304
-    # Benefit: $304 - $100 = $204
-    al_tanf: 204
+    # Benefit: $304 - $50 = $254
+    al_tanf: 254
 
 - name: Case 10, single pregnant person full benefit.
   period: 2024-01
@@ -273,21 +276,21 @@
         state_code: AL
   output:
     # Monthly employment: $450
-    # Work expense deduction (20%): $450 * 0.20 = $90
-    # After work expense: $450 - $90 = $360
+    # Work expense deduction (30%): $450 * 0.30 = $135
+    # After work expense: $450 - $135 = $315
     # Childcare deduction: $200
-    # Countable earned: max($360 - $200, 0) = $160
+    # Countable earned: max($315 - $200, 0) = $115
     # Payment standard (2 persons): $304
-    # Benefit: $304 - $160 = $144
-    al_tanf: 144
+    # Benefit: $304 - $115 = $189
+    al_tanf: 189
 
-- name: Edge Case 2, eligible with zero benefit.
+- name: Edge Case 2, unearned income at payment standard - zero benefit.
   period: 2024-01
   input:
     people:
       person1:
         age: 30
-        employment_income_before_lsr: 4_560  # $380/month
+        child_support_received: 3_648  # $304/month unearned (no work deduction)
       person2:
         age: 5
     spm_units:
@@ -299,9 +302,7 @@
         state_code: AL
   output:
     # Family of 2: payment standard = $304
-    # Monthly employment: $380
-    # Work expense deduction (20%): $380 * 0.20 = $76
-    # Countable earned: $380 - $76 = $304
+    # Monthly unearned income: $304 (no deductions on unearned)
     # Countable income: $304
     # $304 <= $304, eligible (tests <= boundary)
     # Benefit: $304 - $304 = $0

--- a/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/al_tanf_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/al_tanf_countable_earned_income.yaml
@@ -1,7 +1,10 @@
 # Unit tests for Alabama TANF countable earned income
-# Reference: https://dhr.alabama.gov/wp-content/uploads/2022/04/Appendix-N-Sec-2-Public-Assistance-Payment-Manual.pdf#page=37
+# Reference: Ala. Admin. Code r. 660-2-2-.30(2) (effective 05/15/2022)
+# https://admincode.legislature.state.al.us/api/chapter/660-2-2
 # Countable earned = max(gross_earned - work_expense - childcare, 0)
-# Work expense = gross_earned * 0.20
+# Work expense = gross_earned * 0.30 (the first 30% of gross earnings)
+# (The 12-month new-employment full disregard is not modeled; established
+# employment is assumed.)
 
 - name: Case 1, no earned income.
   period: 2024-01
@@ -40,9 +43,9 @@
         state_code: AL
   output:
     # Monthly employment income: $1,000
-    # Work expense deduction: $1,000 * 0.20 = $200
-    # Countable earned: $1,000 - $200 = $800
-    al_tanf_countable_earned_income: 800
+    # Work expense deduction: $1,000 * 0.30 = $300
+    # Countable earned: $1,000 - $300 = $700
+    al_tanf_countable_earned_income: 700
 
 - name: Case 3, self-employment income only.
   period: 2024-01
@@ -62,9 +65,9 @@
         state_code: AL
   output:
     # Monthly self-employment income: $1,000
-    # Work expense deduction: $1,000 * 0.20 = $200
-    # Countable earned: $1,000 - $200 = $800
-    al_tanf_countable_earned_income: 800
+    # Work expense deduction: $1,000 * 0.30 = $300
+    # Countable earned: $1,000 - $300 = $700
+    al_tanf_countable_earned_income: 700
 
 - name: Case 4, combined employment and self-employment.
   period: 2024-01
@@ -85,9 +88,9 @@
         state_code: AL
   output:
     # Monthly earned: $500 + $500 = $1,000
-    # Work expense deduction: $1,000 * 0.20 = $200
-    # Countable earned: $1,000 - $200 = $800
-    al_tanf_countable_earned_income: 800
+    # Work expense deduction: $1,000 * 0.30 = $300
+    # Countable earned: $1,000 - $300 = $700
+    al_tanf_countable_earned_income: 700
 
 - name: Case 5, low income.
   period: 2024-01
@@ -107,9 +110,9 @@
         state_code: AL
   output:
     # Monthly employment income: $50
-    # Work expense deduction: $50 * 0.20 = $10
-    # Countable earned: $50 - $10 = $40
-    al_tanf_countable_earned_income: 40
+    # Work expense deduction: $50 * 0.30 = $15
+    # Countable earned: $50 - $15 = $35
+    al_tanf_countable_earned_income: 35
 
 - name: Case 6, two earners in household.
   period: 2024-01
@@ -133,9 +136,9 @@
   output:
     # Person1: $1,000/month, Person2: $500/month
     # Total earned: $1,500
-    # Work expense deduction: $1,500 * 0.20 = $300
-    # Countable earned: $1,500 - $300 = $1,200
-    al_tanf_countable_earned_income: 1_200
+    # Work expense deduction: $1,500 * 0.30 = $450
+    # Countable earned: $1,500 - $450 = $1,050
+    al_tanf_countable_earned_income: 1_050
 
 - name: Case 7, with childcare expenses.
   period: 2024-01
@@ -156,11 +159,11 @@
         state_code: AL
   output:
     # Monthly employment: $500
-    # Work expense deduction: $500 * 0.20 = $100
-    # After work expense: $500 - $100 = $400
+    # Work expense deduction: $500 * 0.30 = $150
+    # After work expense: $500 - $150 = $350
     # Childcare: $300/month
-    # Countable earned: max($400 - $300, 0) = $100
-    al_tanf_countable_earned_income: 100
+    # Countable earned: max($350 - $300, 0) = $50
+    al_tanf_countable_earned_income: 50
 
 - name: Case 8, childcare exceeds earnings after work expense.
   period: 2024-01
@@ -181,10 +184,10 @@
         state_code: AL
   output:
     # Monthly employment: $200
-    # Work expense deduction: $200 * 0.20 = $40
-    # After work expense: $200 - $40 = $160
+    # Work expense deduction: $200 * 0.30 = $60
+    # After work expense: $200 - $60 = $140
     # Childcare: $300/month
-    # Countable earned: max($160 - $300, 0) = max(-$140, 0) = $0
+    # Countable earned: max($140 - $300, 0) = max(-$160, 0) = $0
     al_tanf_countable_earned_income: 0
 
 # ============================================================================
@@ -214,8 +217,8 @@
   output:
     # Person1: $250/month, Person2: $200/month
     # Total gross earned: $450
-    # Work expense deduction: $450 * 0.20 = $90
-    # After work expense: $450 - $90 = $360
+    # Work expense deduction: $450 * 0.30 = $135
+    # After work expense: $450 - $135 = $315
     # Childcare: $200/month
-    # Countable earned: max($360 - $200, 0) = $160
-    al_tanf_countable_earned_income: 160
+    # Countable earned: max($315 - $200, 0) = $115
+    al_tanf_countable_earned_income: 115

--- a/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/al_tanf_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/al_tanf_income_eligible.yaml
@@ -1,6 +1,9 @@
 # Unit tests for Alabama TANF income eligibility
-# Reference: https://dhr.alabama.gov/wp-content/uploads/2022/04/Appendix-N-Sec-2-Public-Assistance-Payment-Manual.pdf#page=37
+# Reference: Ala. Admin. Code r. 660-2-2 (Income r. .30, effective 05/15/2022;
+# Payment Standard r. .31; Grant Computation r. .32)
+# https://admincode.legislature.state.al.us/api/chapter/660-2-2
 # Income eligible if countable income <= payment standard
+# Work expense deduction: the first 30% of gross earnings
 # Payment standards: $264 (1 person), $304 (2), $344 (3), $392 (4), $440 (5)
 
 - name: Case 1, no income - eligible.
@@ -43,19 +46,19 @@
         state_code: AL
   output:
     # Monthly employment: $250
-    # Work expense deduction (20%): $250 * 0.20 = $50
-    # Countable earned: $250 - $50 = $200
+    # Work expense deduction (30%): $250 * 0.30 = $75
+    # Countable earned: $250 - $75 = $175
     # Payment standard (2 persons): $304
-    # $200 <= $304, eligible
+    # $175 <= $304, eligible
     al_tanf_income_eligible: true
 
-- name: Case 3, income at payment standard - eligible.
+- name: Case 3, unearned income at payment standard - eligible.
   period: 2024-01
   input:
     people:
       person1:
         age: 30
-        employment_income_before_lsr: 4_560  # $380/month
+        child_support_received: 3_648  # $304/month unearned (no work deduction)
       person2:
         age: 5
     spm_units:
@@ -66,11 +69,10 @@
         members: [person1, person2]
         state_code: AL
   output:
-    # Monthly employment: $380
-    # Work expense deduction (20%): $380 * 0.20 = $76
-    # Countable earned: $380 - $76 = $304
+    # Monthly unearned income: $304 (no deductions on unearned)
+    # Countable income: $304
     # Payment standard (2 persons): $304
-    # $304 <= $304, eligible
+    # $304 <= $304, eligible (tests <= boundary)
     al_tanf_income_eligible: true
 
 - name: Case 4, income exceeds payment standard - ineligible.
@@ -91,10 +93,10 @@
         state_code: AL
   output:
     # Monthly employment: $500
-    # Work expense deduction (20%): $500 * 0.20 = $100
-    # Countable earned: $500 - $100 = $400
+    # Work expense deduction (30%): $500 * 0.30 = $150
+    # Countable earned: $500 - $150 = $350
     # Payment standard (2 persons): $304
-    # $400 > $304, ineligible
+    # $350 > $304, ineligible
     al_tanf_income_eligible: false
 
 - name: Case 5, family of 3 below threshold - eligible.
@@ -117,10 +119,10 @@
         state_code: AL
   output:
     # Monthly employment: $350
-    # Work expense deduction (20%): $350 * 0.20 = $70
-    # Countable earned: $350 - $70 = $280
+    # Work expense deduction (30%): $350 * 0.30 = $105
+    # Countable earned: $350 - $105 = $245
     # Payment standard (3 persons): $344
-    # $280 <= $344, eligible
+    # $245 <= $344, eligible
     al_tanf_income_eligible: true
 
 - name: Case 6, family of 4 with childcare expenses - eligible.
@@ -146,12 +148,12 @@
         state_code: AL
   output:
     # Monthly employment: $500
-    # Work expense deduction (20%): $500 * 0.20 = $100
-    # After work expense: $400
+    # Work expense deduction (30%): $500 * 0.30 = $150
+    # After work expense: $350
     # Childcare deduction: $300
-    # Countable earned: max($400 - $300, 0) = $100
+    # Countable earned: max($350 - $300, 0) = $50
     # Payment standard (4 persons): $392
-    # $100 <= $392, eligible
+    # $50 <= $392, eligible
     al_tanf_income_eligible: true
 
 - name: Case 7, family of 5 with unearned income - ineligible.
@@ -179,12 +181,12 @@
         state_code: AL
   output:
     # Monthly employment: $500
-    # Work expense deduction (20%): $500 * 0.20 = $100
-    # Countable earned: $500 - $100 = $400
+    # Work expense deduction (30%): $500 * 0.30 = $150
+    # Countable earned: $500 - $150 = $350
     # Unearned: $100/month
-    # Countable income: $400 + $100 = $500
+    # Countable income: $350 + $100 = $450
     # Payment standard (5 persons): $440
-    # $500 > $440, ineligible
+    # $450 > $440, ineligible
     al_tanf_income_eligible: false
 
 - name: Case 8, single person household - eligible.
@@ -204,10 +206,10 @@
         state_code: AL
   output:
     # Monthly employment: $200
-    # Work expense deduction (20%): $200 * 0.20 = $40
-    # Countable earned: $200 - $40 = $160
+    # Work expense deduction (30%): $200 * 0.30 = $60
+    # Countable earned: $200 - $60 = $140
     # Payment standard (1 person): $264
-    # $160 <= $264, eligible
+    # $140 <= $264, eligible
     al_tanf_income_eligible: true
 
 # ============================================================================

--- a/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/dhs/tanf/integration.yaml
@@ -1,8 +1,9 @@
 # Integration tests for Alabama TANF - full pipeline testing
 # Tests realistic family scenarios with complete eligibility and benefit calculations
-# Reference: https://dhr.alabama.gov/wp-content/uploads/2022/04/Appendix-N-Sec-2-Public-Assistance-Payment-Manual.pdf#page=37
+# Reference: Ala. Admin. Code r. 660-2-2 (Income r. .30, effective 05/15/2022)
+# https://admincode.legislature.state.al.us/api/chapter/660-2-2
 # Key rules:
-# - Work expense deduction: 20% of earned income
+# - Work expense deduction: the first 30% of gross earnings
 # - Childcare is deducted directly from earned income
 # - No asset limit in Alabama
 
@@ -64,15 +65,15 @@
   output:
     # Family size: 2
     # Monthly gross earned income: $600
-    # Work expense deduction: $600 * 0.20 = $120
-    # Countable earned income: $600 - $120 = $480
-    # Countable income: $480
+    # Work expense deduction: $600 * 0.30 = $180
+    # Countable earned income: $600 - $180 = $420
+    # Countable income: $420
     # Payment standard (family of 2): $304
-    # Ineligible: $480 > $304
+    # Ineligible: $420 > $304
     # Benefit: $0
     is_person_demographic_tanf_eligible: [false, true]
-    al_tanf_countable_earned_income: 480
-    al_tanf_countable_income: 480
+    al_tanf_countable_earned_income: 420
+    al_tanf_countable_income: 420
     al_tanf_income_eligible: false
     al_tanf_eligible: false
     al_tanf: 0
@@ -102,18 +103,18 @@
   output:
     # Family size: 3
     # Monthly gross earned income: $400
-    # Work expense deduction: $400 * 0.20 = $80
-    # Countable earned income: $400 - $80 = $320
-    # Countable income: $320
+    # Work expense deduction: $400 * 0.30 = $120
+    # Countable earned income: $400 - $120 = $280
+    # Countable income: $280
     # Payment standard (family of 3): $344
-    # $320 <= $344, eligible
-    # Benefit: $344 - $320 = $24
+    # $280 <= $344, eligible
+    # Benefit: $344 - $280 = $64
     is_person_demographic_tanf_eligible: [false, true, true]
-    al_tanf_countable_earned_income: 320
-    al_tanf_countable_income: 320
+    al_tanf_countable_earned_income: 280
+    al_tanf_countable_income: 280
     al_tanf_income_eligible: true
     al_tanf_eligible: true
-    al_tanf: 24
+    al_tanf: 64
 
 - name: Scenario 4 - Family of 4 with self-employment income.
   period: 2024-01
@@ -142,18 +143,18 @@
   output:
     # Family size: 4
     # Monthly self-employment: $400
-    # Work expense deduction: $400 * 0.20 = $80
-    # Countable earned income: $400 - $80 = $320
-    # Countable income: $320
+    # Work expense deduction: $400 * 0.30 = $120
+    # Countable earned income: $400 - $120 = $280
+    # Countable income: $280
     # Payment standard (family of 4): $392
-    # $320 <= $392, eligible
-    # Benefit: $392 - $320 = $72
+    # $280 <= $392, eligible
+    # Benefit: $392 - $280 = $112
     is_person_demographic_tanf_eligible: [false, false, true, true]
-    al_tanf_countable_earned_income: 320
-    al_tanf_countable_income: 320
+    al_tanf_countable_earned_income: 280
+    al_tanf_countable_income: 280
     al_tanf_income_eligible: true
     al_tanf_eligible: true
-    al_tanf: 72
+    al_tanf: 112
 
 - name: Scenario 5 - Family with combined earned and unearned income.
   period: 2024-01
@@ -179,19 +180,19 @@
   output:
     # Family size: 2
     # Monthly gross earned income: $300
-    # Work expense deduction: $300 * 0.20 = $60
-    # Countable earned: $300 - $60 = $240
+    # Work expense deduction: $300 * 0.30 = $90
+    # Countable earned: $300 - $90 = $210
     # Monthly unearned: $50
-    # Countable income: $240 + $50 = $290
+    # Countable income: $210 + $50 = $260
     # Payment standard (family of 2): $304
-    # $290 <= $304, eligible
-    # Benefit: $304 - $290 = $14
+    # $260 <= $304, eligible
+    # Benefit: $304 - $260 = $44
     is_person_demographic_tanf_eligible: [false, true]
-    al_tanf_countable_earned_income: 240
-    al_tanf_countable_income: 290
+    al_tanf_countable_earned_income: 210
+    al_tanf_countable_income: 260
     al_tanf_income_eligible: true
     al_tanf_eligible: true
-    al_tanf: 14
+    al_tanf: 44
 
 - name: Scenario 6 - Family of 5 with childcare expenses.
   period: 2024-01
@@ -223,20 +224,20 @@
   output:
     # Family size: 5
     # Monthly gross earned income: $600
-    # Work expense deduction: $600 * 0.20 = $120
-    # After work expense: $600 - $120 = $480
+    # Work expense deduction: $600 * 0.30 = $180
+    # After work expense: $600 - $180 = $420
     # Childcare: $200
-    # Countable earned: max($480 - $200, 0) = $280
-    # Countable income: $280
+    # Countable earned: max($420 - $200, 0) = $220
+    # Countable income: $220
     # Payment standard (family of 5): $440
-    # $280 <= $440, eligible
-    # Benefit: $440 - $280 = $160
+    # $220 <= $440, eligible
+    # Benefit: $440 - $220 = $220
     is_person_demographic_tanf_eligible: [false, false, true, true, true]
-    al_tanf_countable_earned_income: 280
-    al_tanf_countable_income: 280
+    al_tanf_countable_earned_income: 220
+    al_tanf_countable_income: 220
     al_tanf_income_eligible: true
     al_tanf_eligible: true
-    al_tanf: 160
+    al_tanf: 220
 
 - name: Scenario 7 - Refugee family eligible.
   period: 2024-01
@@ -263,18 +264,18 @@
   output:
     # Family size: 2
     # Monthly gross earned income: $200
-    # Work expense deduction: $200 * 0.20 = $40
-    # Countable earned: $200 - $40 = $160
-    # Countable income: $160
+    # Work expense deduction: $200 * 0.30 = $60
+    # Countable earned: $200 - $60 = $140
+    # Countable income: $140
     # Payment standard (family of 2): $304
-    # $160 <= $304, eligible
-    # Benefit: $304 - $160 = $144
+    # $140 <= $304, eligible
+    # Benefit: $304 - $140 = $164
     is_person_demographic_tanf_eligible: [false, true]
-    al_tanf_countable_earned_income: 160
-    al_tanf_countable_income: 160
+    al_tanf_countable_earned_income: 140
+    al_tanf_countable_income: 140
     al_tanf_income_eligible: true
     al_tanf_eligible: true
-    al_tanf: 144
+    al_tanf: 164
 
 # ============================================================================
 # Edge Case Tests
@@ -315,18 +316,18 @@
   output:
     # Family size: 8
     # Monthly gross earned income: $400
-    # Work expense deduction: $400 * 0.20 = $80
-    # Countable earned income: $400 - $80 = $320
-    # Countable income: $320
+    # Work expense deduction: $400 * 0.30 = $120
+    # Countable earned income: $400 - $120 = $280
+    # Countable income: $280
     # Payment standard (family of 8): $584
-    # $320 <= $584, eligible
-    # Benefit: $584 - $320 = $264
+    # $280 <= $584, eligible
+    # Benefit: $584 - $280 = $304
     is_person_demographic_tanf_eligible: [false, false, true, true, true, true, true, true]
-    al_tanf_countable_earned_income: 320
-    al_tanf_countable_income: 320
+    al_tanf_countable_earned_income: 280
+    al_tanf_countable_income: 280
     al_tanf_income_eligible: true
     al_tanf_eligible: true
-    al_tanf: 264
+    al_tanf: 304
 
 - name: Edge Case 2 - Childcare exceeds after-work-expense income.
   period: 2024-01
@@ -351,10 +352,10 @@
         state_code: AL
   output:
     # Monthly employment: $300
-    # Work expense deduction: $300 * 0.20 = $60
-    # After work expense: $240
+    # Work expense deduction: $300 * 0.30 = $90
+    # After work expense: $210
     # Childcare: $300
-    # Countable earned: max($240 - $300, 0) = max(-$60, 0) = $0
+    # Countable earned: max($210 - $300, 0) = max(-$90, 0) = $0
     # Payment standard (2 persons): $304
     # Benefit: $304 - $0 = $304
     is_person_demographic_tanf_eligible: [false, true]

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/dhs/tea/ar_tea.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/dhs/tea/ar_tea.yaml
@@ -1,8 +1,11 @@
 # Unit tests for ar_tea (final benefit amount)
-# Benefit calculation (per TEA Manual Section 2362, effective 01/01/2023):
+# Benefit calculation (per TEA Policy Manual Section 2362, effective 01/01/2023,
+# https://humanservices.arkansas.gov/wp-content/uploads/TEA_MANUAL-10.1.24.pdf#page=93):
+# Income eligibility (countable income <= $513) is enforced by ar_tea_eligible.
+# The payment is a flat grant, never gap-filled:
 # 1. If not eligible: $0
-# 2. If gross income < $1026: benefit = max(payment_standard - countable_income, 0)
-# 3. If gross income >= $1026: benefit = payment_standard * 0.5 (no subtraction)
+# 2. If gross income < $1,026: benefit = full maximum grant for family size
+# 3. If gross income >= $1,026: benefit = maximum grant * 0.5
 
 - name: Case 1, ineligible receives zero.
   period: 2024-01
@@ -26,7 +29,7 @@
     ar_tea: 0
     # Not eligible -> no benefit
 
-- name: Case 2, eligible with zero income receives full benefit.
+- name: Case 2, eligible with zero income receives full grant.
   period: 2024-01
   input:
     people:
@@ -46,9 +49,9 @@
         ar_tea_countable_income: 0
   output:
     ar_tea: 204
-    # max(204 - 0, 0) = 204
+    # Gross income 0 < 1,026 -> full maximum grant of 204
 
-- name: Case 3, eligible with countable income below payment standard.
+- name: Case 3, eligible with earnings below trigger receives full grant.
   period: 2024-01
   input:
     people:
@@ -67,11 +70,38 @@
         ar_tea_maximum_benefit: 204
         ar_tea_countable_income: 128
   output:
-    ar_tea: 76
-    # Gross income 400 < 1026 trigger, so full payment standard applies
-    # max(204 - 128, 0) = 76
+    ar_tea: 204
+    # Gross income 400 < 1,026 -> full maximum grant of 204
+    # (countable income is not subtracted from the grant)
 
-- name: Case 4, gross income at trigger causes 50 percent reduction.
+- name: Case 4, TEA Manual Section 2362 Example 1, gross income below trigger.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        tanf_gross_earned_income: 0
+        tanf_gross_unearned_income: 150
+      person2:
+        age: 10
+      person3:
+        age: 8
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: AR
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        ar_tea_eligible: true
+        ar_tea_maximum_benefit: 204
+        ar_tea_countable_income: 150
+  output:
+    ar_tea: 204
+    # Manual Example 1: monthly gross income of 150 is less than 1,026,
+    # so payment is the maximum grant for a family size of three, or 204.
+
+- name: Case 5, gross income at trigger causes 50 percent reduction.
   period: 2024-01
   input:
     people:
@@ -94,7 +124,7 @@
     # Gross income 1,026 >= 1,026 trigger, so 50% reduction
     # 204 * 0.5 = 102 (no subtraction when above trigger)
 
-- name: Case 5, gross income above trigger with countable income.
+- name: Case 6, TEA Manual Section 2362 Example 2, gross income above trigger.
   period: 2024-01
   input:
     people:
@@ -102,22 +132,24 @@
         age: 30
         tanf_gross_earned_income: 1_200
         tanf_gross_unearned_income: 0
+      person2:
+        age: 10
     households:
       household:
-        members: [person1]
+        members: [person1, person2]
         state_code: AR
     spm_units:
       spm_unit:
-        members: [person1]
+        members: [person1, person2]
         ar_tea_eligible: true
         ar_tea_maximum_benefit: 162
         ar_tea_countable_income: 384
   output:
     ar_tea: 81
-    # Gross income 1,200 >= 1,026 trigger, so 50% reduction
-    # 162 * 0.5 = 81 (no subtraction when above trigger)
+    # Manual Example 2: gross countable income of 1,200 exceeds 1,026,
+    # so payment is 50% of the maximum for a two-person family, or 81.
 
-- name: Case 6, benefit would be negative clipped to zero.
+- name: Case 7, small grant below trigger still receives full grant.
   period: 2024-01
   input:
     people:
@@ -136,5 +168,6 @@
         ar_tea_maximum_benefit: 81
         ar_tea_countable_income: 100
   output:
-    ar_tea: 0
-    # max(81 - 100, 0) = max(-19, 0) = 0
+    ar_tea: 81
+    # Gross income 0 < 1,026 -> full maximum grant of 81
+    # (countable income is not subtracted, so no negative-clip occurs)

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/dhs/tea/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/dhs/tea/integration.yaml
@@ -39,10 +39,9 @@
     ar_tea_maximum_benefit: 204
     # Family size 3 -> $204 payment standard
     ar_tea: 204
-    # Gross income 0 < 1,026, so no reduction
-    # max(204 - 0, 0) = 204
+    # Gross income 0 < 1,026, so full maximum grant of 204
 
-- name: Case 2, ongoing family of 3 with earned income below trigger receives partial benefit.
+- name: Case 2, ongoing family of 3 with earned income below trigger receives full grant.
   period: 2024-01
   absolute_error_margin: 0.01
   input:
@@ -80,9 +79,9 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 204
-    ar_tea: 76
-    # Gross income 400 < 1,026, so no reduction
-    # max(204 - 128, 0) = 76
+    ar_tea: 204
+    # Gross income 400 < 1,026, so full maximum grant of 204
+    # (countable income is not subtracted from the grant)
 
 - name: Case 3, ongoing family of 2 with earnings below trigger.
   period: 2024-01
@@ -119,9 +118,8 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 162
-    ar_tea: 19.28
-    # Gross income 446 < 1026, so no reduction
-    # max(162 - 142.72, 0) = 19.28
+    ar_tea: 162
+    # Gross income 446 < 1,026, so full maximum grant of 162
 
 - name: Case 4, ongoing family of 4 with earnings below trigger.
   period: 2024-01
@@ -162,9 +160,8 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 247
-    ar_tea: 87
-    # Gross income 500 < 1026, so no reduction
-    # max(247 - 160, 0) = 87
+    ar_tea: 247
+    # Gross income 500 < 1,026, so full maximum grant of 247
 
 - name: Case 5, ongoing recipient with 550 gross earnings below trigger.
   period: 2024-01
@@ -202,11 +199,10 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 204
-    ar_tea: 28
-    # Gross income 550 < 1026, so no reduction
-    # max(204 - 176, 0) = 28
+    ar_tea: 204
+    # Gross income 550 < 1,026, so full maximum grant of 204
 
-- name: Case 6, ongoing recipient with high earnings but still income eligible.
+- name: Case 6, ongoing recipient with high earnings below trigger but still income eligible.
   period: 2024-01
   input:
     people:
@@ -241,9 +237,9 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 204
-    ar_tea: 0
-    # Gross income 800 < 1,026, so no reduction
-    # max(204 - 256, 0) = 0 (countable income exceeds maximum benefit)
+    ar_tea: 204
+    # Gross income 800 < 1,026, so full maximum grant of 204
+    # (income eligible since countable income 256 <= 513)
 
 - name: Case 7, resources exceed limit making family ineligible.
   period: 2024-01
@@ -314,9 +310,9 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 204
-    ar_tea: 0
-    # Gross income 400 < 1,026, so no reduction
-    # max(204 - 320, 0) = 0
+    ar_tea: 204
+    # Gross income 400 < 1,026, so full maximum grant of 204
+    # (applicant income eligible since countable income 320 <= 513)
 
 - name: Case 9, ongoing recipient with gross income above trigger.
   period: 2024-01
@@ -472,9 +468,9 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 247
-    ar_tea: 0
-    # Gross income 476.74 < 1026, so no reduction
-    # max(247 - 381.39, 0) = 0
+    ar_tea: 247
+    # Manual Example #2 establishes income eligibility (381.39 <= 513).
+    # Gross income 476.74 < 1,026, so full maximum grant of 247.
 
 # TEA Manual Section 2362 Examples (Gross Income Trigger)
 
@@ -554,9 +550,8 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 204
-    ar_tea: 0
-    # Gross income 1,025 < 1,026, so NO reduction
-    # max(204 - 328, 0) = 0 (countable income exceeds maximum benefit)
+    ar_tea: 204
+    # Gross income 1,025 < 1,026, so full maximum grant of 204
 
 - name: Boundary test, gross income $1,027 (one above trigger - 50% reduction).
   period: 2024-01
@@ -634,9 +629,8 @@
 
     # Benefit calculation
     ar_tea_maximum_benefit: 162
-    ar_tea: 19.6
-    # Gross income 445 < 446, so NO reduction
-    # max(162 - 142.4, 0) = 19.6
+    ar_tea: 162
+    # Gross income 445 < 446, so full maximum grant of 162
 
 - name: Historical test 2022, ongoing recipient above $446 trigger.
   period: 2022-01

--- a/policyengine_us/variables/gov/states/al/dhs/tanf/income/al_tanf_countable_earned_income.py
+++ b/policyengine_us/variables/gov/states/al/dhs/tanf/income/al_tanf_countable_earned_income.py
@@ -7,13 +7,24 @@ class al_tanf_countable_earned_income(Variable):
     unit = USD
     label = "Alabama TANF countable earned income"
     definition_period = MONTH
-    reference = "https://dhr.alabama.gov/wp-content/uploads/2022/04/Appendix-N-Sec-2-Public-Assistance-Payment-Manual.pdf#page=37"
+    reference = "https://admincode.legislature.state.al.us/api/chapter/660-2-2"
     defined_for = StateCode.AL
 
     def formula(spm_unit, period, parameters):
+        # Per Ala. Admin. Code r. 660-2-2-.30(2) (effective 05/15/2022), earned
+        # income deductions are: (a) disregard all earnings from timely reported
+        # new employment for the first twelve months, then thereafter (b) deduct
+        # the first 30% of gross earnings, and (c) child care / incapacitated
+        # adult care costs.
+        #
+        # The 12-month new-employment disregard in (a) depends on how long each
+        # earner has held their current job, which is not available in the input
+        # data, so it is not modeled here; this assumes established (>12-month)
+        # employment, under which only the 30% work expense and care-cost
+        # deductions in (b) and (c) apply.
         p = parameters(period).gov.states.al.dhs.tanf.income
         gross_earned = add(spm_unit, period, ["tanf_gross_earned_income"])
         work_expense = gross_earned * p.work_expense_rate
-        # Child care is deducted from earned income per Section 3115.B
+        # Child care is deducted from earned income per r. 660-2-2-.30(2)(c).
         childcare_expenses = spm_unit("childcare_expenses", period)
         return max_(gross_earned - work_expense - childcare_expenses, 0)

--- a/policyengine_us/variables/gov/states/ar/dhs/tea/ar_tea.py
+++ b/policyengine_us/variables/gov/states/ar/dhs/tea/ar_tea.py
@@ -13,30 +13,34 @@ class ar_tea(Variable):
     defined_for = "ar_tea_eligible"
 
     def formula(spm_unit, period, parameters):
-        # Per TEA Manual Section 2362 - Reduced Payment - Gross Income Trigger
+        # Per TEA Policy Manual Section 2362 - Reduced Payment - Gross Income
+        # Trigger (effective 01/01/2023). Income eligibility (countable income
+        # <= $513) is already enforced by ar_tea_eligible, so a family reaching
+        # this formula is income eligible. The payment is a flat grant, not a
+        # gap-filled benefit: it is the full maximum grant for the family size
+        # when gross income is below the trigger, and 50% of that maximum when
+        # gross income is at or above the trigger. Countable income is never
+        # subtracted from the grant (Section 2362 Example #1: $150 gross income
+        # yields the full $204 grant for a family of three).
         p = parameters(period).gov.states.ar.dhs.tea
 
         maximum_benefit = spm_unit("ar_tea_maximum_benefit", period)
-        countable_income = spm_unit("ar_tea_countable_income", period)
 
-        # Check if gross income triggers 50% payment reduction
+        # Countable monthly gross income, excluding assigned child support.
         gross_income = add(
             spm_unit,
             period,
             ["tanf_gross_earned_income", "tanf_gross_unearned_income"],
         )
 
+        # When gross income >= trigger: payment reduced by 50% of the maximum.
+        # When gross income < trigger: payment is the full maximum grant.
         above_trigger = gross_income >= p.payment_standard.trigger.amount
         reduced_payment = maximum_benefit * (
             1 - p.payment_standard.trigger.reduction_rate
         )
-
-        # When gross income >= trigger: payment is 50% of max (no subtraction)
-        # When gross income < trigger: payment is max - countable income
-        below_trigger_benefit = max_(maximum_benefit - countable_income, 0)
-        capped_benefit = min_(below_trigger_benefit, maximum_benefit)
         return where(
             above_trigger,
             reduced_payment,
-            capped_benefit,
+            maximum_benefit,
         )


### PR DESCRIPTION
## Summary

Source-first review of three TANF/TEA parameters flagged by Axiom encoding. Two were genuine defects (fixed here); one was already correct (verified, references dated).

## Per-issue verdicts

### Arkansas TEA below-trigger payment — FIX (Fixes #8841)
The below-trigger branch subtracted countable income from the maximum grant, which contradicts the **TEA Policy Manual Section 2362** ("Reduced Payment – Gross Income Trigger", effective 01/01/2023, [manual p. 93](https://humanservices.arkansas.gov/wp-content/uploads/TEA_MANUAL-10.1.24.pdf#page=93)).

The manual defines a **flat grant**, not a gap-filled benefit. Income eligibility (countable income ≤ $513) is a separate gate:
- **Section 2362 Example #1**: family of 3, $150 monthly gross income → "their payment is **the maximum grant for a family size of three (3) or $204**."
- **Section 2362 Example #2**: family of 2, $1,200 monthly gross income (≥ $1,026 trigger) → "the Browns' payment is **50% of the maximum for a two-person family, or $81**."

Corrected `ar_tea` to return the full maximum grant below the trigger and 50% of the maximum at/above it. Updated the unit and integration tests, anchoring cases directly to Examples #1 and #2.

### Alabama TANF earned-income work expense — FIX (Fixes #8840)
PolicyEngine used a 20% work-expense rate from the DHR Public Assistance Payment Manual (2022). The current **Ala. Admin. Code r. 660-2-2-.30(2)** (chapter revised 2/14/2025; this section's amendment effective 05/15/2022, [source](https://admincode.legislature.state.al.us/api/chapter/660-2-2)) provides earned-income deductions of:

> (a) disregard all earnings from new employment that is timely and accurately reported in the first twelve months in which wages are received, then deduct the following work expenses thereafter; **(b) the first 30% of gross earnings;** and (c) the cost … of child care …

The Administrative Code is the promulgated regulation and controls over the sub-regulatory payment manual (and is the newer source). Changes:
- `work_expense_rate`: added `2022-05-15: 0.3` (kept the prior `2002-01-01: 0.2`), with Admin Code reference.
- Documented the **first-12-month new-employment full earnings disregard** (660-2-2-.30(2)(a)) as a known limitation in `al_tanf_countable_earned_income` — it depends on months-of-current-employment, which is not in the input data, so established (>12-month) employment is assumed. Not fabricating an input we cannot populate.
- Recomputed all Alabama TANF tests for the 30% rate.

Confirmed separately that `al_tanf` (payment standard − countable income) matches **r. 660-2-2-.32** ("The grant amount is computed by subtracting rounded total net income from the payment standard"), so the gap-fill structure is correct.

### Montana TANF standards source hierarchy — VERIFIED CORRECT (Addresses #8842)
No value change. **ARM 37.78.420** on Cornell/LII carries fixed tables from the **2011 amendment based on the FY2007 FPL** (2-person payment standard $401). But Montana's own current **DPHHS TANF 001 Monthly Income Standards** (effective **07/01/2025**, which cites ARM 37.78.420 as its authority, [source](https://dphhs.mt.gov/assets/hcsd/tanfmanual/TANF001.pdf)) publishes standards derived from the **current FPL**:

| AU size | GMI | NMI | Benefit std | Payment std |
|--------:|----:|----:|------------:|------------:|
| 1 | 859 | 464 | 365 | 425 |
| 2 | 1,162 | 628 | 493 | 575 |
| 3 | 1,465 | 792 | 622 | 725 |

The manual states these are Payment = **35% of 2023 FPL**, Benefit/GMI/NMI = **30% of 2023 FPL**. PolicyEngine's computed values match to the dollar (e.g. 2-person: payment 575.17, benefit 493.00, net 628.03, gross 1,161.85). The manual is the operative, annually-refreshed expression of ARM 37.78.420 and supersedes the rule's stale 2011 fixed table; PE is correct. Dated the TANF 001 references in the two FPL-rate parameters to make the source hierarchy explicit.

The ARM **post-employment payment-standard** branch ($375/$275/$175 for months 1–3 after leaving TANF for work) is a narrow special-case program not modeled here; recommend closing #8842 as verified, with that branch tracked separately if desired.

## Tests
All via `policyengine_core ... test ... -c policyengine_us`:
- Montana TANF: **158 passed**
- Arkansas TEA: **59 passed** (was 58; +1 Section 2362 Example case)
- Alabama TANF: **55 passed**
- Combined: **272 passed**

Touched Python files pass `ruff format --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
