### PR TITLE
Use gross countable income for NE Child Care Subsidy per 392 NAC 3-005.02

### DIFF
--- a/changelog.d/ne-ccs-countable-income.changed.md
+++ b/changelog.d/ne-ccs-countable-income.changed.md
@@ -1,0 +1,1 @@
+Nebraska Child Care Subsidy income eligibility and family fee now use gross countable income per 392 NAC 3-005.02, replacing federal adjusted gross income and SPM unit net income.

--- a/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/earned.yaml
+++ b/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/earned.yaml
@@ -4,7 +4,7 @@ values:
     - employment_income
     - self_employment_income
     - sstb_self_employment_income
-    - farm_income
+    - farm_operations_income
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/earned.yaml
+++ b/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/earned.yaml
@@ -1,0 +1,22 @@
+description: Nebraska counts these income sources as earned income under the Child Care Subsidy program.
+values:
+  2011-06-28:
+    - employment_income
+    - self_employment_income
+    - sstb_self_employment_income
+    - farm_income
+metadata:
+  unit: list
+  period: year
+  label: Nebraska Child Care Subsidy earned income sources
+  reference:
+    - title: 392 NAC 3-005.02(3), (27)-(28)
+      href: https://dhhs.ne.gov/Documents/Title-392-Complete.pdf#page=13
+    - title: Nebraska DHHS Title 392 Guidance Document, 392 NAC 2-010.01(A)
+      href: https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=3
+# 392 NAC 3-005.02B applies a standard 49% deduction to gross self-employment
+# income when the household reports at least one allowable expense. We use net
+# self-employment income at the moment because we do not track gross
+# self-employment receipts or reported expenses.
+# We do not track in-kind income received in lieu of wages (item 5) or
+# work-study income (item 4) at the moment.

--- a/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/unearned.yaml
@@ -1,0 +1,34 @@
+description: Nebraska counts these income sources as unearned income under the Child Care Subsidy program.
+values:
+  2011-06-28:
+    - applicable_ssi
+    - ne_aabd
+    - social_security
+    - dividend_income
+    - interest_income
+    - rental_income
+    - pension_income
+    - veterans_benefits
+    - strike_benefits
+    - unemployment_compensation
+    - workers_compensation
+    - child_support_received
+    - alimony_income
+metadata:
+  unit: list
+  period: year
+  label: Nebraska Child Care Subsidy unearned income sources
+  reference:
+    - title: 392 NAC 3-005.02(1)-(2), (7)-(9), (12), (16)-(19), (23)-(25)
+      href: https://dhhs.ne.gov/Documents/Title-392-Complete.pdf#page=13
+    - title: Nebraska DHHS Title 392 Guidance Document, 392 NAC 2-010.01(A)
+      href: https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=3
+# 392 NAC 3-005.03 excludes the ADC grant, earned income credits, tax refunds,
+# gifts, loans, lump-sum inheritances or insurance payments, capital gains,
+# SNAP and other federal nutrition benefits, educational grants, adoption or
+# guardianship subsidies, energy assistance, HUD or local housing assistance,
+# and military combat pay.
+# We do not track estates, trust funds, land lease income, boarder or lodger
+# payments, royalties, military allotments, contributions, lump-sum payments,
+# annuities, or payments by an absent parent for child care, rent, or house
+# payments (items 10-11, 13-15, 18, 20-22, 26) at the moment.

--- a/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/sources/unearned.yaml
@@ -2,7 +2,6 @@ description: Nebraska counts these income sources as unearned income under the C
 values:
   2011-06-28:
     - applicable_ssi
-    - ne_aabd
     - social_security
     - dividend_income
     - interest_income
@@ -19,10 +18,14 @@ metadata:
   period: year
   label: Nebraska Child Care Subsidy unearned income sources
   reference:
-    - title: 392 NAC 3-005.02(1)-(2), (7)-(9), (12), (16)-(19), (23)-(25)
+    - title: 392 NAC 3-005.02(1), (7)-(9), (12), (16)-(19), (23)-(25)
       href: https://dhhs.ne.gov/Documents/Title-392-Complete.pdf#page=13
     - title: Nebraska DHHS Title 392 Guidance Document, 392 NAC 2-010.01(A)
       href: https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=3
+# We do not include AABD payments (item 2) at the moment to avoid a circular
+# dependency — `ne_aabd`'s standard of need depends on `housing_cost`, which
+# depends on `housing_assistance`, which depends on TANF, which deducts
+# childcare expenses net of child care subsidies (including this program).
 # 392 NAC 3-005.03 excludes the ADC grant, earned income credits, tax refunds,
 # gifts, loans, lump-sum inheritances or insurance payments, capital gains,
 # SNAP and other federal nutrition benefits, educational grants, adoption or

--- a/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/student_earner_age_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/income/student_earner_age_threshold.yaml
@@ -1,0 +1,10 @@
+description: Nebraska excludes the earnings of in-school children at or below this age from countable income under the Child Care Subsidy program.
+values:
+  2009-03-10: 18
+metadata:
+  unit: year
+  period: year
+  label: Nebraska Child Care Subsidy student earner age threshold
+  reference:
+    - title: 392 NAC 3-005.03(17)
+      href: https://dhhs.ne.gov/Documents/Title-392-Complete.pdf#page=16

--- a/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ne/dhhs/child_care_subsidy/rate.yaml
@@ -1,4 +1,4 @@
-description: Nebraska obligates families participating in the child care subsidy program to pay childcare expenses of this fraction of income excess over federal poverty guidelines. 
+description: Nebraska sets the child care family fee to this share of household gross income under the Child Care Subsidy program.
 
 values:
   2021-08-28: 0.07
@@ -10,3 +10,5 @@ metadata:
   reference:
     - title: Nebraska DHHS, Department of Health and Human Services, LB 485 FAQ
       href: https://dhhs.ne.gov/Child%20Care%20Documents/LB%20485%20FAQ.pdf#page=4
+    - title: Nebraska DHHS Title 392 Guidance Document, 392 NAC 2-011
+      href: https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=4

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy.yaml
@@ -4,7 +4,7 @@
     ne_child_care_subsidy_eligible: true
     spm_unit_pre_subsidy_childcare_expenses: 50
     spm_unit_fpg: 100
-    spm_unit_net_income: 100
+    ne_child_care_subsidy_countable_income: 100
     state_code: NE
   output:
     ne_child_care_subsidy: 50
@@ -15,7 +15,7 @@
     ne_child_care_subsidy_eligible: true
     spm_unit_pre_subsidy_childcare_expenses: 50
     spm_unit_fpg: 100
-    spm_unit_net_income: 200
+    ne_child_care_subsidy_countable_income: 200
     state_code: NE
   output:
     ne_child_care_subsidy: 36 # 50 - 0.07 * 200
@@ -26,7 +26,7 @@
     ne_child_care_subsidy_eligible: true
     spm_unit_pre_subsidy_childcare_expenses: 50
     spm_unit_fpg: 100
-    spm_unit_net_income: 2_000
+    ne_child_care_subsidy_countable_income: 2_000
     state_code: NE
   output:
     ne_child_care_subsidy: 0 # 50 - 0.07 * 2000 < 0
@@ -37,7 +37,7 @@
     ne_child_care_subsidy_eligible: false
     spm_unit_pre_subsidy_childcare_expenses: 50
     spm_unit_fpg: 100
-    spm_unit_net_income: 100
+    ne_child_care_subsidy_countable_income: 100
     state_code: NE
   output:
     ne_child_care_subsidy: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_countable_income.yaml
@@ -123,3 +123,21 @@
   output:
     # max(-5,000 + 2,000, 0)
     ne_child_care_subsidy_countable_income: 0
+
+- name: Case 7, active farm operations income counts.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        farm_operations_income: 18_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: NE
+  output:
+    ne_child_care_subsidy_countable_income: 18_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_countable_income.yaml
@@ -1,0 +1,125 @@
+- name: Case 1, adult earnings and SSI both count.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 20_000
+        ssi: 5_000
+      person2:
+        age: 8
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NE
+  output:
+    # 20,000 employment income + 5,000 SSI
+    ne_child_care_subsidy_countable_income: 25_000
+
+- name: Case 2, earnings of an in-school child age 18 or younger are excluded.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income: 30_000
+      person2:
+        age: 17
+        is_in_k12_school: true
+        employment_income: 6_000
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NE
+  output:
+    # Only the parent's 30,000; the in-school child's 6,000 is excluded
+    ne_child_care_subsidy_countable_income: 30_000
+
+- name: Case 3, earnings of an out-of-school child are counted.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 35
+        employment_income: 30_000
+      person2:
+        age: 17
+        is_in_k12_school: false
+        employment_income: 6_000
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NE
+  output:
+    # 30,000 + 6,000
+    ne_child_care_subsidy_countable_income: 36_000
+
+- name: Case 4, capital gains are excluded.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        long_term_capital_gains: 10_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: NE
+  output:
+    ne_child_care_subsidy_countable_income: 0
+
+- name: Case 5, unearned sources count.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        unemployment_compensation: 4_000
+        child_support_received: 3_600
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: NE
+  output:
+    # 4,000 unemployment compensation + 3,600 child support
+    ne_child_care_subsidy_countable_income: 7_600
+
+- name: Case 6, a self-employment loss does not produce negative countable income.
+  period: 2024
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        self_employment_income: -5_000
+        unemployment_compensation: 2_000
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: NE
+  output:
+    # max(-5,000 + 2,000, 0)
+    ne_child_care_subsidy_countable_income: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_income_eligible.yaml
@@ -2,7 +2,7 @@
   period: 2024
   input:
     spm_unit_fpg: 100
-    adjusted_gross_income: 185
+    ne_child_care_subsidy_countable_income: 185
     state_code: NE
   output:
     ne_child_care_subsidy_income_eligible: true
@@ -11,7 +11,7 @@
   period: 2024
   input:
     spm_unit_fpg: 100
-    adjusted_gross_income: 183
+    ne_child_care_subsidy_countable_income: 183
     state_code: NE
   output:
     ne_child_care_subsidy_income_eligible: true
@@ -20,7 +20,7 @@
   period: 2024
   input:
     spm_unit_fpg: 100
-    adjusted_gross_income: 186
+    ne_child_care_subsidy_countable_income: 186
     state_code: NE
   output:
     ne_child_care_subsidy_income_eligible: false

--- a/policyengine_us/variables/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy.py
+++ b/policyengine_us/variables/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy.py
@@ -7,12 +7,13 @@ class ne_child_care_subsidy(Variable):
     entity = SPMUnit
     label = "Nebraska Child Care Subsidy"
     definition_period = YEAR
+    reference = "https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=4"
     defined_for = "ne_child_care_subsidy_eligible"
 
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.ne.dhhs.child_care_subsidy
         childcare_expenses = spm_unit("spm_unit_pre_subsidy_childcare_expenses", period)
-        income = spm_unit("spm_unit_net_income", period)
+        income = spm_unit("ne_child_care_subsidy_countable_income", period)
         fpg = spm_unit("spm_unit_fpg", period)
         fpg_fraction = fpg * p.fpg_fraction.fee_free_limit
         income_above_fpg_fraction = income > fpg_fraction

--- a/policyengine_us/variables/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_countable_income.py
+++ b/policyengine_us/variables/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_countable_income.py
@@ -1,0 +1,27 @@
+from policyengine_us.model_api import *
+
+
+class ne_child_care_subsidy_countable_income(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "Nebraska Child Care Subsidy countable income"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://dhhs.ne.gov/Documents/Title-392-Complete.pdf#page=13",
+        "https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=3",
+    )
+    defined_for = StateCode.NE
+
+    def formula(spm_unit, period, parameters):
+        p = parameters(period).gov.states.ne.dhhs.child_care_subsidy.income
+        person = spm_unit.members
+        # 392 NAC 3-005.03(17) excludes the earnings of in-school children.
+        age = person("age", period)
+        excluded_student = person("is_in_k12_school", period) & (
+            age <= p.student_earner_age_threshold
+        )
+        earned = add(person, period, p.sources.earned)
+        countable_earned = spm_unit.sum(earned * ~excluded_student)
+        unearned = add(spm_unit, period, p.sources.unearned)
+        return max_(countable_earned + unearned, 0)

--- a/policyengine_us/variables/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_income_eligible.py
+++ b/policyengine_us/variables/gov/states/ne/dhhs/child_care_subsidy/ne_child_care_subsidy_income_eligible.py
@@ -9,12 +9,13 @@ class ne_child_care_subsidy_income_eligible(Variable):
     reference = (
         "https://nebraskalegislature.gov/laws/statutes.php?statute=68-1206",
         "https://dhhs.ne.gov/Pages/Child-Care-Parents.aspx",
+        "https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=5",
     )
     defined_for = StateCode.NE
 
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.ne.dhhs.child_care_subsidy.fpg_fraction
-        income = add(spm_unit, period, ["adjusted_gross_income"])
+        income = spm_unit("ne_child_care_subsidy_countable_income", period)
         fpg = spm_unit("spm_unit_fpg", period)
         income_limit = fpg * p.initial_eligibility
         return income <= income_limit


### PR DESCRIPTION
## Summary

Replaces both income measures in the Nebraska Child Care Subsidy model with a single gross countable income definition matching 392 NAC 3-005.02:

- **Eligibility** (`ne_child_care_subsidy_income_eligible`): previously summed federal `adjusted_gross_income` across the SPM unit.
- **Family fee** (`ne_child_care_subsidy`): previously applied the 7% fee to `spm_unit_net_income`, which counts legally excluded benefits (ADC grant, SNAP, LIHEAP, housing subsidies) and subtracts taxes and SPM expenses.

Both now use a new `ne_child_care_subsidy_countable_income` variable.

Closes #8953

## Legal basis

- [392 NAC 3-005.02](https://dhhs.ne.gov/Documents/Title-392-Complete.pdf#page=13) lists 28 countable income sources, including SSI, AABD payments, gross wages, RSDI before Medicare premium deductions, veterans' pensions, unemployment and workers' compensation, court-ordered child and spousal support, and net self-employment income.
- [392 NAC 3-005.03](https://dhhs.ne.gov/Documents/Title-392-Complete.pdf#page=15) excludes the ADC grant, EITC, tax refunds, capital gains, SNAP, LIHEAP, housing assistance, educational grants, and the earnings of a child age 18 or younger who is in school (item 17).
- [Title 392 guidance, 392 NAC 2-011](https://dhhs.ne.gov/Guidance%20Docs/Title%20392%20-%20Child%20Care%20Subsidy.pdf#page=4): "The total amount of the sliding fee assessed will be based on 7% of the household's **gross income**."

## Changes

- `ne_child_care_subsidy_countable_income` (SPMUnit, YEAR): sums parameter-listed earned sources (employment, self-employment, farm operations income) and unearned sources (`applicable_ssi`, Social Security, dividends, interest, rental income, pensions, veterans' benefits, strike benefits, unemployment compensation, workers' compensation, child support received, alimony), excluding the earned income of in-school children age 18 or younger, floored at zero.
- `ne_child_care_subsidy_income_eligible`: reads the new countable income instead of AGI.
- `ne_child_care_subsidy`: applies the 7% fee to the new countable income instead of SPM unit net income.
- `rate.yaml`: corrected description (the 7% fee applies to gross income, not to income in excess of the poverty guideline) and added the Title 392 guidance reference.

## Not modeled (documented in parameter comments)

- AABD payments (392 NAC 3-005.02, item 2) — including `ne_aabd` creates a circular dependency in microsimulation: its standard of need depends on `housing_cost` → `housing_assistance` → HUD income → TANF → childcare expenses → child care subsidies, looping back to this program.
- The 49% standard self-employment expense disregard (392 NAC 3-005.02B) — we track net rather than gross self-employment income.
- In-kind income, estates, trust funds, military allotments, contributions, and lump sums — not tracked as variables.
- The 10% gross earned income disregard after 12 continuous months and the Transitional Child Care 200% FPL / 85% SMI tiers (§68-1206(2)(b)) — pre-existing gaps listed in #8953 as related but out of scope.

## Test plan

- [x] New `ne_child_care_subsidy_countable_income.yaml` unit tests: adult earnings + SSI counted, in-school child earnings excluded, out-of-school child earnings counted, capital gains excluded, unearned sources counted, zero floor with self-employment losses, farm operations income counted.
- [x] Existing eligibility and fee tests updated to input the new countable income variable.
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)