### PR TITLE
Extend MD EITC minimum-age disregard to married childless filers

### DIFF
--- a/changelog.d/md-eitc-married-childless-age-disregard.fixed.md
+++ b/changelog.d/md-eitc-married-childless-age-disregard.fixed.md
@@ -1,0 +1,1 @@
+Extend the Maryland EITC federal minimum-age disregard to married childless filers.

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_married_childless_age_disregard.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_married_childless_age_disregard.yaml
@@ -1,0 +1,40 @@
+# Integration test for issue #8934: a married childless couple who fail only the
+# federal EITC minimum-age test may still claim the Maryland EITC on a pro forma
+# federal credit computed as if the minimum-age requirement did not apply.
+# MD, MFJ, ages 23/24, no dependents, $10,476 combined wages.
+# TaxAct return shows Line 22 = $325 (worksheet 50% of federal), Line 44 refundable.
+
+- name: MD married childless couple under 25 claims the age-disregarded EITC
+  period: 2025
+  input:
+    people:
+      head:
+        age: 23
+        employment_income: 5_238
+      spouse:
+        age: 24
+        employment_income: 5_238
+    marital_units:
+      marital_unit:
+        members: [head, spouse]
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+    families:
+      family:
+        members: [head, spouse]
+    spm_units:
+      spm_unit:
+        members: [head, spouse]
+    households:
+      household:
+        members: [head, spouse]
+        state_code: MD
+  output:
+    eitc: 0  # age-gated federal credit denied to the under-25 childless
+    federal_eitc_without_age_minimum: 649
+    # 45% of $649 refundable, less MD tax before credits ($0 for this household).
+    md_refundable_eitc: 292.05
+    # Total MD EITC is the 45% refundable amount regardless of how it splits
+    # between the tax-limited non-refundable and refundable portions.
+    md_eitc: 292.05

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_married_or_has_child_non_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_married_or_has_child_non_refundable_eitc.yaml
@@ -1,30 +1,49 @@
 # Tests for Maryland non-refundable EITC for married/has child filers
-# Per §10-704(c)(1): credit is the LESSER of 50% of federal EITC OR state income tax
+# Per §10-704(c)(1): credit is the LESSER of 50% of federal EITC OR state income tax.
+# Childless filers use the federal EITC computed without the minimum-age test
+# (federal_eitc_without_age_minimum); with-child filers use the actual federal EITC.
 
-- name: Non-refundable EITC equals 50% of federal when tax is higher
+- name: Married childless uses the federal EITC without the minimum-age test
   period: 2021
   input:
     md_qualifies_for_unmarried_childless_eitc: false
-    eitc: 300
-    md_income_tax_before_credits: 200  # Tax > 50% of EITC ($150)
+    eitc_child_count: 0
+    eitc: 0  # age-gated federal credit is zero for the under-25 childless
+    federal_eitc_without_age_minimum: 300
+    md_income_tax_before_credits: 200  # Tax > 50% of credit ($150)
     state_code: MD
   output:
     md_married_or_has_child_non_refundable_eitc: 150  # 50% of 300
 
-- name: Non-refundable EITC capped at tax liability when tax is lower
+- name: Married childless non-refundable capped at tax liability when tax is lower
   period: 2021
   input:
     md_qualifies_for_unmarried_childless_eitc: false
-    eitc: 1_000
-    md_income_tax_before_credits: 100  # Tax < 50% of EITC ($500)
+    eitc_child_count: 0
+    eitc: 0
+    federal_eitc_without_age_minimum: 1_000
+    md_income_tax_before_credits: 100  # Tax < 50% of credit ($500)
     state_code: MD
   output:
     md_married_or_has_child_non_refundable_eitc: 100  # Capped at tax
 
-- name: Non-refundable EITC capped at tax for typical EITC household
+- name: With-child filer uses the actual age-gated federal EITC
+  period: 2021
+  input:
+    md_qualifies_for_unmarried_childless_eitc: false
+    eitc_child_count: 1
+    eitc: 1_000
+    federal_eitc_without_age_minimum: 0  # ignored for with-child filers
+    md_income_tax_before_credits: 800  # Tax > 50% of credit ($500)
+    state_code: MD
+  output:
+    md_married_or_has_child_non_refundable_eitc: 500  # 50% of 1000
+
+- name: Non-refundable EITC capped at tax for typical with-child EITC household
   period: 2026
   input:
     md_qualifies_for_unmarried_childless_eitc: false
+    eitc_child_count: 1
     eitc: 4_427  # Typical baseline federal EITC for $25k income family
     md_income_tax_before_credits: 353.62
     state_code: MD
@@ -35,7 +54,8 @@
   period: 2021
   input:
     md_qualifies_for_unmarried_childless_eitc: false
-    eitc: 1_000
+    eitc_child_count: 0
+    federal_eitc_without_age_minimum: 1_000
     md_income_tax_before_credits: 0
     state_code: MD
   output:
@@ -45,7 +65,9 @@
   period: 2021
   input:
     md_qualifies_for_unmarried_childless_eitc: true
+    eitc_child_count: 0
     eitc: 300
+    federal_eitc_without_age_minimum: 300
     md_income_tax_before_credits: 200
     state_code: MD
   output:

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_married_or_has_child_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/credits/eitc/md_married_or_has_child_refundable_eitc.yaml
@@ -1,28 +1,51 @@
-- name: 45% of the federal EITC, minus MD tax before credits.
+# Tests for Maryland refundable EITC for married/has child filers.
+# Per §10-704(c)(2)(ii): 45% of federal EITC minus MD tax before credits.
+# Childless filers use the federal EITC computed without the minimum-age test
+# (federal_eitc_without_age_minimum); with-child filers use the actual federal EITC.
+
+- name: Married childless uses the federal EITC without the minimum-age test
   period: 2021
   input:
     md_qualifies_for_unmarried_childless_eitc: false
-    eitc: 1_000
+    eitc_child_count: 0
+    eitc: 0  # age-gated federal credit is zero for the under-25 childless
+    federal_eitc_without_age_minimum: 1_000
     md_income_tax_before_credits: 100
     state_code: MD
   output:
-    md_married_or_has_child_refundable_eitc: 350 # 1000*0.45 - 100
+    md_married_or_has_child_refundable_eitc: 350  # 1000*0.45 - 100
 
-- name: Zero if MD refundable EITC allowed is less than tax before credits.
+- name: Zero if MD refundable EITC allowed is less than tax before credits
   period: 2021
   input:
     md_qualifies_for_unmarried_childless_eitc: false
-    eitc: 1_000
+    eitc_child_count: 0
+    eitc: 0
+    federal_eitc_without_age_minimum: 1_000
     md_income_tax_before_credits: 500
     state_code: MD
   output:
-    md_married_or_has_child_refundable_eitc: 0 # max(0, 1000*0.45 - 500)
+    md_married_or_has_child_refundable_eitc: 0  # max(0, 1000*0.45 - 500)
 
-- name: Zero if single and childless (they receive a different variable).
+- name: With-child filer uses the actual age-gated federal EITC
+  period: 2021
+  input:
+    md_qualifies_for_unmarried_childless_eitc: false
+    eitc_child_count: 1
+    eitc: 1_000
+    federal_eitc_without_age_minimum: 0  # ignored for with-child filers
+    md_income_tax_before_credits: 100
+    state_code: MD
+  output:
+    md_married_or_has_child_refundable_eitc: 350  # 1000*0.45 - 100
+
+- name: Zero if single and childless (they receive a different variable)
   period: 2021
   input:
     md_qualifies_for_unmarried_childless_eitc: true
+    eitc_child_count: 0
     eitc: 1_000
+    federal_eitc_without_age_minimum: 1_000
     md_income_tax_before_credits: 100
     state_code: MD
   output:

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_married_or_has_child_non_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/non_refundable/md_married_or_has_child_non_refundable_eitc.py
@@ -11,7 +11,17 @@ class md_married_or_has_child_non_refundable_eitc(Variable):
     defined_for = StateCode.MD
 
     def formula(tax_unit, period, parameters):
-        federal_eitc = tax_unit("eitc", period)
+        # Childless filers who fail only the federal minimum-age test may still
+        # claim the Maryland credit, computed on a pro forma federal EITC that
+        # disregards the § 32 minimum-age requirement (2025 Resident Booklet,
+        # Instruction 18). With-child filers face no federal age test, so the
+        # actual federal EITC applies to them.
+        childless = tax_unit("eitc_child_count", period) == 0
+        federal_eitc = where(
+            childless,
+            tax_unit("federal_eitc_without_age_minimum", period),
+            tax_unit("eitc", period),
+        )
         md_income_tax = tax_unit("md_income_tax_before_credits", period)
 
         p = parameters(

--- a/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/refundable/md_married_or_has_child_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/credits/eitc/refundable/md_married_or_has_child_refundable_eitc.py
@@ -20,7 +20,16 @@ class md_married_or_has_child_refundable_eitc(Variable):
             "md_qualifies_for_unmarried_childless_eitc", period
         )
 
-        federal_eitc = tax_unit("eitc", period)
+        # Childless filers who fail only the federal minimum-age test may still
+        # claim the Maryland credit, computed on a pro forma federal EITC that
+        # disregards the § 32 minimum-age requirement (2025 Resident Booklet,
+        # Instruction 18). With-child filers face no federal age test.
+        childless = tax_unit("eitc_child_count", period) == 0
+        federal_eitc = where(
+            childless,
+            tax_unit("federal_eitc_without_age_minimum", period),
+            tax_unit("eitc", period),
+        )
         md_tax = tax_unit("md_income_tax_before_credits", period)
         p = parameters(
             period


### PR DESCRIPTION
Fixes #8934.

## Problem

Maryland lets any filer who fails **only** the federal EITC minimum-age test claim the state EITC on a pro forma federal credit computed as if the § 32 minimum-age requirement did not apply ([2025 Resident Booklet, Instruction 18](https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=22): *"There is no minimum age requirement for taxpayers without a qualifying child"*).

PolicyEngine already models the pro forma credit — `federal_eitc_without_age_minimum` — but wired it only into the **unmarried**-childless path. The married-or-has-child branch used the actual age-gated federal credit (`eitc`), so a **married childless couple under 25 received $0**.

## Fix

Feed `federal_eitc_without_age_minimum` into both married-branch formulas (`md_married_or_has_child_non_refundable_eitc`, `md_married_or_has_child_refundable_eitc`) for **childless** filers, gated on `eitc_child_count == 0`:

```python
childless = tax_unit("eitc_child_count", period) == 0
federal_eitc = where(
    childless,
    tax_unit("federal_eitc_without_age_minimum", period),
    tax_unit("eitc", period),
)
```

The gate matters: `eitc` carries takeup and filer conditions that `federal_eitc_without_age_minimum` omits, so an unconditional swap would have silently changed results for **with-child** filers. Childless-gating leaves with-child filers on the actual federal EITC (no age test applies to them) and matches the existing unmarried-childless treatment.

## Reproduction (from the issue)

MD, MFJ, ages 23/24, no dependents, $10,476 wages (2025):

| Variable | Before | After |
|---|---|---|
| `eitc` | 0 | 0 |
| `federal_eitc_without_age_minimum` | 649 | 649 |
| `md_refundable_eitc` | **0** | **292.05** (45% × 649) |

## Tests

- Updated `md_married_or_has_child_{non_refundable,refundable}_eitc.yaml`: childless cases now assert the age-disregarded base, plus new **with-child regression guards** confirming those filers still use the actual federal `eitc`.
- New integration test `md_married_childless_age_disregard.yaml` reproducing the issue household end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)