### PR TITLE
Fix PA employer-plan retirement exemption and NJ 529 deduction ordering (#8848, #8849); close #8830

### DIFF
--- a/LANE_STATUS.md
+++ b/LANE_STATUS.md
@@ -1,0 +1,49 @@
+# Accuracy lane: state-tax (PA #8848, NJ #8849, OK #8830)
+
+## Status: COMPLETE — PR #8922 open as DRAFT, CI running. DO NOT MERGE.
+
+Branch: codex/state-tax-accuracy (pushed to origin = MaxGhenis fork)
+PR: https://github.com/PolicyEngine/policyengine-us/pull/8922 (base PolicyEngine/policyengine-us:main)
+Commit: 36b381387f
+
+## Per-issue verdicts
+
+### #8848 PA post-retirement employer-plan distributions — FIXED
+- Bug: pa_nontaxable_retirement_distributions excluded only taxable_ira_distributions.
+  401(k)/403(b)/SEP/Keogh distributions (all in taxable_retirement_distributions, disjoint
+  from taxable_pension_income which the pension path already handles) stayed taxable at 3.07%.
+- Law: 61 Pa. Code 101.6 groups IRA/SEP/Keogh/qualified employer plans; non-taxable when
+  distributed on/after retirement after reaching plan age or service. PIT Guide + DOR 1099-R
+  FAQ a_id 1470 (Code 7) concur.
+- Fix: new param gov/states/pa/tax/income/nontaxable_retirement_distribution_sources lists all 5
+  sources; variable sums them, keeps 59.5 retirement_age_threshold proxy (mirrors IRA path, matches
+  issue's "same treatment as IRA after 59.5"). Corrected the old Case 3 test that pinned the bug.
+- Tests: PA 356 -> 360. Cases for each plan type + reported household (scenario_085: age 67, $1,560 401k).
+
+### #8849 NJ 529 deduction ordering — FIXED
+- Bug: nj_529_deduction was in subtractions.yaml -> nj_total_income -> nj_agi (gross-income line).
+  Netted into nj_agi before the filing-threshold test, wrongly zeroing 529 contributors just above
+  $10k/$20k gross income AND flipping nj_property_tax_deduction_eligible.
+- Law: NJ-1040 line 29 = gross income (filing threshold, 54A:2-4). 529 = line 37a College
+  Affordability deduction (54A:3-13), applied between gross income and taxable income (line 39).
+- Fix: removed from subtractions.yaml (collapsed redundant 2022 breakpoint); added to
+  nj_total_deductions alongside nj_medical_expense_deduction (its 54A:3 sibling). Income limit reads
+  federal AGI not nj_agi, so no cycle.
+- Tests: NJ 549 -> 550. Boundary test: emp $10,500 + $10k 529 -> nj_agi stays 10,500, deduction lands
+  in nj_total_deductions. Verified property-tax eligibility now True.
+
+### #8830 OK IRC 401 pensions in TY2021 — ALREADY FIXED on main (PR #8911, commit 1f61736c69)
+- ok_pension_subtraction already excludes private (IRC 401) pensions before 2022 via dated bool param
+  private_pension_qualifies (2021 false / 2022 true), page-anchored to Form 511 Schedule 511-A line 6.
+- Reported household verified: age 66, taxable_private_pension_income 20000, state_fips 40 ->
+  ok_pension_subtraction 0 in 2021, 10000 in 2022. Baseline tests already cover this + govt-pension-still-
+  qualifies-2021 case. Recommend closing #8830 with reference to #8911. No code change.
+
+## Verification done
+- Local trees pass: PA 360, NJ 550, OK 187. Structural (6) + metadata (3) + NJ deductions/bond (20) pass.
+- CI (PR #8922): changelog, 6 smoke-imports (3.9-3.14), Lint, bundle metadata, Quick Feedback selective,
+  both codecov = SUCCESS. 23 full-suite shards were in progress at last check, 0 failures.
+
+## Follow-up flagged (out of scope, separate task task_4fc62107)
+- Kentucky pension exclusion (ky_pension_income_exclusion) may over-apply to working-age pension income
+  without retiree-status gating (taxsim record 30551). Needs KRS 141.019 + Schedule P verification.

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,55 @@
+## Summary
+
+Three state income-tax accuracy issues. Two are fixed here with dated, page-anchored parameters and tests; one is already correct on `main` and is documented below with evidence for closing.
+
+| Issue | State | Verdict |
+|---|---|---|
+| #8848 | PA | **Fixed** — employer-plan (401(k), 403(b), SEP, Keogh) distributions now exempt post-retirement, like IRAs |
+| #8849 | NJ | **Fixed** — 529 deduction moved from gross-income subtractions to taxable-income deductions |
+| #8830 | OK | **Already correct on `main`** (PR #8911) — close with evidence |
+
+---
+
+## #8848 — PA post-retirement employer-plan distributions
+
+**Law.** 61 Pa. Code § 101.6 defines "Old Age or Retirement Benefit Plans" to include "Individual Retirement plans (IRA), Simplified Employee Pension Plans (SEP), Keogh plans, Federally qualified employe pension plans and similar old age or retirement benefit plans," and makes their distributions non-taxable when "made upon or after retirement from service after reaching a specific age or after a stated period of employment." The PA PIT Guide (Gross Compensation) and the PA DOR 1099-R FAQ (a_id 1470, Code 7 normal distribution) say the same: a distribution from an eligible PA plan is not taxable once the plan's age/service requirements for retirement are met.
+
+**Bug.** `taxable_401k_distributions`, `taxable_403b_distributions`, `taxable_sep_distributions`, and `keogh_distributions` all sit in `taxable_retirement_distributions` — separate from `taxable_pension_income` (which the pension path already exempts via `pa_nontaxable_pension_income`). `pa_nontaxable_retirement_distributions` only excluded `taxable_ira_distributions`, so post-retirement 401(k)/403(b)/SEP/Keogh distributions stayed in `pa_total_taxable_income` and were taxed at 3.07%.
+
+**Fix.** New parameter `gov/states/pa/tax/income/nontaxable_retirement_distribution_sources` lists all five eligible distribution sources; `pa_nontaxable_retirement_distributions` sums them and applies the existing `retirement_age_threshold` (59½) proxy, mirroring the IRA treatment the issue asks for. The previously-passing "Case 3" test that pinned the old behavior (401(k) at 67 → taxed) is corrected to the exempt result, and cases for 403(b)/SEP/Keogh plus the issue's reported household (PolicyBench scenario_085: PA single, age 67, $1,560 401(k)) are added.
+
+---
+
+## #8849 — NJ 529 deduction shifts the filing threshold
+
+**Law.** NJ's filing-threshold zero-tax floor (N.J.S.A. 54A:2-4) tests **gross income** — Form NJ-1040 line 29 ("more than $20,000 … $10,000 if single/MFS"). The NJBEST 529 contribution deduction (N.J.S.A. 54A:3-13; P.L. 2021 c.419) is a New Jersey College Affordability Act deduction on **line 37a**, in the deductions block (lines 30–37c) between gross income (line 29) and taxable income (line 39) — the same 54A:3 family as the medical-expense deduction PE already models in `nj_total_deductions`.
+
+**Bug.** `nj_529_deduction` was listed in `subtractions.yaml`, which feeds `nj_total_income` → `nj_agi` (PE's gross-income line). Away from the threshold this is harmless (the deduction lands either way), but at the boundary it netted into `nj_agi` and wrongly pulled 529 contributors just above $10k/$20k below the threshold, zeroing their tax and flipping `nj_property_tax_deduction_eligible`.
+
+**Fix.** Remove `nj_529_deduction` from `subtractions.yaml` (collapsing the now-redundant 2022 breakpoint) and add it to `nj_total_deductions` alongside `nj_medical_expense_deduction`. Its income-limit test reads federal `adjusted_gross_income`, not `nj_agi`, so this creates no circular dependency. A boundary test confirms a single filer with $10,500 gross income and $10,000 of 529 contributions keeps `nj_agi = 10,500` (above the threshold, unmoved by the deduction) with the deduction landing in `nj_total_deductions`.
+
+---
+
+## #8830 — OK §401 employer pensions in TY2021 (already fixed)
+
+Fixed on `main` by PR #8911 (commit `1f61736c69`). `ok_pension_subtraction` now excludes private-employer (IRC §401) pension income before 2022 via the dated boolean parameter `private_pension_qualifies` (2021 → `false`, 2022 → `true`), page-anchored to Form 511 Schedule 511-A line 6 for both years. The reported-household case is already covered by baseline tests: age 66 with `taxable_private_pension_income: 20_000` yields `ok_pension_subtraction: 0` in 2021 and `10,000` in 2022, with a companion case confirming government pensions still qualify in 2021. No code change needed; recommend closing #8830 with reference to #8911.
+
+---
+
+## Tests
+
+All baseline state trees pass on this branch:
+
+- PA: 360 (was 356; +4 net from expanded employer-plan and reported-household cases)
+- NJ: 550 (was 549; +1 filing-threshold boundary test)
+- OK: 187 (unchanged; already covers the #8830 year-boundary cases)
+
+Run:
+```
+python -m policyengine_core.scripts.policyengine_command test \
+  policyengine_us/tests/policy/baseline/gov/states/{pa,nj,ok}/ -c policyengine_us
+```
+
+Closes #8848, closes #8849, closes #8830.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/changelog.d/state-tax-accuracy.fixed.md
+++ b/changelog.d/state-tax-accuracy.fixed.md
@@ -1,0 +1,2 @@
+- Exempted post-retirement-age distributions from eligible Pennsylvania employer retirement plans (401(k), 403(b), SEP, Keogh) from PA taxable compensation, matching the existing IRA treatment.
+- Moved the New Jersey 529 (NJBEST) contribution deduction from gross-income subtractions to taxable-income deductions so it no longer shifts the gross-income filing threshold.

--- a/policyengine_us/parameters/gov/states/nj/tax/income/deductions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/nj/tax/income/deductions/plan_529_contributions/cap.yaml
@@ -9,4 +9,7 @@ metadata:
   - title: NJ-1040 Instructions 2024
     href: https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf
 values:
+  # P.L. 2021, c.419 § 1 applies to taxable years beginning on or after
+  # January 1, 2022; no deduction exists before then.
+  2021-01-01: 0
   2022-01-01: 10_000

--- a/policyengine_us/parameters/gov/states/nj/tax/income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/nj/tax/income/subtractions.yaml
@@ -6,8 +6,10 @@ metadata:
     - title: NJ-1040 Instructions (page 21)
       href: https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf
 values:
+  # New Jersey College Affordability Act deductions (including the NJBEST 529
+  # contribution deduction, nj_529_deduction) are N.J.S.A. 54A:3 deductions
+  # applied on Form NJ-1040 lines 37a-37c, after the gross-income line (line
+  # 29) that the filing-threshold test keys on. They therefore reduce taxable
+  # income (nj_total_deductions), not gross income (subtractions). See #8849.
   2021-01-01:
     - us_govt_interest_person
-  2022-01-01:
-    - us_govt_interest_person
-    - nj_529_deduction

--- a/policyengine_us/parameters/gov/states/pa/tax/income/nontaxable_retirement_distribution_sources.yaml
+++ b/policyengine_us/parameters/gov/states/pa/tax/income/nontaxable_retirement_distribution_sources.yaml
@@ -1,0 +1,18 @@
+description: Retirement account distributions that Pennsylvania excludes from compensation once the recipient reaches the qualifying retirement age. 61 Pa. Code Sec. 101.6 treats IRAs, SEPs, Keogh plans, and federally qualified employee pension plans (including 401(k) and 403(b) plans) alike.
+values:
+  2021-01-01:
+    - taxable_ira_distributions
+    - taxable_401k_distributions
+    - taxable_403b_distributions
+    - taxable_sep_distributions
+    - keogh_distributions
+metadata:
+  unit: currency-USD
+  label: PA nontaxable retirement distribution sources
+  reference:
+    - title: 61 Pa. Code Sec. 101.6 - Compensation (old age or retirement benefit plans include IRA, SEP, Keogh, and federally qualified employee pension plans)
+      href: https://www.pacodeandbulletin.gov/Display/pacode?file=/secure/pacode/data/061/chapter101/s101.6.html
+    - title: PA Personal Income Tax Guide - Gross Compensation (old age or retirement benefits paid after reaching a specific age or a stated period of employment)
+      href: https://www.pa.gov/agencies/revenue/forms-and-publications/pa-personal-income-tax-guide/gross-compensation.html
+    - title: PA DOR 1099-R FAQ (a_id 1470) - Code 7 normal distribution from an eligible Pennsylvania retirement plan is not taxable once plan retirement requirements are met
+      href: https://revenue-pa.custhelp.com/app/answers/detail/a_id/1470/

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.yaml
@@ -48,3 +48,22 @@
     self_employment_income: 5_800
   output:
     nj_income_tax_before_refundable_credits: 0
+
+# Issue #8849: the NJBEST 529 deduction (N.J.S.A. 54A:3-13, Form NJ-1040 line
+# 37a) must not net into New Jersey gross income (line 29), which the filing
+# threshold keys on. A single filer with $10,500 of gross income and $10,000
+# of 529 contributions stays above the $10,000 gross-income threshold, so the
+# no-tax floor does not apply. nj_agi therefore equals gross income, unmoved
+# by the deduction, and the deduction instead lands in nj_total_deductions.
+- name: 529 contributions do not push a just-above-threshold filer below the gross-income floor
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    state_code: NJ
+    filing_status: SINGLE
+    employment_income: 10_500
+    investment_in_529_plan_indv: 10_000
+  output:
+    nj_agi: 10_500
+    nj_529_deduction: 10_000
+    nj_total_deductions: 10_000

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/tax/income/nj_income_tax_before_refundable_credits.yaml
@@ -67,3 +67,17 @@
     nj_agi: 10_500
     nj_529_deduction: 10_000
     nj_total_deductions: 10_000
+
+# P.L. 2021, c.419 § 1 applies to taxable years beginning on or after
+# January 1, 2022, so no 529 deduction exists in 2021.
+- name: No 529 deduction before the 2022 College Affordability Act effective date
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    state_code: NJ
+    filing_status: SINGLE
+    employment_income: 50_000
+    investment_in_529_plan_indv: 5_000
+  output:
+    nj_529_deduction: 0
+    nj_total_deductions: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/taxable_income/pa_nontaxable_retirement_distributions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/taxable_income/pa_nontaxable_retirement_distributions.yaml
@@ -1,3 +1,8 @@
+# 61 Pa. Code Sec. 101.6 treats IRAs, SEPs, Keogh plans and federally
+# qualified employee pension plans (401(k), 403(b)) alike: distributions made
+# on or after retirement after reaching the qualifying age are not taxable PA
+# compensation. See issue #8848.
+
 - name: Case 1, IRA distributions are excluded after Pennsylvania retirement age.
   period: 2026
   input:
@@ -26,7 +31,7 @@
   output:
     pa_nontaxable_retirement_distributions: 0
 
-- name: Case 3, employer-plan distributions are not broadly excluded by age alone.
+- name: Case 3, 401(k) distributions are excluded after Pennsylvania retirement age.
   period: 2026
   input:
     people:
@@ -38,4 +43,67 @@
         members: [person1]
         state_code: PA
   output:
+    pa_nontaxable_retirement_distributions: 30_000
+
+- name: Case 4, 401(k) distributions remain taxable before Pennsylvania retirement age.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 58
+        taxable_401k_distributions: 30_000
+    households:
+      household:
+        members: [person1]
+        state_code: PA
+  output:
     pa_nontaxable_retirement_distributions: 0
+
+- name: Case 5, 403(b), SEP and Keogh distributions are excluded after retirement age.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 67
+        taxable_403b_distributions: 10_000
+        taxable_sep_distributions: 5_000
+        keogh_distributions: 4_000
+    households:
+      household:
+        members: [person1]
+        state_code: PA
+  output:
+    pa_nontaxable_retirement_distributions: 19_000
+
+- name: Case 6, employer-plan distributions remain taxable before retirement age.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 58
+        taxable_403b_distributions: 10_000
+        taxable_sep_distributions: 5_000
+        keogh_distributions: 4_000
+    households:
+      household:
+        members: [person1]
+        state_code: PA
+  output:
+    pa_nontaxable_retirement_distributions: 0
+
+# Issue #8848 reported household (PolicyBench scenario_085): PA single filer,
+# age 67, retired, with $1,560 of 401(k) distributions. The 401(k) amount is
+# now excluded from PA taxable compensation.
+- name: Case 7, issue 8848 reported household - retired PA filer with 401(k) distribution.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 67
+        taxable_401k_distributions: 1_560
+    households:
+      household:
+        members: [person1]
+        state_code: PA
+  output:
+    pa_nontaxable_retirement_distributions: 1_560

--- a/policyengine_us/variables/gov/states/nj/tax/income/deductions/nj_total_deductions.py
+++ b/policyengine_us/variables/gov/states/nj/tax/income/deductions/nj_total_deductions.py
@@ -8,5 +8,15 @@ class nj_total_deductions(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = StateCode.NJ
+    reference = (
+        # NJ-1040 deductions, Form NJ-1040 lines 30-37c (medical expenses and
+        # the New Jersey College Affordability Act deductions, line 37a).
+        "https://www.nj.gov/treasury/taxation/pdf/current/1040i.pdf#page=26",
+        "https://law.justia.com/codes/new-jersey/title-54a/section-54a-3-13/",
+    )
 
-    adds = ["nj_medical_expense_deduction"]
+    # nj_529_deduction (NJBEST contribution deduction, N.J.S.A. 54A:3-13, Form
+    # NJ-1040 line 37a) reduces taxable income after the gross-income filing
+    # threshold, alongside its 54A:3 sibling nj_medical_expense_deduction. See
+    # issue #8849.
+    adds = ["nj_medical_expense_deduction", "nj_529_deduction"]

--- a/policyengine_us/variables/gov/states/pa/tax/income/taxable_income/pa_nontaxable_retirement_distributions.py
+++ b/policyengine_us/variables/gov/states/pa/tax/income/taxable_income/pa_nontaxable_retirement_distributions.py
@@ -7,18 +7,30 @@ class pa_nontaxable_retirement_distributions(Variable):
     label = "Retirement distributions taxable by US but not by PA"
     unit = USD
     documentation = (
-        "US taxable non-employer retirement distributions excluded from PA "
-        "AGI after Pennsylvania's qualifying retirement age."
+        "US taxable distributions from IRAs and eligible employer retirement "
+        "plans (401(k), 403(b), SEP, Keogh) excluded from PA compensation "
+        "once the recipient has reached Pennsylvania's qualifying retirement "
+        "age. 61 Pa. Code Sec. 101.6 treats IRAs, SEPs, Keogh plans and "
+        "federally qualified employee pension plans alike: distributions made "
+        "on or after retirement after reaching a specific age (or a stated "
+        "period of employment) are not taxable compensation."
     )
     definition_period = YEAR
     reference = (
+        # PA PIT Guide - Gross Compensation (old age or retirement benefits).
         "https://www.pa.gov/agencies/revenue/forms-and-publications/"
-        "pa-personal-income-tax-guide/gross-compensation.html"
+        "pa-personal-income-tax-guide/gross-compensation.html",
+        # 61 Pa. Code Sec. 101.6 - Compensation (old age or retirement plans).
+        "https://www.pacodeandbulletin.gov/Display/pacode?file=/secure/pacode/data/061/chapter101/s101.6.html",
+        # PA DOR 1099-R FAQ (Code 7 normal distribution from an eligible plan).
+        "https://revenue-pa.custhelp.com/app/answers/detail/a_id/1470/",
     )
     defined_for = StateCode.PA
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.pa.tax.income
         retired = person("age", period) >= p.retirement_age_threshold
-        distributions = person("taxable_ira_distributions", period)
+        distributions = add(
+            person, period, p.nontaxable_retirement_distribution_sources
+        )
         return where(retired, distributions, 0)


### PR DESCRIPTION
## Summary

Three state income-tax accuracy issues. Two are fixed here with dated, page-anchored parameters and tests; one is already correct on `main` and is documented below with evidence for closing.

| Issue | State | Verdict |
|---|---|---|
| #8848 | PA | **Fixed** — employer-plan (401(k), 403(b), SEP, Keogh) distributions now exempt post-retirement, like IRAs |
| #8849 | NJ | **Fixed** — 529 deduction moved from gross-income subtractions to taxable-income deductions |
| #8830 | OK | **Already correct on `main`** (PR #8911) — close with evidence |

---

## #8848 — PA post-retirement employer-plan distributions

**Law.** 61 Pa. Code § 101.6 defines "Old Age or Retirement Benefit Plans" to include "Individual Retirement plans (IRA), Simplified Employee Pension Plans (SEP), Keogh plans, Federally qualified employe pension plans and similar old age or retirement benefit plans," and makes their distributions non-taxable when "made upon or after retirement from service after reaching a specific age or after a stated period of employment." The PA PIT Guide (Gross Compensation) and the PA DOR 1099-R FAQ (a_id 1470, Code 7 normal distribution) say the same: a distribution from an eligible PA plan is not taxable once the plan's age/service requirements for retirement are met.

**Bug.** `taxable_401k_distributions`, `taxable_403b_distributions`, `taxable_sep_distributions`, and `keogh_distributions` all sit in `taxable_retirement_distributions` — separate from `taxable_pension_income` (which the pension path already exempts via `pa_nontaxable_pension_income`). `pa_nontaxable_retirement_distributions` only excluded `taxable_ira_distributions`, so post-retirement 401(k)/403(b)/SEP/Keogh distributions stayed in `pa_total_taxable_income` and were taxed at 3.07%.

**Fix.** New parameter `gov/states/pa/tax/income/nontaxable_retirement_distribution_sources` lists all five eligible distribution sources; `pa_nontaxable_retirement_distributions` sums them and applies the existing `retirement_age_threshold` (59½) proxy, mirroring the IRA treatment the issue asks for. The previously-passing "Case 3" test that pinned the old behavior (401(k) at 67 → taxed) is corrected to the exempt result, and cases for 403(b)/SEP/Keogh plus the issue's reported household (PolicyBench scenario_085: PA single, age 67, $1,560 401(k)) are added.

---

## #8849 — NJ 529 deduction shifts the filing threshold

**Law.** NJ's filing-threshold zero-tax floor (N.J.S.A. 54A:2-4) tests **gross income** — Form NJ-1040 line 29 ("more than $20,000 … $10,000 if single/MFS"). The NJBEST 529 contribution deduction (N.J.S.A. 54A:3-13; P.L. 2021 c.419) is a New Jersey College Affordability Act deduction on **line 37a**, in the deductions block (lines 30–37c) between gross income (line 29) and taxable income (line 39) — the same 54A:3 family as the medical-expense deduction PE already models in `nj_total_deductions`.

**Bug.** `nj_529_deduction` was listed in `subtractions.yaml`, which feeds `nj_total_income` → `nj_agi` (PE's gross-income line). Away from the threshold this is harmless (the deduction lands either way), but at the boundary it netted into `nj_agi` and wrongly pulled 529 contributors just above $10k/$20k below the threshold, zeroing their tax and flipping `nj_property_tax_deduction_eligible`.

**Fix.** Remove `nj_529_deduction` from `subtractions.yaml` (collapsing the now-redundant 2022 breakpoint) and add it to `nj_total_deductions` alongside `nj_medical_expense_deduction`. Its income-limit test reads federal `adjusted_gross_income`, not `nj_agi`, so this creates no circular dependency. A boundary test confirms a single filer with $10,500 gross income and $10,000 of 529 contributions keeps `nj_agi = 10,500` (above the threshold, unmoved by the deduction) with the deduction landing in `nj_total_deductions`.

---

## #8830 — OK §401 employer pensions in TY2021 (already fixed)

Fixed on `main` by PR #8911 (commit `1f61736c69`). `ok_pension_subtraction` now excludes private-employer (IRC §401) pension income before 2022 via the dated boolean parameter `private_pension_qualifies` (2021 → `false`, 2022 → `true`), page-anchored to Form 511 Schedule 511-A line 6 for both years. The reported-household case is already covered by baseline tests: age 66 with `taxable_private_pension_income: 20_000` yields `ok_pension_subtraction: 0` in 2021 and `10,000` in 2022, with a companion case confirming government pensions still qualify in 2021. No code change needed; recommend closing #8830 with reference to #8911.

---

## Tests

All baseline state trees pass on this branch:

- PA: 360 (was 356; +4 net from expanded employer-plan and reported-household cases)
- NJ: 550 (was 549; +1 filing-threshold boundary test)
- OK: 187 (unchanged; already covers the #8830 year-boundary cases)

Run:
```
python -m policyengine_core.scripts.policyengine_command test \
  policyengine_us/tests/policy/baseline/gov/states/{pa,nj,ok}/ -c policyengine_us
```

Closes #8848, closes #8849, closes #8830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
