### PR TITLE
Update Georgia parent/caretaker Medicaid limit for 2025; verify Medicare IRMAA (#8787) and KS CHIP (#8792) accuracy

### DIFF
--- a/changelog.d/fix-ga-parent-medicaid-2025.fixed.md
+++ b/changelog.d/fix-ga-parent-medicaid-2025.fixed.md
@@ -1,0 +1,1 @@
+Update the Georgia parent/caretaker Medicaid income limit to 0.31 FPL from 2025, reflecting the frozen-dollar standard's drift to 26% of FPL (plus the 5% MAGI disregard) per MACPAC Exhibit 36 (July 2025).

--- a/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
@@ -7,6 +7,8 @@ metadata:
   reference:
     - title: MACPAC Exhibit 36, Medicaid Income Eligibility Levels as a Percentage of the FPL (July 2024) - Georgia parents/caretakers 28% + 5% MAGI disregard
       href: https://www.macpac.gov/wp-content/uploads/2024/12/EXHIBIT-36.-Medicaid-Income-Eligibility-Levels-as-a-Percentage-of-the-FPL-for-Non-Aged-Non-Disabled-Non-Pregnant-Adults-July-2024.pdf
+    - title: MACPAC Exhibit 36, Medicaid Income Eligibility Levels as a Percentage of the FPL (July 2025, data as of January 2025) - Georgia parents/caretakers 26% + 5% MAGI disregard
+      href: https://www.macpac.gov/wp-content/uploads/2026/01/EXHIBIT-36.-Medicaid-Income-Eligibility-Levels-as-a-Percentage-of-the-Federal-Poverty-Level-for-Non-Aged-Non-Disabled-Non-Pregnant-Adults-by-State-2025.pdf
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=33
     - title: medicaidscreener.com
@@ -52,8 +54,12 @@ FL:
   2021-01-01: 0.32
 GA:
   2018-01-01: 0.39
+  # Georgia uses a frozen-dollar (Section 1931) parent/caretaker standard, so
+  # its FPL percentage drifts down each year as the FPL rises.
   # 28% FPL parent/caretaker standard + 5% MAGI disregard (MACPAC July 2024)
   2024-01-01: 0.33
+  # 26% FPL parent/caretaker standard + 5% MAGI disregard (MACPAC July 2025)
+  2025-01-01: 0.31
 HI:
   2018-01-01: 1.10
   2021-01-01: 1.10

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/parent/medicaid_parent_income_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/parent/medicaid_parent_income_limit.yaml
@@ -109,3 +109,31 @@
   output:
     medicaid_parent_income_limit: 0.33
   absolute_error_margin: 0.0001
+
+- name: Case 8, Georgia parent limit falls to 0.31 FPL in 2025 (26% + 5% MAGI disregard).
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 30
+    households:
+      household:
+        members: [person1]
+        state_code: GA
+  output:
+    medicaid_parent_income_limit: 0.31
+  absolute_error_margin: 0.0001
+
+- name: Case 9, Georgia frozen-dollar parent standard carries the 0.31 FPL level into 2026.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+    households:
+      household:
+        members: [person1]
+        state_code: GA
+  output:
+    medicaid_parent_income_limit: 0.31
+  absolute_error_margin: 0.0001


### PR DESCRIPTION
## Summary

Accuracy review of three health-program issues (#8787 Medicare IRMAA, #8834 GA parent/caretaker Medicaid, #8792 Kansas CHIP per-capita denominator). All three had already been addressed by recently merged PRs; this PR verifies each against primary sources and lands the one remaining accuracy correction.

**Net code change:** one dated Georgia Medicaid parameter update (2025). The Medicare and Kansas CHIP issues are verified correct as-is and should be closed with the evidence below.

## #8834 — Georgia parent/caretaker Medicaid (fix in this PR)

PR #8913 set `income_limit.GA = 0.33` at `2024-01-01` (28% FPL + 5% MAGI disregard) from MACPAC Exhibit 36 (July 2024), and its own note flagged that the frozen-dollar standard should be re-verified as the FPL rises.

Verified against **MACPAC Exhibit 36 (July 2025 edition, data as of January 2025)**: Georgia's "Parents and caretaker relatives of dependent children" level is now **26% FPL**. Exhibit 36's own note states the effective limit is 5 percentage points higher than the table value (general MAGI disregard), and that states using dollar standards have those dollars converted to an FPL percentage — exactly Georgia's frozen-dollar case. So the effective 2025 limit is **0.31** (26% + 5%).

Cross-check on the +5% convention: MACPAC lists Kansas at 33%, and PE already stores `KS = 0.38` (33% + 5%) — confirming the parameter encodes the with-disregard value.

Note on the DFCS "247% FPL" figure: Georgia DFCS Appendix A2 lists a "Parent/Caretaker with Children" row at 247% FPL. That is the AU-level test for a unit that contains children (governed by the children's higher limit), not the Section 1931 parent floor this parameter models. The parent floor is MACPAC's 26% (frozen dollar ≈ $551/month for a family of three in 2024–early 2025).

Changes:
- Add `GA: 2025-01-01: 0.31` with the July 2025 MACPAC reference.
- Add regression tests pinning GA at 0.31 for 2025 and 2026 (frozen-dollar carry-forward).

## #8787 — Medicare Part B/D IRMAA (verified correct; recommend close)

Already fixed by merged PR #8788. Independently verified every 2026 value against **SSA POMS HI 01101.020** and the CMS 2026 fact sheet figures:

- Part B base premium 2026 = **$202.90** ✓
- Part B IRMAA surcharges 2026 (single/HoH/surviving spouse/joint) = **81.20 / 202.90 / 324.60 / 446.30 / 487.00** ✓ (POMS total premiums 284.10 / 405.80 / 527.50 / 649.20 / 689.90 minus $202.90 base)
- Part B MFS = base+446.30 up to $391,000, then +487.00 ✓; `separate.yaml` correctly carries `type: single_amount` (as do all five filing statuses)
- Part D IRMAA surcharges 2026 = **14.50 / 37.50 / 60.40 / 83.30 / 91.00** ✓
- All MAGI thresholds match ($109k/$137k/$171k/$205k/$500k single; $218k/$274k/$342k/$410k/$750k joint; $391k MFS top)
- Lagged-MAGI reads (`period.offset(-2, "year")` on AGI + tax-exempt interest) are present and correct in both `gross_medicare_part_b_premium` and `income_adjusted_part_d_premium_surcharge`
- Merged PR #8788 already added 2026 boundary tests across filing statuses including MFS

The Medicare test tree passes (120 tests). The only item in #8787 not addressed is **`uprating` metadata for projecting thresholds past 2026** — deliberately left out here rather than guessed, since the statutory rule (CPI-U over the 12 months ending August, rounded to $1,000, with special top-bracket handling) needs an exact encoding; approximating it would reduce accuracy versus holding the last official year. Recommend tracking uprating as a separate enhancement.

## #8792 — Kansas CHIP per-capita denominator (verified correct; recommend close)

Already fixed by merged PR #8798. `per_capita_chip` now explicitly divides **separate-CHIP spending by separate-CHIP enrollment** (the exact concept the issue requested), replacing the total-CHIP denominator (~89,803) the issue flagged.

Verified the Kansas inputs against **MACPAC MACStats (Feb 2026 Data Book, FY2024 data)**:
- Exhibit 32 (Child Enrollment): Kansas separate-CHIP enrollment = **72 thousand** → parameter `72_018` ✓
- Exhibit 33 (CHIP Spending): Kansas "Separate CHIP programs and coverage of pregnant women" total = **$136.6M** → parameter `136_581_734` ✓
- Per-capita = 136,581,734 / 72,018 = **$1,896.49/yr** ✓ (matches the test)

The issue's ~61,100 KLRD figure is superseded by MACPAC, which is the model's cited national calibration source (and the source PE uses for every other state's denominator). No change needed.

## Tests

- Medicare tree: 120 passed
- CHIP tree: 98 passed
- Kansas state tree: 331 passed
- Georgia state tree: 391 passed
- Medicaid tree: 370 passed
- `medicaid_parent_income_limit`: 9 passed (2 new GA cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
