### PR TITLE
Fix Maine EITC childless age expansion (#8927) and 2025 STFC base (#8928); close #8710, #8589 with evidence

### DIFF
--- a/changelog.d/de-me-accuracy.fixed.md
+++ b/changelog.d/de-me-accuracy.fixed.md
@@ -1,0 +1,2 @@
+- Added the Maine EITC childless age expansion (36 M.R.S. Sec. 5219-S) so filers aged 18-24 without a qualifying child receive the credit.
+- Corrected the 2025 Maine sales tax fairness credit base amount to $215 for joint, head of household, and surviving spouse filers.

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/eitc/eligibility/age/min.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/eitc/eligibility/age/min.yaml
@@ -1,0 +1,14 @@
+description: Maine allows filers without a qualifying child who are at least this age to claim the earned income tax credit, lowering the federal minimum age floor.
+values:
+  2020-01-01: 18
+metadata:
+  unit: year
+  period: year
+  label: Maine EITC minimum childless age
+  reference:
+    - title: 36 M.R.S. § 5219-S(6) - "eligible individual" also includes an individual without a qualifying child who is at least 18 and has not attained 25 years of age
+      href: https://legislature.maine.gov/statutes/36/title36sec5219-S.html
+    - title: 36 M.R.S. § 5219-S(5) - credit for a childless individual under 25 is calculated as if the individual were eligible for a federal earned income credit
+      href: https://legislature.maine.gov/statutes/36/title36sec5219-S.html
+    - title: 2025 Instructions for Form 1040ME - Schedule A, Line 2 (Maine EIC Worksheet)
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf#page=10

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/additional/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/additional/head_of_household.yaml
@@ -9,11 +9,13 @@ brackets:
     amount:
       2021-01-01: 25
       2024-01-01: 30
+      2025-01-01: 35
   - threshold:
       2021-01-01: 3
     amount:
       2021-01-01: 55
       2024-01-01: 60
+      2025-01-01: 65
 
 metadata:
   unit: currency-USD
@@ -28,7 +30,9 @@ metadata:
     - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
     - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4
+    - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   period: year
   label: Maine sales tax fairness credit head of household additional amount
   type: single_amount

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/additional/joint.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/additional/joint.yaml
@@ -9,11 +9,13 @@ brackets:
     amount:
       2021-01-01: 25
       2024-01-01: 30
+      2025-01-01: 35
   - threshold:
       2021-01-01: 2
     amount:
       2021-01-01: 55
       2024-01-01: 60
+      2025-01-01: 65
 
 metadata:
   unit: currency-USD
@@ -28,7 +30,9 @@ metadata:
     - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
     - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4
+    - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   period: year
   label: Maine sales tax fairness credit joint additional amount
   type: single_amount

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/additional/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/additional/surviving_spouse.yaml
@@ -9,11 +9,13 @@ brackets:
     amount:
       2021-01-01: 25
       2024-01-01: 30
+      2025-01-01: 35
   - threshold:
       2021-01-01: 2
     amount:
       2021-01-01: 55
       2024-01-01: 60
+      2025-01-01: 65
 
 metadata:
   unit: currency-USD
@@ -28,7 +30,9 @@ metadata:
     - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
     - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4
+    - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   period: year
   label: Maine sales tax fairness credit surviving spouse additional amount
   type: single_amount

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/base.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/base.yaml
@@ -17,7 +17,7 @@ JOINT:
     2022-01-01: 185
     2023-01-01: 200
     2024-01-01: 210
-    2025-01-01: 220
+    2025-01-01: 215
   metadata:
     uprating:
       parameter: gov.irs.uprating
@@ -39,7 +39,7 @@ HEAD_OF_HOUSEHOLD:
     2022-01-01: 185
     2023-01-01: 200
     2024-01-01: 210
-    2025-01-01: 220
+    2025-01-01: 215
   metadata:
     uprating:
       parameter: gov.irs.uprating
@@ -52,7 +52,7 @@ SURVIVING_SPOUSE:
     2022-01-01: 185
     2023-01-01: 200
     2024-01-01: 210
-    2025-01-01: 220
+    2025-01-01: 215
   metadata:
     uprating:
       parameter: gov.irs.uprating
@@ -75,7 +75,7 @@ metadata:
     - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
     - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4
     - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
       href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   period: year

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
@@ -362,3 +362,47 @@
     # Per-column: $550 of $660 pre-EITC credits used (line 27a+27b),
     # then NR EITC (~$50) applied to higher-income column (line 30).
     de_income_tax: 309
+
+- name: FS4 young couple one dependent - per-column personal credit cap (issue #8710)
+  # DE, MFJ, both age 20, one dependent, $21,790 taxable interest split 50/50,
+  # filed separate/combined. Reported by NBER TAXSIM (policyengine-taxsim#1007).
+  # Each column has $169.155 tax (PIT-RES Line 26). Column A uses its own $110
+  # (1 exemption) personal credit; Column B's $220 (2 exemptions) credit is
+  # capped at its own $169.155 tax (Line 32 <= Line 26), so the surplus is lost
+  # rather than offsetting Column A. Balance = $59.155 in Column A, $0 in
+  # Column B. The form/TAXSIM ground truth is $58; the ~$1.16 residual is
+  # PolicyEngine's continuous rate-bracket computation vs the form's rounded tax
+  # table, not the credit pooling this test pins. Fixed on main by #7940.
+  period: 2025
+  absolute_error_margin: 0.5
+  input:
+    people:
+      person1:
+        age: 20
+        taxable_interest_income: 10_895
+        is_tax_unit_head: true
+      person2:
+        age: 20
+        taxable_interest_income: 10_895
+        is_tax_unit_spouse: true
+      child1:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2, child1]
+        premium_tax_credit: 0
+    families:
+      family:
+        members: [person1, person2, child1]
+    spm_units:
+      spm_unit:
+        members: [person1, person2, child1]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1, person2, child1]
+        state_fips: 10
+  output:
+    de_files_separately: true
+    de_income_tax: 59.155

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/eitc/me_childless_eitc_age_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/eitc/me_childless_eitc_age_eligible.yaml
@@ -1,0 +1,107 @@
+# 36 M.R.S. § 5219-S(6): childless filers aged 18-24 (up to the federal
+# maximum childless age of 64) are treated as eligible individuals.
+- name: Childless single aged 18 is age-eligible for the Maine expansion
+  period: 2025
+  input:
+    people:
+      head:
+        age: 18
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    me_childless_eitc_age_eligible: true
+
+- name: Childless single aged 24 is age-eligible for the Maine expansion
+  period: 2025
+  input:
+    people:
+      head:
+        age: 24
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    me_childless_eitc_age_eligible: true
+
+- name: Childless single aged 17 is below the Maine floor
+  period: 2025
+  input:
+    people:
+      head:
+        age: 17
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    me_childless_eitc_age_eligible: false
+
+- name: Childless single aged 25 has attained 25 and is outside the added cohort
+  period: 2025
+  input:
+    people:
+      head:
+        age: 25
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    # Age 25+ childless filers are already federally eligible (no expansion
+    # needed); the added cohort is only 18-24.
+    me_childless_eitc_age_eligible: false
+
+- name: Childless single aged 65 is outside the added cohort
+  period: 2025
+  input:
+    people:
+      head:
+        age: 65
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    me_childless_eitc_age_eligible: false
+
+- name: Filer aged 20 with a qualifying child is not in the childless expansion
+  period: 2025
+  input:
+    people:
+      head:
+        age: 20
+        employment_income: 8_000
+      child:
+        age: 3
+    tax_units:
+      tax_unit:
+        members: [head, child]
+    households:
+      household:
+        members: [head, child]
+        state_code: ME
+  output:
+    me_childless_eitc_age_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/eitc/me_pro_forma_childless_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/eitc/me_pro_forma_childless_eitc.yaml
@@ -1,0 +1,42 @@
+# 36 M.R.S. § 5219-S(5): the credit for the 18-24 childless cohort is computed
+# as if the individual were eligible for a federal earned income credit. The
+# pro forma equals the federal phase-in/reduction with the age gate removed.
+- name: 2025 childless couple aged 23 and 24 with $10,476 earnings gets full childless max
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 23
+        employment_income: 10_476
+      spouse:
+        age: 24
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+    households:
+      household:
+        members: [head, spouse]
+        state_code: ME
+  output:
+    # Earnings above the childless phase-in end and AGI below the MFJ phase-out
+    # start yield the 2025 childless maximum of $649.
+    me_pro_forma_childless_eitc: 649
+
+- name: Pro forma is zero for tax units outside the expansion cohort
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 10_476
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    me_pro_forma_childless_eitc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/me_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/me_eitc.yaml
@@ -99,3 +99,91 @@
         state_code: ME
   output:
     me_eitc: 125
+
+# 36 M.R.S. § 5219-S(5)-(6): childless filers aged 18-24 receive the Maine
+# EITC computed as if they qualified federally, even though federal § 32 bars
+# them on the minimum-age floor. Issue #8927; reported household from
+# PolicyEngine/policyengine-taxsim#1056 (TaxAct return shows $325 on 1040ME).
+- name: 2025 MFJ childless couple aged 23 and 24 gets the Maine expansion credit
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 23
+        employment_income: 10_476
+      spouse:
+        age: 24
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+    households:
+      household:
+        members: [head, spouse]
+        state_code: ME
+  output:
+    eitc: 0
+    me_pro_forma_childless_eitc: 649
+    me_eitc: 324.50
+
+- name: 2025 childless couple aged 25 and 26 unaffected (federal EITC path)
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 25
+        employment_income: 10_476
+      spouse:
+        age: 26
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+    households:
+      household:
+        members: [head, spouse]
+        state_code: ME
+  output:
+    eitc: 649
+    me_eitc: 324.50
+
+- name: 2025 childless single aged 17 below Maine floor gets no credit
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 17
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    me_childless_eitc_age_eligible: false
+    me_eitc: 0
+
+- name: 2025 childless single aged 70 outside the expansion gets no credit
+  # Federal Sec. 32 already bars childless filers above age 64; Maine does not
+  # extend the upper bound, and 70 is outside the added 18-24 cohort.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 70
+        employment_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: ME
+  output:
+    eitc: 0
+    me_childless_eitc_age_eligible: false
+    me_eitc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/sales_tax_fairness_credit/me_sales_tax_fairness_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/tax/income/credits/sales_tax_fairness_credit/me_sales_tax_fairness_credit.yaml
@@ -77,3 +77,69 @@
     me_sales_and_property_tax_fairness_credit_income: 52_630
   output:
     me_sales_tax_fairness_credit: 240
+
+# 2025 Schedule PTFC/STFC (line 17 table, page 4) pins the base amount
+# independently of the dependent add-ons for issue #8928.
+# https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
+- name: 2025 ME STFC MFJ no dependents lowest income band equals form base of 215
+  period: 2025
+  input:
+    me_sales_tax_fairness_credit_eligible: true
+    ctc_qualifying_children: 0
+    filing_status: JOINT
+    me_sales_and_property_tax_fairness_credit_income: 0
+  output:
+    me_sales_tax_fairness_credit: 215
+
+- name: 2025 ME STFC head of household no dependents lowest income band equals form base of 215
+  period: 2025
+  input:
+    me_sales_tax_fairness_credit_eligible: true
+    ctc_qualifying_children: 0
+    filing_status: HEAD_OF_HOUSEHOLD
+    me_sales_and_property_tax_fairness_credit_income: 0
+  output:
+    me_sales_tax_fairness_credit: 215
+
+- name: 2025 ME STFC surviving spouse no dependents lowest income band equals form base of 215
+  period: 2025
+  input:
+    me_sales_tax_fairness_credit_eligible: true
+    ctc_qualifying_children: 0
+    filing_status: SURVIVING_SPOUSE
+    me_sales_and_property_tax_fairness_credit_income: 0
+  output:
+    me_sales_tax_fairness_credit: 215
+
+- name: 2025 ME STFC MFJ one dependent lowest income band equals form 250
+  period: 2025
+  input:
+    me_sales_tax_fairness_credit_eligible: true
+    ctc_qualifying_children: 1
+    filing_status: JOINT
+    me_sales_and_property_tax_fairness_credit_income: 0
+  output:
+    me_sales_tax_fairness_credit: 250
+
+- name: 2025 ME STFC single no dependents lowest income band equals form 155
+  period: 2025
+  input:
+    me_sales_tax_fairness_credit_eligible: true
+    ctc_qualifying_children: 0
+    filing_status: SINGLE
+    me_sales_and_property_tax_fairness_credit_income: 0
+  output:
+    me_sales_tax_fairness_credit: 155
+
+# 2024 Schedule PTFC/STFC (line 17 table, page 4): MFJ no dependents = 210.
+# Confirms the base/add-on re-split for 2025 leaves 2024 untouched.
+# https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4
+- name: 2024 ME STFC MFJ no dependents lowest income band still equals form base of 210
+  period: 2024
+  input:
+    me_sales_tax_fairness_credit_eligible: true
+    ctc_qualifying_children: 0
+    filing_status: JOINT
+    me_sales_and_property_tax_fairness_credit_income: 0
+  output:
+    me_sales_tax_fairness_credit: 210

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/tax/income/integration.yaml
@@ -52,3 +52,44 @@
         state_fips: 42
   output:
     pa_income_tax: 0
+
+- name: Retired couple past retirement age owes no PA tax on pensions, IRA, and Social Security (issue #8589)
+  # 61 Pa. Code Sec. 101.6: qualified retirement distributions received after
+  # reaching the plan's retirement age are not taxable, and PA does not tax
+  # Social Security. Both spouses are past retirement age (67 and 65), so the
+  # pension, IRA, and Social Security income are all exempt. Fixed by #8922
+  # (employer-plan and IRA distributions) plus the pre-existing pension and
+  # Social Security exemptions. Reproducer from the issue.
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        age: 67
+        taxable_pension_income: 40_000
+        taxable_ira_distributions: 30_000
+        social_security: 30_000
+      person2:
+        age: 65
+        taxable_pension_income: 20_000
+        social_security: 20_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        premium_tax_credit: 0
+        local_income_tax: 0
+        state_sales_tax: 0
+        pa_use_tax: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_fips: 42
+  output:
+    pa_total_taxable_income: 0
+    state_income_tax: 0

--- a/policyengine_us/variables/gov/states/me/tax/income/credits/eitc/me_childless_eitc_age_eligible.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/credits/eitc/me_childless_eitc_age_eligible.py
@@ -1,0 +1,33 @@
+from policyengine_us.model_api import *
+
+
+class me_childless_eitc_age_eligible(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "In the Maine childless EITC age expansion cohort"
+    definition_period = YEAR
+    reference = "https://legislature.maine.gov/statutes/36/title36sec5219-S.html"
+    defined_for = StateCode.ME
+
+    def formula(tax_unit, period, parameters):
+        # 36 M.R.S. Sec. 5219-S(6) extends "eligible individual" to a filer
+        # without a qualifying child who is at least 18 and has not attained 25
+        # before the close of the tax year. That cohort is exactly the group
+        # federal Sec. 32 excludes on the minimum-age floor; childless filers
+        # aged 25 to the federal maximum are already federally eligible and do
+        # not need this expansion. This variable flags the added 18-24 cohort.
+        p = parameters(period).gov.states.me.tax.income.credits.eitc
+
+        person = tax_unit.members
+        no_qualifying_children = tax_unit("eitc_child_count", period) == 0
+
+        age = person("age", period)
+        is_head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        # Maine lowers the age floor to 18; the added cohort ends where federal
+        # childless eligibility begins (the federal minimum childless age).
+        federal_min_age = parameters(period).gov.irs.credits.eitc.eligibility.age.min
+        in_expanded_age_range = (
+            (age >= p.eligibility.age.min) & (age < federal_min_age) & is_head_or_spouse
+        )
+
+        return no_qualifying_children & tax_unit.any(in_expanded_age_range)

--- a/policyengine_us/variables/gov/states/me/tax/income/credits/eitc/me_pro_forma_childless_eitc.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/credits/eitc/me_pro_forma_childless_eitc.py
@@ -1,0 +1,36 @@
+from policyengine_us.model_api import *
+
+
+class me_pro_forma_childless_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maine pro forma federal EITC for the childless age expansion"
+    unit = USD
+    documentation = (
+        "Federal earned income credit recomputed for the 18-24 childless "
+        "cohort Maine restores under 36 M.R.S. § 5219-S(5)-(6), ignoring the "
+        "federal minimum-age floor. All other federal § 32 requirements "
+        "(earnings, phase-out, investment income, taxpayer identification) "
+        "still apply."
+    )
+    definition_period = YEAR
+    reference = "https://legislature.maine.gov/statutes/36/title36sec5219-S.html"
+    defined_for = "me_childless_eitc_age_eligible"
+
+    def formula(tax_unit, period, parameters):
+        # § 5219-S(5): the credit "must be calculated in the same manner as it
+        # would be calculated if that individual were eligible for a federal
+        # earned income credit." The federal phase-in and reduction amounts are
+        # age-independent, so the pro forma equals the ordinary federal EITC
+        # computation with the demographic (age) gate dropped, retaining the
+        # investment-income and identification (SSN) requirements of § 32.
+        phased_in = tax_unit("eitc_phased_in", period)
+        maximum = tax_unit("eitc_maximum", period)
+        reduction = tax_unit("eitc_reduction", period)
+        investment_eligible = tax_unit("eitc_investment_income_eligible", period)
+        filer_has_ssn = tax_unit("filer_meets_eitc_identification_requirements", period)
+        return (
+            min_(phased_in, max_(0, maximum - reduction))
+            * investment_eligible
+            * filer_has_ssn
+        )

--- a/policyengine_us/variables/gov/states/me/tax/income/credits/me_eitc.py
+++ b/policyengine_us/variables/gov/states/me/tax/income/credits/me_eitc.py
@@ -13,7 +13,15 @@ class me_eitc(Variable):
     defined_for = StateCode.ME
 
     def formula(tax_unit, period, parameters):
-        federal_eitc = tax_unit("eitc", period)
+        # 36 M.R.S. § 5219-S(5)-(6): childless filers aged 18-24 who fail the
+        # federal EITC only on the minimum-age floor are treated as eligible,
+        # with the credit computed as if they qualified federally. Take the
+        # larger of the actual federal EITC and the pro forma amount for that
+        # cohort; the pro forma is zero for tax units outside the expansion.
+        federal_eitc = max_(
+            tax_unit("eitc", period),
+            tax_unit("me_pro_forma_childless_eitc", period),
+        )
         p = parameters(period).gov.states.me.tax.income.credits.eitc
         match_rate = where(
             tax_unit("eitc_child_count", period) > 0,


### PR DESCRIPTION
## Summary

Accuracy-fix lane covering four issues. Two need code changes (Maine EITC #8927, Maine STFC #8928) and are fixed here with page-anchored citations and tests including the reported households. Two are already correct on `main` and are documented with reproductions for closing.

| Issue | State | Verdict |
|---|---|---|
| #8927 | ME | **Fixed** — childless EITC age expansion (18-24) added |
| #8928 | ME | **Fixed** — 2025 STFC base corrected to $215 |
| #8710 | DE | **Already fixed** on `main` by #7940 — close with evidence |
| #8589 | PA | **Already fixed** on `main` by #8922 — close with evidence |

Draft — lead reviews before merge/ready/close.

---

## #8927 — Maine EITC omits the §5219-S childless age expansion (FIXED)

**Law.** [36 M.R.S. § 5219-S](https://legislature.maine.gov/statutes/36/title36sec5219-S.html):
- **sub-§6** (verbatim): *"'eligible individual' has the same meaning as under Section 32(c)(1) of the Code except that 'eligible individual' also includes an individual who does not have a qualifying child for the taxable year, who is at least 18 years of age and has not attained 25 years of age before the close of the taxable year and who also meets the qualifications under Section 32(c)(1)(A)(ii)(I) and (III) of the Code."*
- **sub-§5** (verbatim): *"The credit for an eligible individual who is entitled to a credit under subsections 1 to 3-A, has not attained 25 years of age and does not have a qualifying child for the taxable year must be calculated in the same manner as it would be calculated if that individual were eligible for a federal earned income credit."*
- Section history: sub-§5/§6 added by PL 2019 c. 527 Pt. B, applying to tax years beginning on or after January 1, 2020.

**Bug.** `me_eitc` returned `eitc * match_rate`, and `eitc` is the actual federal credit — which is $0 for childless filers under the federal age floor (25 in 2022+). So a childless Maine filer aged 18-24 received $0 instead of 50% of a pro forma federal EIC.

**Fix.** New `me_childless_eitc_age_eligible` (childless tax unit with head/spouse aged 18 up to the federal minimum childless age) and `me_pro_forma_childless_eitc` (federal phase-in/reduction with the age gate dropped, retaining the § 32 investment-income and SSN tests, mirroring Maryland's `federal_eitc_without_age_minimum`). `me_eitc` now applies the match rate to `max(eitc, me_pro_forma_childless_eitc)`. Maine lowers only the age floor; the federal childless maximum age (64) is preserved, so 65+ childless filers still get $0.

**Reproduction** (2025, ME, MFJ, ages 23/24, no dependents, $10,476 wages; from PolicyEngine/policyengine-taxsim#1056):
- Before: `eitc` = 0, `me_eitc` = **0**
- After: pro forma childless EIC = $649 → `me_eitc` = **$324.50** (TaxAct return shows $325 on Form 1040ME)

Fixes #8927.

---

## #8928 — Maine STFC 2025 base amount is $220, form shows $215 (FIXED)

**Source.** [2025 Schedule PTFC/STFC, line 17 table, page 4](https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4). Lowest income band:

| Filing status | 0 dep | 1 dep | 2+ dep |
|---|---|---|---|
| MFJ / QSS (≤ $50,950) | **215** | 250 | 280 |
| Head of household (≤ $38,200), cols 0-1 / 2 / 3+ | **215** | 250 | 280 |
| Single (≤ $25,450) | 155 | — | — |

The model had a 2025 base of **$220** for joint/HoH/surviving-spouse (single $155 was correct). It matched the form for filers *with* dependents ($220 + $30 = $250, $220 + $60 = $280) but overstated the 0-dependent credit by $5. The 2+-dependent integration test from #8266 was insensitive to the base/add-on split, so the error passed.

**Fix.** Set the 2025 joint/HoH/surviving-spouse base to $215 and re-split the 2025 dependent add-ons to $35/$65 (from $30/$60), keeping the with-dependent totals at $250/$280. Adjacent years verified against their forms and left unchanged: 2023 = $200 ([2023 form](https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4)), 2024 = $210 ([2024 form](https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4)). Also corrected the 2024 reference links (they pointed at the 2023 file). Added 0-dependent pin tests (joint/HoH/surviving-spouse) plus a 2024 control.

**Reproduction** (2025, ME, MFJ, no dependents, low income): `me_sales_tax_fairness_credit` = **220.00** before, **215.00** after (matches form).

Fixes #8928.

---

## #8710 — DE separate/combined non-refundable credit cap (ALREADY FIXED — recommend close)

Reported cause: non-refundable credits capped against combined tax instead of per-column. **This was fixed on `main` by #7940** ("Fix DE Filing Status 4 per-column credit allocation", merged 2026-07-05, closing the sister issue #7931), which rewired the separate path so `de_income_tax_before_refundable_credits_separate` applies per-column credits in `de_income_tax_after_non_refundable_credits_indv` (PIT-RES Line 32 ≤ Line 26 per column). The draft PR #8726 that targeted this issue is now closed.

**Reproduction of the issue's household on current `main`** (DE, MFJ, both age 20, 1 dependent, $21,790 interest split 50/50, separate/combined): `de_income_tax` = **$59.16** (was the reported $8.33). Column B's $220 personal credit is correctly capped at its own $169.16 tax; the surplus does not offset Column A. Form/TAXSIM ground truth is $58; the ~$1.16 residual is PolicyEngine's continuous rate-bracket computation vs the form's rounded tax table, unrelated to the credit-pooling bug. Every DE non-refundable credit (`de_personal_credit`, `de_aged_personal_credit`, `de_cdcc`, `de_non_refundable_eitc`) was audited: none cross-offsets between columns on the separate path.

Added the reported household as a regression test. Recommend closing #8710 with reference to #7940.

---

## #8589 — PA over-charges qualified retirement income for retirees (ALREADY FIXED — recommend close)

Reported cause: PA taxes pension/IRA/401(k) distributions for past-retirement-age retirees. **This was fixed on `main` by #8922** (merged 2026-07-06), which added `pa_nontaxable_retirement_distributions` covering IRA/401(k)/403(b)/SEP/Keogh under 61 Pa. Code § 101.6. The issue's household also includes `taxable_pension_income` (handled by the pre-existing `pa_nontaxable_pension_income`) and Social Security (handled by `tax_exempt_social_security`), so all four income components are exempt.

**Reproduction of the issue's exact household on current `main`** (2026, PA, MFJ, ages 67/65, $60k pensions + $30k IRA + $50k SS): `state_income_tax` = **$0.00** (expected $0.00). The pre-retirement gating still works: a 401(k) or pension distribution at age 50 is taxed ($614 on $20k), at age 67 is exempt ($0) — no source type is missed.

Added the reported household as a regression test. Recommend closing #8589 with reference to #8922.

---

## Tests

All baseline trees pass on this branch (local `policyengine-core test`):

- ME: 568 (was 550; +18 for the EITC expansion and STFC base pins)
- DE: 319 (was 318; +1 #8710 reported-household regression)
- PA: 361 (was 360; +1 #8589 reported-household regression)

```
policyengine-core test policyengine_us/tests/policy/baseline/gov/states/{me,de,pa}/ -c policyengine_us
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
