### PR TITLE
Add pre-OBBBA SNAP ABAWD work requirements counterfactual reform

### DIFF
--- a/changelog.d/snap-pre-obbba-work-requirement.added.md
+++ b/changelog.d/snap-pre-obbba-work-requirement.added.md
@@ -1,0 +1,1 @@
+Added pre-OBBBA SNAP ABAWD work requirements counterfactual reform, modeling 2026/2027 SNAP rules as if the P.L. 119-21 work requirement changes had not passed.

--- a/changelog.d/snap-pre-obbba-work-requirement.added.md
+++ b/changelog.d/snap-pre-obbba-work-requirement.added.md
@@ -1,1 +1,1 @@
-Added pre-OBBBA SNAP ABAWD work requirements counterfactual reform, modeling 2026/2027 SNAP rules as if the P.L. 119-21 work requirement changes had not passed.
+Added pre-OBBBA SNAP ABAWD work requirements counterfactual reform, reverting the P.L. 119-21 Section 10102 exemption and age provisions for periods where the toggle is enabled.

--- a/policyengine_us/parameters/gov/contrib/snap/pre_obbba_abawd_work_requirements/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/snap/pre_obbba_abawd_work_requirements/in_effect.yaml
@@ -1,0 +1,13 @@
+description: SNAP Able-Bodied Adult Without Dependents (ABAWD) work requirements revert to pre-OBBBA (P.L. 119-21) rules, if this is true.
+metadata:
+  unit: bool
+  period: year
+  label: Pre-OBBBA SNAP ABAWD work requirements in effect
+  reference:
+    - title: Public Law 119-21, Section 10102(a) - Modifications to SNAP ABAWD Requirements
+      href: https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=81
+    - title: 7 U.S.C. 2015(o)(3) - ABAWD Time Limit Exceptions
+      href: https://www.law.cornell.edu/uscode/text/7/2015#o_3
+
+values:
+  0000-01-01: false

--- a/policyengine_us/parameters/gov/contrib/snap/pre_obbba_abawd_work_requirements/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/snap/pre_obbba_abawd_work_requirements/in_effect.yaml
@@ -1,4 +1,4 @@
-description: SNAP Able-Bodied Adult Without Dependents (ABAWD) work requirements revert to pre-OBBBA (P.L. 119-21) rules, if this is true.
+description: SNAP Able-Bodied Adult Without Dependents (ABAWD) work requirement exemption and age provisions revert to pre-OBBBA (P.L. 119-21, Section 10102) rules, if this is true; post-OBBBA area waiver geography and data-assigned discretionary exemptions are not reverted, and the pre-OBBBA rules reflect law as of June 2025 (without the Fiscal Responsibility Act sunset scheduled for October 2030).
 metadata:
   unit: bool
   period: year

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -79,6 +79,7 @@ from .ctc import (
 from .snap import (
     create_abolish_snap_deductions_reform,
     create_abolish_snap_net_income_test_reform,
+    create_pre_obbba_snap_abawd_work_requirements_reform,
 )
 from .states.dc.property_tax import create_dc_property_tax_credit_reform
 
@@ -427,6 +428,9 @@ def create_structural_reforms_from_parameters(parameters, period):
     abolish_snap_net_income_test = create_abolish_snap_net_income_test_reform(
         parameters, period
     )
+    pre_obbba_snap_abawd_work_requirements = (
+        create_pre_obbba_snap_abawd_work_requirements_reform(parameters, period)
+    )
     dc_property_tax_credit = create_dc_property_tax_credit_reform(parameters, period)
     limit_salt_deduction_to_property_taxes = (
         create_limit_salt_deduction_to_property_taxes_reform(parameters, period)
@@ -611,6 +615,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         ctc_older_child_supplement,
         abolish_snap_deductions,
         abolish_snap_net_income_test,
+        pre_obbba_snap_abawd_work_requirements,
         dc_property_tax_credit,
         limit_salt_deduction_to_property_taxes,
         nyc_school_tax_credit_with_phase_out,

--- a/policyengine_us/reforms/snap/__init__.py
+++ b/policyengine_us/reforms/snap/__init__.py
@@ -4,3 +4,6 @@ from .abolish_snap_deductions import (
 from .abolish_snap_net_income_test import (
     create_abolish_snap_net_income_test_reform,
 )
+from .pre_obbba_snap_abawd_work_requirements import (
+    create_pre_obbba_snap_abawd_work_requirements_reform,
+)

--- a/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
+++ b/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
@@ -1,0 +1,42 @@
+from policyengine_us.model_api import *
+from policyengine_core.periods import period as period_
+
+
+def create_pre_obbba_snap_abawd_work_requirements() -> Reform:
+    class reform(Reform):
+        def apply(self):
+            # The baseline ABAWD formulas branch on this person-level
+            # variable between post-HR1 rules and a pre-HR1 (2025-06-01)
+            # parameter snapshot. Neutralizing it (bool default: false)
+            # restores the pre-OBBBA work requirement in every state,
+            # overriding the federal toggle and the CA/HI/AK delayed
+            # adoption parameters.
+            self.neutralize_variable("is_snap_abawd_hr1_in_effect")
+
+    return reform
+
+
+def create_pre_obbba_snap_abawd_work_requirements_reform(
+    parameters, period, bypass: bool = False
+):
+    if bypass:
+        return create_pre_obbba_snap_abawd_work_requirements()
+
+    p = parameters.gov.contrib.snap.pre_obbba_abawd_work_requirements
+    reform_active = False
+    current_period = period_(period)
+
+    for _ in range(5):
+        if p(current_period).in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
+        return create_pre_obbba_snap_abawd_work_requirements()
+    return None
+
+
+pre_obbba_snap_abawd_work_requirements = (
+    create_pre_obbba_snap_abawd_work_requirements_reform(None, None, bypass=True)
+)

--- a/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
+++ b/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
@@ -3,7 +3,7 @@
 When gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect is true
 for a period, the ABAWD work requirement reverts to pre-OBBBA
 (P.L. 119-21, Section 10102) rules for that period in every state:
-exempt ages (55+ instead of 65+), the dependent-child age threshold
+exempt ages (55+ instead of 65+), the household-child age threshold
 (18 instead of 14), and the homeless, veteran, and former foster youth
 exemptions.
 

--- a/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
+++ b/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
@@ -1,17 +1,85 @@
+"""Pre-OBBBA SNAP ABAWD work requirements counterfactual.
+
+When gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect is true
+for a period, the ABAWD work requirement reverts to pre-OBBBA
+(P.L. 119-21, Section 10102) rules for that period in every state:
+exempt ages (55+ instead of 65+), the dependent-child age threshold
+(18 instead of 14), and the homeless, veteran, and former foster youth
+exemptions.
+
+Scope and limitations:
+- Covers the Section 10102 ABAWD exemption and age provisions only.
+  Post-OBBBA area waiver geography
+  (gov.usda.snap.work_requirements.abawd.waived_county_fips) is not
+  reverted, so counterfactual waiver coverage after 2026-10 reflects
+  OBBBA-era waiver rules.
+- State discretionary exemption flags
+  (is_snap_abawd_discretionary_exempt) are assigned at microdata
+  construction among the post-OBBBA covered population and are not
+  re-drawn under the counterfactual.
+- The pre-OBBBA path reads the frozen 2025-06-01 parameter snapshot in
+  the baseline formulas, so scheduled pre-OBBBA law changes (the Fiscal
+  Responsibility Act sunset on 2030-10-01) are not modeled; the reform
+  is intended for analysis windows before then (e.g., 2026/2027).
+- Medicaid community engagement pass-through eligibility
+  (medicaid_community_engagement_pass_through_eligible) evaluates SNAP
+  work compliance under whichever SNAP rules are in force, so it also
+  reverts under this reform. This is the intended counterfactual: in a
+  world without the OBBBA SNAP work requirement, the Medicaid pass-through
+  would reference actual (pre-OBBBA) SNAP rules.
+"""
+
 from policyengine_us.model_api import *
 from policyengine_core.periods import period as period_
 
 
 def create_pre_obbba_snap_abawd_work_requirements() -> Reform:
+    class is_snap_abawd_hr1_in_effect(Variable):
+        value_type = bool
+        entity = Person
+        label = "HR1 ABAWD work requirement changes are in effect for this person"
+        definition_period = MONTH
+        reference = (
+            "https://www.congress.gov/119/plaws/publ21/PLAW-119publ21.pdf#page=81",
+            "https://www.cdss.ca.gov/Portals/9/Additional-Resources/Letters-and-Notices/ACLs/2025/25-93.pdf",
+        )
+
+        def formula(person, period, parameters):
+            p_contrib = parameters(
+                period
+            ).gov.contrib.snap.pre_obbba_abawd_work_requirements
+            # Baseline logic, mirrored from
+            # variables/gov/usda/snap/eligibility/work_requirements/
+            # is_snap_abawd_hr1_in_effect.py — keep in sync.
+            federal = parameters(period).gov.usda.snap.work_requirements.abawd.in_effect
+            state_code = person.household("state_code", period.this_year)
+            ca = parameters(
+                period
+            ).gov.states.ca.cdss.snap.work_requirements.abawd.hr1_in_effect
+            hi = parameters(
+                period
+            ).gov.states.hi.dhs.snap.work_requirements.abawd.hr1_in_effect
+            ak = parameters(
+                period
+            ).gov.states.ak.dpa.snap.work_requirements.abawd.hr1_in_effect
+            baseline = select(
+                [
+                    state_code == StateCode.CA,
+                    state_code == StateCode.HI,
+                    state_code == StateCode.AK,
+                ],
+                [ca, hi, ak],
+                default=federal,
+            )
+            # Period-gated: only months where the contrib toggle is true
+            # revert to pre-OBBBA rules; other months keep baseline
+            # behavior, so a future-dated toggle does not apply
+            # retroactively.
+            return where(p_contrib.in_effect, False, baseline)
+
     class reform(Reform):
         def apply(self):
-            # The baseline ABAWD formulas branch on this person-level
-            # variable between post-HR1 rules and a pre-HR1 (2025-06-01)
-            # parameter snapshot. Neutralizing it (bool default: false)
-            # restores the pre-OBBBA work requirement in every state,
-            # overriding the federal toggle and the CA/HI/AK delayed
-            # adoption parameters.
-            self.neutralize_variable("is_snap_abawd_hr1_in_effect")
+            self.update_variable(is_snap_abawd_hr1_in_effect)
 
     return reform
 

--- a/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
+++ b/policyengine_us/reforms/snap/pre_obbba_snap_abawd_work_requirements.py
@@ -21,6 +21,11 @@ Scope and limitations:
   the baseline formulas, so scheduled pre-OBBBA law changes (the Fiscal
   Responsibility Act sunset on 2030-10-01) are not modeled; the reform
   is intended for analysis windows before then (e.g., 2026/2027).
+- The OBBBA-created Indian, Urban Indian, and California Indian
+  exemption (7 U.S.C. 2015(o)(3)(F)-(G)) does not exist under the
+  counterfactual, so individuals exempt only through it become subject
+  to the pre-OBBBA rules. This is the sole case where the reform
+  tightens rather than loosens the requirement.
 - Medicaid community engagement pass-through eligibility
   (medicaid_community_engagement_pass_through_eligible) evaluates SNAP
   work compliance under whichever SNAP rules are in force, so it also

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -70,6 +70,7 @@
         members: [person1, person2]
         state_code: TX
   output:
+    is_snap_abawd_hr1_in_effect: [false, false]
     meets_snap_abawd_work_requirements: [true, true]
 
 - name: Homeless exemption is restored under the reform.

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -59,12 +59,6 @@
         age: 15
         is_disabled: false
         is_tax_unit_dependent: true
-    spm_units:
-      spm_unit:
-        members: [person1, person2]
-    tax_units:
-      tax_unit:
-        members: [person1, person2]
     households:
       household:
         members: [person1, person2]

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -127,6 +127,30 @@
   output:
     meets_snap_abawd_work_requirements: true
 
+- name: Baseline contrast without the reform, post-OBBBA rules apply in 2026.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age: 60
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: TX
+  output:
+    is_snap_abawd_hr1_in_effect: true
+    meets_snap_abawd_work_requirements: false
+
+- name: Baseline contrast without the reform, California has not yet adopted HR1 in early 2026.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age: 60
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: CA
+  output:
+    is_snap_abawd_hr1_in_effect: false
+    meets_snap_abawd_work_requirements: true
+
 - name: With the reform applied but the toggle off, current law applies (period gating).
   period: 2026-01
   absolute_error_margin: 0.1

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -88,6 +88,9 @@
         members: [person1, person2]
         state_code: TX
   output:
+    is_parent: [true, false]
+    is_tax_unit_dependent: [false, true]
+    monthly_age: [40, 13]
     meets_snap_abawd_work_requirements: [true, true]
 
 - name: Homeless exemption is restored under the reform.

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -1,0 +1,128 @@
+# Counterfactual reform: 2026/2027 SNAP ABAWD work requirements as if
+# the OBBBA (P.L. 119-21, Section 10102) changes had not passed.
+# Restores pre-HR1 rules: 18-54 subject (55+ exempt), dependent-child
+# age threshold of 18, and homeless / veteran / former foster youth
+# exemptions, in every state.
+
+- name: Age 60 non-worker is age-exempt under pre-OBBBA rules in 2026.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 60
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: Age 60 non-worker is age-exempt under pre-OBBBA rules in 2027.
+  period: 2027-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 60
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: Age 30 non-exempt non-worker still fails under the reform.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 30
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: false
+
+- name: Parent of a 15-year-old is exempt under the pre-OBBBA dependent threshold.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    people:
+      person1:
+        age: 40
+        weekly_hours_worked_before_lsr: 1
+        is_disabled: false
+        is_parent: true
+      person2:
+        age: 15
+        is_disabled: false
+        is_tax_unit_dependent: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: [true, true]
+
+- name: Homeless exemption is restored under the reform.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 30
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    is_homeless: true
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: Veteran exemption is restored under the reform.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 30
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    is_veteran: true
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: Former foster youth exemption is restored under the reform.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 24
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    was_in_foster_care: true
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: California follows pre-OBBBA rules under the reform after its delayed adoption date.
+  period: 2027-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 60
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: CA
+  output:
+    meets_snap_abawd_work_requirements: true

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -126,3 +126,43 @@
     state_code: CA
   output:
     meets_snap_abawd_work_requirements: true
+
+- name: With the reform applied but the toggle off, current law applies (period gating).
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    age: 60
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: TX
+  output:
+    is_snap_abawd_hr1_in_effect: true
+    meets_snap_abawd_work_requirements: false
+
+- name: Medicaid community engagement pass-through follows pre-OBBBA SNAP rules under the reform.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    people:
+      person1:
+        # Age 57: subject to the post-OBBBA ABAWD time limit (exempt at
+        # 65) but age-exempt pre-OBBBA (55+); complies with general work
+        # requirements via work program participation with fewer than the
+        # 20 weekly hours the ABAWD requirement needs.
+        age: 57
+        weekly_hours_worked_before_lsr: 0
+        is_snap_work_program_participant: true
+        is_disabled: false
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 200
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    medicaid_community_engagement_pass_through_eligible: true

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -59,6 +59,9 @@
         age: 15
         is_disabled: false
         is_tax_unit_dependent: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
     households:
       household:
         members: [person1, person2]
@@ -91,6 +94,7 @@
     is_parent: [true, false]
     is_tax_unit_dependent: [false, true]
     monthly_age: [40, 13]
+    spm_unit_size: 2
     meets_snap_abawd_work_requirements: [true, true]
 
 - name: Homeless exemption is restored under the reform.

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -67,6 +67,29 @@
     is_snap_abawd_hr1_in_effect: [false, false]
     meets_snap_abawd_work_requirements: [true, true]
 
+- name: Diagnostic, parent of a 13-year-old is exempt under both dependent thresholds.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    people:
+      person1:
+        age: 40
+        weekly_hours_worked_before_lsr: 1
+        is_disabled: false
+        is_parent: true
+      person2:
+        age: 13
+        is_disabled: false
+        is_tax_unit_dependent: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: [true, true]
+
 - name: Homeless exemption is restored under the reform.
   period: 2026-01
   absolute_error_margin: 0.1

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -1,6 +1,6 @@
 # Counterfactual reform: 2026/2027 SNAP ABAWD work requirements as if
 # the OBBBA (P.L. 119-21, Section 10102) changes had not passed.
-# Restores pre-HR1 rules: 18-54 subject (55+ exempt), dependent-child
+# Restores pre-HR1 rules: 18-54 subject (55+ exempt), household-child
 # age threshold of 18, and homeless / veteran / former foster youth
 # exemptions, in every state.
 
@@ -43,7 +43,13 @@
   output:
     meets_snap_abawd_work_requirements: false
 
-- name: Parent of a 15-year-old is exempt under the pre-OBBBA dependent threshold.
+# The household-child ABAWD exception (7 CFR 273.24(c)(4)) is handled in
+# meets_snap_work_requirements_person: a household member under the age
+# threshold routes the person around the ABAWD test. The pre-OBBBA
+# threshold is 18; OBBBA lowered it to 14. The adult here complies with
+# general work requirements via work program participation but fails the
+# 20-hour ABAWD test, so only the routing determines the outcome.
+- name: A 15-year-old household member routes the adult around the ABAWD test under the pre-OBBBA threshold.
   period: 2026-01
   absolute_error_margin: 0.1
   reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
@@ -52,13 +58,12 @@
     people:
       person1:
         age: 40
-        weekly_hours_worked_before_lsr: 1
+        weekly_hours_worked_before_lsr: 0
+        is_snap_work_program_participant: true
         is_disabled: false
-        is_parent: true
       person2:
         age: 15
         is_disabled: false
-        is_tax_unit_dependent: true
     spm_units:
       spm_unit:
         members: [person1, person2]
@@ -68,34 +73,30 @@
         state_code: TX
   output:
     is_snap_abawd_hr1_in_effect: [false, false]
-    meets_snap_abawd_work_requirements: [true, true]
+    meets_snap_work_requirements_person: [true, true]
 
-- name: Diagnostic, parent of a 13-year-old is exempt under both dependent thresholds.
+- name: Baseline contrast, a 15-year-old household member does not trigger the routing under the post-OBBBA threshold of 14.
   period: 2026-01
   absolute_error_margin: 0.1
-  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
   input:
-    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
     people:
       person1:
         age: 40
-        weekly_hours_worked_before_lsr: 1
+        weekly_hours_worked_before_lsr: 0
+        is_snap_work_program_participant: true
         is_disabled: false
-        is_parent: true
       person2:
-        age: 13
+        age: 15
         is_disabled: false
-        is_tax_unit_dependent: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
     households:
       household:
         members: [person1, person2]
         state_code: TX
   output:
-    is_parent: [true, false]
-    is_tax_unit_dependent: [false, true]
-    monthly_age: [40, 13]
-    spm_unit_size: 2
-    meets_snap_abawd_work_requirements: [true, true]
+    meets_snap_work_requirements_person: [false, true]
 
 - name: Homeless exemption is restored under the reform.
   period: 2026-01

--- a/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml
@@ -127,6 +127,61 @@
   output:
     meets_snap_abawd_work_requirements: true
 
+- name: Hawaii follows pre-OBBBA rules under the reform after its delayed adoption date.
+  period: 2027-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    age: 60
+    weekly_hours_worked_before_lsr: 1
+    is_disabled: false
+    state_code: HI
+  output:
+    meets_snap_abawd_work_requirements: true
+
+- name: End to end, an age-exempt non-worker with no income becomes SNAP eligible under the reform.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  reforms: policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements.pre_obbba_snap_abawd_work_requirements
+  input:
+    gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect: true
+    people:
+      person1:
+        age: 60
+        weekly_hours_worked_before_lsr: 0
+        is_disabled: false
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    meets_snap_work_requirements: true
+    is_snap_eligible: true
+
+- name: End to end baseline contrast, the same person is SNAP ineligible under current law.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    people:
+      person1:
+        age: 60
+        weekly_hours_worked_before_lsr: 0
+        is_disabled: false
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    meets_snap_work_requirements: false
+    is_snap_eligible: false
+
 - name: Baseline contrast without the reform, post-OBBBA rules apply in 2026.
   period: 2026-01
   absolute_error_margin: 0.1

--- a/policyengine_us/tests/policy/contrib/snap/test_pre_obbba_snap_abawd_work_requirements.py
+++ b/policyengine_us/tests/policy/contrib/snap/test_pre_obbba_snap_abawd_work_requirements.py
@@ -1,0 +1,73 @@
+"""Unit tests for the pre-OBBBA SNAP ABAWD work requirements autoloader.
+
+YAML tests force-apply the reform via the `reforms:` directive, which
+bypasses `create_pre_obbba_snap_abawd_work_requirements_reform`. These
+tests exercise the autoloader directly: the bypass flag, the
+default-inactive return-None path, and the 5-year forward-lookahead
+window. The lookahead cases use a lightweight parameter stub because
+constructing real parameter trees with future-dated toggles requires a
+`copy.deepcopy(system.parameters)` per case, which pushes peak memory
+past the CI runner cap when this directory's batch runs.
+"""
+
+from types import SimpleNamespace
+
+from policyengine_us.reforms.snap.pre_obbba_snap_abawd_work_requirements import (
+    create_pre_obbba_snap_abawd_work_requirements_reform,
+)
+from policyengine_us.system import system
+
+
+def _stub_parameters(in_effect_start_year):
+    """Parameter-tree stub whose in_effect toggle turns true at a given year."""
+
+    def node(period):
+        return SimpleNamespace(in_effect=period.start.year >= in_effect_start_year)
+
+    return SimpleNamespace(
+        gov=SimpleNamespace(
+            contrib=SimpleNamespace(
+                snap=SimpleNamespace(pre_obbba_abawd_work_requirements=node)
+            )
+        )
+    )
+
+
+def test_autoloader_returns_none_when_in_effect_false_throughout_window():
+    """Default parameters: in_effect is false for all years; autoloader returns None."""
+    result = create_pre_obbba_snap_abawd_work_requirements_reform(
+        system.parameters, "2026"
+    )
+    assert result is None
+
+
+def test_bypass_flag_skips_lookahead_and_returns_reform():
+    """bypass=True returns the reform without checking in_effect."""
+    result = create_pre_obbba_snap_abawd_work_requirements_reform(
+        None, None, bypass=True
+    )
+    assert result is not None
+
+
+def test_autoloader_activates_when_in_effect_true_at_simulation_year():
+    """in_effect true at the simulated year activates on the first lookahead step."""
+    result = create_pre_obbba_snap_abawd_work_requirements_reform(
+        _stub_parameters(2026), "2026"
+    )
+    assert result is not None
+
+
+def test_autoloader_activates_when_in_effect_true_at_window_edge():
+    """in_effect true four years out (last year of the 5-year window) activates."""
+    result = create_pre_obbba_snap_abawd_work_requirements_reform(
+        _stub_parameters(2030), "2026"
+    )
+    assert result is not None
+
+
+def test_autoloader_returns_none_when_in_effect_true_beyond_window():
+    """in_effect true five years out (past the 5-year window) does not activate."""
+    result = create_pre_obbba_snap_abawd_work_requirements_reform(
+        _stub_parameters(2031), "2026"
+    )
+    assert result is None

--- a/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_abawd_hr1_in_effect.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/work_requirements/is_snap_abawd_hr1_in_effect.py
@@ -12,6 +12,12 @@ class is_snap_abawd_hr1_in_effect(Variable):
     )
 
     def formula(person, period, parameters):
+        # This variable must remain the sole access point for the federal
+        # abawd.in_effect and state hr1_in_effect parameters: the
+        # pre-OBBBA counterfactual reform
+        # (reforms/snap/pre_obbba_snap_abawd_work_requirements.py)
+        # overrides this variable, so formulas reading those parameters
+        # directly would bypass the reform.
         # States that delay HR1 adoption have their own hr1_in_effect
         # parameter with a later effective date. Add new states here.
         federal = parameters(period).gov.usda.snap.work_requirements.abawd.in_effect


### PR DESCRIPTION
Fixes #8943

## Summary

Adds a contributed counterfactual-baseline reform modeling 2026/2027 SNAP rules **as if the OBBBA (P.L. 119-21, §10102) ABAWD work requirement exemption and age provisions had not passed**.

Since the OBBBA provisions are now encoded in the current-law baseline, this provides the inverse lever of the pre-passage `gov/contrib/reconciliation/snap_abawd_work_requirement` reform: toggling `gov.contrib.snap.pre_obbba_abawd_work_requirements.in_effect` restores prior law against the post-OBBBA baseline.

## Implementation

The baseline ABAWD formulas (`meets_snap_abawd_work_requirements`, `meets_snap_work_requirements`) already branch on the person-level `is_snap_abawd_hr1_in_effect` variable, using a `parameters("2025-06-01")` pre-HR1 snapshot for the prior-law path. The reform overrides `is_snap_abawd_hr1_in_effect` with a formula that returns false for periods where the contrib toggle is true and otherwise mirrors the baseline logic, restoring in every state (including CA/HI/AK delayed adoption):

- exempt ages 18–54 subject / 55+ exempt (vs 18–64 subject post-OBBBA)
- dependent-child age threshold of 18 (vs 14)
- homeless, veteran, and former foster youth exemptions (removed by OBBBA)

The per-period override (rather than `neutralize_variable`) ensures a future-dated toggle does not apply retroactively to earlier simulated years. Follows the standard contrib factory pattern (`in_effect` toggle, 5-year lookahead, module-level `bypass=True` instance, registration in `reforms.py`).

## Review round (multi-angle, findings addressed here)

An 8-angle adversarial review surfaced and this PR addresses:

1. **Retroactivity bug (fixed):** the original `neutralize_variable` approach ignored the toggle's start date — a toggle dated 2028 reverted 2026 results. Now period-gated and covered by a test.
2. **Medicaid interaction (documented + tested):** `medicaid_community_engagement_pass_through_eligible` reads `is_snap_abawd_hr1_in_effect`, so the pass-through follows the counterfactual SNAP rules. This is the intended behavior (in a no-OBBBA-SNAP-WR world, the Medicaid pass-through references actual SNAP rules); documented in the module docstring and covered by a test (57-year-old work-program participant flips eligible).
3. **Scope narrowed (documented):** OBBBA §10102 also rewrote area waivers; post-OBBBA waiver geography (`waived_county_fips`) is not reverted. Parameter description, changelog, and docstring now claim only the exemption and age provisions.
4. **Data-layer caveat (documented):** discretionary exemption flags are assigned at microdata construction among the post-OBBBA covered population and are not re-drawn under the counterfactual.
5. **FRA sunset caveat (documented):** the pre-OBBBA path is a frozen 2025-06 snapshot, so the FRA's scheduled 2030-10-01 sunset is not modeled; the reform targets pre-2030 windows (e.g., 2026/2027).
6. **Bypass fragility (mitigated):** the baseline `is_snap_abawd_hr1_in_effect` now documents that it must remain the sole access point for the underlying federal/state parameters.

## Verification

- 12 YAML tests pass (`tests/policy/contrib/snap/pre_obbba_abawd_work_requirements.yaml`): age exemption in 2026/2027, non-exempt control, parent of a 15-year-old, homeless/veteran/former-foster-youth exemptions, CA after delayed adoption, period gating (reform applied, toggle off ⇒ current law), baseline-contrast cases (no reform ⇒ post-OBBBA rules), and the Medicaid pass-through interaction. 5 pytest unit tests cover the autoloader (bypass, default-inactive, and the 5-year lookahead window edges). Federal cases pin `state_code: TX` since the default state (CA) is pre-HR1 through 2026-05 in baseline.
- All 111 existing baseline work-requirement and Medicaid CE pass-through tests pass.
- End-to-end via structural registration: TX 60-year-old non-worker in 2026-01 is ineligible in baseline, eligible under the reform; a 2028-dated toggle leaves 2026 at current law.

## Microsimulation note

On the default CPS-based dataset, this reform (and the baseline OBBBA work requirement itself) produces **no population-level SNAP delta**, because `weekly_hours_worked_before_lsr` defaults to 40 for every person when the dataset lacks hours data — everyone trivially satisfies the 20-hour ABAWD test. Population-level analysis of SNAP work requirements requires microdata with real hours and exemption assignment (tracked under the #8820 data work / PolicyEngine/populace#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
