### PR TITLE
Correct four Colorado income tax provisions (QBI Schedule F, 2026 deduction addback, 2026 CDCC, low-income CDCC sunset)

### DIFF
--- a/changelog.d/co-tax-accuracy.fixed.md
+++ b/changelog.d/co-tax-accuracy.fixed.md
@@ -1,0 +1,1 @@
+Corrected four Colorado income tax provisions: the section 199A addback Schedule F farming exception, the 2026 federal deduction addback exemptions ($1,000 single / $2,000 joint), the 2026 child and dependent care credit (70% of the federal credit before the section 26 liability limitation, AGI up to $60,000), and the low-income child care credit statutory sunset after 2025.

--- a/policyengine_us/parameters/gov/states/co/tax/income/additions/federal_deductions/exemption.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/additions/federal_deductions/exemption.yaml
@@ -7,6 +7,16 @@ metadata:
   # 2023 values only appear in the Individual Income Tax Guide
   - title: C.R.S. 39-22-104 . Income tax imposed on individuals, estates, and trusts - section (3)(p)
     href: https://casetext.com/statute/colorado-revised-statutes/title-39-taxation/specific-taxes/income-tax/article-22-income-tax/part-1-general/section-39-22-104-effective-upon-official-proclamation-by-governor-income-tax-imposed-on-individuals-estates-and-trusts-single-rate-report-legislative-declaration-definitions-repeal
+  # 2023-2025: C.R.S. 39-22-104(3)(p.5)(I)(A)-(B) ($12,000 single / $16,000 joint)
+  - title: C.R.S. 39-22-104(3)(p.5)(I) (Colorado Revised Statutes 2025, official compilation, p. 382)
+    href: https://olls.info/crs/crs2025-title-39.pdf
+  # 2026+: C.R.S. 39-22-104(3)(p.7)(I)(A)-(B) ($1,000 single / $2,000 joint),
+  # added by HB25-1274 SECTION 18, effective because Proposition MM passed in
+  # November 2025.
+  - title: C.R.S. 39-22-104(3)(p.7)(I) (Colorado Revised Statutes 2025, official compilation, pp. 383-384)
+    href: https://olls.info/crs/crs2025-title-39.pdf
+  - title: HB25-1274 SECTION 18 (Session Laws of Colorado 2025, Chapter 402)
+    href: https://leg.colorado.gov/bills/hb25-1274
   - title: 2022 Colorado Individual Income Tax Filing Guide, 104 Book - Additions - Line 4
     href: https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=5
   - title: 2023 Colorado Individual Income Tax Filing Guide, 104 Book - Additions - Line 4
@@ -19,18 +29,25 @@ metadata:
     href: https://tax.colorado.gov/sites/tax/files/documents/Book104_2025.pdf#page=9
   breakdown:
     - filing_status
+# (3)(p.7) names only "single return" and "joint return"; non-joint statuses
+# follow the existing convention of using the single-return amount.
 JOINT:
   2022-01-01: 60_000
   2023-01-01: 16_000
+  2026-01-01: 2_000
 SINGLE:
   2022-01-01: 30_000
   2023-01-01: 12_000
+  2026-01-01: 1_000
 SEPARATE:
   2022-01-01: 30_000
   2023-01-01: 12_000
+  2026-01-01: 1_000
 HEAD_OF_HOUSEHOLD:
   2022-01-01: 30_000
   2023-01-01: 12_000
+  2026-01-01: 1_000
 SURVIVING_SPOUSE:
   2022-01-01: 30_000
   2023-01-01: 12_000
+  2026-01-01: 1_000

--- a/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/low_income/available.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/low_income/available.yaml
@@ -1,0 +1,21 @@
+description: Colorado allows the low-income child care expenses credit only for the income tax years within this statutory window.
+values:
+  # Credit first available for income tax years beginning on or after 2014-01-01.
+  2014-01-01: true
+  # Not available for income tax years beginning on or after 2017-01-01 ...
+  2017-01-01: false
+  # ... and again available for income tax years beginning on or after 2018-01-01 ...
+  2018-01-01: true
+  # ... but not for income tax years beginning on or after 2026-01-01.
+  2026-01-01: false
+metadata:
+  period: year
+  unit: bool
+  label: Colorado low-income child care expenses credit available
+  reference:
+    - title: C.R.S. 39-22-119.5(3)(a) (window narrowed to before 2026-01-01 by HB24-1134, SECTION 2)
+      href: https://leg.colorado.gov/sites/default/files/2024a_1134_signed.pdf#page=3
+    - title: "Colorado Revised Statutes 39-22-119.5(3)(a). Child care expenses tax credit"
+      href: https://law.justia.com/codes/colorado/title-39/specific-taxes/income-tax/article-22/part-1/section-39-22-119-5/
+    - title: "Income Tax Topics: Child and Dependent Care Expenses Credit (Revised January 2026)"
+      href: https://tax.colorado.gov/sites/tax/files/documents/ITT_Child_and_Dependent_Care_Expenses_Credit_Jan_2026.pdf

--- a/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/max_agi.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/max_agi.yaml
@@ -1,0 +1,19 @@
+description: Colorado allows the child and dependent care credit only to filers with federal adjusted gross income at or below this amount, for tax years beginning in 2026 or later. The limit is adjusted for inflation beginning in tax year 2027.
+values:
+  2026-01-01: 60_000
+metadata:
+  period: year
+  unit: currency-USD
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: nearest
+      interval: 1_000
+  label: Colorado child and dependent care credit maximum AGI
+  reference:
+    - title: C.R.S. 39-22-119(1.7)(b) and (1.7)(c) (as amended by HB24-1134, SECTION 1)
+      href: https://leg.colorado.gov/sites/default/files/2024a_1134_signed.pdf#page=3
+    - title: "Colorado Revised Statutes 39-22-119. Expenses related to child care - credits against state tax"
+      href: https://law.justia.com/codes/colorado/title-39/specific-taxes/income-tax/article-22/part-1/section-39-22-119/
+    - title: "Income Tax Topics: Child and Dependent Care Expenses Credit (Revised January 2026) - Income limits"
+      href: https://tax.colorado.gov/sites/tax/files/documents/ITT_Child_and_Dependent_Care_Expenses_Credit_Jan_2026.pdf

--- a/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/rate.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/rate.yaml
@@ -1,0 +1,14 @@
+description: Colorado matches this fraction of the federal child and dependent care credit for tax years beginning in 2026 or later, when the income-graduated match schedule no longer applies.
+values:
+  2026-01-01: 0.70
+metadata:
+  period: year
+  unit: /1
+  label: Colorado child and dependent care credit rate
+  reference:
+    - title: C.R.S. 39-22-119(1.7)(b) (as amended by HB24-1134, SECTION 1)
+      href: https://leg.colorado.gov/sites/default/files/2024a_1134_signed.pdf#page=3
+    - title: "Colorado Revised Statutes 39-22-119. Expenses related to child care - credits against state tax"
+      href: https://law.justia.com/codes/colorado/title-39/specific-taxes/income-tax/article-22/part-1/section-39-22-119/
+    - title: "Income Tax Topics: Child and Dependent Care Expenses Credit (Revised January 2026)"
+      href: https://tax.colorado.gov/sites/tax/files/documents/ITT_Child_and_Dependent_Care_Expenses_Credit_Jan_2026.pdf

--- a/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/uses_federal_credit_before_liability_limitation.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/credits/cdcc/uses_federal_credit_before_liability_limitation.yaml
@@ -1,0 +1,13 @@
+description: Whether Colorado bases its child and dependent care credit on the federal credit allowed under IRC section 21 before the section 26 tax-liability limitation. Before 2026 the credit is based on the federal credit the taxpayer actually claimed and was allowed (after the liability limitation); beginning in 2026 it is based on the full federal credit the taxpayer was eligible for.
+values:
+  2018-01-01: false
+  2026-01-01: true
+metadata:
+  period: year
+  unit: bool
+  label: Colorado child and dependent care credit uses pre-liability-limitation federal base
+  reference:
+    - title: C.R.S. 39-22-119(1.7)(b) (as amended by HB24-1134, SECTION 1) - "seventy percent of the federal credit allowed pursuant to section 21 ... calculated without regard to the limitation imposed by section 26"
+      href: https://leg.colorado.gov/sites/default/files/2024a_1134_signed.pdf#page=3
+    - title: "Income Tax Topics: Child and Dependent Care Expenses Credit (Revised January 2026) - Credit calculation"
+      href: https://tax.colorado.gov/sites/tax/files/documents/ITT_Child_and_Dependent_Care_Expenses_Credit_Jan_2026.pdf

--- a/policyengine_us/tests/policy/baseline/gov/irs/tax_unit_files_schedule_f.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/tax_unit_files_schedule_f.yaml
@@ -1,0 +1,49 @@
+- name: No farm operations income means no Schedule F
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    tax_unit_files_schedule_f: false
+
+- name: Positive farm operations income requires Schedule F
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: 40_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    tax_unit_files_schedule_f: true
+
+- name: Farm operations loss still requires Schedule F
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: -5_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+  output:
+    tax_unit_files_schedule_f: true
+
+- name: Farm operations income of one spouse counts for the tax unit
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: 0
+      person2:
+        farm_operations_income: 12_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+  output:
+    tax_unit_files_schedule_f: true

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/federal_deduction/co_federal_deduction_addback.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/federal_deduction/co_federal_deduction_addback.yaml
@@ -324,3 +324,49 @@
     taxable_income_deductions: 20_000
   output:
     co_federal_deduction_addback: 1_850
+
+# C.R.S. 39-22-104(3)(p.7): for 2026+, the exemption drops to $1,000 (single)
+# and $2,000 (joint).
+- name: In 2026, single filer, deduction 1_500, exemption 1_000, addback 500.
+  period: 2026
+  input:
+    state_code: CO
+    co_federal_deduction_addback_required: true
+    filing_status: SINGLE
+    tax_unit_itemizes: false
+    standard_deduction: 1_500
+  output:
+    co_federal_deduction_addback: 500
+
+- name: In 2026, joint filer, deduction 3_500, exemption 2_000, addback 1_500.
+  period: 2026
+  input:
+    state_code: CO
+    co_federal_deduction_addback_required: true
+    filing_status: JOINT
+    tax_unit_itemizes: false
+    standard_deduction: 3_500
+  output:
+    co_federal_deduction_addback: 1_500
+
+- name: In 2026, single filer at the exemption, no addback.
+  period: 2026
+  input:
+    state_code: CO
+    co_federal_deduction_addback_required: true
+    filing_status: SINGLE
+    tax_unit_itemizes: false
+    standard_deduction: 1_000
+  output:
+    co_federal_deduction_addback: 0
+
+- name: In 2026, head of household uses the single-return exemption of 1_000.
+  period: 2026
+  input:
+    state_code: CO
+    co_federal_deduction_addback_required: true
+    filing_status: HEAD_OF_HOUSEHOLD
+    tax_unit_itemizes: false
+    standard_deduction: 2_000
+  output:
+    co_federal_deduction_addback: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/federal_deduction/co_federal_deduction_addback_required.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/federal_deduction/co_federal_deduction_addback_required.yaml
@@ -42,3 +42,32 @@
     tax_unit_itemizes: false
   output:
     co_federal_deduction_addback_required: false
+
+# C.R.S. 39-22-104(3)(p.5)/(3)(p.7): the addback applies to AGI "equal to or
+# exceeding" the threshold, so AGI exactly at the threshold is included.
+- name: In 2023, AGI exactly at the 300_000 threshold is subject to the addback.
+  period: 2023
+  input:
+    state_code: CO
+    adjusted_gross_income: 300_000
+    tax_unit_itemizes: false
+  output:
+    co_federal_deduction_addback_required: true
+
+- name: In 2023, AGI one dollar below the threshold is not subject.
+  period: 2023
+  input:
+    state_code: CO
+    adjusted_gross_income: 299_999
+    tax_unit_itemizes: false
+  output:
+    co_federal_deduction_addback_required: false
+
+- name: In 2026, AGI exactly at the 300_000 threshold is subject to the addback.
+  period: 2026
+  input:
+    state_code: CO
+    adjusted_gross_income: 300_000
+    tax_unit_itemizes: false
+  output:
+    co_federal_deduction_addback_required: true

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/qualified_business_income_deduction/co_qualified_business_income_deduction_addback.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/qualified_business_income_deduction/co_qualified_business_income_deduction_addback.yaml
@@ -1,0 +1,41 @@
+# C.R.S. 39-22-104(3)(o). The addback equals the section 199A deduction for
+# high-AGI filers, except that it does not apply to a taxpayer required to
+# file Schedule F (Profit or Loss From Farming).
+
+- name: High-AGI joint filer with no farm income adds back the 199A deduction
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 1_100_000
+        filing_status: JOINT
+        qualified_business_income_deduction: 30_000
+    households:
+      household:
+        members: [person1]
+        state_code: CO
+  output:
+    co_qualified_business_income_deduction_addback: 30_000
+
+- name: Schedule F exception blocks the 199A addition for a farmer
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: 250_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 1_100_000
+        filing_status: JOINT
+        qualified_business_income_deduction: 30_000
+    households:
+      household:
+        members: [person1]
+        state_code: CO
+  output:
+    co_qualified_business_income_deduction_addback: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/qualified_business_income_deduction/co_qualified_business_income_deduction_addback_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/additions/qualified_business_income_deduction/co_qualified_business_income_deduction_addback_eligible.yaml
@@ -42,3 +42,41 @@
     filing_status: SURVIVING_SPOUSE
   output:
     co_qualified_business_income_deduction_addback_required: false
+
+# C.R.S. 39-22-104(3)(o): the addback does not apply to a taxpayer required
+# to file Schedule F (Profit or Loss From Farming).
+- name: Above AGI limit but files Schedule F, addback not required
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: 200_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 1_100_000
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1]
+        state_code: CO
+  output:
+    co_qualified_business_income_deduction_addback_required: false
+
+- name: Above AGI limit with no farm income, addback required
+  period: 2026
+  input:
+    people:
+      person1:
+        farm_operations_income: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 1_100_000
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1]
+        state_code: CO
+  output:
+    co_qualified_business_income_deduction_addback_required: true

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/cdcc/co_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/cdcc/co_cdcc.yaml
@@ -91,3 +91,85 @@
         state_code: CO
   output:
     co_cdcc: 0  # co_low_income_cdcc = 750
+
+# C.R.S. 39-22-119(1.7)(b): for tax years beginning on or after January 1,
+# 2026, the credit is 70% of the federal section 21 credit computed without
+# regard to the section 26 liability limitation (cdcc_potential), for filers
+# with federal AGI at or below $60,000.
+- name: In 2026, 70% of the pre-liability-limit federal credit when liability is ample.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 35
+        employment_income: 30_000
+      person2:
+        is_tax_unit_spouse: true
+        age: 34
+        employment_income: 30_000
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2, child]
+        tax_unit_childcare_expenses: 6_000
+    households:
+      household:
+        members: [person1, person2, child]
+        state_code: CO
+  output:
+    # cdcc_potential = min(6_000, 3_000 one-child cap) x 0.35 = 1_050
+    # co_cdcc = 0.70 x 1_050 = 735
+    co_cdcc: 735
+
+- name: In 2026, credit is allowed even with no federal tax liability to cap it.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 35
+        employment_income: 12_000
+      person2:
+        is_tax_unit_spouse: true
+        age: 34
+        employment_income: 12_000
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2, child]
+        tax_unit_childcare_expenses: 6_000
+    households:
+      household:
+        members: [person1, person2, child]
+        state_code: CO
+  output:
+    # capped_cdcc = 0 (no liability) but cdcc_potential = 3_000 x 0.45 = 1_350
+    # co_cdcc = 0.70 x 1_350 = 945
+    co_cdcc: 945
+
+- name: In 2026, no credit above the $60,000 AGI limit.
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 35
+        employment_income: 61_000
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, child]
+        tax_unit_childcare_expenses: 6_000
+    households:
+      household:
+        members: [person1, child]
+        state_code: CO
+  output:
+    co_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/cdcc/co_low_income_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/cdcc/co_low_income_cdcc.yaml
@@ -167,3 +167,55 @@
     # All $1,600 of childcare expenses belong to the only child:
     # min(500, 0.25 x min(1_600, 5_000)) = 400
     co_low_income_cdcc: 400
+
+# C.R.S. 39-22-119.5: the low-income credit is repealed for tax years
+# beginning on or after January 1, 2026. A filer who would otherwise qualify
+# (low income, no federal credit) receives nothing in 2026.
+- name: In 2025, a low-income filer with no federal credit receives the credit.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 35
+        employment_income: 12_000
+      spouse:
+        age: 34
+        employment_income: 12_000
+      child_1:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, spouse, child_1]
+        tax_unit_childcare_expenses: 2_000
+    households:
+      household:
+        state_code: CO
+        members: [head, spouse, child_1]
+  output:
+    # min(500, 0.25 x min(2_000, 12_000)) = 500
+    co_low_income_cdcc: 500
+
+- name: In 2026, the same filer receives nothing because the credit is repealed.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 35
+        employment_income: 12_000
+      spouse:
+        age: 34
+        employment_income: 12_000
+      child_1:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, spouse, child_1]
+        tax_unit_childcare_expenses: 2_000
+    households:
+      household:
+        state_code: CO
+        members: [head, spouse, child_1]
+  output:
+    co_low_income_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/cdcc/co_low_income_cdcc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/cdcc/co_low_income_cdcc_eligible.yaml
@@ -7,6 +7,26 @@
   output:
     co_low_income_cdcc_eligible: true
 
+# C.R.S. 39-22-119.5(3)(a): the credit is available for income tax years
+# beginning before January 1, 2026 (repealed for 2026+ by HB24-1134).
+- name: In 2025, within the statutory window, a low-income filer is eligible.
+  period: 2025
+  input:
+    state_code: CO
+    capped_cdcc: 0
+    adjusted_gross_income: 24_999
+  output:
+    co_low_income_cdcc_eligible: true
+
+- name: In 2026, past the statutory sunset, the same filer is ineligible.
+  period: 2026
+  input:
+    state_code: CO
+    capped_cdcc: 0
+    adjusted_gross_income: 24_999
+  output:
+    co_low_income_cdcc_eligible: false
+
 - name: co_low_income_cdcc_eligible unit test 2
   period: 2022
   input:

--- a/policyengine_us/variables/gov/irs/tax_unit_files_schedule_f.py
+++ b/policyengine_us/variables/gov/irs/tax_unit_files_schedule_f.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class tax_unit_files_schedule_f(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "required to file Schedule F (Profit or Loss From Farming)"
+    documentation = (
+        "Whether the tax unit is required to file a federal Schedule F "
+        "(Profit or Loss From Farming), or successor form, for the tax year. "
+        "Defaults to whether any member has farm operations income; may be "
+        "set directly as an input."
+    )
+    definition_period = YEAR
+    reference = "https://www.irs.gov/forms-pubs/about-schedule-f-form-1040"
+
+    def formula(tax_unit, period, parameters):
+        # A taxpayer with active farming operations income (or loss) files
+        # Schedule F. farm_operations_income is defined as Schedule F income;
+        # farm rental income (Form 4835 / Schedule E) is excluded.
+        farm_operations_income = add(tax_unit, period, ["farm_operations_income"])
+        return farm_operations_income != 0

--- a/policyengine_us/variables/gov/states/co/tax/income/additions/federal_deductions/co_federal_deduction_addback.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/additions/federal_deductions/co_federal_deduction_addback.py
@@ -10,6 +10,9 @@ class co_federal_deduction_addback(Variable):
     reference = (
         # C.R.S. 39-22-104 . Income tax imposed on individuals, estates, and trusts - section (3)(p)
         "https://casetext.com/statute/colorado-revised-statutes/title-39-taxation/specific-taxes/income-tax/article-22-income-tax/part-1-general/section-39-22-104-effective-upon-official-proclamation-by-governor-income-tax-imposed-on-individuals-estates-and-trusts-single-rate-report-legislative-declaration-definitions-repeal",
+        # C.R.S. 39-22-104(3)(p.5)(I) (2023-2025) and (3)(p.7)(I) (2026+),
+        # Colorado Revised Statutes 2025 official compilation, pp. 382-384
+        "https://olls.info/crs/crs2025-title-39.pdf",
         # 2022 Colorado Individual Income Tax Filing Guide - Additions - Line 4
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=5",
         # Individual Income Tax Guide - Part 3 Additions to Taxable Income - Federal itemized or standard deductions

--- a/policyengine_us/variables/gov/states/co/tax/income/additions/federal_deductions/co_federal_deduction_addback_required.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/additions/federal_deductions/co_federal_deduction_addback_required.py
@@ -9,6 +9,10 @@ class co_federal_deduction_addback_required(Variable):
     reference = (
         # C.R.S. 39-22-104 . Income tax imposed on individuals, estates, and trusts - section (3)(p)
         "https://casetext.com/statute/colorado-revised-statutes/title-39-taxation/specific-taxes/income-tax/article-22-income-tax/part-1-general/section-39-22-104-effective-upon-official-proclamation-by-governor-income-tax-imposed-on-individuals-estates-and-trusts-single-rate-report-legislative-declaration-definitions-repeal",
+        # C.R.S. 39-22-104(3)(p), (3)(p.5), (3)(p.7) (Colorado Revised Statutes
+        # 2025 official compilation, pp. 382-384): "equal to or exceeding" the
+        # AGI threshold.
+        "https://olls.info/crs/crs2025-title-39.pdf",
         # 2022 Colorado Individual Income Tax Filing Guide - Additions - Line 4
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=5",
         # Individual Income Tax Guide - Part 3 Additions to Taxable Income - Federal itemized or standard deductions
@@ -18,7 +22,9 @@ class co_federal_deduction_addback_required(Variable):
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.co.tax.income.additions.federal_deductions
-        income_test = tax_unit("adjusted_gross_income", period) > p.agi_threshold
+        # The statute applies to filers whose AGI is "equal to or exceeding"
+        # the threshold, so use >= rather than >.
+        income_test = tax_unit("adjusted_gross_income", period) >= p.agi_threshold
         if p.itemized_only:
             return income_test & tax_unit("tax_unit_itemizes", period)
         return income_test

--- a/policyengine_us/variables/gov/states/co/tax/income/additions/qualified_business_income_deduction/co_qualified_business_income_deduction_addback_required.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/additions/qualified_business_income_deduction/co_qualified_business_income_deduction_addback_required.py
@@ -9,6 +9,11 @@ class co_qualified_business_income_deduction_addback_required(Variable):
     reference = (
         # C.R.S. 39-22-104 . Income tax imposed on individuals, estates, and trusts - section (3) (o)
         "https://casetext.com/statute/colorado-revised-statutes/title-39-taxation/specific-taxes/income-tax/article-22-income-tax/part-1-general/section-39-22-104-effective-until-official-proclamation-by-governor-income-tax-imposed-on-individuals-estates-and-trusts-single-rate-report-legislative-declaration-definitions-repeal",
+        # C.R.S. 39-22-104(3)(o) Schedule F exception (Colorado Revised
+        # Statutes 2025 official compilation, p. 383); addback continued
+        # indefinitely by HB25B-1001 (2025 special session B), SECTION 2.
+        "https://olls.info/crs/crs2025-title-39.pdf",
+        "https://leg.colorado.gov/sites/default/files/2025b_1001_signed.pdf#page=1",
         # 2022 Colorado Individual Income Tax Filing Guide - Additions
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=5",
         # 2021 Colorado Individual Income Tax Filing Guide - Additions
@@ -24,4 +29,10 @@ class co_qualified_business_income_deduction_addback_required(Variable):
         p = parameters(
             period
         ).gov.states.co.tax.income.additions.qualified_business_income_deduction
-        return agi > p.agi_threshold[filing_status]
+        above_agi_threshold = agi > p.agi_threshold[filing_status]
+        # C.R.S. 39-22-104(3)(o): the addback does not apply to a taxpayer who
+        # is required to file a Schedule F (Profit or Loss From Farming), or
+        # successor form, with the federal return for the tax year in which the
+        # section 199A deduction is claimed.
+        files_schedule_f = tax_unit("tax_unit_files_schedule_f", period)
+        return above_agi_threshold & ~files_schedule_f

--- a/policyengine_us/variables/gov/states/co/tax/income/credits/cdcc/co_cdcc.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/credits/cdcc/co_cdcc.py
@@ -10,15 +10,33 @@ class co_cdcc(Variable):
         "https://advance.lexis.com/documentpage/?pdmfid=1000516&crid=d14880b7-7410-4295-bcf1-2e099e57d8f3&pdistocdocslideraccess=true&config=014FJAAyNGJkY2Y4Zi1mNjgyLTRkN2YtYmE4OS03NTYzNzYzOTg0OGEKAFBvZENhdGFsb2d592qv2Kywlf8caKqYROP5&pddocfullpath=%2Fshared%2Fdocument%2Fstatutes-legislation%2Furn%3AcontentItem%3A65HV-06G3-CGX8-050B-00008-00&pdcomponentid=234177&pdtocnodeidentifier=ABPAACAACAABAACABA&ecomp=k2vckkk&prid=e2e32763-f8fa-4832-8191-f70124d877f6"
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=46"
     )
+    reference = (
+        # C.R.S. 39-22-119(1.7) (2026+ regime added by HB24-1134, SECTION 1)
+        "https://leg.colorado.gov/sites/default/files/2024a_1134_signed.pdf#page=3",
+        # Income Tax Topics: Child and Dependent Care Expenses Credit (Revised January 2026)
+        "https://tax.colorado.gov/sites/tax/files/documents/ITT_Child_and_Dependent_Care_Expenses_Credit_Jan_2026.pdf",
+    )
     definition_period = YEAR
     defined_for = StateCode.CO
 
     def formula(tax_unit, period, parameters):
-        # follow 2022 DR 0347 form and its instructions (in Book cited above):
         p = parameters(period).gov.states.co.tax.income.credits
         fed_agi = tax_unit("adjusted_gross_income", period)  # Line 4
-        # calculate regular Colorado CDCC in Part III
+        if p.cdcc.uses_federal_credit_before_liability_limitation:
+            # C.R.S. 39-22-119(1.7)(b): for income tax years beginning on and
+            # after January 1, 2026, the credit is 70% of the federal section
+            # 21 credit calculated without regard to the section 26 tax-
+            # liability limitation, for filers with federal AGI at or below the
+            # limit. cdcc_potential is the federal credit before the liability
+            # limitation; capped_cdcc and cdcc apply that limitation.
+            fed_cdcc_before_limit = tax_unit("cdcc_potential", period)
+            agi_eligible = fed_agi <= p.cdcc.max_agi
+            return agi_eligible * p.cdcc.rate * fed_cdcc_before_limit
+        # Before 2026, follow the 2022 DR 0347 form and its instructions:
+        # the credit is an income-graduated match of the federal credit the
+        # taxpayer actually claimed and was allowed (after the liability cap).
         capped_fed_cdcc = tax_unit("capped_cdcc", period)  # Line 8
         match_rate = p.cdcc.match.calc(fed_agi, right=True)
         return capped_fed_cdcc * match_rate  # Line 9
         # calculate low-income Colorado CDCC in Part IV in co_low_income_cdcc
+        # (repealed for tax years beginning on or after January 1, 2026)

--- a/policyengine_us/variables/gov/states/co/tax/income/credits/cdcc/co_low_income_cdcc_eligible.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/credits/cdcc/co_low_income_cdcc_eligible.py
@@ -6,20 +6,40 @@ class co_low_income_cdcc_eligible(Variable):
     entity = TaxUnit
     label = "Eligible for the Colorado Low-income Child Care Expenses Credit"
     documentation = (
+        # C.R.S. 39-22-119.5(3)(a) eligibility conditions and statutory window.
+        # PolicyEngine models the availability window, the $25,000 AGI limit,
+        # the insufficient-federal-liability condition (no federal CDCC allowed
+        # after the section 26 liability limitation), and the IRC 21(e)(2)
+        # joint-return requirement. The provider identification / due-diligence
+        # requirements (provider name, address, and TIN under (3)(a)(V)-(VI))
+        # and the dependent identification requirements are administrative
+        # inputs PolicyEngine does not model and are assumed satisfied. The
+        # dependent-under-age-13 condition (3)(a)(III) is applied in
+        # co_low_income_cdcc.
         "https://casetext.com/statute/colorado-revised-statutes/title-39-taxation/specific-taxes/income-tax/article-22-income-tax/part-1-general/section-39-22-1195-child-care-expenses-tax-credit-legislative-declaration-definitions"
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=46"
+    )
+    reference = (
+        # C.R.S. 39-22-119.5(3)(a) (window narrowed to before 2026 by HB24-1134)
+        "https://leg.colorado.gov/sites/default/files/2024a_1134_signed.pdf#page=3",
     )
     definition_period = YEAR
     defined_for = StateCode.CO
 
     def formula(tax_unit, period, parameters):
-        no_fed_cdcc = tax_unit("capped_cdcc", period) <= 0
-        # The credit backstops filers whose federal CDCC is zeroed out by
-        # their income tax liability; a separate filer excluded from the
-        # federal credit by the IRC 21(e)(2) joint-return requirement
-        # remains ineligible.
-        filing_status_eligible = tax_unit("cdcc_filing_status_eligible", period)
         p = parameters(period).gov.states.co.tax.income.credits
+        # C.R.S. 39-22-119.5(3)(a): the credit is available only for income tax
+        # years within the statutory window (2014-2016 and 2018-2025; repealed
+        # for tax years beginning on or after January 1, 2026 by HB24-1134).
+        available = p.cdcc.low_income.available
+        # C.R.S. 39-22-119.5(3)(a)(II): the filer has insufficient tax liability
+        # to claim any credit under section 39-22-119. The credit backstops
+        # filers whose federal CDCC is zeroed out by their income tax
+        # liability; a separate filer excluded from the federal credit by the
+        # IRC 21(e)(2) joint-return requirement remains ineligible.
+        no_fed_cdcc = tax_unit("capped_cdcc", period) <= 0
+        filing_status_eligible = tax_unit("cdcc_filing_status_eligible", period)
+        # C.R.S. 39-22-119.5(3)(a)(I): federal AGI at or below $25,000.
         fed_agi = tax_unit("adjusted_gross_income", period)
         agi_eligible = fed_agi <= p.cdcc.low_income.federal_agi_threshold
-        return no_fed_cdcc & agi_eligible & filing_status_eligible
+        return available & no_fed_cdcc & agi_eligible & filing_status_eligible


### PR DESCRIPTION
## Summary

Corrects four Colorado income tax provisions surfaced by Axiom's Colorado RuleSpec encodings of Title 39. Each was verified against the **Colorado Revised Statutes 2025 official compilation**, the **enacting bills**, and current **Colorado DOR guidance** before any code changed.

Fixes #8754
Fixes #8755
Fixes #8544
Fixes #8756
Fixes #8757

## Per-issue verdicts and evidence

### #8754 — QBI addback Schedule F exception (CONFIRMED gap, fixed)
C.R.S. 39-22-104(3)(o) adds back the IRC §199A deduction for high-AGI filers "except that this subsection (3)(o) does not apply to a taxpayer who is required to file a schedule F, profit or loss from farming, or successor form." PE modeled only the AGI threshold and omitted the exception.

- The addback was continued **indefinitely** by **HB25B-1001** (2025 special session B, SECTION 2), which struck the "but before January 1, 2026" end date. The Schedule F exception is retained.
- Fix: new federal variable `tax_unit_files_schedule_f` (derived from `farm_operations_income`, which PE documents as Schedule F income; farm rental income is excluded). The CO addback-required predicate now excludes tax units that file Schedule F.
- Verified: joint filer, AGI $1.1M, §199A deduction $30,000, Schedule F required → addback **$0**; same filer without farm income → addback **$30,000**.

### #8755 / #8544 — 2026 federal deduction addback exemptions (CONFIRMED gap, fixed; these two issues duplicate each other — #8544 is still open, not merged)
C.R.S. 39-22-104(3)(p.7)(I) (added by **HB25-1274** SECTION 18, effective because **Proposition MM passed** in November 2025) sets, for tax years beginning on or after January 1, 2026, at the $300,000 AGI threshold: single-return exemption **$1,000**, joint-return exemption **$2,000**. The predecessor (3)(p.5)(I) ($12,000 / $16,000) was amended to end "before January 1, 2026", so the single exemption parameter transitions cleanly from $12k/$16k (2023–2025) to $1k/$2k (2026+).

- Fix: added 2026 values to `federal_deductions/exemption.yaml`. The $300,000 AGI threshold and the itemized-or-standard scope were already correct from 2023.
- Also corrected the AGI-threshold comparison in `co_federal_deduction_addback_required` from `>` to `>=`: (3)(p), (3)(p.5), and (3)(p.7) all apply to filers "equal to or exceeding" the threshold, so a filer with AGI exactly at the threshold (e.g. $300,000) is subject. This is a pre-existing off-by-one at the boundary, corrected for all years.
- Verified: single, deduction $1,500 → addback **$500**; joint, deduction $3,500 → addback **$1,500**; AGI exactly $300,000 → subject; AGI $299,999 → not subject.
- Note: (3)(p.7) self-terminates if the healthy school meals for all program is repealed. PE does not model that contingency (the program is not repealed); documented in the parameter reference.

### #8756 — 2026 CDCC 70% rate and pre-§26 base (CONFIRMED gap, fixed; bill citation corrected)
C.R.S. 39-22-119(1.7)(b) (added by **HB24-1134** SECTION 1 — **not** HB24-1311 as the RuleSpec/issue stated) provides that for tax years beginning on or after January 1, 2026 the credit is "seventy percent of the federal credit allowed pursuant to section 21 of the internal revenue code and calculated without regard to the limitation imposed by section 26." Eligibility is federal AGI ≤ $60,000 (inflation-adjusted from 2027), with no federal-credit-claimed requirement, and the credit is refundable. DOR's *Income Tax Topics: Child and Dependent Care Expenses Credit* (Revised January 2026) confirms: "the Colorado credit is based on the full federal credit the taxpayer was eligible for, even if they could not claim the entire federal credit because they did not have sufficient federal tax liability."

- The pre-§26 base is PE's `cdcc_potential` (the §21 amount before the liability cap); `capped_cdcc`/`cdcc` apply the cap.
- Fix: new parameters `cdcc/rate.yaml` (0.70 from 2026), `cdcc/max_agi.yaml` ($60,000 from 2026, uprated), and `cdcc/uses_federal_credit_before_liability_limitation.yaml`; `co_cdcc` branches on the flag. Pre-2026 behavior (income-graduated match of the post-cap federal credit) is unchanged.
- Verified: 2026 joint, two earners, ample liability → 70% × $1,050 = **$735**; 2026 low-income (no federal liability) → 70% × $1,350 = **$945** (was $0 before); AGI $61,000 → **$0** (cliff at $60,000).

### #8757 — Low-income CDCC statutory window/sunset (CONFIRMED gap, fixed)
C.R.S. 39-22-119.5(3)(a) (amended by **HB24-1134** SECTION 2) makes the low-income credit available for tax years 2014–2016 and 2018–2025, and **repealed for tax years beginning on or after January 1, 2026**. PE had no sunset.

- Fix: new `cdcc/low_income/available.yaml` window (true 2014, false 2017, true 2018, false 2026); `co_low_income_cdcc_eligible` now gates on it. The four statutory eligibility conditions — AGI ≤ $25,000, insufficient §39-22-119 liability, dependent under 13, would-qualify-under-§21 — are already modeled or applied in the amount; the provider/dependent identification and due-diligence requirements are administrative inputs PE does not model and are now documented as assumed satisfied.
- Verified: same low-income filer eligible in 2025, ineligible in 2026; `co_low_income_cdcc` = $500 in 2025, **$0** in 2026.

## Tests
- New: `tax_unit_files_schedule_f.yaml` (4), `co_qualified_business_income_deduction_addback.yaml` (2).
- Extended with boundary cases: QBI addback-required (+2 Schedule F), federal-deduction addback amount (+4 for 2026), federal-deduction addback-required (+3 threshold boundary), `co_cdcc` (+3 for 2026), `co_low_income_cdcc` (+2 sunset), `co_low_income_cdcc_eligible` (+2 sunset).
- Full CO baseline tree + new federal variable: **524 passed**. Federal CDCC + tax_unit: **89 passed**. Parameter/structure validation: **11 passed**. National microsimulation for 2026 computes all changed variables with no NaNs; the 2026 CDCC fires at exactly 0.70 × the pre-liability federal base for qualifying units.

## References (primary sources)
- Colorado Revised Statutes 2025 official compilation, Title 39 (39-22-104 pp. 382–384; 39-22-119; 39-22-119.5).
- HB24-1134 (2024) SECTIONS 1–2; HB25-1274 (2025, Ch. 402) SECTION 18 + Proposition MM; HB25B-1001 (2025 special session B) SECTION 2.
- Colorado DOR, *Income Tax Topics: Child and Dependent Care Expenses Credit* (Revised January 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
