### PR TITLE
Raise Oregon EITC match to 14%/17% for 2026 (SB 1507)

### DIFF
--- a/changelog.d/or-eitc-sb1507.changed.md
+++ b/changelog.d/or-eitc-sb1507.changed.md
@@ -1,0 +1,1 @@
+Increase the Oregon Earned Income Tax Credit match to 14% (17% for filers with a dependent under age 3) from tax year 2026 under SB 1507.

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/has_young_child.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/has_young_child.yaml
@@ -1,6 +1,7 @@
 description: Oregon matches the federal Earned Income Tax Credit at this rate for filers with young children.
 values:
   2001-01-01: 0.12
+  2026-01-01: 0.17
 metadata:
   unit: /1
   period: year
@@ -8,6 +9,8 @@ metadata:
   reference:
     - title: Chapter 315 — Personal and Corporate Income or Excise Tax Credits 315.266 (1)(b)
       href: https://www.oregonlegislature.gov/bills_laws/ors/ors315.html
+    - title: SB 1507 (2026), Oregon Laws 2026 chapter 142 - raises the EITC match to 17% for filers with a dependent under age 3 for tax years beginning on or after January 1, 2026
+      href: https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/SB1507/Enrolled
     - title: 2021 Oregon Income Tax Form OR-40 Instructions
       href: https://www.oregon.gov/dor/forms/FormsPubs/form-or-40-inst_101-040-1_2021.pdf#page=18
     - title: 2022 Oregon Income Tax Form OR-40 Instructions

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/has_young_child.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/has_young_child.yaml
@@ -9,8 +9,10 @@ metadata:
   reference:
     - title: Chapter 315 — Personal and Corporate Income or Excise Tax Credits 315.266 (1)(b)
       href: https://www.oregonlegislature.gov/bills_laws/ors/ors315.html
-    - title: SB 1507 (2026), Oregon Laws 2026 chapter 142 - raises the EITC match to 17% for filers with a dependent under age 3 for tax years beginning on or after January 1, 2026
-      href: https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/SB1507/Enrolled
+    - title: SB 1507 (2026) Section 3, Oregon Laws 2026 chapter 142 - amends ORS 315.266(1)(b)
+      href: https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/SB1507/Enrolled#page=1
+    - title: SB 1507 (2026) Measure Overview - Oregon Laws 2026 chapter 142
+      href: https://olis.oregonlegislature.gov/liz/2026R1/Measures/Overview/SB1507
     - title: 2021 Oregon Income Tax Form OR-40 Instructions
       href: https://www.oregon.gov/dor/forms/FormsPubs/form-or-40-inst_101-040-1_2021.pdf#page=18
     - title: 2022 Oregon Income Tax Form OR-40 Instructions

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/no_young_child.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/no_young_child.yaml
@@ -9,8 +9,10 @@ metadata:
   reference:
     - title: Chapter 315 — Personal and Corporate Income or Excise Tax Credits 315.266 (1)(a)
       href: https://www.oregonlegislature.gov/bills_laws/ors/ors315.html
-    - title: SB 1507 (2026), Oregon Laws 2026 chapter 142 - raises the EITC match to 14% for tax years beginning on or after January 1, 2026
-      href: https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/SB1507/Enrolled
+    - title: SB 1507 (2026) Section 3, Oregon Laws 2026 chapter 142 - amends ORS 315.266(1)(a)
+      href: https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/SB1507/Enrolled#page=1
+    - title: SB 1507 (2026) Measure Overview - Oregon Laws 2026 chapter 142
+      href: https://olis.oregonlegislature.gov/liz/2026R1/Measures/Overview/SB1507
     - title: 2021 Oregon Income Tax Form OR-40 Instructions
       href: https://www.oregon.gov/dor/forms/FormsPubs/form-or-40-inst_101-040-1_2021.pdf#page=18
     - title: 2022 Oregon Income Tax Form OR-40 Instructions

--- a/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/no_young_child.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/credits/eitc/match/no_young_child.yaml
@@ -1,6 +1,7 @@
 description: Oregon matches the federal Earned Income Tax Credit at this rate for filers with no young children.
 values:
   2001-01-01: 0.09
+  2026-01-01: 0.14
 metadata:
   unit: /1
   period: year
@@ -8,6 +9,8 @@ metadata:
   reference:
     - title: Chapter 315 — Personal and Corporate Income or Excise Tax Credits 315.266 (1)(a)
       href: https://www.oregonlegislature.gov/bills_laws/ors/ors315.html
+    - title: SB 1507 (2026), Oregon Laws 2026 chapter 142 - raises the EITC match to 14% for tax years beginning on or after January 1, 2026
+      href: https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/SB1507/Enrolled
     - title: 2021 Oregon Income Tax Form OR-40 Instructions
       href: https://www.oregon.gov/dor/forms/FormsPubs/form-or-40-inst_101-040-1_2021.pdf#page=18
     - title: 2022 Oregon Income Tax Form OR-40 Instructions

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_eitc.yaml
@@ -66,10 +66,50 @@
   output:
     or_eitc: 12
 
+# 2025 cases pin the pre-2026 rates (9% / 12%) so an accidental effective date
+# on either match parameter would be caught.
+- name: 2025 no young child gets 9% match
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent: {}
+      child:
+        age: 3
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        eitc: 100
+    households:
+      household:
+        members: [parent, child]
+        state_code: OR
+  output:
+    or_eitc: 9
+
+- name: 2025 with a dependent under 3 gets 12% match
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent: {}
+      child:
+        age: 2
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        eitc: 100
+    households:
+      household:
+        members: [parent, child]
+        state_code: OR
+  output:
+    or_eitc: 12
+
 # SB 1507 (2026) raised the match to 14% / 17% (dependent under 3) from 2026.
 - name: 2026 no young child gets 14% match
   period: 2026
-  absolute_error_margin: 1
+  absolute_error_margin: 0.01
   input:
     people:
       parent: {}
@@ -88,7 +128,7 @@
 
 - name: 2026 with a dependent under 3 gets 17% match
   period: 2026
-  absolute_error_margin: 1
+  absolute_error_margin: 0.01
   input:
     people:
       parent: {}
@@ -104,3 +144,12 @@
         state_code: OR
   output:
     or_eitc: 17
+
+- name: 2026 no EITC, no matched credit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    state_code: OR
+    eitc: 0
+  output:
+    or_eitc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/or/tax/income/credits/or_eitc.yaml
@@ -49,19 +49,58 @@
   period: 2022
   absolute_error_margin: 1
   input:
-    people: 
+    people:
       parent: {}
-      child1: 
+      child1:
         age: 2
-      child2: 
+      child2:
         age: 5
-    tax_units: 
-      tax_unit: 
+    tax_units:
+      tax_unit:
         members: [parent, child1, child2]
         eitc: 100
-    households: 
+    households:
       household:
         members: [parent, child1, child2]
         state_code: OR
   output:
     or_eitc: 12
+
+# SB 1507 (2026) raised the match to 14% / 17% (dependent under 3) from 2026.
+- name: 2026 no young child gets 14% match
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    people:
+      parent: {}
+      child:
+        age: 3
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        eitc: 100
+    households:
+      household:
+        members: [parent, child]
+        state_code: OR
+  output:
+    or_eitc: 14
+
+- name: 2026 with a dependent under 3 gets 17% match
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    people:
+      parent: {}
+      child:
+        age: 2
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        eitc: 100
+    households:
+      household:
+        members: [parent, child]
+        state_code: OR
+  output:
+    or_eitc: 17


### PR DESCRIPTION
Adds Oregon's 2026 EITC increase to the baseline — the one enacted-but-missing item surfaced by a sweep of 2026 state legislative sessions.

## Change
**SB 1507** (2026 regular session, **Oregon Laws 2026 ch. 142**, signed by Gov. Kotek **2026-04-09**) amends **ORS 315.266** to raise the state EITC match:
- filers with **no** dependent under age 3: **9% → 14%**
- filers **with** a dependent under age 3: **12% → 17%**

Applicable to **tax years beginning on or after January 1, 2026**.

## Verified against the enrolled statute
Confirmed directly from the enrolled bill text (not a summary):
- §3, *"ORS 315.266 is amended to read"* — `[nine] 14 percent` and `[12] 17 percent` (old values struck, new inserted)
- §10(1) — *"the amendments to ORS 315.266 by section 3 of this 2026 Act apply to tax years beginning on or after January 1, 2026"*

[Enrolled measure](https://olis.oregonlegislature.gov/liz/2026R1/Downloads/MeasureDocument/SB1507/Enrolled) · [Staff analysis](https://olis.oregonlegislature.gov/liz/2026R1/Measures/Analysis/SB1507)

## Files
- `or/.../eitc/match/no_young_child.yaml`: add `2026-01-01: 0.14`
- `or/.../eitc/match/has_young_child.yaml`: add `2026-01-01: 0.17`
- `or_eitc.yaml`: add 2026 test cases (14% / 17%)
- changelog fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)