### PR TITLE
Remove Virginia's unenacted July 2023 TANF standards increase

### DIFF
--- a/changelog.d/va-tanf-2023-multiplier-fix.fixed.md
+++ b/changelog.d/va-tanf-2023-multiplier-fix.fixed.md
@@ -1,0 +1,1 @@
+Removed Virginia's unenacted July 2023 TANF standards increase; the standard multiplier now stops at 1.155.

--- a/policyengine_us/parameters/gov/states/va/dss/tanf/standard_multiplier.yaml
+++ b/policyengine_us/parameters/gov/states/va/dss/tanf/standard_multiplier.yaml
@@ -17,14 +17,15 @@ metadata:
       href: https://budget.lis.virginia.gov/amendment/2021/2/HB1800/introduced/CR/350/2c/
     - title: HB30 Conference Report 341#2c - 2022 TANF Standards Increase
       href: https://budget.lis.virginia.gov/amendment/2022/2/HB30/Introduced/CR/341/2c/
-    - title: SB800 Budget Amendment 341#1s - 2023 TANF Standards Increase
-      href: https://budget.lis.virginia.gov/amendment/2023/1/SB800/Introduced/FA/341/1s/
 
 # Multipliers calculated relative to 2020-07-01 base values in parameter tables                                                                                             
-# Historical increases: Jan 2016 (+2.5%), Jul 2016 (+2.5%), Jul 2017 (+2.5%),                                                                                               
-# Jul 2019 (+5%), Jul 2020 (+15%), Jul 2021 (+10%), Jul 2022 (+5%), Jul 2023 (+10%)
+# Historical increases: Jan 2016 (+2.5%), Jul 2016 (+2.5%), Jul 2017 (+2.5%),
+# Jul 2019 (+5%), Jul 2020 (+15%), Jul 2021 (+10%), Jul 2022 (+5%)
+# The 10% July 2023 increase (SB800 341#1s, Senate floor-approved) was NOT
+# enacted in the final 2023 budget (HB6001, 2023 Special Session I), so the
+# multiplier stops at 1.155.
 values:
-  # Pre-2016 base (before any increases since 2016) 
+  # Pre-2016 base (before any increases since 2016)
   1996-01-01: 0.7691
   2016-01-01: 0.7883
   2016-07-01: 0.808
@@ -33,4 +34,3 @@ values:
   2020-07-01: 1.0
   2021-07-01: 1.1
   2022-07-01: 1.155
-  2023-07-01: 1.2705

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/tanf/va_tanf.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/tanf/va_tanf.yaml
@@ -73,9 +73,9 @@
     va_tanf: 6_000
 
 # Max payment cap tests -- max payment = ceil(base_max * standard_multiplier)
-# For 2023: multiplier is 1.155 (Jan-Jun) and 1.2705 (Jul-Dec)
-# Group III TANF: ceil(745*1.155)=861 (Jan-Jun), ceil(745*1.2705)=947 (Jul-Dec)
-# Annual max = 6*861 + 6*947 = 10_848
+# For 2023: multiplier is 1.155 for all 12 months
+# Group III TANF: ceil(745*1.155)=861
+# Annual max = 12*861 = 10_332
 
 - name: Group III TANF capped at scaled max payment.
   period: 2023
@@ -87,11 +87,11 @@
     va_tanf_countable_income: 0
     county_str: ARLINGTON_COUNTY_VA
   output:
-    # Payment 15000 capped at Group III max: 6*861 + 6*947 = 10_848
-    va_tanf: 10_848
+    # Payment 15000 capped at Group III max: 12*861 = 10_332
+    va_tanf: 10_332
 
-# Group II TANF: ceil(625*1.155)=722 (Jan-Jun), ceil(625*1.2705)=795 (Jul-Dec)
-# Annual max = 6*722 + 6*795 = 9_102
+# Group II TANF: ceil(625*1.155)=722
+# Annual max = 12*722 = 8_664
 
 - name: Group II TANF capped at scaled max payment.
   period: 2023
@@ -103,11 +103,11 @@
     va_tanf_countable_income: 0
     county_str: PITTSYLVANIA_COUNTY_VA
   output:
-    # Payment 15000 capped at Group II max: 6*722 + 6*795 = 9_102
-    va_tanf: 9_102
+    # Payment 15000 capped at Group II max: 12*722 = 8_664
+    va_tanf: 8_664
 
-# Group III TANF-UP: ceil(648*1.155)=749 (Jan-Jun), ceil(648*1.2705)=824 (Jul-Dec)
-# Annual max = 6*749 + 6*824 = 9_438
+# Group III TANF-UP: ceil(648*1.155)=749
+# Annual max = 12*749 = 8_988
 
 - name: Group III TANF-UP capped at scaled max payment.
   period: 2023
@@ -119,11 +119,11 @@
     va_tanf_countable_income: 0
     county_str: ARLINGTON_COUNTY_VA
   output:
-    # Payment 15000 capped at Group III UP max: 6*749 + 6*824 = 9_438
-    va_tanf: 9_438
+    # Payment 15000 capped at Group III UP max: 12*749 = 8_988
+    va_tanf: 8_988
 
-# Group II TANF-UP: ceil(544*1.155)=629 (Jan-Jun), ceil(544*1.2705)=692 (Jul-Dec)
-# Annual max = 6*629 + 6*692 = 7_926
+# Group II TANF-UP: ceil(544*1.155)=629
+# Annual max = 12*629 = 7_548
 
 - name: Group II TANF-UP capped at scaled max payment.
   period: 2023
@@ -135,8 +135,8 @@
     va_tanf_countable_income: 0
     county_str: PITTSYLVANIA_COUNTY_VA
   output:
-    # Payment 15000 capped at Group II UP max: 6*629 + 6*692 = 7_926
-    va_tanf: 7_926
+    # Payment 15000 capped at Group II UP max: 12*629 = 7_548
+    va_tanf: 7_548
 
 - name: Payment below cap is not reduced.
   period: 2023
@@ -148,6 +148,6 @@
     va_tanf_countable_income: 1_200
     county_str: ARLINGTON_COUNTY_VA
   output:
-    # Payment = 9600 - 1200 = 8400, Group III monthly max = 861/947
-    # Monthly payment = 700, which is below both caps
+    # Payment = 9600 - 1200 = 8400, Group III monthly max = 861
+    # Monthly payment = 700, which is below the cap
     va_tanf: 8_400


### PR DESCRIPTION
## Summary

Virginia's `standard_multiplier.yaml` applied a `2023-07-01: 1.2705` value — a 10% July 2023 increase to the TANF standards of assistance — that **was never enacted**. Applied to the frozen July‑2020 base tables, it overstated Virginia's current TANF grant standard by ~10% on both locality tiers. This PR removes the entry so the multiplier stops at `1.155` (July 2022).

Closes #8965

For a family of 3:

| Tier | Base (Jul 2020) | Before (×1.2705) | After (×1.155) |
|---|---|---|---|
| Group III | $508 | ~$645 | ~$587 |
| Group II | $417 | ~$530 | ~$481 |

## Why the 1.2705 entry is wrong

1. **Not in the enacted budget.** Virginia's 2023 regular session produced no enacted budget; the only enacted amendments to the 2022–24 biennium were [HB6001 (2023 Special Session I), Item 325](https://budget.lis.virginia.gov/item/2024/2/HB6001/Chapter/1/325/), which contains **no** 10% TANF standards increase.
2. **The cited source was a non‑enacted Senate floor amendment.** [SB800 341#1s](https://budget.lis.virginia.gov/amendment/2023/1/SB800/Introduced/FA/341/1s/) reached "Floor Approved" but did not survive into HB6001. The 2020/2021/2022 entries all cite enacted Conference Reports.
3. **Two independent 2024 sources confirm the current max is $587 (= 1.155):** the Urban Institute Welfare Rules Database (Group III family‑of‑3 = $587 "Ongoing" since July 1, 2022) and the NCCP Virginia TANF profile (Aug 2024, range $481–$587).

## Changes

- `standard_multiplier.yaml`: removed `2023-07-01: 1.2705`; updated the historical‑increases comment; removed the non‑enacted SB800 341#1s reference.
- `va_tanf.yaml` tests: updated the four max‑payment cap cases, which previously blended 1.155 (Jan–Jun) and 1.2705 (Jul–Dec) across whole‑year 2023, to a flat 1.155:
  - Group III TANF cap 10,848 → 10,332
  - Group II TANF cap 9,102 → 8,664
  - Group III TANF‑UP cap 9,438 → 8,988
  - Group II TANF‑UP cap 7,926 → 7,548

Other VA TANF tests are unaffected: `2023-01` cases use January (1.155 either way), and the income‑eligibility cases feed the standards as direct inputs, bypassing the multiplier.

## Note

If Virginia later *enacts* a genuine increase (2024/2025 sessions), it should be added as a new entry verified against a Chapter/Conference Report.

## Test plan
- [x] Updated affected YAML tests
- [ ] CI passes
