### PR TITLE
Add snap_enrolled and use_reported_snap for partner-reported SNAP participation

### DIFF
--- a/changelog.d/head-start-snap-eligibility.fixed.md
+++ b/changelog.d/head-start-snap-eligibility.fixed.md
@@ -1,0 +1,1 @@
+Head Start categorical eligibility treats a positive computed SNAP amount as evidence of SNAP eligibility even when reported participation is false, per 45 CFR 1302.12(c)(1)(ii).

--- a/changelog.d/snap-enrolled.added.md
+++ b/changelog.d/snap-enrolled.added.md
@@ -1,1 +1,1 @@
-Add snap_enrolled and use_reported_snap so API partners can report actual SNAP participation to programs whose eligibility depends on SNAP receipt.
+Add snap_enrolled and use_reported_snap so API partners can report actual SNAP participation to programs whose eligibility depends on SNAP receipt, and applicable_snap with reported_snap_amount so programs that count SNAP benefits as income follow the reported amount.

--- a/changelog.d/snap-enrolled.added.md
+++ b/changelog.d/snap-enrolled.added.md
@@ -1,0 +1,1 @@
+Add snap_enrolled and use_reported_snap so API partners can report actual SNAP participation to programs whose eligibility depends on SNAP receipt.

--- a/changelog.d/tx-ceap-snap-receipt.fixed.md
+++ b/changelog.d/tx-ceap-snap-receipt.fixed.md
@@ -1,0 +1,1 @@
+Texas CEAP categorical eligibility keys on SNAP receipt rather than SNAP eligibility, per 42 USC 8624(b)(2)(A).

--- a/policyengine_us/parameters/gov/ed/pell_grant/efc/simplified/benefits.yaml
+++ b/policyengine_us/parameters/gov/ed/pell_grant/efc/simplified/benefits.yaml
@@ -1,7 +1,7 @@
 description: The Department of Education will used a simplified formula if a household has any of these benefits.
 values:
   2023-01-01:
-    - snap
+    - snap_enrolled
     - school_meal_net_subsidy
     - tanf
     - wic

--- a/policyengine_us/parameters/gov/fcc/lifeline/categorical_eligibility.yaml
+++ b/policyengine_us/parameters/gov/fcc/lifeline/categorical_eligibility.yaml
@@ -2,7 +2,7 @@ description: Program participation that entitles a non-tribal household to the L
 values:
   2016-12-01:
     - medicaid_enrolled
-    - snap
+    - snap_enrolled
     - ssi
     # Also not implemented:
     # - Veterans and Survivors Pension Benefit

--- a/policyengine_us/parameters/gov/local/ca/la/dwp/ez_save/income_sources.yaml
+++ b/policyengine_us/parameters/gov/local/ca/la/dwp/ez_save/income_sources.yaml
@@ -17,7 +17,7 @@ values:
     - social_security
     - ssi
     - tanf
-    - snap
+    - applicable_snap
     - veterans_benefits
     - unemployment_compensation
     - pension_income

--- a/policyengine_us/parameters/gov/states/ca/cpuc/care/eligibility/categorical.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cpuc/care/eligibility/categorical.yaml
@@ -3,7 +3,7 @@ values:
   2022-06-01:
     - medicaid_enrolled
     - wic
-    - snap
+    - snap_enrolled
     - ssi
     # Also these, not in our model:
     # NSL

--- a/policyengine_us/parameters/gov/states/ca/cpuc/income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/ca/cpuc/income_sources.yaml
@@ -28,7 +28,7 @@ values:
   # Public assistance payments
   - tanf
   - ssi
-  - snap
+  - applicable_snap
   - wic
   # Social Security
   - social_security

--- a/policyengine_us/parameters/gov/states/ma/dot/mbta/income_eligible_reduced_fares/applicable_programs.yaml
+++ b/policyengine_us/parameters/gov/states/ma/dot/mbta/income_eligible_reduced_fares/applicable_programs.yaml
@@ -3,7 +3,7 @@ values:
   2024-01-01:
     - ma_eaedc
     - ma_tafdc
-    - snap
+    - snap_enrolled
     # Medicaid includes MassHealth CarePlus, MassHealth Family Assistance,
     # MassHealth Limited, and MassHealth Standard
     - medicaid_enrolled

--- a/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/income/disallowed_deductions.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/income/disallowed_deductions.yaml
@@ -5,7 +5,7 @@ values:
     - tax_exempt_unemployment_compensation
     - tax_exempt_pension_income
     - tax_exempt_interest_income
-    - snap
+    - applicable_snap
     - ssi
     - ma_state_supplement
     - tanf

--- a/policyengine_us/parameters/gov/states/tx/dart/qualifying_programs.yaml
+++ b/policyengine_us/parameters/gov/states/tx/dart/qualifying_programs.yaml
@@ -5,7 +5,7 @@ values:
     - medicaid_enrolled
     - is_medicare_eligible # medicare
     - wic
-    - snap
+    - snap_enrolled
     - tanf
     # Comprehensive Energy Assistance Program (CEAP)
     # Housing Choice Voucher Program (Section 8)

--- a/policyengine_us/parameters/gov/usda/school_meals/categorical_eligibility.yaml
+++ b/policyengine_us/parameters/gov/usda/school_meals/categorical_eligibility.yaml
@@ -2,7 +2,7 @@ description: Program participation that qualifies families for free school meals
 
 values:
   2009-09-01:
-    - snap # Supplemental Nutrition Assistance Program.
+    - snap_enrolled # Supplemental Nutrition Assistance Program.
     - tanf # Temporary Assistance to Needy Families. Currently only available in CA and IL.
     - fdpir # Food Distribution Program on Indian Reservations.
     - was_in_foster_care

--- a/policyengine_us/tests/policy/baseline/gov/hhs/head_start/is_head_start_categorically_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/head_start/is_head_start_categorically_eligible.yaml
@@ -164,3 +164,19 @@
     # 140% FPL for 2-person household in 2024
     # Computed SNAP > 0 at this income, making family categorically eligible
     is_head_start_categorically_eligible: [true, true]
+
+- name: Case 10, computed SNAP receipt qualifies even when participation is not reported.
+  period: 2024
+  input:
+    use_reported_snap: true
+    receives_snap: false
+    tanf: 0
+    ssi: 0
+    # A positive computed SNAP amount is evidence of SNAP eligibility, which
+    # 45 CFR 1302.12(c)(1)(ii) requires; reported non-participation does not
+    # remove it.
+    snap: 200
+    is_homeless: false
+    was_in_foster_care: false
+  output:
+    is_head_start_categorically_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tdhca/ceap/tx_ceap_eligible.yaml
@@ -17,7 +17,6 @@
     employment_income: 60_000
     spm_unit_size: 4
     state_code: TX
-    is_snap_eligible: false
   output:
     tx_ceap_eligible: false
 
@@ -60,17 +59,45 @@
     employment_income: 50_000
     spm_unit_size: 4
     state_code: TX
-    is_snap_eligible: false
+    # This income passes the TX 165% FPG BBCE limit, so SNAP computes a
+    # small positive allotment; the household does not participate.
+    snap: 0
   output:
     tx_ceap_eligible: false
 
-- name: Case 7, SNAP-eligible household above income limit is categorically eligible.
+- name: Case 7, household receiving SNAP above the income limit is categorically eligible.
   absolute_error_margin: 0.1
   period: 2024
   input:
     employment_income: 80_000
     spm_unit_size: 1
     state_code: TX
-    is_snap_eligible: true
+    # 42 USC 8624(b)(2)(A) keys on receiving SNAP, not SNAP eligibility.
+    snap: 2_400
   output:
     tx_ceap_eligible: true
+
+- name: Case 8, reported SNAP participation grants categorical eligibility.
+  absolute_error_margin: 0.1
+  period: 2024
+  input:
+    employment_income: 80_000
+    spm_unit_size: 1
+    state_code: TX
+    use_reported_snap: true
+    receives_snap: true
+  output:
+    tx_ceap_eligible: true
+
+- name: Case 9, reported non-participation removes the categorical route.
+  absolute_error_margin: 0.1
+  period: 2024
+  input:
+    employment_income: 80_000
+    spm_unit_size: 1
+    state_code: TX
+    use_reported_snap: true
+    receives_snap: false
+    snap: 2_400
+  output:
+    tx_ceap_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/school_meals/meets_school_meal_categorical_eligibility.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/school_meals/meets_school_meal_categorical_eligibility.yaml
@@ -90,3 +90,34 @@
       is_homeless: [False, False, True, True, False, False, False, False]
   output:
       meets_school_meal_categorical_eligibility: [True, True, True, True, False, False, False, False]
+
+- name: Reported SNAP participation qualifies despite a zero calculated amount.
+  period: 2025
+  input:
+      use_reported_snap: true
+      receives_snap: true
+      snap: 0
+      tanf: 0
+      fdpir: 0
+      was_in_foster_care: false
+      is_homeless: false
+      is_runaway_child: false
+      is_migratory_child: false
+      is_head_start_eligible: false
+  output:
+      meets_school_meal_categorical_eligibility: true
+
+- name: Reported non-participation overrides a positive calculated SNAP amount.
+  period: 2025
+  input:
+      use_reported_snap: true
+      snap: 1
+      tanf: 0
+      fdpir: 0
+      was_in_foster_care: false
+      is_homeless: false
+      is_runaway_child: false
+      is_migratory_child: false
+      is_head_start_eligible: false
+  output:
+      meets_school_meal_categorical_eligibility: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/applicable_snap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/applicable_snap.yaml
@@ -6,11 +6,12 @@
   output:
     applicable_snap: 3_600
 
-- name: Case 2, uses the reported amount when provided.
+- name: Case 2, uses the reported amount when participating.
   period: 2025
   absolute_error_margin: 0.01
   input:
     use_reported_snap: true
+    receives_snap: true
     reported_snap_amount: 5_000
     snap: 3_600
   output:
@@ -36,11 +37,22 @@
   output:
     applicable_snap: 0
 
-- name: Case 5, the reported amount wins even without the participation flag.
+- name: Case 5, a reported amount alone does not count without the participation flag.
   period: 2025
   absolute_error_margin: 0.01
   input:
     use_reported_snap: true
     reported_snap_amount: 5_000
   output:
-    applicable_snap: 5_000
+    applicable_snap: 0
+
+- name: Case 6, reported non-participation wins over a reported amount.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    use_reported_snap: true
+    receives_snap: false
+    reported_snap_amount: 5_000
+    snap: 3_600
+  output:
+    applicable_snap: 0

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/applicable_snap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/applicable_snap.yaml
@@ -1,0 +1,46 @@
+- name: Case 1, defaults to calculated SNAP when use_reported_snap is false.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    snap: 3_600
+  output:
+    applicable_snap: 3_600
+
+- name: Case 2, uses the reported amount when provided.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    use_reported_snap: true
+    reported_snap_amount: 5_000
+    snap: 3_600
+  output:
+    applicable_snap: 5_000
+
+- name: Case 3, falls back to calculated SNAP when participating without a reported amount.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    use_reported_snap: true
+    receives_snap: true
+    # snap is month-defined, so this is January's amount.
+    snap: 300
+  output:
+    applicable_snap: 300
+
+- name: Case 4, zero when neither a reported amount nor participation is provided.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    use_reported_snap: true
+    snap: 3_600
+  output:
+    applicable_snap: 0
+
+- name: Case 5, the reported amount wins even without the participation flag.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    use_reported_snap: true
+    reported_snap_amount: 5_000
+  output:
+    applicable_snap: 5_000

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_enrolled.yaml
@@ -37,3 +37,36 @@
     snap: 0
   output:
     snap_enrolled: true
+
+- name: Case 6, a positive reported amount counts as participation.
+  period: 2025-01
+  input:
+    use_reported_snap: true
+    reported_snap_amount: 1_200
+    snap: 0
+  output:
+    snap_enrolled: true
+
+- name: Case 7, reported non-participation does not change the computed snap amount.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    state_code: TX
+    employment_income: 0
+    use_reported_snap: true
+    receives_snap: false
+  output:
+    snap: 292
+    snap_enrolled: false
+
+- name: Case 8, reported participation does not add dollars to the computed snap amount.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    state_code: TX
+    employment_income: 120_000
+    use_reported_snap: true
+    receives_snap: true
+  output:
+    snap: 0
+    snap_enrolled: true

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_enrolled.yaml
@@ -38,14 +38,14 @@
   output:
     snap_enrolled: true
 
-- name: Case 6, a positive reported amount counts as participation.
+- name: Case 6, a reported amount alone does not count as participation.
   period: 2025-01
   input:
     use_reported_snap: true
     reported_snap_amount: 1_200
     snap: 0
   output:
-    snap_enrolled: true
+    snap_enrolled: false
 
 - name: Case 7, reported non-participation does not change the computed snap amount.
   period: 2025-01

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_enrolled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_enrolled.yaml
@@ -1,0 +1,39 @@
+- name: Case 1, defaults to calculated SNAP participation when use_reported_snap is false.
+  period: 2025-01
+  input:
+    snap: 200
+  output:
+    snap_enrolled: true
+
+- name: Case 2, not enrolled by default when the calculated SNAP amount is zero.
+  period: 2025-01
+  input:
+    snap: 0
+  output:
+    snap_enrolled: false
+
+- name: Case 3, reported participation wins over a zero calculated amount.
+  period: 2025-01
+  input:
+    use_reported_snap: true
+    receives_snap: true
+    snap: 0
+  output:
+    snap_enrolled: true
+
+- name: Case 4, a positive calculated amount is ignored when participation is not reported.
+  period: 2025-01
+  input:
+    use_reported_snap: true
+    snap: 200
+  output:
+    snap_enrolled: false
+
+- name: Case 5, reported participation applies over the whole year.
+  period: 2025
+  input:
+    use_reported_snap: true
+    receives_snap: true
+    snap: 0
+  output:
+    snap_enrolled: true

--- a/policyengine_us/variables/gov/hhs/head_start/is_head_start_categorically_eligible.py
+++ b/policyengine_us/variables/gov/hhs/head_start/is_head_start_categorically_eligible.py
@@ -17,9 +17,13 @@ class is_head_start_categorically_eligible(Variable):
             "was_in_foster_care", period
         )
 
-        # Family-level: family eligible for public assistance (aggregated at spm_unit)
+        # Family-level: family eligible for public assistance (aggregated at
+        # spm_unit). 45 CFR 1302.12(c)(1)(ii) requires only eligibility for
+        # public assistance, so a positive computed SNAP amount qualifies as
+        # evidence of eligibility even when reported participation is false;
+        # snap_enrolled additionally captures reported participation.
         family_eligible = (
-            add(person.spm_unit, period, ["tanf", "ssi", "snap_enrolled"]) > 0
-        )
+            add(person.spm_unit, period, ["tanf", "ssi", "snap"]) > 0
+        ) | person.spm_unit("snap_enrolled", period)
 
         return family_eligible | person_eligible

--- a/policyengine_us/variables/gov/hhs/head_start/is_head_start_categorically_eligible.py
+++ b/policyengine_us/variables/gov/hhs/head_start/is_head_start_categorically_eligible.py
@@ -18,6 +18,8 @@ class is_head_start_categorically_eligible(Variable):
         )
 
         # Family-level: family eligible for public assistance (aggregated at spm_unit)
-        family_eligible = add(person.spm_unit, period, ["tanf", "ssi", "snap"]) > 0
+        family_eligible = (
+            add(person.spm_unit, period, ["tanf", "ssi", "snap_enrolled"]) > 0
+        )
 
         return family_eligible | person_eligible

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_community_engagement_pass_through_eligible.py
@@ -13,7 +13,7 @@ class medicaid_community_engagement_pass_through_eligible(Variable):
 
     def formula(person, period, parameters):
         snap_work = parameters(period).gov.usda.snap.work_requirements
-        snap = person.spm_unit("snap", period) > 0
+        snap = person.spm_unit("snap_enrolled", period)
         tanf = person.spm_unit("is_tanf_enrolled", period)
 
         age = person("monthly_age", period)

--- a/policyengine_us/variables/gov/states/id/tax/income/credits/grocery/eligible/id_grocery_credit_qualifying_month.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/credits/grocery/eligible/id_grocery_credit_qualifying_month.py
@@ -13,6 +13,6 @@ class id_grocery_credit_qualifying_month(Variable):
     )
 
     def formula(person, period, parameters):
-        snap_received = person.spm_unit("snap", period) > 0
+        snap_received = person.spm_unit("snap_enrolled", period)
         # Incarcerated people are not eligible for the grocery credit
         return ~person("is_incarcerated", period) & ~snap_received

--- a/policyengine_us/variables/gov/states/il/tollway/ipass_assist/il_ipass_assist_categorical_eligible.py
+++ b/policyengine_us/variables/gov/states/il/tollway/ipass_assist/il_ipass_assist_categorical_eligible.py
@@ -14,6 +14,6 @@ class il_ipass_assist_categorical_eligible(Variable):
 
     def formula(spm_unit, period, parameters):
         # IL Tollway: eligible if "currently participating in SNAP or TANF"
-        snap = spm_unit("snap", period) > 0
+        snap = spm_unit("snap_enrolled", period)
         tanf = spm_unit("il_tanf", period) > 0
         return snap | tanf

--- a/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_eligible.py
+++ b/policyengine_us/variables/gov/states/tx/tdhca/ceap/tx_ceap_eligible.py
@@ -34,7 +34,7 @@ class tx_ceap_eligible(Variable):
         # Categorical eligibility per 42 USC 8624(b)(2)(A)
         # and FY 2024 State Plan Section 1.4
         tanf = spm_unit("is_tanf_enrolled", period)
-        snap = spm_unit("is_snap_eligible", period)
+        snap = spm_unit("snap_enrolled", period)
         person = spm_unit.members
         ssi = spm_unit.any(person("is_ssi_eligible", period))
         categorically_eligible = tanf | snap | ssi

--- a/policyengine_us/variables/gov/states/wa/dcyf/eceap/birth_to_three_eceap/wa_birth_to_three_eceap_eligible.py
+++ b/policyengine_us/variables/gov/states/wa/dcyf/eceap/birth_to_three_eceap/wa_birth_to_three_eceap_eligible.py
@@ -14,8 +14,8 @@ class wa_birth_to_three_eceap_eligible(Variable):
         # categorical pathway is Basic Food (federal SNAP or state FAP); it
         # does NOT include the homeless or IEP pathways from standard ECEAP.
         # FAP serves SNAP-ineligible legal immigrants and is not modeled
-        # separately at the moment, so we use SNAP eligibility or an
-        # explicitly provided SNAP benefit as the proxy for receipt.
+        # separately at the moment, so we use SNAP eligibility or SNAP
+        # enrollment (computed or reported) as the proxy for receipt.
         #
         # Early Head Start coordination: DCYF ECEAP Performance Standards
         # PAO-38(10) prohibit simultaneous enrollment in B-3 ECEAP and Early
@@ -29,5 +29,5 @@ class wa_birth_to_three_eceap_eligible(Variable):
         age_eligible = person("wa_birth_to_three_eceap_age_eligible", period)
         income_eligible = person("wa_birth_to_three_eceap_income_eligible", period)
         snap_eligible = person.spm_unit("is_snap_eligible", period)
-        snap_receipt = person.spm_unit("snap", period) > 0
+        snap_receipt = person.spm_unit("snap_enrolled", period)
         return age_eligible & (income_eligible | snap_eligible | snap_receipt)

--- a/policyengine_us/variables/gov/usda/snap/applicable_snap.py
+++ b/policyengine_us/variables/gov/usda/snap/applicable_snap.py
@@ -10,10 +10,10 @@ class applicable_snap(Variable):
     documentation = (
         "SNAP amount to use when another program counts SNAP benefits as "
         "income. Usually this is the calculated snap amount. If "
-        "use_reported_snap is True, a positive reported_snap_amount is "
-        "used first. If no positive reported amount is provided but "
-        "receives_snap is True, this uses the calculated snap amount. "
-        "If neither is provided, this is zero."
+        "use_reported_snap is True, receives_snap controls: when True, a "
+        "positive reported_snap_amount is used if provided and the "
+        "calculated snap amount otherwise; when False, this is zero "
+        "regardless of any reported amount."
     )
 
     def formula(spm_unit, period, parameters):
@@ -21,5 +21,5 @@ class applicable_snap(Variable):
         reported = spm_unit("reported_snap_amount", period)
         enrolled = spm_unit("receives_snap", period)
         computed = spm_unit("snap", period)
-        reported_value = where(reported > 0, reported, enrolled * computed)
+        reported_value = enrolled * where(reported > 0, reported, computed)
         return where(use_reported, reported_value, computed)

--- a/policyengine_us/variables/gov/usda/snap/applicable_snap.py
+++ b/policyengine_us/variables/gov/usda/snap/applicable_snap.py
@@ -1,0 +1,25 @@
+from policyengine_us.model_api import *
+
+
+class applicable_snap(Variable):
+    value_type = float
+    entity = SPMUnit
+    definition_period = MONTH
+    unit = USD
+    label = "Applicable SNAP for program income tests"
+    documentation = (
+        "SNAP amount to use when another program counts SNAP benefits as "
+        "income. Usually this is the calculated snap amount. If "
+        "use_reported_snap is True, a positive reported_snap_amount is "
+        "used first. If no positive reported amount is provided but "
+        "receives_snap is True, this uses the calculated snap amount. "
+        "If neither is provided, this is zero."
+    )
+
+    def formula(spm_unit, period, parameters):
+        use_reported = spm_unit("use_reported_snap", period.this_year)
+        reported = spm_unit("reported_snap_amount", period)
+        enrolled = spm_unit("receives_snap", period)
+        computed = spm_unit("snap", period)
+        reported_value = where(reported > 0, reported, enrolled * computed)
+        return where(use_reported, reported_value, computed)

--- a/policyengine_us/variables/gov/usda/snap/reported_snap_amount.py
+++ b/policyengine_us/variables/gov/usda/snap/reported_snap_amount.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class reported_snap_amount(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "Reported SNAP amount"
+    unit = USD
+    definition_period = YEAR
+    documentation = (
+        "Amount of Supplemental Nutrition Assistance Program benefits the "
+        "household reports receiving. API partner input; programs only "
+        "count this amount when use_reported_snap is True, and the "
+        "calculated snap variable is never affected. See applicable_snap."
+    )

--- a/policyengine_us/variables/gov/usda/snap/snap_enrolled.py
+++ b/policyengine_us/variables/gov/usda/snap/snap_enrolled.py
@@ -10,16 +10,14 @@ class snap_enrolled(Variable):
         "Whether the SPM unit participates in SNAP, for programs whose "
         "eligibility depends on SNAP receipt. Usually this is whether "
         "the calculated snap amount is positive. If use_reported_snap "
-        "is True, the reported receives_snap input (or a positive "
-        "reported_snap_amount) is used instead and the calculated snap "
-        "amount is ignored. The snap variable itself is never affected."
+        "is True, the reported receives_snap input is used instead and "
+        "the calculated snap amount is ignored. The snap variable "
+        "itself is never affected."
     )
     reference = "https://www.law.cornell.edu/uscode/text/7/2020"
 
     def formula(spm_unit, period, parameters):
         use_reported = spm_unit("use_reported_snap", period.this_year)
-        reported_participation = spm_unit("receives_snap", period)
-        reported_amount = spm_unit("reported_snap_amount", period)
-        reported = reported_participation | (reported_amount > 0)
+        reported = spm_unit("receives_snap", period)
         computed = spm_unit("snap", period) > 0
         return where(use_reported, reported, computed)

--- a/policyengine_us/variables/gov/usda/snap/snap_enrolled.py
+++ b/policyengine_us/variables/gov/usda/snap/snap_enrolled.py
@@ -1,0 +1,23 @@
+from policyengine_us.model_api import *
+
+
+class snap_enrolled(Variable):
+    value_type = bool
+    entity = SPMUnit
+    definition_period = MONTH
+    label = "SNAP enrolled"
+    documentation = (
+        "Whether the SPM unit participates in SNAP, for programs whose "
+        "eligibility depends on SNAP receipt. Usually this is whether "
+        "the calculated snap amount is positive. If use_reported_snap "
+        "is True, the reported receives_snap input is used instead and "
+        "the calculated snap amount is ignored. The snap variable "
+        "itself is never affected."
+    )
+    reference = "https://www.law.cornell.edu/uscode/text/7/2017"
+
+    def formula(spm_unit, period, parameters):
+        use_reported = spm_unit("use_reported_snap", period.this_year)
+        reported = spm_unit("receives_snap", period)
+        computed = spm_unit("snap", period) > 0
+        return where(use_reported, reported, computed)

--- a/policyengine_us/variables/gov/usda/snap/snap_enrolled.py
+++ b/policyengine_us/variables/gov/usda/snap/snap_enrolled.py
@@ -10,14 +10,16 @@ class snap_enrolled(Variable):
         "Whether the SPM unit participates in SNAP, for programs whose "
         "eligibility depends on SNAP receipt. Usually this is whether "
         "the calculated snap amount is positive. If use_reported_snap "
-        "is True, the reported receives_snap input is used instead and "
-        "the calculated snap amount is ignored. The snap variable "
-        "itself is never affected."
+        "is True, the reported receives_snap input (or a positive "
+        "reported_snap_amount) is used instead and the calculated snap "
+        "amount is ignored. The snap variable itself is never affected."
     )
-    reference = "https://www.law.cornell.edu/uscode/text/7/2017"
+    reference = "https://www.law.cornell.edu/uscode/text/7/2020"
 
     def formula(spm_unit, period, parameters):
         use_reported = spm_unit("use_reported_snap", period.this_year)
-        reported = spm_unit("receives_snap", period)
+        reported_participation = spm_unit("receives_snap", period)
+        reported_amount = spm_unit("reported_snap_amount", period)
+        reported = reported_participation | (reported_amount > 0)
         computed = spm_unit("snap", period) > 0
         return where(use_reported, reported, computed)

--- a/policyengine_us/variables/gov/usda/snap/use_reported_snap.py
+++ b/policyengine_us/variables/gov/usda/snap/use_reported_snap.py
@@ -6,10 +6,13 @@ class use_reported_snap(Variable):
     entity = SPMUnit
     definition_period = YEAR
     default_value = False
-    label = "Use reported SNAP participation in program eligibility tests"
+    label = "Use reported SNAP in program eligibility and income tests"
     documentation = (
-        "When True, programs that check snap_enrolled use the reported "
-        "receives_snap input instead of the calculated snap amount. This "
-        "lets API partners pass through actual SNAP participation while "
-        "still receiving the calculated snap entitlement as an output."
+        "API partner opt-in toggle for reported SNAP. When True, programs "
+        "that check snap_enrolled use the reported receives_snap input (or "
+        "a positive reported_snap_amount) instead of the calculated snap "
+        "amount, and programs that count SNAP benefits as income use "
+        "applicable_snap. This lets API partners pass through actual SNAP "
+        "participation while still receiving the calculated snap "
+        "entitlement as an output."
     )

--- a/policyengine_us/variables/gov/usda/snap/use_reported_snap.py
+++ b/policyengine_us/variables/gov/usda/snap/use_reported_snap.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class use_reported_snap(Variable):
+    value_type = bool
+    entity = SPMUnit
+    definition_period = YEAR
+    default_value = False
+    label = "Use reported SNAP participation in program eligibility tests"
+    documentation = (
+        "When True, programs that check snap_enrolled use the reported "
+        "receives_snap input instead of the calculated snap amount. This "
+        "lets API partners pass through actual SNAP participation while "
+        "still receiving the calculated snap entitlement as an output."
+    )

--- a/policyengine_us/variables/gov/usda/snap/use_reported_snap.py
+++ b/policyengine_us/variables/gov/usda/snap/use_reported_snap.py
@@ -9,10 +9,9 @@ class use_reported_snap(Variable):
     label = "Use reported SNAP in program eligibility and income tests"
     documentation = (
         "API partner opt-in toggle for reported SNAP. When True, programs "
-        "that check snap_enrolled use the reported receives_snap input (or "
-        "a positive reported_snap_amount) instead of the calculated snap "
-        "amount, and programs that count SNAP benefits as income use "
-        "applicable_snap. This lets API partners pass through actual SNAP "
-        "participation while still receiving the calculated snap "
-        "entitlement as an output."
+        "that check snap_enrolled use the reported receives_snap input "
+        "instead of the calculated snap amount, and programs that count "
+        "SNAP benefits as income use applicable_snap. This lets API "
+        "partners pass through actual SNAP participation while still "
+        "receiving the calculated snap entitlement as an output."
     )

--- a/policyengine_us/variables/gov/usda/wic/meets_wic_categorical_eligibility.py
+++ b/policyengine_us/variables/gov/usda/wic/meets_wic_categorical_eligibility.py
@@ -12,7 +12,7 @@ class meets_wic_categorical_eligibility(Variable):
     def formula(person, period, parameters):
         spm_unit = person.spm_unit
         # https://www.law.cornell.edu/uscode/text/42/1786#d_2_A_ii
-        receives_snap_or_tanf = add(spm_unit, period, ["snap", "tanf"]) > 0
+        receives_snap_or_tanf = add(spm_unit, period, ["snap_enrolled", "tanf"]) > 0
         # https://www.law.cornell.edu/uscode/text/42/1786#d_2_A_iii
         receives_medicaid = person("medicaid_enrolled", period)
         # "is a member of a family in which a pregnant woman or an infant receives [Medicaid]."


### PR DESCRIPTION
## Summary

Adds a reported-SNAP mechanism for API partners: `snap_enrolled` (a boolean gate for programs that depend on SNAP *receipt*) and `applicable_snap` (a dollar amount for programs that count SNAP benefits as *income*), driven by the partner inputs `use_reported_snap`, `receives_snap`, and `reported_snap_amount`.

Closes #8959

This is the SNAP counterpart of `applicable_ssi` (#8951) and `applicable_tanf` (#8957), with one deliberate difference: **the calculated `snap` is never overridden.** Partners request `snap` as an output (PolicyEngine computes the entitlement), so it stays a pure output; only the downstream consumers switch to the wrapper variables.

## Partner contract

`receives_snap` is authoritative when the toggle is on: a reported amount only refines the dollar figure once participation is affirmed, and can never create participation by itself.

| Partner sends (`use_reported_snap: true`) | `snap_enrolled` (receipt gates) | `applicable_snap` (income tests) |
|---|---|---|
| `receives_snap: true` + `reported_snap_amount` | `true` | reported amount |
| `receives_snap: true` only | `true`, even if calculated `snap` is $0 | calculated `snap` |
| `receives_snap: false` (any amount ignored) | `false`, even if calculated `snap` is positive | 0 |
| neither flag nor amount | `false` | 0 |
| **Toggle omitted** (default; web app and all microsimulation) | `snap > 0` | calculated `snap` — identical to prior behavior |

## New variables

| Variable | Entity | Period | Type | Role |
|---|---|---|---|---|
| `use_reported_snap` | SPMUnit | YEAR | bool, default `false` | Opt-in toggle |
| `snap_enrolled` | SPMUnit | MONTH | bool | Receipt gate read by downstream programs |
| `reported_snap_amount` | SPMUnit | YEAR | USD | Reported dollar channel |
| `applicable_snap` | SPMUnit | MONTH | USD | SNAP-as-income amount |

(`receives_snap` — SPMUnit/MONTH bool input — already existed; it becomes the reported-participation channel.)

## Receipt gates switched to `snap_enrolled`

| Consumer | Change |
|---|---|
| `gov/usda/school_meals/categorical_eligibility.yaml` | list entry (SUN Bucks flows through school meals) |
| `meets_wic_categorical_eligibility` | `add(spm_unit, period, ["snap_enrolled", "tanf"]) > 0` |
| `gov/fcc/lifeline/categorical_eligibility.yaml` | list entry (also feeds ACP) |
| `gov/ed/pell_grant/efc/simplified/benefits.yaml` | list entry |
| `gov/states/ca/cpuc/care/eligibility/categorical.yaml` | list entry |
| `gov/states/tx/dart/qualifying_programs.yaml` | list entry |
| `gov/states/ma/dot/mbta/.../applicable_programs.yaml` | list entry |
| `il_ipass_assist_categorical_eligible` | direct read |
| `medicaid_community_engagement_pass_through_eligible` | direct read |
| `id_grocery_credit_qualifying_month` | was `snap > 0`; negative gate — SNAP receipt disqualifies the month (Idaho Code 63-3024A) |
| `wa_birth_to_three_eceap_eligible` | was `snap > 0`; Basic Food receipt pathway |
| `tx_ceap_eligible` | was `is_snap_eligible`; 42 USC 8624(b)(2)(A) keys on *receiving* SNAP |

## Head Start uses an eligibility standard, not receipt

45 CFR 1302.12(c)(1)(ii) requires only that the family be **eligible for** public assistance, so `is_head_start_categorically_eligible` uses `snap > 0 | snap_enrolled`: computed and reported are independent grants, and reported non-participation cannot veto a positive computed amount (eligibility is a legal computation; participation reports can't falsify it).

Rule of thumb encoded in this PR: **"receiving/participates" statutes → `snap_enrolled` alone** (reported replaces computed); **"eligible for" statutes → `snap > 0 | snap_enrolled`** (either grants, neither vetoes).

## Income tests switched to `applicable_snap`

The three programs that count SNAP dollars as income, each verified against its primary source (CalFresh/food stamps are countable income in all three):

- `gov/states/ca/cpuc/income_sources.yaml` (CARE/FERA)
- `gov/local/ca/la/dwp/ez_save/income_sources.yaml`
- MA Senior Circuit Breaker `disallowed_deductions.yaml`

## Kept on calculated `snap` (by design)

| Where | Why |
|---|---|
| `spm_unit_benefits`, `household_benefits.yaml`, `cbo_means_tested_transfers.yaml` | Benefit aggregates use computed values (same decision as the SSI/TANF PRs) |
| Head Start's `snap > 0` leg | Eligibility evidence per 45 CFR 1302.12 (see above) |
| MD CCS copay waiver (`receives_snap` direct read) | Already keyed on the reported input; unchanged |

## Year-period reads

`snap_enrolled` is a MONTH bool (STOCK in core), so YEAR-defined consumers read December's value rather than the annual any-month aggregate the summed dollar `snap` provided. Under the partner contract (year-keyed inputs dispatch uniformly to all 12 months) December equals every month, so partners are unaffected. On the computed path this narrows "received at any point in the year" to "enrolled in December" for households whose eligibility flips mid-year (e.g., the OBBBA ABAWD dependent-age change, July 2025) — accepted to keep `snap_enrolled` a clean boolean at every period.

## Microsimulation safety

- `receives_snap`, `use_reported_snap`, `reported_snap_amount`, `snap_enrolled`, and `applicable_snap` are not present in any CPS dataset, so nothing can be dataset-populated.
- Toggle defaults to `false` → every existing calculation path is unchanged.
- No dependency cycles: the reported inputs are leaf inputs, and nothing in the SNAP computation chain reads the wrappers.

## Interaction with open PRs

#8951 and #8957 touch the same gate lines (school meals, WIC, Pell lists) and the same three income-source lists, so whichever merges last needs a trivial conflict resolution. Two follow-ups for #8957 identified while building this: its receipt gates read `applicable_tanf > 0`, which drops reported-enrolled families whose computed TANF is $0 (needs a `tanf_enrolled` boolean like this PR's), and its amount-first precedence lets a reported amount count without the enrollment flag, which contradicts the partner contract above.

## Test plan

- [x] `snap_enrolled.yaml` — 8 cases: computed/reported truth table, amount-alone does not count as participation, and the invariant that reported inputs never change the calculated `snap` in either direction
- [x] `applicable_snap.yaml` — 6 cases: full contract truth table including the contradictory-input row (`receives_snap: false` + amount → 0)
- [x] `meets_school_meal_categorical_eligibility.yaml` — reported participation qualifies despite $0 calculated; reported non-participation overrides a positive calculated amount
- [x] `is_head_start_categorically_eligible.yaml` — computed SNAP receipt qualifies even when participation is reported false (eligibility standard)
- [x] `tx_ceap_eligible.yaml` — receipt-based categorical route: computed receipt, reported participation, and reported non-participation cases
- [x] Existing school meals/WIC/Lifeline tests unchanged — they set `snap` as an input, which still flows through `snap_enrolled` by default
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
