### PR TITLE
Federal credit accuracy: reduce CDCC by section 129 benefits (+ 25C/clean-vehicle findings)

### DIFF
--- a/changelog.d/federal-credits-accuracy.fixed.md
+++ b/changelog.d/federal-credits-accuracy.fixed.md
@@ -1,0 +1,1 @@
+- Reduced the federal Child and Dependent Care Credit dollar limit by employer-provided dependent care benefits excluded under IRC section 129, as required by section 21(c) and Form 2441 Part III, and added the One Big Beautiful Bill Act increase to the section 129 exclusion cap.

--- a/policyengine_us/parameters/gov/irs/gross_income/dependent_care_assistance_programs/reduction_amount.yaml
+++ b/policyengine_us/parameters/gov/irs/gross_income/dependent_care_assistance_programs/reduction_amount.yaml
@@ -1,18 +1,25 @@
-description: IRS reduces the dependent care benefit limit by this amount, based on filing status.
+description: The IRS limits the amount of dependent care assistance excludable from gross income to this amount, based on filing status.
 SINGLE:
   2018-01-01: 5_000
+  2026-01-01: 7_500
 JOINT:
   2018-01-01: 5_000
+  2026-01-01: 7_500
 SEPARATE:
   2018-01-01: 2_500
+  2026-01-01: 3_750
 HEAD_OF_HOUSEHOLD:
   2018-01-01: 5_000
+  2026-01-01: 7_500
 SURVIVING_SPOUSE:
   2018-01-01: 5_000
+  2026-01-01: 7_500
 metadata:
   breakdown: filing_status
   unit: currency-USD
-  label: IRS reduction amount from gross income for dependent care assistance
+  label: IRS dependent care assistance exclusion cap
   reference:
-    - title: 26 U.S. Code § 129 - Dependent care assistance programs, (a)(2)(A)
+    - title: 26 U.S. Code § 129(a)(2)(A)
       href: https://www.law.cornell.edu/uscode/text/26/129#a_2_A
+    - title: One Big Beautiful Bill Act, Pub. L. No. 119-21, § 70404 (2025) # Raises the § 129(a)(2)(A) exclusion cap to $7,500 ($3,750 MFS) for tax years beginning after 2025-12-31.
+      href: https://www.govinfo.gov/content/pkg/PLAW-119publ21/html/PLAW-119publ21.htm

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/cdcc/cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/cdcc/cdcc.yaml
@@ -148,3 +148,86 @@
     cdcc_filing_status_eligible: true
     cdcc_potential: 600
     cdcc: 600
+
+# IRC section 21(c) / Form 2441 Part III: employer-provided dependent care
+# benefits excluded under section 129 reduce the CDCC dollar limit, preventing
+# a credit on the same dollars already excluded from income (issue #8737).
+- name: Section 129 employer benefits reduce the CDCC (no double-dipping)
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      parent1:
+        age: 40
+        employment_income: 80_000
+        dependent_care_employer_benefits: 5_000
+      parent2:
+        age: 38
+        employment_income: 60_000
+      child1:
+        age: 5
+      child2:
+        age: 7
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child1, child2]
+        filing_status: JOINT
+        tax_unit_childcare_expenses: 6_000
+  output:
+    # Form 2441 Part III: $5,000 excluded under section 129.
+    dependent_care_assistance_exclusion: 5_000
+    # Section 21(c): $6,000 two-child limit reduced by $5,000 exclusion.
+    cdcc_limit: 1_000
+    cdcc_relevant_expenses: 1_000
+    # $1,000 x 20% applicable percentage.
+    cdcc: 200
+
+- name: Section 129 benefits at the cap fully eliminate a one-child CDCC
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      parent1:
+        age: 40
+        employment_income: 80_000
+        dependent_care_employer_benefits: 5_000
+      child1:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [parent1, child1]
+        filing_status: HEAD_OF_HOUSEHOLD
+        tax_unit_childcare_expenses: 6_000
+  output:
+    dependent_care_assistance_exclusion: 5_000
+    # max($3,000 one-child limit - $5,000 exclusion, 0) = $0.
+    cdcc_limit: 0
+    cdcc_relevant_expenses: 0
+    cdcc: 0
+
+- name: Without section 129 benefits the CDCC is unchanged
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      parent1:
+        age: 40
+        employment_income: 80_000
+      parent2:
+        age: 38
+        employment_income: 60_000
+      child1:
+        age: 5
+      child2:
+        age: 7
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child1, child2]
+        filing_status: JOINT
+        tax_unit_childcare_expenses: 6_000
+  output:
+    dependent_care_assistance_exclusion: 0
+    cdcc_limit: 6_000
+    cdcc_relevant_expenses: 6_000
+    # $6,000 x 20% = $1,200.
+    cdcc: 1_200

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/cdcc/cdcc_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/cdcc/cdcc_limit.yaml
@@ -18,3 +18,32 @@
     capped_count_cdcc_eligible: 0
   output:
     cdcc_limit: 0
+
+# IRC section 21(c): the dollar limit is reduced by the section 129 exclusion
+# (Form 2441 Part III, line 27 minus line 28).
+- name: Two children, limit reduced by a $5,000 section 129 exclusion
+  period: 2024
+  input:
+    capped_count_cdcc_eligible: 2
+    dependent_care_assistance_exclusion: 5_000
+  output:
+    # $6,000 - $5,000 = $1,000.
+    cdcc_limit: 1_000
+
+- name: One child, exclusion exceeding the limit floors it at zero
+  period: 2024
+  input:
+    capped_count_cdcc_eligible: 1
+    dependent_care_assistance_exclusion: 5_000
+  output:
+    # max($3,000 - $5,000, 0) = $0.
+    cdcc_limit: 0
+
+- name: Two children, exclusion reduces but does not eliminate the limit
+  period: 2024
+  input:
+    capped_count_cdcc_eligible: 2
+    dependent_care_assistance_exclusion: 2_500
+  output:
+    # $6,000 - $2,500 = $3,500.
+    cdcc_limit: 3_500

--- a/policyengine_us/tests/policy/baseline/gov/irs/credits/cdcc/dependent_care_assistance_exclusion.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/credits/cdcc/dependent_care_assistance_exclusion.yaml
@@ -1,0 +1,106 @@
+# IRC section 129 dependent care assistance exclusion, as reconciled on
+# Form 2441 Part III. The exclusion is the lesser of the employer benefits,
+# the section 129(a)(2)(A) dollar cap (by filing status), and the section
+# 129(b) earned-income limit.
+
+- name: No employer dependent care benefits gives no exclusion
+  period: 2024
+  input:
+    dependent_care_employer_benefits: 0
+    filing_status: JOINT
+    min_head_spouse_earned: 50_000
+  output:
+    dependent_care_assistance_exclusion: 0
+
+- name: Benefits below the cap and earned income are excluded in full
+  period: 2024
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        employment_income: 80_000
+        dependent_care_employer_benefits: 4_000
+      spouse:
+        is_tax_unit_spouse: true
+        employment_income: 60_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+  output:
+    # min($4,000 benefits, $5,000 cap, lesser earnings) = $4,000.
+    dependent_care_assistance_exclusion: 4_000
+
+- name: Section 129(a)(2)(A) dollar cap limits the exclusion (joint)
+  period: 2024
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        employment_income: 80_000
+        dependent_care_employer_benefits: 6_000
+      spouse:
+        is_tax_unit_spouse: true
+        employment_income: 60_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+  output:
+    # min($6,000 benefits, $5,000 cap, lesser earnings) = $5,000.
+    dependent_care_assistance_exclusion: 5_000
+
+- name: Section 129(b) earned-income limit caps the exclusion
+  period: 2024
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        employment_income: 80_000
+        dependent_care_employer_benefits: 5_000
+      spouse:
+        is_tax_unit_spouse: true
+        employment_income: 2_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+  output:
+    # min($5,000 benefits, $5,000 cap, $2,000 lesser earnings) = $2,000.
+    dependent_care_assistance_exclusion: 2_000
+
+- name: Married filing separately uses the $2,500 cap
+  period: 2024
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        employment_income: 80_000
+        dependent_care_employer_benefits: 5_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SEPARATE
+  output:
+    # min($5,000 benefits, $2,500 MFS cap, earnings) = $2,500.
+    dependent_care_assistance_exclusion: 2_500
+
+- name: OBBBA raises the joint cap to $7,500 for 2026
+  period: 2026
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        employment_income: 80_000
+        dependent_care_employer_benefits: 7_000
+      spouse:
+        is_tax_unit_spouse: true
+        employment_income: 60_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+  output:
+    # Benefits ($7,000) below the new $7,500 cap and below earnings, so the
+    # full amount is excluded. (Input uprating is disabled for a clean check.)
+    dependent_care_assistance_exclusion: 7_000

--- a/policyengine_us/variables/gov/irs/credits/cdcc/cdcc_limit.py
+++ b/policyengine_us/variables/gov/irs/credits/cdcc/cdcc_limit.py
@@ -12,4 +12,10 @@ class cdcc_limit(Variable):
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.irs.credits.cdcc
         capped_count_cdcc_eligible = tax_unit("capped_count_cdcc_eligible", period)
-        return p.max * capped_count_cdcc_eligible
+        dollar_limit = p.max * capped_count_cdcc_eligible
+        # IRC section 21(c) flush language: the $3,000 / $6,000 dollar limit
+        # "shall be reduced by the aggregate amount excludable from gross
+        # income under section 129 for the taxable year." This is the Form
+        # 2441 Part III -> Part II reconciliation (line 27 minus line 28).
+        exclusion = tax_unit("dependent_care_assistance_exclusion", period)
+        return max_(dollar_limit - exclusion, 0)

--- a/policyengine_us/variables/gov/irs/credits/cdcc/dependent_care_assistance_exclusion.py
+++ b/policyengine_us/variables/gov/irs/credits/cdcc/dependent_care_assistance_exclusion.py
@@ -1,0 +1,38 @@
+from policyengine_us.model_api import *
+
+
+class dependent_care_assistance_exclusion(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Dependent care assistance excluded from gross income"
+    documentation = (
+        "Amount of employer-provided dependent care benefits excludable from "
+        "gross income under IRC section 129. This is the amount that reduces "
+        "the section 21(c) CDCC dollar limit (Form 2441 Part III)."
+    )
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        # Exclusion and its two limits.
+        "https://www.law.cornell.edu/uscode/text/26/129#a_2",  # Dollar cap.
+        "https://www.law.cornell.edu/uscode/text/26/129#b",  # Earned income limit.
+        # Form 2441 Part III lines 12-26 compute the excluded benefit.
+        "https://www.irs.gov/instructions/i2441",
+    )
+
+    def formula(tax_unit, period, parameters):
+        # Total employer-provided dependent care benefits (Form 2441 line 12,
+        # W-2 box 10).
+        benefits = add(tax_unit, period, ["dependent_care_employer_benefits"])
+        p = parameters(period).gov.irs.gross_income.dependent_care_assistance_programs
+        # Section 129(a)(2)(A) dollar cap by filing status (Form 2441 line 21;
+        # $5,000, $2,500 MFS, raised to $7,500 / $3,750 after 2025 by OBBBA).
+        filing_status = tax_unit("filing_status", period)
+        dollar_cap = p.reduction_amount[filing_status]
+        # Section 129(b) earned-income limitation: the exclusion cannot exceed
+        # the taxpayer's earned income, or, for a married taxpayer, the lesser
+        # of the taxpayer's and spouse's earned income (Form 2441 lines 18-19).
+        # min_head_spouse_earned returns the taxpayer's earnings when unmarried
+        # and the lesser of the two when married filing jointly.
+        earned_income_limit = tax_unit("min_head_spouse_earned", period)
+        return min_(benefits, min_(dollar_cap, earned_income_limit))


### PR DESCRIPTION
## Summary

Federal credit accuracy pass over three issues. Only one required a code change; the other two are addressed with evidence and recommendations for the reviewer (no code change, and the linked issues are **not** closed here — the lead decides).

| Issue | Verdict | Action |
|---|---|---|
| #8737 — CDCC does not reduce the § 21(c) cap by § 129 benefits | **Fix** | Code + tests in this PR (`Fixes #8737`) |
| #8760 — Align clean-vehicle credits with § 25E / § 30D | **Already compliant / not an accuracy bug** | Recommend close (evidence below) |
| #8703 — Update § 25C for current law | **Already fixed by #8901; residual is a feature** | Recommend close (evidence below) |

---

## #8737 — CDCC § 21(c) reduction by § 129 employer dependent-care benefits (FIXED)

**Primary sources read.**
- IRC § 21(c) flush sentence (uscode.house.gov): "The amount determined under paragraph (1) or (2) … **shall be reduced by the aggregate amount excludable from gross income under section 129 for the taxable year.**"
- IRC § 129(a)(2)(A): exclusion cap $5,000 ($2,500 MFS); § 129(b): earned-income limitation (lesser of taxpayer / spouse earned income).
- Form 2441 Part III (IRS i2441): lines 27–31 reduce the $3,000 / $6,000 limit by the § 129 excluded benefits before Part II.
- OBBBA Pub. L. 119-21 **§ 70404** (139 STAT. 214): strikes "$5,000 ($2,500" and inserts "$7,500 ($3,750", effective for tax years beginning after 2025-12-31.

**Defect.** `cdcc_limit` returned `p.max * capped_count` with no § 129 reduction. `dependent_care_employer_benefits` (W-2 box 10) existed as an input but was consumed only by Hawaii, never by the federal cap — so a filer with a dependent-care FSA could claim the CDCC on dollars already excluded from income (double-dip).

**Fix.**
- New `dependent_care_assistance_exclusion` (TaxUnit) = `min(employer benefits, § 129(a)(2)(A) dollar cap [by filing status], § 129(b) earned-income limit)`.
- `cdcc_limit` now returns `max(dollar_limit − exclusion, 0)`.
- Added the OBBBA § 70404 cap increase ($7,500 / $3,750) to `reduction_amount.yaml` (the existing § 129(a)(2)(A) parameter), 2026-01-01.

**Verified mechanic (Form 2441 Part III), MFJ, 2 children, $6,000 childcare, ample earnings:**

| § 129 benefits | exclusion | cdcc_limit | cdcc |
|---:|---:|---:|---:|
| $0 | $0 | $6,000 | $1,200 |
| $2,500 | $2,500 | $3,500 | $700 |
| $5,000 | $5,000 | $1,000 | $200 |

Earned-income limit and MFS $2,500 cap each verified to bind independently.

**Scope note.** The reduction flows through `cdcc_relevant_expenses` / `cdcc_potential` into the many state CDCCs that reuse those federal variables. Three states (CA `ca_cdcc_relevant_expenses`, ID `id_cdcc_limit`, VA `va_child_dependent_care_deduction_cdcc_limit`) independently recompute the raw `p.max * count` dollar limit and therefore do **not** inherit the § 129 reduction; whether each state conforms to the § 129 exclusion is a separate per-state question left untouched here. Because `dependent_care_employer_benefits` defaults to 0 and is not imputed in the microdata or generally sent by API partners, there is no change to population/microsimulation or partner outputs — this is a household-calculator correctness fix.

**Tests (local, `policyengine-core test … -c policyengine_us`):**
- Federal CDCC tree: **86 passed** (incl. new `dependent_care_assistance_exclusion.yaml` 6 cases, expanded `cdcc_limit.yaml`, 3 new `cdcc.yaml` integration cases).
- Coupled state CDCC + partner analytics trees (CA, HI, GA, SC, MS, KY, CO, IA, WV, RI, PA, NM, NJ + analytics): **167 passed**.
- Additional CDCC-consumer states (MD, DC, AR, NE, DE, KS, OH, NY, ID, VA, AZ): **61 passed**.
- ME / OK / LA child-care credits (also consume `cdcc_relevant_expenses`): **26 passed**.
- **0 regressions.**

---

## #8760 — Clean vehicle credits vs. § 25E / § 30D (RECOMMEND CLOSE — not an accuracy bug)

Read against IRC § 30D / § 25E and IRA §§ 13401–13402. The statutory boundaries that could be "misaligned" are already correctly encoded:

- **OBBBA termination** (§ 30D(h) / § 25E(g), Pub. L. 119-21 §§ 70501/70502, vehicles acquired after 2025-09-30): both `new/eligibility/in_effect.yaml` and `used/eligibility/in_effect.yaml` already carry `2026-01-01: false` with the § 70501/70502 citations (landed in #8901, merged 2026-07-05). Verified: new/used credits compute $7,500 / $4,000 for a qualifying vehicle in 2024–2025 and **$0 in 2026**.
- **MSRP caps** ($80k van/SUV/pickup, $55k other), **income limits** (§ 30D $300k/$225k/$150k; § 25E $150k/$112.5k/$75k), **used sale-price limit** ($25k), **used amount** (lesser of $4,000 / 30% of price) all match the statute.

The issue itself does not allege a specific statutory value that contradicts the code — it asks PolicyEngine to expose **narrower legal-boundary variables/parameters** so Axiom's per-vehicle RuleSpec outputs can be mapped one-to-one as oracle targets ("PE would need either narrower legal-boundary variables … or an adapter contract"). That is an interface/feature request about oracle granularity, not a wrong answer for encoded law. Recommend closing as such (or relabeling as an enhancement).

*Known modeling simplification (documented, not raised in the issue):* the used-vehicle MAGI test uses current-year AGI only, whereas § 25E(b)(3)(B) allows the lesser of current- and prior-year MAGI (`used_clean_vehicle_credit_eligible` comment: "Assume AGI in current year for now"). This is a scoping simplification, not a contradiction of a value, and would be its own enhancement.

---

## #8703 — § 25C energy efficient home improvement credit (RECOMMEND CLOSE — already fixed; residual is a feature)

The issue (filed 2026-06-21) states `in_effect.yaml` "turns the credit off on 2033-01-01". That is stale: **#8901 (merged 2026-07-05, after the issue)** set `2026-01-01: false` with the OBBBA § 70505 citation (§ 25C(i): does not apply to property placed in service after 2025-12-31). Verified with positive window/insulation expenditures:

| Year | 25C potential | 25C credit |
|---:|---:|---:|
| 2024 | $720 | $720 |
| 2025 | $761 | $761 |
| 2026 | **$0** | **$0** |

Post-termination years already return $0; pre-termination values track the IRA § 25C structure. The only remaining item the issue raises — the § 25C(h) product-identification-number (PIN) requirement for specified property placed in service after 2024-12-31 — is a **new input** (a PIN-present flag) that does not yet exist and would default all such property to failing. That is a feature addition, not a wrong answer for currently encoded law, and is already flagged as a known limitation in the `in_effect.yaml` comment. Recommend closing the accuracy issue (and, if desired, opening a scoped feature issue for the § 25C(h) PIN gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
