### PR TITLE
Include disabled adult care expenses in SNAP dependent care deduction

### DIFF
--- a/changelog.d/snap-adult-care-expenses.changed.md
+++ b/changelog.d/snap-adult-care-expenses.changed.md
@@ -1,0 +1,1 @@
+Include disabled adult care expenses in the SNAP dependent care deduction per 7 CFR 273.9(d)(4).

--- a/changelog.d/snap-adult-care-expenses.changed.md
+++ b/changelog.d/snap-adult-care-expenses.changed.md
@@ -1,1 +1,1 @@
-Include disabled adult care expenses in the SNAP dependent care deduction per 7 CFR 273.9(d)(4).
+Include disabled adult care expenses in the SNAP dependent care deduction per 7 CFR 273.9(d)(4); this also extends New York's 200% FPL SNAP BBCE gross income limit to households with adult dependent care costs per NY OTDA 16-ADM-06.

--- a/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/ny/dependent_care.yaml
+++ b/policyengine_us/parameters/gov/hhs/tanf/non_cash/income_limit/ny/dependent_care.yaml
@@ -8,5 +8,10 @@ metadata:
   period: year
   label: New York SNAP BBCE dependent care gross income limit
   reference:
+    # Section 2.I(C): categorical eligibility extends to 200% of FPL for SNAP
+    # households with out-of-pocket dependent care expenses for a member of
+    # the SNAP household.
+    - title: NY OTDA 16-ADM-06, Expansion of Categorical Eligibility for SNAP Households with Earned Income
+      href: https://otda.ny.gov/policy/directives/2016/ADM/16-ADM-06.pdf#page=2
     - title: SNAP Screener SNAP Eligibility Parameters
       href: https://www.snapscreener.com/?p=table

--- a/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.yaml
@@ -98,6 +98,51 @@
   output:
     meets_tanf_non_cash_gross_income_test: true
 
+- name: NY with adult dependent care expenses computed from care_expenses is eligible through 200% FPL
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 25
+        is_incapable_of_self_care: true
+        care_expenses: 1_200
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap_gross_income_fpg_ratio: 1.9
+        snap_earned_income: 0
+        has_usda_elderly_disabled: false
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NY
+  output:
+    meets_tanf_non_cash_gross_income_test: true
+
+- name: NY without care expenses through the computed deduction is capped at 130% FPL
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 25
+        is_incapable_of_self_care: true
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap_gross_income_fpg_ratio: 1.9
+        snap_earned_income: 0
+        has_usda_elderly_disabled: false
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NY
+  output:
+    meets_tanf_non_cash_gross_income_test: false
+
 - name: NY elderly or disabled household is eligible through 200% FPL
   period: 2026-01
   input:

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_dependent_care_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_dependent_care_deduction.yaml
@@ -1,0 +1,70 @@
+- name: Case 1, childcare expenses only.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        childcare_expenses: 2_400
+  output:
+    # 2,400 / 12 = 200 per month
+    snap_dependent_care_deduction: 200
+
+- name: Case 2, disabled adult care expenses only.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 25
+        is_incapable_of_self_care: true
+        care_expenses: 1_200
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    # 1,200 / 12 = 100 per month
+    snap_dependent_care_deduction: 100
+
+- name: Case 3, both childcare and disabled adult care expenses.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 5
+      person3:
+        age: 25
+        is_incapable_of_self_care: true
+        care_expenses: 1_200
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        childcare_expenses: 2_400
+  output:
+    # 2,400 / 12 + 1,200 / 12 = 200 + 100 = 300 per month
+    snap_dependent_care_deduction: 300
+
+- name: Case 4, no care expenses.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+      person2:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+  output:
+    snap_dependent_care_deduction: 0

--- a/policyengine_us/variables/gov/usda/snap/income/deductions/snap_dependent_care_deduction.py
+++ b/policyengine_us/variables/gov/usda/snap/income/deductions/snap_dependent_care_deduction.py
@@ -6,7 +6,16 @@ class snap_dependent_care_deduction(Variable):
     entity = SPMUnit
     label = "SNAP dependent care deduction"
     unit = USD
-    documentation = "Deduction from SNAP gross income for dependent care"
+    documentation = (
+        "Deduction from SNAP gross income for dependent care. "
+        "Non-modeled provision: 7 CFR 273.9(d)(4) allows these costs "
+        "only when necessary for a household member to search for, "
+        "accept, or continue employment, comply with SNAP E&T, or "
+        "attend training or education preparatory to employment; we "
+        "do not track that condition at the moment, so all reported "
+        "childcare and adult dependent care expenses flow into the "
+        "deduction."
+    )
     definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/uscode/text/7/2014#e_3",

--- a/policyengine_us/variables/gov/usda/snap/income/deductions/snap_dependent_care_deduction.py
+++ b/policyengine_us/variables/gov/usda/snap/income/deductions/snap_dependent_care_deduction.py
@@ -8,6 +8,11 @@ class snap_dependent_care_deduction(Variable):
     unit = USD
     documentation = "Deduction from SNAP gross income for dependent care"
     definition_period = MONTH
-    reference = "https://www.law.cornell.edu/uscode/text/7/2014#e_3"
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/7/2014#e_3",
+        "https://www.law.cornell.edu/cfr/text/7/273.9#d_4",
+    )
 
-    adds = ["childcare_expenses"]
+    # Per 7 CFR 273.9(d)(4), deductible costs cover care of a child under
+    # age 18 or an incapacitated person of any age.
+    adds = ["childcare_expenses", "care_expenses"]


### PR DESCRIPTION
## Summary

Adds the person-level `care_expenses` input (care for a disabled adult dependent or spouse) to the SNAP dependent care deduction, which previously only counted `childcare_expenses`.

Part of #8811.

## Regulatory Authority

- [7 U.S.C. § 2014(e)(3)](https://www.law.cornell.edu/uscode/text/7/2014#e_3): dependent care deduction for "the actual cost of payments necessary for the care of a dependent" — no dollar cap.
- [7 CFR § 273.9(d)(4)](https://www.law.cornell.edu/cfr/text/7/273.9#d_4): deductible costs are "limited to the care of an individual for whom the household provides dependent care, **including care of a child under the age of 18 or an incapacitated person of any age** in need of care".

## Changes

- `snap_dependent_care_deduction`: `adds = ["childcare_expenses"]` → `adds = ["childcare_expenses", "care_expenses"]`, with the CFR citation added to `reference`.
- New unit test `snap_dependent_care_deduction.yaml` covering childcare-only, adult-care-only, combined, and zero-expense cases.

## Impact

- `care_expenses` defaults to 0, so existing test expectations, partner contract tests, and microsimulation results are unchanged unless the input is supplied. The two partner fixtures that set `care_expenses` (CDCC edge cases) assert only tax outputs, not SNAP.

## Test plan

- [x] 4 unit test cases for the deduction
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)