### PR TITLE
Compute the NYC School Tax Credit with a formula so household output shows one credit line

### DIFF
--- a/changelog.d/nyc-stc-single-line.fixed.md
+++ b/changelog.d/nyc-stc-single-line.fixed.md
@@ -1,0 +1,1 @@
+The NYC School Tax Credit now computes through a formula so household output shows only the final credit rather than its fixed and rate-reduction components.

--- a/policyengine_us/reforms/local/nyc/stc/adjust_income_limit_by_filing_status_and_eligibility_by_children.py
+++ b/policyengine_us/reforms/local/nyc/stc/adjust_income_limit_by_filing_status_and_eligibility_by_children.py
@@ -33,10 +33,17 @@ def create_adjust_income_limit_and_min_children_by_filing_status() -> Reform:
         definition_period = YEAR
         defined_for = "nyc_school_tax_credit_eligible"
 
-        adds = [
-            "nyc_school_tax_credit_fixed_amount",
-            "nyc_school_tax_credit_rate_reduction_amount",
-        ]
+        def formula(tax_unit, period, parameters):
+            # Formula rather than an adds list so household output surfaces
+            # only the final credit (#8938).
+            return add(
+                tax_unit,
+                period,
+                [
+                    "nyc_school_tax_credit_fixed_amount",
+                    "nyc_school_tax_credit_rate_reduction_amount",
+                ],
+            )
 
     class reform(Reform):
         def apply(self):

--- a/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/school/nyc_school_tax_credit.py
+++ b/policyengine_us/variables/gov/local/ny/nyc/tax/income/credits/school/nyc_school_tax_credit.py
@@ -9,7 +9,15 @@ class nyc_school_tax_credit(Variable):
     definition_period = YEAR
     defined_for = "in_nyc"
 
-    adds = [
-        "nyc_school_tax_credit_fixed_amount",
-        "nyc_school_tax_credit_rate_reduction_amount",
-    ]
+    def formula(tax_unit, period, parameters):
+        # Computed with a formula rather than an adds list so that household
+        # output surfaces only the final credit; the fixed and rate-reduction
+        # pieces are components of one credit, not separate credits (#8938).
+        return add(
+            tax_unit,
+            period,
+            [
+                "nyc_school_tax_credit_fixed_amount",
+                "nyc_school_tax_credit_rate_reduction_amount",
+            ],
+        )


### PR DESCRIPTION
## What

Converts `nyc_school_tax_credit` (and the adjust-income-limit reform variant) from an `adds` list to a formula using `add()`. The computation is identical — $129.12 = $63 fixed + $66.12 rate reduction for a $40k NYC single filer, verified before/after — but the variable no longer publishes `adds` metadata, which is what household net-income breakdowns expand into separate line items. The phase-out reform variant already used a formula.

## Why

Fixes #8938 (migrated from policyengine-app#2760): household impacts displayed the rate-reduction amount alongside the final credit. The model was never double-counting — `nyc_refundable_credits` includes the credit exactly once, and the components appear in no other list — but the `adds` metadata let the app render the internal decomposition as if it were two credits.

## Tests

- NY local tree: 65 passed
- NYC STC contrib reform tests: 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)