### PR TITLE
Align Florida TCA and document OSS against the DCF ESS manual (#8728, #8772)

### DIFF
--- a/changelog.d/fl-programs-accuracy.fixed.md
+++ b/changelog.d/fl-programs-accuracy.fixed.md
@@ -1,0 +1,1 @@
+- Aligned Florida TCA payment standard, income tests, earned income disregard, and minimum issuance with the DCF ESS Program Policy Manual and Appendix A-5.

--- a/policyengine_us/parameters/gov/states/fl/dcf/tanf/max_family_size.yaml
+++ b/policyengine_us/parameters/gov/states/fl/dcf/tanf/max_family_size.yaml
@@ -1,4 +1,4 @@
-description: Florida caps family size at this number for the payment standard table under the Temporary Cash Assistance program.
+description: Florida caps family size at this number for the payment standard table under the Temporary Cash Assistance program. Appendix A-5 tabulates explicit payment standards through filing unit size 24; sizes above 24 use the size-24 standard (the additional-person increment beyond 24 is not modeled).
 
 metadata:
   unit: person
@@ -7,6 +7,8 @@ metadata:
   reference:
     - title: Florida Statutes 414.095(10) - Payment Standards
       href: https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&URL=0400-0499/0414/Sections/0414.095.html
+    - title: FL DCF ESS Program Policy Manual, Appendix A-5 - Temporary Cash Assistance Income Standards (Filing Unit Size column tabulated through 24)
+      href: https://ffic.myflfamilies.com/manual/essfiles/30441.pdf
 
 values:
-  1996-01-01: 13
+  1996-01-01: 24

--- a/policyengine_us/parameters/gov/states/fl/dcf/tanf/minimum_benefit.yaml
+++ b/policyengine_us/parameters/gov/states/fl/dcf/tanf/minimum_benefit.yaml
@@ -1,0 +1,12 @@
+description: Florida does not issue Temporary Cash Assistance benefits for monthly amounts below this threshold; a deficit of at least this amount is required to issue a benefit.
+
+values:
+  1996-01-01: 10
+
+metadata:
+  unit: currency-USD
+  period: month
+  label: Florida TCA minimum benefit
+  reference:
+    - title: FL DCF ESS Program Policy Manual 2620.0111.01 - Income Test and Benefit Determination (TCA), Step 6 "If a deficit of at least $10 results, the remainder is the amount of the benefit to be issued" and Note "Cash benefits are not issued for amounts less than $10."
+      href: https://ffic.myflfamilies.com/manual/2600.pdf

--- a/policyengine_us/parameters/gov/states/fl/dcf/tanf/payment_standard/high_shelter.yaml
+++ b/policyengine_us/parameters/gov/states/fl/dcf/tanf/payment_standard/high_shelter.yaml
@@ -4,13 +4,15 @@ metadata:
   unit: currency-USD
   period: month
   breakdown:
-    - range(0, 20)
+    - range(0, 25)
   label: Florida TCA high shelter payment standard
   reference:
     - title: Florida Statutes 414.095(10) - Payment Standards
       href: https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&URL=0400-0499/0414/Sections/0414.095.html
     - title: FAC 65A-4.220 - Amount and Duration of Cash Payment
       href: https://www.law.cornell.edu/regulations/florida/Fla-Admin-Code-Ann-R-65A-4-220
+    - title: FL DCF ESS Program Policy Manual, Appendix A-5 - Temporary Cash Assistance Income Standards (Tier I Payment Standard column, "$50.01/UP"; filing unit sizes through 24)
+      href: https://ffic.myflfamilies.com/manual/essfiles/30441.pdf
 
 1:
   1992-01-01: 180
@@ -38,3 +40,25 @@ metadata:
   1992-01-01: 857
 13:
   1992-01-01: 919
+14:
+  1992-01-01: 981
+15:
+  1992-01-01: 1043
+16:
+  1992-01-01: 1105
+17:
+  1992-01-01: 1167
+18:
+  1992-01-01: 1229
+19:
+  1992-01-01: 1291
+20:
+  1992-01-01: 1353
+21:
+  1992-01-01: 1415
+22:
+  1992-01-01: 1477
+23:
+  1992-01-01: 1539
+24:
+  1992-01-01: 1601

--- a/policyengine_us/parameters/gov/states/fl/dcf/tanf/payment_standard/low_shelter.yaml
+++ b/policyengine_us/parameters/gov/states/fl/dcf/tanf/payment_standard/low_shelter.yaml
@@ -4,13 +4,15 @@ metadata:
   unit: currency-USD
   period: month
   breakdown:
-    - range(0, 20)
+    - range(0, 25)
   label: Florida TCA low shelter payment standard
   reference:
     - title: Florida Statutes 414.095(10) - Payment Standards
       href: https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&URL=0400-0499/0414/Sections/0414.095.html
     - title: FAC 65A-4.220 - Amount and Duration of Cash Payment
       href: https://www.law.cornell.edu/regulations/florida/Fla-Admin-Code-Ann-R-65A-4-220
+    - title: FL DCF ESS Program Policy Manual, Appendix A-5 - Temporary Cash Assistance Income Standards (Tier II Payment Standard column, ".01-$50"; filing unit sizes through 24)
+      href: https://ffic.myflfamilies.com/manual/essfiles/30441.pdf
 
 1:
   1992-01-01: 153
@@ -38,3 +40,25 @@ metadata:
   1992-01-01: 728
 13:
   1992-01-01: 781
+14:
+  1992-01-01: 834
+15:
+  1992-01-01: 887
+16:
+  1992-01-01: 940
+17:
+  1992-01-01: 993
+18:
+  1992-01-01: 1046
+19:
+  1992-01-01: 1099
+20:
+  1992-01-01: 1152
+21:
+  1992-01-01: 1205
+22:
+  1992-01-01: 1258
+23:
+  1992-01-01: 1311
+24:
+  1992-01-01: 1364

--- a/policyengine_us/parameters/gov/states/fl/dcf/tanf/payment_standard/zero_shelter.yaml
+++ b/policyengine_us/parameters/gov/states/fl/dcf/tanf/payment_standard/zero_shelter.yaml
@@ -4,13 +4,15 @@ metadata:
   unit: currency-USD
   period: month
   breakdown:
-    - range(0, 20)
+    - range(0, 25)
   label: Florida TCA zero shelter payment standard
   reference:
     - title: Florida Statutes 414.095(10) - Payment Standards
       href: https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&URL=0400-0499/0414/Sections/0414.095.html
     - title: FAC 65A-4.220 - Amount and Duration of Cash Payment
       href: https://www.law.cornell.edu/regulations/florida/Fla-Admin-Code-Ann-R-65A-4-220
+    - title: FL DCF ESS Program Policy Manual, Appendix A-5 - Temporary Cash Assistance Income Standards (Tier III Payment Standard column, "0"; filing unit sizes through 24)
+      href: https://ffic.myflfamilies.com/manual/essfiles/30441.pdf
 
 1:
   1996-01-01: 95
@@ -38,3 +40,25 @@ metadata:
   1996-01-01: 630
 13:
   1996-01-01: 678
+14:
+  1996-01-01: 726
+15:
+  1996-01-01: 774
+16:
+  1996-01-01: 822
+17:
+  1996-01-01: 870
+18:
+  1996-01-01: 918
+19:
+  1996-01-01: 966
+20:
+  1996-01-01: 1014
+21:
+  1996-01-01: 1062
+22:
+  1996-01-01: 1110
+23:
+  1996-01-01: 1158
+24:
+  1996-01-01: 1206

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/oss/fl_oss.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/oss/fl_oss.yaml
@@ -186,3 +186,33 @@
     # Even with hugely negative income, OSS is capped at max.
     # Max OSS (Redesign, I) = $184.40/month.
     fl_oss: [184.40]
+
+- name: Case 8, matches manual 2640.0131.04 single-individual computation.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        fl_oss_community_care_type: ALF
+        fl_oss_program_track: REDESIGN
+        age: 70
+        is_ssi_eligible: true
+        ssi_claim_is_joint: false
+        uncapped_ssi: 1  # > 0 -> Group 1 (receives SSI)
+        # $1,050/month countable income = $12,600/year.
+        ssi_countable_income: 12_600
+    households:
+      household:
+        members: [person1]
+        state_code: FL
+  output:
+    # Hand-worked per DCF ESS Program Policy Manual 2640.0131.04:
+    #   Recognized cost of care (Redesign provider rate, Jan 2025) = $991.40.
+    #   Personal needs allowance = $160.
+    #   Step 1: income available for cost of care = income - PNA
+    #           = $1,050 - $160 = $890.
+    #   Step 2: deficit = cost of care - available = $991.40 - $890 = $101.40.
+    #   Deficit ($101.40) is below the Max OSS Payment ($184.40), so it is not
+    #   capped. This equals PE's (provider_rate + PNA) - countable_income
+    #   = ($991.40 + $160) - $1,050 = $101.40.
+    fl_oss: [101.40]

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca.yaml
@@ -28,7 +28,7 @@
     # Countable income: $230
     # Benefit: 241 - 230 = $11
 
-- name: Case 2, benefit of $1.
+- name: Case 2, deficit of $1 not issued (below $10 minimum).
   period: 2024-01
   input:
     people:
@@ -46,10 +46,53 @@
         members: [person1, person2]
         state_code: FL
   output:
-    fl_tca: 1
-    # Payment standard: $241
-    # Countable income: $240
-    # Benefit: 241 - 240 = $1
+    fl_tca: 0
+    # Payment standard: $241; countable income: $240; deficit = $1.
+    # Per DCF 2620.0111.01 Step 6 and Note, cash benefits are not issued for
+    # amounts less than $10, so a $1 deficit produces $0.
+
+- name: Case 2b, deficit of exactly $10 is issued.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        social_security: 2_772  # $231/month annual
+        pre_subsidy_rent: 12_000
+      person2:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: FL
+  output:
+    fl_tca: 10
+    # Payment standard: $241; countable income: $231; deficit = $10.
+    # 2620.0111.01 Step 6: "a deficit of at least $10" is issued.
+
+- name: Case 2c, deficit of $9 not issued (below $10 minimum).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 30
+        social_security: 2_784  # $232/month annual
+        pre_subsidy_rent: 12_000
+      person2:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: FL
+  output:
+    fl_tca: 0
+    # Payment standard: $241; countable income: $232; deficit = $9 < $10 -> $0.
 
 - name: Case 3, maximum family size 13 full benefit.
   period: 2024-01

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_countable_earned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_countable_earned_income.yaml
@@ -1,7 +1,21 @@
-# Tests Florida TCA earned income disregard
-# Formula: Countable = max(max(Gross - $90, 0) - $200, 0) * 0.5
-# Per DCF 2620.0111.01: Step 2 subtract $90, Step 3 subtract $200 and 1/2 of remainder
-# Source: Florida Statutes 414.095(11), DCF Policy Manual 2620.0111.01
+# Tests Florida TCA countable earned income.
+# Per DCF ESS Program Policy Manual 2620.0111.01:
+#   Step 2 - subtract the $90 standard disregard (always).
+#   Step 3 - subtract the remainder of the "$200 and 1/2" disregard "if eligible".
+# The $200 and 1/2 disregard is granted (2420.0314-.0315) when income after the
+# $90 disregard is below the payment standard for the size of the SFU; otherwise
+# only the $90 is deducted.
+#
+# The disregard-formula cases below use a large filing unit with high shelter so
+# the payment standard ($610 for size 8) is high enough that the $200 and 1/2
+# disregard applies, exercising the full formula. A dedicated block at the end
+# tests the predicate = False path (income after $90 at or above the payment
+# standard), where only the $90 is deducted.
+
+# ============================================================
+# $200 and 1/2 disregard applies (income after $90 < payment standard).
+# Size-8 filing unit, high shelter -> payment standard $610.
+# ============================================================
 
 - name: Case 1, zero earned income.
   period: 2024-01
@@ -9,221 +23,238 @@
     people:
       person1:
         employment_income_before_lsr: 0
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 0
-    # $0 earned → $0 countable
-
-- name: Case 2, earned income at $200 (below $290 threshold).
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 2_400  # $200/month
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 0
-    # $200/month: max(max(200-90,0)-200,0)*0.5 = max(110-200,0)*0.5 = 0
-
-- name: Case 3, earned income $500.
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 6_000  # $500/month
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 105
-    # $500: After $90 = 410, after $200 = 210, * 0.5 = $105
-
-- name: Case 4, earned income $1000.
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 12_000  # $1,000/month
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 355
-    # $1000: After $90 = 910, after $200 = 710, * 0.5 = $355
-
-- name: Case 5, earned income $100 (below $90 disregard).
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 1_200  # $100/month
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 0
-    # $100: After $90 = 10, after $200 = 0, * 0.5 = $0
-
-- name: Case 6, multiple earners $800 combined.
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 6_000  # $500/month
-      person2:
-        employment_income_before_lsr: 3_600  # $300/month
+        pre_subsidy_rent: 24_000
+        age: 35
+      person2: {age: 10}
+      person3: {age: 9}
+      person4: {age: 8}
+      person5: {age: 7}
+      person6: {age: 6}
+      person7: {age: 5}
+      person8: {age: 4}
     spm_units:
       spm_unit:
-        members: [person1, person2]
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
     households:
       household:
-        members: [person1, person2]
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
         state_code: FL
   output:
-    fl_tca_countable_earned_income: 255
-    # Combined: $800, after $90 = 710, after $200 = 510, * 0.5 = $255
+    fl_tca_countable_earned_income: 0
+    # $0 earned -> $0 countable.
 
-# ============================================================
-# Edge Cases
-# ============================================================
-
-- name: Case 7, earned income at $290 threshold.
+- name: Case 2, earned income $290 (exactly at $90 + $200 threshold).
   period: 2024-01
   input:
     people:
       person1:
         employment_income_before_lsr: 3_480  # $290/month
+        pre_subsidy_rent: 24_000
+        age: 35
+      person2: {age: 10}
+      person3: {age: 9}
+      person4: {age: 8}
+      person5: {age: 7}
+      person6: {age: 6}
+      person7: {age: 5}
+      person8: {age: 4}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
     households:
       household:
-        members: [person1]
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
         state_code: FL
   output:
     fl_tca_countable_earned_income: 0
-    # $290: After $90 = 200, after $200 = 0, * 0.5 = $0
-    # Tests: exact threshold ($90 + $200 = $290)
+    # After $90 = $200 (< $610, disregard applies); after $200 = $0; * 0.5 = $0.
 
-- name: Case 8, earned income $291 (one dollar above threshold).
+- name: Case 3, earned income $291 (one dollar above $90 + $200 threshold).
   period: 2024-01
   input:
     people:
       person1:
         employment_income_before_lsr: 3_492  # $291/month
+        pre_subsidy_rent: 24_000
+        age: 35
+      person2: {age: 10}
+      person3: {age: 9}
+      person4: {age: 8}
+      person5: {age: 7}
+      person6: {age: 6}
+      person7: {age: 5}
+      person8: {age: 4}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
     households:
       household:
-        members: [person1]
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
         state_code: FL
   output:
     fl_tca_countable_earned_income: 0.5
-    # $291: After $90 = 201, after $200 = 1, * 0.5 = $0.50
+    # After $90 = $201 (< $610); after $200 = $1; * 0.5 = $0.50.
 
-- name: Case 9, very high earned income $5000.
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 60_000  # $5,000/month
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 2_355
-    # $5000: After $90 = 4910, after $200 = 4710, * 0.5 = $2,355
-
-- name: Case 10, multiple earners $550 combined.
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 6_000  # $500/month
-      person2:
-        employment_income_before_lsr: 600  # $50/month
-    spm_units:
-      spm_unit:
-        members: [person1, person2]
-    households:
-      household:
-        members: [person1, person2]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 130
-    # Combined: $550, after $90 = 460, after $200 = 260, * 0.5 = $130
-
-- name: Case 11, earned income exactly at $90.
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 1_080  # $90/month
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 0
-    # $90: After $90 = 0, after $200 = 0, * 0.5 = $0
-
-- name: Case 12, earned income $400.
-  period: 2024-01
-  input:
-    people:
-      person1:
-        employment_income_before_lsr: 4_800  # $400/month
-    households:
-      household:
-        members: [person1]
-        state_code: FL
-  output:
-    fl_tca_countable_earned_income: 55
-    # $400: After $90 = 310, after $200 = 110, * 0.5 = $55
-
-- name: Case 13, earned income $300.
+- name: Case 4, earned income $300.
   period: 2024-01
   input:
     people:
       person1:
         employment_income_before_lsr: 3_600  # $300/month
+        pre_subsidy_rent: 24_000
+        age: 35
+      person2: {age: 10}
+      person3: {age: 9}
+      person4: {age: 8}
+      person5: {age: 7}
+      person6: {age: 6}
+      person7: {age: 5}
+      person8: {age: 4}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
     households:
       household:
-        members: [person1]
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
         state_code: FL
   output:
     fl_tca_countable_earned_income: 5
-    # $300: After $90 = 210, after $200 = 10, * 0.5 = $5
+    # After $90 = $210 (< $610); after $200 = $10; * 0.5 = $5.
 
-- name: Case 14, earned income $89 (one dollar below $90 disregard).
+- name: Case 5, earned income $400.
   period: 2024-01
   input:
     people:
       person1:
-        employment_income_before_lsr: 1_068  # $89/month
+        employment_income_before_lsr: 4_800  # $400/month
+        pre_subsidy_rent: 24_000
+        age: 35
+      person2: {age: 10}
+      person3: {age: 9}
+      person4: {age: 8}
+      person5: {age: 7}
+      person6: {age: 6}
+      person7: {age: 5}
+      person8: {age: 4}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
     households:
       household:
-        members: [person1]
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
         state_code: FL
   output:
-    fl_tca_countable_earned_income: 0
-    # $89: After $90 = max(89-90, 0) = 0
+    fl_tca_countable_earned_income: 55
+    # After $90 = $310 (< $610); after $200 = $110; * 0.5 = $55.
 
-- name: Case 15, earned income $91 (one dollar above $90 disregard).
+- name: Case 6, earned income $500.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        employment_income_before_lsr: 6_000  # $500/month
+        pre_subsidy_rent: 24_000
+        age: 35
+      person2: {age: 10}
+      person3: {age: 9}
+      person4: {age: 8}
+      person5: {age: 7}
+      person6: {age: 6}
+      person7: {age: 5}
+      person8: {age: 4}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
+        state_code: FL
+  output:
+    fl_tca_countable_earned_income: 105
+    # After $90 = $410 (< $610); after $200 = $210; * 0.5 = $105.
+
+- name: Case 7, earned income $91 (one dollar above $90 disregard, below $290).
   period: 2024-01
   input:
     people:
       person1:
         employment_income_before_lsr: 1_092  # $91/month
+        pre_subsidy_rent: 24_000
+        age: 35
+      person2: {age: 10}
+      person3: {age: 9}
+      person4: {age: 8}
+      person5: {age: 7}
+      person6: {age: 6}
+      person7: {age: 5}
+      person8: {age: 4}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
+        state_code: FL
+  output:
+    fl_tca_countable_earned_income: 0
+    # After $90 = $1 (< $610); after $200 = $0; * 0.5 = $0.
+
+# ============================================================
+# $200 and 1/2 disregard does NOT apply: income after the $90 standard
+# disregard is at or above the payment standard (2420.0315). Only the $90 is
+# deducted. Single person, high shelter -> payment standard $180.
+# ============================================================
+
+- name: Case 8, single earner $400/month, income after $90 above payment standard.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        employment_income_before_lsr: 4_800  # $400/month
+        pre_subsidy_rent: 12_000
+        age: 35
+    households:
+      household:
+        members: [person1]
+        state_code: FL
+  output:
+    fl_tca_countable_earned_income: 310
+    # Payment standard (size 1, high shelter) = $180.
+    # After $90 = $310, which is >= $180, so the $200 and 1/2 disregard does not
+    # apply. Only the $90 is deducted: countable = $310.
+
+- name: Case 9, single earner $290/month at the disregard-eligibility boundary.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        employment_income_before_lsr: 3_480  # $290/month
+        pre_subsidy_rent: 12_000
+        age: 35
+    households:
+      household:
+        members: [person1]
+        state_code: FL
+  output:
+    fl_tca_countable_earned_income: 200
+    # Payment standard (size 1, high shelter) = $180.
+    # After $90 = $200, which is >= $180, so only the $90 is deducted:
+    # countable = $200 (not $0 as it would be under an unconditional disregard).
+
+- name: Case 10, earned income at $90 (fully absorbed by the standard disregard).
+  period: 2024-01
+  input:
+    people:
+      person1:
+        employment_income_before_lsr: 1_080  # $90/month
+        pre_subsidy_rent: 12_000
+        age: 35
     households:
       household:
         members: [person1]
         state_code: FL
   output:
     fl_tca_countable_earned_income: 0
-    # $91: After $90 = 1, after $200 = max(1-200, 0) = 0
+    # After $90 = $0; income after the $90 disregard ($0) is below the payment
+    # standard, so the person is disregard-eligible, but there is nothing left to
+    # disregard: countable = $0.

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_eligible.yaml
@@ -89,7 +89,7 @@
     # Gross test: 0 < 185% FPL ($3,151) -> Pass
     # Net test: 0 < $241 payment standard -> Pass
 
-- name: Case 5, moderate income eligible.
+- name: Case 5, moderate income small family ineligible ($200 and 1/2 disregard denied).
   period: 2024-01
   input:
     people:
@@ -107,11 +107,13 @@
         members: [person1, person2]
         state_code: FL
   output:
-    fl_tca_eligible: true
-    # Gross test: $500 < 185% FPL -> Pass
-    # Net test: max(max(500-90,0)-200,0)*0.5 = 105 < $241 -> Pass
+    fl_tca_eligible: false
+    # Gross test: $500 < 185% FPL -> Pass.
+    # $200 and 1/2 disregard (2420.0315): income after $90 = $410 >= payment
+    # standard $241, so the disregard is denied; only the $90 is deducted.
+    # Net test: countable $410 > $241 -> Fail. Over-income for TCA.
 
-- name: Case 6, larger family with higher thresholds.
+- name: Case 6, larger family income above payment standard after $90 ineligible.
   period: 2024-01
   input:
     people:
@@ -133,10 +135,39 @@
         members: [person1, person2, person3, person4]
         state_code: FL
   output:
+    fl_tca_eligible: false
+    # Size 4, >$50 shelter payment standard: $364.
+    # Income after $90 = $910 >= $364, so the $200 and 1/2 disregard is denied.
+    # Net test: countable $910 > $364 -> Fail. (Under an unconditional disregard
+    # this case would incorrectly compute countable $355 and appear eligible.)
+
+- name: Case 7 (new), large family low earnings eligible with $200 and 1/2 disregard.
+  period: 2024-01
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income_before_lsr: 3_600  # $300/month
+        pre_subsidy_rent: 24_000
+      person2: {age: 12}
+      person3: {age: 10}
+      person4: {age: 8}
+      person5: {age: 6}
+      person6: {age: 4}
+      person7: {age: 2}
+      person8: {age: 1}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5, person6, person7, person8]
+        state_code: FL
+  output:
     fl_tca_eligible: true
-    # Size 4, >$50 shelter payment standard: $364
-    # Countable income: max(max(1000-90,0)-200,0)*0.5 = 355
-    # Net test: 355 < $364 -> Pass
+    # Size 8, >$50 shelter payment standard: $610.
+    # Income after $90 = $210 < $610, so the $200 and 1/2 disregard applies:
+    # countable = max(max(300-90,0)-200,0)*0.5 = $5 < $610 -> net test passes.
 
 - name: Case 7, adult-only household ineligible.
   period: 2024-01

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_gross_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_gross_income_eligible.yaml
@@ -1,7 +1,9 @@
 # Tests Florida TCA gross income test (185% of FPL)
-# Formula: Total Gross Income (earned + unearned) < 185% FPL
-# Per DCF 2620.0109.01: NO disregards applied in gross test
-# Source: FAC 65A-4.220, DCF Policy Manual 2620.0109.01
+# Formula: Total Gross Income (earned + unearned) <= 185% FPL
+# Per DCF 2620.0107 gross income "cannot exceed" the standard and 2620.0109.02
+# Step 2 treats an exact equal as meeting the requirements, so the boundary is
+# <= (gross exactly at the standard is eligible). NO disregards applied.
+# Source: FAC 65A-4.220, DCF Policy Manual 2620.0107 / 2620.0109.01-.02
 
 # 2024: 185% FPL for 2 people = $20,440 * 1.85 / 12 = $3,151.17/month
 
@@ -42,7 +44,7 @@
   output:
     fl_tca_gross_income_eligible: true
 
-- name: Case 3, at threshold ineligible.
+- name: Case 3, at threshold eligible (exact equal meets the requirements).
   period: 2024-01
   input:
     people:
@@ -59,7 +61,9 @@
         members: [person1, person2]
         state_code: FL
   output:
-    fl_tca_gross_income_eligible: false
+    # Gross income exactly at 185% FPL passes: 2620.0107 "cannot exceed" and
+    # 2620.0109.02 Step 2 "Exact Equal: Meets the Requirements."
+    fl_tca_gross_income_eligible: true
 
 - name: Case 4, one dollar above threshold ineligible.
   period: 2024-01

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_net_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_net_income_eligible.yaml
@@ -1,6 +1,9 @@
 # Tests Florida TCA net income test (payment standard test)
-# Net countable income must be less than payment standard
-# Source: Florida Statutes 414.095(12), FAC 65A-4.220
+# Net countable income must not exceed the payment standard (<=).
+# Per DCF 2620.0107 net income "cannot exceed" the income limit and 2620.0111.01
+# Step 5 makes the AG ineligible only "if a surplus results"; an exact equal
+# produces no surplus (2620.0109.02 Step 2), so the boundary is <=.
+# Source: DCF Policy Manual 2620.0107 / 2620.0109.02 / 2620.0111.01
 
 # Payment standard for size 2, >$50 shelter: $241
 
@@ -43,7 +46,7 @@
   output:
     fl_tca_net_income_eligible: true
 
-- name: Case 3, at threshold ineligible.
+- name: Case 3, at threshold eligible (exact equal produces no surplus).
   period: 2024-01
   input:
     people:
@@ -61,7 +64,9 @@
         members: [person1, person2]
         state_code: FL
   output:
-    fl_tca_net_income_eligible: false
+    # Countable income exactly at the payment standard passes: no surplus
+    # results (2620.0111.01 Step 5; 2620.0109.02 Step 2 "Exact Equal").
+    fl_tca_net_income_eligible: true
 
 - name: Case 4, one dollar above threshold ineligible.
   period: 2024-01

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_payment_standard.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/fl_tca_payment_standard.yaml
@@ -83,14 +83,16 @@
   output:
     fl_tca_payment_standard: 303
 
-- name: Case 10, size 14 caps at size 13.
+- name: Case 10, size 14 high shelter uses Appendix A-5 size-14 standard.
   period: 2024-01
   input:
     spm_unit_size: 14
     pre_subsidy_rent: 12_000
     state_code: FL
   output:
-    fl_tca_payment_standard: 919
+    fl_tca_payment_standard: 981
+    # Appendix A-5 tabulates payment standards through size 24; size 14 Tier I
+    # (>$50 shelter) = $981. Previously PE incorrectly capped this at size 13.
 
 - name: Case 11, shelter cost $1 (minimum low tier).
   period: 2024-01
@@ -101,3 +103,44 @@
   output:
     fl_tca_payment_standard: 205
     # $1 shelter is in $1-$50 tier, not zero tier
+
+- name: Case 12, size 24 high shelter uses Appendix A-5 size-24 standard.
+  period: 2024-01
+  input:
+    spm_unit_size: 24
+    pre_subsidy_rent: 12_000
+    state_code: FL
+  output:
+    fl_tca_payment_standard: 1_601
+    # Appendix A-5 size 24 Tier I (>$50 shelter) = $1,601.
+
+- name: Case 13, size above 24 caps at the size-24 standard.
+  period: 2024-01
+  input:
+    spm_unit_size: 26
+    pre_subsidy_rent: 12_000
+    state_code: FL
+  output:
+    fl_tca_payment_standard: 1_601
+    # max_family_size = 24; sizes above 24 use the size-24 standard (the
+    # additional-person increment beyond 24 is not modeled).
+
+- name: Case 14, size 14 low shelter uses Appendix A-5 Tier II size-14 standard.
+  period: 2024-01
+  input:
+    spm_unit_size: 14
+    pre_subsidy_rent: 12  # $1/month -> $1-$50 tier
+    state_code: FL
+  output:
+    fl_tca_payment_standard: 834
+    # Appendix A-5 size 14 Tier II (.01-$50 shelter) = $834.
+
+- name: Case 15, size 14 zero shelter uses Appendix A-5 Tier III size-14 standard.
+  period: 2024-01
+  input:
+    spm_unit_size: 14
+    pre_subsidy_rent: 0
+    state_code: FL
+  output:
+    fl_tca_payment_standard: 726
+    # Appendix A-5 size 14 Tier III (0 shelter) = $726.

--- a/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/fl/dcf/tanf/integration.yaml
@@ -47,7 +47,7 @@
     fl_tca: 241
     # Benefit: 241 - 0 = $241
 
-- name: Case 2, single parent with earnings and child.
+- name: Case 2, single parent with earnings and child ineligible (disregard denied).
   period: 2024-01
   input:
     people:
@@ -66,23 +66,23 @@
         state_code: FL
   output:
     # Income calculations
-    fl_tca_countable_earned_income: 105
-    # Earned: $500/month
-    # After $90: 410, after $200: 210, * 0.5 = 105
-    fl_tca_countable_income: 105
-    # 105 + 0 = 105
+    fl_tca_countable_earned_income: 410
+    # Earned $500/month. Income after the $90 disregard = $410 >= payment
+    # standard $241, so the $200 and 1/2 disregard is denied (2420.0315); only
+    # the $90 is deducted.
+    fl_tca_countable_income: 410
 
     # Eligibility tests
     fl_tca_gross_income_eligible: true
     # Gross: $500 < $3,151 -> Pass
-    fl_tca_net_income_eligible: true
-    # Countable: 105 < 241 -> Pass
-    fl_tca_eligible: true
+    fl_tca_net_income_eligible: false
+    # Countable: 410 > 241 -> Fail
+    fl_tca_eligible: false
 
     # Benefit calculation
     fl_tca_payment_standard: 241
-    fl_tca: 136
-    # Benefit: 241 - 105 = $136
+    fl_tca: 0
+    # Over-income for TCA (income after $90 exceeds the payment standard).
 
 - name: Case 3, family of 3 with zero shelter obligation.
   period: 2024-01
@@ -184,15 +184,16 @@
         state_code: FL
   output:
     # Income calculations
-    fl_tca_countable_earned_income: 355
-    # After $90: 910, after $200: 710, * 0.5 = 355
-    fl_tca_countable_income: 355
+    fl_tca_countable_earned_income: 910
+    # Earned $1,000/month. Income after the $90 disregard = $910 >= payment
+    # standard $241, so the $200 and 1/2 disregard is denied; only $90 deducted.
+    fl_tca_countable_income: 910
 
     # Eligibility tests
     fl_tca_gross_income_eligible: true
     # Gross: $1,000 < $3,151 -> Pass
     fl_tca_net_income_eligible: false
-    # 355 > $241 -> Fail
+    # 910 > $241 -> Fail
     fl_tca_eligible: false
     # Failed net test
 
@@ -219,17 +220,18 @@
         members: [person1, person2]
         state_code: FL
   output:
-    fl_tca_countable_earned_income: 1_855
-    # After $90: 3910, after $200: 3710, * 0.5 = 1,855
-    fl_tca_countable_income: 1_855
+    fl_tca_countable_earned_income: 3_910
+    # Earned $4,000/month. Income after the $90 disregard = $3,910 >> payment
+    # standard $241, so the $200 and 1/2 disregard is denied; only $90 deducted.
+    fl_tca_countable_income: 3_910
     fl_tca_gross_income_eligible: false
     # Gross: $4,000 > $3,151 -> Fail
     fl_tca_net_income_eligible: false
-    # 1,855 > $241 -> Also fails
+    # 3,910 > $241 -> Also fails
     fl_tca_eligible: false
     fl_tca: 0
 
-- name: Case 8, small benefit with unearned income.
+- name: Case 8, eligible but deficit below $10 minimum not issued.
   period: 2024-01
   input:
     people:
@@ -252,11 +254,12 @@
     fl_tca_gross_income_eligible: true
     # 235 < $3,151 -> Pass
     fl_tca_net_income_eligible: true
-    # 235 < $241 -> Pass
+    # 235 <= $241 -> Pass (the AG is eligible)
     fl_tca_eligible: true
     fl_tca_payment_standard: 241
-    fl_tca: 6
-    # Benefit: 241 - 235 = $6
+    fl_tca: 0
+    # Deficit = 241 - 235 = $6 < $10, so no benefit is issued
+    # (2620.0111.01 Step 6 and Note). Eligibility stands; the payment is $0.
 
 - name: Case 9, two parents with two children eligible.
   period: 2024-01
@@ -314,18 +317,21 @@
         members: [person1, person2, person3]
         state_code: FL
   output:
-    fl_tca_countable_earned_income: 55
-    # After $90: 310, after $200: 110, * 0.5 = 55
-    fl_tca_countable_income: 255
-    # 55 + 200 = 255
+    fl_tca_countable_earned_income: 310
+    # Earned $400/month; unearned $200/month. The $200 and 1/2 disregard test
+    # (2420.0315) compares income after the $90 disregard to the payment
+    # standard: ($400 - $90) + $200 = $510 >= $303, so the disregard is denied.
+    # Only the $90 is deducted from earnings: countable earned = $310.
+    fl_tca_countable_income: 510
+    # 310 earned + 200 unearned = 510
     fl_tca_gross_income_eligible: true
     # Gross: 400 + 200 = 600 < $3,981 -> Pass
-    fl_tca_net_income_eligible: true
-    # 255 < $303 -> Pass
-    fl_tca_eligible: true
+    fl_tca_net_income_eligible: false
+    # 510 > $303 -> Fail
+    fl_tca_eligible: false
     fl_tca_payment_standard: 303
-    fl_tca: 48
-    # Benefit: 303 - 255 = $48
+    fl_tca: 0
+    # Over-income for TCA once the $200 and 1/2 disregard is correctly denied.
 
 - name: Case 11, larger family size 5 zero income.
   period: 2024-01
@@ -470,7 +476,7 @@
     fl_tca: 10
     # Benefit: 241 - 231 = $10
 
-- name: Case 16, benefit of $9.
+- name: Case 16, deficit of $9 not issued (below $10 minimum).
   period: 2024-01
   input:
     people:
@@ -494,8 +500,8 @@
     fl_tca_net_income_eligible: true
     fl_tca_eligible: true
     fl_tca_payment_standard: 241
-    fl_tca: 9
-    # Benefit: 241 - 232 = $9
+    fl_tca: 0
+    # Deficit = 241 - 232 = $9 < $10 -> not issued (2620.0111.01 Step 6, Note).
 
 - name: Case 17, multiple earners with varying income.
   period: 2024-01
@@ -518,18 +524,19 @@
         members: [person1, person2, person3]
         state_code: FL
   output:
-    fl_tca_countable_earned_income: 105
-    # Combined: 300 + 200 = 500
-    # After $90: 410, after $200: 210, * 0.5 = 105
-    fl_tca_countable_income: 105
+    fl_tca_countable_earned_income: 410
+    # Combined earnings 300 + 200 = 500. Income after the $90 disregard = $410
+    # >= payment standard $303, so the $200 and 1/2 disregard is denied; only
+    # the $90 is deducted: countable earned = $410.
+    fl_tca_countable_income: 410
     fl_tca_gross_income_eligible: true
     # Gross: $500 < $3,981 -> Pass
-    fl_tca_net_income_eligible: true
-    # 105 < 303 -> Pass
-    fl_tca_eligible: true
+    fl_tca_net_income_eligible: false
+    # 410 > 303 -> Fail
+    fl_tca_eligible: false
     fl_tca_payment_standard: 303
-    fl_tca: 198
-    # 303 - 105 = $198
+    fl_tca: 0
+    # Over-income for TCA once the disregard is correctly denied.
 
 - name: Case 18, assets at limit with income.
   period: 2024-01

--- a/policyengine_us/variables/gov/states/fl/dcf/oss/fl_oss.py
+++ b/policyengine_us/variables/gov/states/fl/dcf/oss/fl_oss.py
@@ -11,12 +11,50 @@ class fl_oss(Variable):
     reference = (
         "https://www.flrules.org/gateway/RuleNo.asp?title=PUBLIC%20ASSISTANCE&ID=65A-2.036",
         "https://www.myflfamilies.com/sites/default/files/2025-05/Appendix%20A-12%20-%20State%20Funded%20Programs%20Eligibility%20Standards.pdf",
+        "https://ffic.myflfamilies.com/manual/2600.pdf",
     )
+    documentation = """
+    Optional State Supplementation payment.
+
+    This implements the DCF ESS Program Policy Manual 2640.0131.04 single-
+    individual computation, expressed in the algebraically equivalent
+    "recognized cost of care + personal needs allowance - countable income"
+    form:
+
+      2640.0131.04 Step 1: available income = gross income - PNA
+      2640.0131.04 Step 2: deficit = recognized cost of care - available income
+                         = cost of care - (income - PNA)
+                         = (cost of care + PNA) - income
+
+    Here fl_oss_provider_rate is the recognized standard for cost of care (the
+    provider rate in Appendix A-12) and p.pna is the personal needs allowance,
+    so total_needs = provider_rate + PNA and the payment is total_needs -
+    ssi_countable_income, floored at $0 and capped by the Appendix A-12 Maximum
+    OSS Payment (fl_oss_max_oss). The benefit is paid "in dollars and cents"
+    (2640.0131.03); it is not rounded.
+
+    Scope limitations relative to the manual (documented, not modeled):
+      - 2640.0131.02/.05 dependent allocation: when an OSS individual has a
+        non-institutionalized ineligible spouse/child in the community, a
+        portion of income above the PNA is diverted to the dependent's need
+        ($146 spouse, $65 per child), which raises the OSS payment. The
+        person-level snapshot does not represent an OSS resident with a
+        separate community-dependent unit and that unit's income, so this
+        allocation is not applied. Its omission is conservative (it can only
+        increase the payment).
+      - 2640.0131.03 month-of-placement proration: PE computes full-month
+        benefits; partial-month placement proration is not represented.
+    """
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.fl.dcf.oss
+        # Recognized standard for cost of care (2640.0131.04); the provider rate
+        # in Appendix A-12.
         provider_rate = person("fl_oss_provider_rate", period)
+        # total_needs = recognized cost of care + personal needs allowance.
         total_needs = provider_rate + p.pna
         countable_income = person("ssi_countable_income", period)
         max_oss = person("fl_oss_max_oss", period)
+        # Deficit (2640.0131.04 Step 2), floored at $0 and capped by the
+        # Appendix A-12 Maximum OSS Payment.
         return min_(max_(total_needs - countable_income, 0), max_oss)

--- a/policyengine_us/variables/gov/states/fl/dcf/oss/fl_oss_eligible.py
+++ b/policyengine_us/variables/gov/states/fl/dcf/oss/fl_oss_eligible.py
@@ -23,7 +23,34 @@ class fl_oss_eligible(Variable):
     reference = (
         "https://www.flrules.org/gateway/RuleNo.asp?title=PUBLIC%20ASSISTANCE&ID=65A-2.032",
         "https://www.flrules.org/gateway/RuleNo.asp?title=PUBLIC%20ASSISTANCE&ID=65A-2.033",
+        "https://ffic.myflfamilies.com/manual/200.pdf",
     )
+    documentation = """
+    Maps the DCF ESS Program Policy Manual 0240.0118 OSS eligibility criteria
+    to the inputs the model can represent:
+
+      1. Age 65+ or 18+ blind/disabled (Title XVI)  -> is_ssi_eligible
+      2. Living in Florida with intent to remain     -> defined_for StateCode.FL
+                                                        (state modeled; "intent
+                                                        to remain" not an input)
+      3. US citizen or qualified noncitizen          -> is_ssi_eligible
+                                                        (SSI immigration test)
+      4. Income within Department standards          -> income_within_standard
+      5. Assets within SSI standards                 -> is_ssi_eligible
+                                                        (SSI resource test)
+      6. Applies/pursues all other benefits          -> not modeled (behavioral;
+                                                        no input)
+      7. Lives in a licensed ALF/AFCH/MHRTF meeting  -> in_facility (facility
+         the individual's needs                         type; licensure and
+                                                        needs-match not modeled)
+      8. Certified by a counselor as in need         -> not modeled
+                                                        (administrative; no input)
+
+    Criteria 2, 6, and 8 are administrative or behavioral gates with no
+    representation in a static household snapshot; they are treated as met.
+    This over-includes only households that satisfy the financial, categorical,
+    and facility conditions but would fail an administrative gate.
+    """
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.fl.dcf.oss

--- a/policyengine_us/variables/gov/states/fl/dcf/tanf/eligibility/fl_tca_gross_income_eligible.py
+++ b/policyengine_us/variables/gov/states/fl/dcf/tanf/eligibility/fl_tca_gross_income_eligible.py
@@ -16,6 +16,11 @@ class fl_tca_gross_income_eligible(Variable):
         # Per DCF 2620.0109.01: Gross income test - NO disregards applied
         # "The standard earned income disregard, 200 and 1/2 which includes
         # the standard earned income disregard of $90, is not deducted in this test."
+        # Per DCF 2620.0107: total gross income "cannot exceed" the appropriate
+        # Eligibility Standard, and 2620.0109.02 Step 2 counts an exact equal as
+        # meeting the requirements (deficit or exact equal passes; only a surplus
+        # is ineligible). The boundary is therefore <= (gross at exactly the
+        # standard is eligible), not strict <.
         p = parameters(period).gov.states.fl.dcf.tanf.income.gross_test
 
         gross_income = spm_unit("fl_tca_gross_income", period)
@@ -24,4 +29,4 @@ class fl_tca_gross_income_eligible(Variable):
         fpg = spm_unit("spm_unit_fpg", period)
         gross_income_limit = fpg * p.gross_income_limit_rate
 
-        return gross_income < gross_income_limit
+        return gross_income <= gross_income_limit

--- a/policyengine_us/variables/gov/states/fl/dcf/tanf/eligibility/fl_tca_net_income_eligible.py
+++ b/policyengine_us/variables/gov/states/fl/dcf/tanf/eligibility/fl_tca_net_income_eligible.py
@@ -13,7 +13,12 @@ class fl_tca_net_income_eligible(Variable):
     defined_for = StateCode.FL
 
     def formula(spm_unit, period, parameters):
-        # Per Florida Statutes 414.095(12): Net countable income < payment standard
+        # Per DCF 2620.0107, total net income "cannot exceed" the appropriate
+        # income limit (the payment standard), and 2620.0111.01 Step 5 makes the
+        # AG ineligible only "if a surplus results." An exact equal produces no
+        # surplus (2620.0109.02 Step 2: "Deficit or Exact Equal: Meets the
+        # Requirements"), so countable income exactly at the payment standard is
+        # eligible. The boundary is <=, not strict <.
         countable_income = spm_unit("fl_tca_countable_income", period)
         payment_standard = spm_unit("fl_tca_payment_standard", period)
-        return countable_income < payment_standard
+        return countable_income <= payment_standard

--- a/policyengine_us/variables/gov/states/fl/dcf/tanf/fl_tca.py
+++ b/policyengine_us/variables/gov/states/fl/dcf/tanf/fl_tca.py
@@ -15,9 +15,15 @@ class fl_tca(Variable):
 
     def formula(spm_unit, period, parameters):
         # Per Florida Statutes 414.095(12) and FAC 65A-4.220
+        p = parameters(period).gov.states.fl.dcf.tanf
         payment_standard = spm_unit("fl_tca_payment_standard", period)
         countable_income = spm_unit("fl_tca_countable_income", period)
 
-        # Benefit = Payment Standard - Countable Income
-        benefit = max_(payment_standard - countable_income, 0)
-        return min_(benefit, payment_standard)
+        # Benefit = Payment Standard - Countable Income (bounded by the payment
+        # standard when countable income is negative).
+        benefit = min_(max_(payment_standard - countable_income, 0), payment_standard)
+
+        # Per DCF 2620.0111.01 Step 6, a benefit is issued only when the deficit
+        # is at least $10; the Note confirms "Cash benefits are not issued for
+        # amounts less than $10." Deficits from $0.01 to $9.99 produce $0.
+        return where(benefit >= p.minimum_benefit, benefit, 0)

--- a/policyengine_us/variables/gov/states/fl/dcf/tanf/income/fl_tca_200_and_half_disregard_eligible.py
+++ b/policyengine_us/variables/gov/states/fl/dcf/tanf/income/fl_tca_200_and_half_disregard_eligible.py
@@ -1,0 +1,38 @@
+from policyengine_us.model_api import *
+
+
+class fl_tca_200_and_half_disregard_eligible(Variable):
+    value_type = bool
+    entity = SPMUnit
+    label = "Florida TCA eligible for the $200 and 1/2 earned income disregard"
+    definition_period = MONTH
+    reference = "https://ffic.myflfamilies.com/manual/2400.pdf"
+    defined_for = StateCode.FL
+    documentation = """
+    Whether the assistance group may receive the remainder of the "$200 and 1/2"
+    earned income disregard under DCF ESS Program Policy Manual 2420.0314-.0315.
+
+    Per 2420.0315, a member receives the $200 and 1/2 disregard if the individual:
+      (1) has been eligible for and received TCA in one of the past four months; OR
+      (2) has gross countable income (earned + unearned), less the $90 standard
+          earned income disregard, that is less than the applicable payment
+          standard.
+
+    PolicyEngine cannot observe prior-month TCA receipt from a static snapshot, so
+    condition (1) is not represented. This variable encodes the computable
+    condition (2): (gross earned + unearned - $90 standard disregard) < payment
+    standard. Because condition (1) can only expand eligibility, applying condition
+    (2) alone is the conservative, manual-aligned choice for new applicants; it
+    understates eligibility only for continuing recipients whose income has risen
+    above the payment standard after the $90 disregard.
+    """
+
+    def formula(spm_unit, period, parameters):
+        p = parameters(period).gov.states.fl.dcf.tanf.income.disregard
+        gross_earned = add(spm_unit, period, ["tanf_gross_earned_income"])
+        unearned = add(spm_unit, period, ["tanf_gross_unearned_income"])
+        payment_standard = spm_unit("fl_tca_payment_standard", period)
+        # 2420.0315(2): gross countable income less the $90 standard earned income
+        # disregard, compared to the payment standard.
+        income_after_standard = max_(gross_earned - p.standard_disregard, 0) + unearned
+        return income_after_standard < payment_standard

--- a/policyengine_us/variables/gov/states/fl/dcf/tanf/income/fl_tca_countable_earned_income.py
+++ b/policyengine_us/variables/gov/states/fl/dcf/tanf/income/fl_tca_countable_earned_income.py
@@ -7,19 +7,27 @@ class fl_tca_countable_earned_income(Variable):
     label = "Florida TCA countable earned income"
     unit = USD
     definition_period = MONTH
-    reference = "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&URL=0400-0499/0414/Sections/0414.095.html"
+    reference = (
+        "https://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&URL=0400-0499/0414/Sections/0414.095.html",
+        "https://ffic.myflfamilies.com/manual/2400.pdf",
+    )
     defined_for = StateCode.FL
 
     def formula(spm_unit, period, parameters):
         # Per DCF 2620.0111.01: Income Test and Benefit Determination
         # Step 2: Subtract $90 standard disregard
-        # Step 3: Subtract $200 and 1/2 of remainder
+        # Step 3: Subtract the remainder of the $200 and 1/2 disregard "if eligible"
         p = parameters(period).gov.states.fl.dcf.tanf.income.disregard
         gross_earned = add(spm_unit, period, ["tanf_gross_earned_income"])
 
-        # Step 2: Subtract $90 standard disregard
+        # Step 2: Subtract $90 standard disregard (always allowed).
         after_standard = max_(gross_earned - p.standard_disregard, 0)
 
-        # Step 3: Subtract $200, then 50% of remainder is countable
+        # Step 3: The remainder of the $200 and 1/2 disregard is subtracted only
+        # "if eligible" (2620.0111.01 Step 3). Per 2420.0314-.0315 the $200 and
+        # 1/2 disregard is granted when income after the $90 disregard is below
+        # the payment standard (condition 2); otherwise only the $90 applies.
+        eligible = spm_unit("fl_tca_200_and_half_disregard_eligible", period)
         remaining_after_first = max_(after_standard - p.first_amount, 0)
-        return remaining_after_first * (1 - p.remaining_rate)
+        countable_with_full_disregard = remaining_after_first * (1 - p.remaining_rate)
+        return where(eligible, countable_with_full_disregard, after_standard)


### PR DESCRIPTION
Audits Florida TCA (#8728) and Florida OSS (#8772) against the Florida DCF ESS Program Policy Manual, adjudicating each reported boundary against the verbatim manual text. Concrete wrong answers are fixed with tests; boundaries that are non-representable modeling simplifications are documented rather than force-fit.

Primary sources (page-anchored citations added to parameter/variable metadata):
- ESS Program Policy Manual ch. 2400 (Budgeting Income): https://ffic.myflfamilies.com/manual/2400.pdf
- ESS Program Policy Manual ch. 2600 (Calculation of Benefits): https://ffic.myflfamilies.com/manual/2600.pdf
- ESS Program Policy Manual ch. 200 (0240.0118 OSS eligibility): https://ffic.myflfamilies.com/manual/200.pdf
- Appendix A-5 (TCA Income Standards): https://ffic.myflfamilies.com/manual/essfiles/30441.pdf
- Appendix A-12 (State Funded Programs Eligibility Standards): confirmed OSS parameter values unchanged and correct

Fixes #8728
Fixes #8772

---

## #8728 — Florida TCA

| # | Allegation | Verdict | Manual basis |
|---|---|---|---|
| 1 | Payment-standard family-size cap at 13 | **Fixed** | Appendix A-5 tabulates payment standards through filing-unit size 24. Extended zero/low/high-shelter tables and `max_family_size` from 13 to 24; sizes >24 use the size-24 standard (additional-person increment beyond 24 documented as not modeled). |
| 2 | Gross-income test uses strict `<` | **Fixed** | 2620.0107: gross income "cannot exceed" the Eligibility Standard. 2620.0109.02 Step 2: "(Eligibility Standards) − (Total Gross Income) = (Deficit or **Exact Equal: Meets the Requirements**) or (Surplus: Ineligible)." Changed to `<=`. |
| 3 | Net-income test uses strict `<` | **Fixed** | 2620.0107 ("cannot exceed" the income limit) and 2620.0111.01 Step 5 ("If a surplus results, the AG is ineligible") — an exact equal produces no surplus. Changed to `<=`. |
| 4 | `$200 and 1/2` disregard applied unconditionally | **Fixed (computable condition)** | 2620.0111.01 Step 3 subtracts the remainder of the `$200 and 1/2` disregard "**if eligible**". 2420.0315 grants it when (2) income after the $90 standard disregard is below the payment standard (condition (1), TCA receipt in one of the past four months, is not representable). New `fl_tca_200_and_half_disregard_eligible` encodes condition (2); `fl_tca_countable_earned_income` deducts only the $90 when the predicate fails. |
| 5 | Minimum issuance below $10 | **Fixed** | 2620.0111.01 Step 6 ("If a deficit of at least $10 results, the remainder is the amount of the benefit") and Note ("Cash benefits are not issued for amounts less than $10"). New `gov.states.fl.dcf.tanf.minimum_benefit` parameter; `fl_tca` returns $0 for deficits of $0.01–$9.99. |
| 6 | Resource base uses `spm_unit_cash_assets` | **Documented simplification** | The manual's TCA standard filing unit countable assets (excluding TCA-deemed individuals' assets) is not representable without an SFU-vs-SPM-unit asset input the snapshot lacks. Left as the existing input boundary; not force-fit. |

### Behavioral changes (verified against the manual text)
- Boundary equality now passes both income tests (gross exactly at 185% FPL; net exactly at the payment standard).
- Deficits below $10 now produce $0; a deficit of exactly $10 is issued.
- The `$200 and 1/2` disregard is correctly denied when a filing unit's income after the $90 disregard already meets or exceeds its (low) payment standard. This removes prior false positives for small filing units with moderate earnings (e.g., a 2-person unit earning $500/month no longer qualifies, because $500 − $90 = $410 exceeds the $241 payment standard).

The `fl_tca_countable_earned_income` predicate reads `fl_tca_payment_standard` (which depends only on shelter and size, not on income), so no circular dependency is introduced; full-household `household_net_income` computes cleanly.

## #8772 — Florida OSS

| Allegation | Verdict | Basis |
|---|---|---|
| `fl_oss` computes `provider_rate + PNA − SSI countable income` rather than the source-local manual calculation | **Not an error (documented equivalence)** | 2640.0131.04 (Single Individual): available income = gross − PNA; deficit = recognized cost of care − available = `(cost of care + PNA) − income`. With `fl_oss_provider_rate` as the recognized cost of care and `p.pna` the PNA, PE's `(provider_rate + PNA) − ssi_countable_income` is algebraically identical. Verified with a hand-worked Jan-2025 Redesign case ($1,050/month income → available $890 → deficit $101.40 = PE output). Added a test locking in the manual walkthrough and expanded `fl_oss` documentation. |
| `fl_oss_eligible` narrower than the full 0240.0118 conditions | **Documented mapping** | Criteria 1/3/4/5/7 (age/disability, citizenship, income standard, assets, licensed facility) are represented via `is_ssi_eligible`, `fl_oss_income_standard`, and `fl_oss_living_arrangement`. Criteria 2 (intent to remain), 6 (pursuit of other benefits), and 8 (counselor certification) are administrative/behavioral gates with no snapshot representation; documented as treated-met. Added the criterion-by-criterion mapping to `fl_oss_eligible`. |
| 2640.0131.05 dependent allocation not represented | **Documented scope limit** | Allocation to a non-institutionalized community spouse ($146) / child ($65) requires an OSS resident paired with a separate community-dependent unit and that unit's income — not representable in the current person-level model. Its omission is conservative (it can only increase the payment). Documented in `fl_oss`. |
| 2640.0131.01–.03 benefit-test / placement-month / proration | **Represented / documented** | The benefit test (income at or below the OSS income standard) is implemented in `fl_oss_eligible`. Month-of-placement proration (only the placement month is prorated) is not represented; PE computes full-month benefits. Documented. |

Appendix A-12 parameter values (provider rates, PNA, income standards, max OSS, couple reductions) were re-checked and are correct; no value changes were required for OSS.

## Tests
Run: `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/fl/dcf -c policyengine_us`

- FL DCF (TCA + OSS): **156 passed** locally.
- Full FL tree: **271 passed** locally.
- Federal `gov/hhs/tanf` (includes the FL-referencing `tanf_negative_income_cap`): **74 passed** locally.

Updated the issue-reported and boundary households (minimum-benefit at $9/$10, income-test exact-equality, disregard predicate at the payment-standard boundary, size-14/24 payment standards) and added a manual-walkthrough OSS case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
