### PR TITLE
Add North Dakota primary residence credit (HB 1176)

### DIFF
--- a/changelog.d/nd-primary-residence-credit.added.md
+++ b/changelog.d/nd-primary-residence-credit.added.md
@@ -1,1 +1,1 @@
-Add the North Dakota primary residence credit (HB 1176), raising the maximum credit to $1,600 from tax year 2026, and restore the North Dakota renter's refund to the 2026 state property tax credit aggregate.
+Add the North Dakota primary residence credit (HB 1176), raising the maximum credit to $1,600 from tax year 2025, and restore the North Dakota renter's refund to the 2026 state property tax credit aggregate.

--- a/changelog.d/nd-primary-residence-credit.added.md
+++ b/changelog.d/nd-primary-residence-credit.added.md
@@ -1,1 +1,1 @@
-Add the North Dakota primary residence credit (HB 1176), raising the maximum credit to $1,600 from tax year 2025, and restore the North Dakota renter's refund to the 2026 state property tax credit aggregate.
+Add the North Dakota primary residence credit (HB 1176), raising the maximum credit to $1,600 from tax year 2026, and restore the North Dakota renter's refund to the 2026 state property tax credit aggregate.

--- a/changelog.d/nd-primary-residence-credit.added.md
+++ b/changelog.d/nd-primary-residence-credit.added.md
@@ -1,0 +1,1 @@
+Add the North Dakota primary residence credit (HB 1176), raising the maximum credit to $1,600 from tax year 2025, and restore the North Dakota renter's refund to the 2026 state property tax credit aggregate.

--- a/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
@@ -129,6 +129,7 @@ values:
     - mo_property_tax_credit
     - mt_elderly_homeowner_or_renter_credit
     - mt_property_tax_rebate
+    - nd_primary_residence_credit
     - nd_renters_refund
     - nj_property_tax_credit
     - nm_property_tax_rebate
@@ -153,6 +154,7 @@ values:
     - mo_property_tax_credit
     - mt_elderly_homeowner_or_renter_credit
     - mt_property_tax_rebate
+    - nd_primary_residence_credit
     - nd_renters_refund
     - nj_property_tax_credit
     - nm_property_tax_rebate
@@ -180,6 +182,8 @@ values:
     - mo_property_tax_credit
     - mt_elderly_homeowner_or_renter_credit
     - mt_property_tax_rebate
+    - nd_primary_residence_credit
+    - nd_renters_refund
     - nj_property_tax_credit
     - nm_property_tax_rebate
     - ny_real_property_tax_credit

--- a/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
@@ -1,0 +1,15 @@
+description: North Dakota provides this maximum primary residence credit against property tax on an owner-occupied primary residence.
+values:
+  2024-01-01: 500
+  2025-01-01: 1_600
+metadata:
+  unit: currency-USD
+  period: year
+  label: North Dakota primary residence credit amount
+  reference:
+    - title: Primary Residence Credit | North Dakota Office of State Tax Commissioner
+      href: https://www.tax.nd.gov/prc
+    - title: HB 1176 (2025), 69th Legislative Assembly - increases the primary residence credit from $500 to $1,600
+      href: https://ndlegis.gov/assembly/69-2025/regular/bill-overview/bo1176.html?bill_year=2025-2026
+    - title: N.D.C.C. 57-02-08.9 - Primary residence credit
+      href: https://ndlegis.gov/cencode/t57c02.pdf

--- a/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
@@ -1,7 +1,7 @@
 description: North Dakota provides this maximum primary residence credit against property tax on an owner-occupied primary residence.
 values:
   2024-01-01: 500
-  2025-01-01: 1_600
+  2026-01-01: 1_600
 metadata:
   unit: currency-USD
   period: year
@@ -9,7 +9,7 @@ metadata:
   reference:
     - title: Primary Residence Credit | North Dakota Office of State Tax Commissioner
       href: https://www.tax.nd.gov/prc
-    - title: HB 1176 (2025), 69th Legislative Assembly - increases the primary residence credit from $500 to $1,600
-      href: https://ndlegis.gov/assembly/69-2025/regular/bill-overview/bo1176.html?bill_year=2025-2026
+    - title: HB 1176 (2025), ch. 555, N.D.C.C. 57-02-08.9 - $1,600 for taxable years beginning after December 31, 2025 (tax year 2026); prior amount $500
+      href: https://ndlegis.gov/assembly/69-2025/regular/documents/25-1003-06000.pdf
     - title: N.D.C.C. 57-02-08.9 - Primary residence credit
       href: https://ndlegis.gov/cencode/t57c02.pdf

--- a/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
@@ -1,7 +1,7 @@
-description: North Dakota provides this maximum primary residence credit against property tax on an owner-occupied primary residence.
+description: North Dakota provides this amount as the maximum primary residence credit against property tax on an owner-occupied primary residence.
 values:
   2024-01-01: 500
-  2026-01-01: 1_600
+  2025-01-01: 1_600
 metadata:
   unit: currency-USD
   period: year
@@ -9,7 +9,7 @@ metadata:
   reference:
     - title: Primary Residence Credit | North Dakota Office of State Tax Commissioner
       href: https://www.tax.nd.gov/prc
-    - title: HB 1176 (2025), ch. 555, N.D.C.C. 57-02-08.9 - $1,600 for taxable years beginning after December 31, 2025 (tax year 2026); prior amount $500
-      href: https://ndlegis.gov/assembly/69-2025/regular/documents/25-1003-06000.pdf
-    - title: N.D.C.C. 57-02-08.9 - Primary residence credit
+    - title: HB 1176 (2025), ch. 555 - Section 10 (page 11) sets N.D.C.C. 57-02-08.9 to $1,600, effective for taxable years beginning after December 31, 2024 (tax year 2025) per Section 31(1) and the Section 32 emergency clause (page 44); Section 11 is the parallel tax-year-2026+ version; prior amount $500
+      href: https://ndlegis.gov/assembly/69-2025/regular/documents/25-1003-06000.pdf#page=11
+    - title: N.D.C.C. 57-02-08.9 - Primary residence credit (Chapter 57-02)
       href: https://ndlegis.gov/cencode/t57c02.pdf

--- a/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/property/primary_residence_credit/amount.yaml
@@ -11,5 +11,7 @@ metadata:
       href: https://www.tax.nd.gov/prc
     - title: HB 1176 (2025), ch. 555 - Section 10 (page 11) sets N.D.C.C. 57-02-08.9 to $1,600, effective for taxable years beginning after December 31, 2024 (tax year 2025) per Section 31(1) and the Section 32 emergency clause (page 44); Section 11 is the parallel tax-year-2026+ version; prior amount $500
       href: https://ndlegis.gov/assembly/69-2025/regular/documents/25-1003-06000.pdf#page=11
+    - title: HB 1158 (2023) - Section 2 creates N.D.C.C. 57-02-08.9 with a $500 credit for tax years 2024 and 2025
+      href: https://ndlegis.gov/assembly/68-2023/regular/documents/23-0351-06000.pdf#page=2
     - title: N.D.C.C. 57-02-08.9 - Primary residence credit (Chapter 57-02)
-      href: https://ndlegis.gov/cencode/t57c02.pdf
+      href: https://ndlegis.gov/cencode/t57c02.pdf#page=21

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/nd_primary_residence_credit_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/nd_primary_residence_credit_in_aggregate.yaml
@@ -1,0 +1,46 @@
+# Guards that both North Dakota property-tax credits flow through the
+# state_property_tax_credits umbrella (taxsim_state_property_tax_credit). The
+# original nd_renters_refund drop from the 2026 block went uncaught because only
+# variable-level tests existed; these assert the aggregate membership directly.
+
+- name: 2026 umbrella sums both the primary residence credit and the renter's refund
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 65
+        real_estate_taxes: 2_000
+        rent: 9_600
+    tax_units:
+      tax_unit:
+        members: [person1]
+        nd_renters_refund_income: 35_000
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    # PRC min($1,600, 2,000) = 1,600; renter's refund
+    # min(600, 9,600 x 0.2 - 35,000 x 0.04) = 520; umbrella = 2,120.
+    nd_primary_residence_credit: 1_600
+    nd_renters_refund: 520
+    taxsim_state_property_tax_credit: 2_120
+
+- name: 2025 umbrella includes the primary residence credit
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 1_600
+    taxsim_state_property_tax_credit: 1_600

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.yaml
@@ -1,10 +1,10 @@
 # North Dakota primary residence credit (HB 1176, 2025): a flat credit against
 # property tax on an owner-occupied primary residence, with no age or income
-# limit. HB 1176 raised the maximum from $500 to $1,600 for taxable years
-# beginning after December 31, 2025 (tax year 2026); tax years 2024 and 2025
-# remained at $500.
+# limit. HB 1176 Section 10 raised the maximum from $500 to $1,600 effective for
+# taxable years beginning after December 31, 2024 (tax year 2025), per Section
+# 31(1) and the Section 32 emergency clause; tax year 2024 remained at $500.
 
-- name: 2025 homeowner above the $500 cap is limited to $500
+- name: 2025 homeowner above the cap receives the $1,600 maximum
   period: 2025
   input:
     people:
@@ -18,14 +18,14 @@
         members: [person1]
         state_code: ND
   output:
-    nd_primary_residence_credit: 500
+    nd_primary_residence_credit: 1_600
 
-- name: 2025 homeowner below the $500 cap receives the property tax
+- name: 2025 homeowner below the cap receives the property tax
   period: 2025
   input:
     people:
       person1:
-        real_estate_taxes: 300
+        real_estate_taxes: 900
     tax_units:
       tax_unit:
         members: [person1]
@@ -34,7 +34,23 @@
         members: [person1]
         state_code: ND
   output:
-    nd_primary_residence_credit: 300
+    nd_primary_residence_credit: 900
+
+- name: 2025 homeowner at the cap boundary receives the property tax
+  period: 2025
+  input:
+    people:
+      person1:
+        real_estate_taxes: 1_600
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 1_600
 
 - name: 2024 homeowner is limited to the prior $500 maximum
   period: 2024
@@ -84,7 +100,26 @@
   output:
     nd_primary_residence_credit: 0
 
-- name: 2026 homeowner above the cap receives the $1,600 maximum
+- name: 2025 multi-person tax unit is capped once per return
+  period: 2025
+  input:
+    people:
+      person1:
+        real_estate_taxes: 1_000
+      person2:
+        real_estate_taxes: 1_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: ND
+  output:
+    # Combined $2,000 of property tax is capped at $1,600 for the tax unit.
+    nd_primary_residence_credit: 1_600
+
+- name: 2026 homeowner still receives the $1,600 maximum
   period: 2026
   input:
     people:
@@ -99,19 +134,3 @@
         state_code: ND
   output:
     nd_primary_residence_credit: 1_600
-
-- name: 2026 homeowner below the cap receives the property tax
-  period: 2026
-  input:
-    people:
-      person1:
-        real_estate_taxes: 1_000
-    tax_units:
-      tax_unit:
-        members: [person1]
-    households:
-      household:
-        members: [person1]
-        state_code: ND
-  output:
-    nd_primary_residence_credit: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.yaml
@@ -1,0 +1,99 @@
+# North Dakota primary residence credit (HB 1176, 2025): a flat credit against
+# property tax on an owner-occupied primary residence, with no age or income
+# limit. HB 1176 raised the maximum from $500 to $1,600 starting tax year 2025.
+
+- name: 2025 homeowner with property tax above the cap receives the maximum
+  period: 2025
+  input:
+    people:
+      person1:
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 1_600
+
+- name: 2025 homeowner with property tax below the cap receives the property tax
+  period: 2025
+  input:
+    people:
+      person1:
+        real_estate_taxes: 900
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 900
+
+- name: 2024 homeowner is limited to the prior $500 maximum
+  period: 2024
+  input:
+    people:
+      person1:
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 500
+
+- name: 2025 renter with no real estate taxes receives no credit
+  period: 2025
+  input:
+    people:
+      person1:
+        real_estate_taxes: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 0
+
+- name: 2025 non-North Dakota homeowner receives no credit
+  period: 2025
+  input:
+    people:
+      person1:
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    nd_primary_residence_credit: 0
+
+- name: 2026 homeowner still receives the $1,600 maximum
+  period: 2026
+  input:
+    people:
+      person1:
+        real_estate_taxes: 5_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 1_600

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.yaml
@@ -1,8 +1,10 @@
 # North Dakota primary residence credit (HB 1176, 2025): a flat credit against
 # property tax on an owner-occupied primary residence, with no age or income
-# limit. HB 1176 raised the maximum from $500 to $1,600 starting tax year 2025.
+# limit. HB 1176 raised the maximum from $500 to $1,600 for taxable years
+# beginning after December 31, 2025 (tax year 2026); tax years 2024 and 2025
+# remained at $500.
 
-- name: 2025 homeowner with property tax above the cap receives the maximum
+- name: 2025 homeowner above the $500 cap is limited to $500
   period: 2025
   input:
     people:
@@ -16,14 +18,14 @@
         members: [person1]
         state_code: ND
   output:
-    nd_primary_residence_credit: 1_600
+    nd_primary_residence_credit: 500
 
-- name: 2025 homeowner with property tax below the cap receives the property tax
+- name: 2025 homeowner below the $500 cap receives the property tax
   period: 2025
   input:
     people:
       person1:
-        real_estate_taxes: 900
+        real_estate_taxes: 300
     tax_units:
       tax_unit:
         members: [person1]
@@ -32,7 +34,7 @@
         members: [person1]
         state_code: ND
   output:
-    nd_primary_residence_credit: 900
+    nd_primary_residence_credit: 300
 
 - name: 2024 homeowner is limited to the prior $500 maximum
   period: 2024
@@ -82,7 +84,7 @@
   output:
     nd_primary_residence_credit: 0
 
-- name: 2026 homeowner still receives the $1,600 maximum
+- name: 2026 homeowner above the cap receives the $1,600 maximum
   period: 2026
   input:
     people:
@@ -97,3 +99,19 @@
         state_code: ND
   output:
     nd_primary_residence_credit: 1_600
+
+- name: 2026 homeowner below the cap receives the property tax
+  period: 2026
+  input:
+    people:
+      person1:
+        real_estate_taxes: 1_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: ND
+  output:
+    nd_primary_residence_credit: 1_000

--- a/policyengine_us/variables/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.py
+++ b/policyengine_us/variables/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class nd_primary_residence_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "North Dakota primary residence credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://www.tax.nd.gov/prc",
+        "https://ndlegis.gov/assembly/69-2025/regular/bill-overview/bo1176.html?bill_year=2025-2026",
+        "https://ndlegis.gov/cencode/t57c02.pdf",
+    )
+    defined_for = StateCode.ND
+
+    def formula(tax_unit, period, parameters):
+        # The primary residence credit reduces property tax on an
+        # owner-occupied primary residence, capped at a flat amount, with no
+        # age or income limitation. Renters have no real estate taxes, so the
+        # credit is zero for them.
+        p = parameters(period).gov.states.nd.tax.property.primary_residence_credit
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+        return min_(p.amount, property_tax)

--- a/policyengine_us/variables/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.py
+++ b/policyengine_us/variables/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.py
@@ -9,8 +9,8 @@ class nd_primary_residence_credit(Variable):
     definition_period = YEAR
     reference = (
         "https://www.tax.nd.gov/prc",
-        "https://ndlegis.gov/assembly/69-2025/regular/bill-overview/bo1176.html?bill_year=2025-2026",
-        "https://ndlegis.gov/cencode/t57c02.pdf",
+        "https://ndlegis.gov/assembly/69-2025/regular/documents/25-1003-06000.pdf#page=11",
+        "https://ndlegis.gov/cencode/t57c02.pdf#page=21",
     )
     defined_for = StateCode.ND
 

--- a/policyengine_us/variables/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.py
+++ b/policyengine_us/variables/gov/states/nd/tax/property/primary_residence_credit/nd_primary_residence_credit.py
@@ -19,6 +19,10 @@ class nd_primary_residence_credit(Variable):
         # owner-occupied primary residence, capped at a flat amount, with no
         # age or income limitation. Renters have no real estate taxes, so the
         # credit is zero for them.
+        # N.D.C.C. 57-02-08.9(1)(c)-(d) limits the credit to the property tax
+        # due AFTER other chapter 57 credits (e.g. the homestead credit and the
+        # disabled veteran credit). Those credits are not modeled, so this caps
+        # against gross real_estate_taxes; revisit this base if they are added.
         p = parameters(period).gov.states.nd.tax.property.primary_residence_credit
         property_tax = add(tax_unit, period, ["real_estate_taxes"])
         return min_(p.amount, property_tax)


### PR DESCRIPTION
## Summary

Adds North Dakota's **Primary Residence Credit (PRC)**, which [HB 1176 (2025, 69th Legislative Assembly)](https://ndlegis.gov/assembly/69-2025/regular/bill-overview/bo1176.html?bill_year=2025-2026) raised from **\$500 to \$1,600** starting **tax year 2025**.

The PRC is a flat credit against property tax on an owner-occupied primary residence, with **no age or income limitation** and **one credit per household** ([N.D. Office of State Tax Commissioner](https://www.tax.nd.gov/prc); N.D.C.C. 57-02-08.9). It is modeled as `min(amount, real_estate_taxes)`, so renters (who have no real estate taxes) receive \$0.

## Changes

- **New variable** `nd_primary_residence_credit` (`TaxUnit`, `defined_for = StateCode.ND`) = `min(amount, real_estate_taxes)`.
- **New parameter** `gov.states.nd.tax.property.primary_residence_credit.amount`: `$500` (2024) → `$1,600` (2025+), matching prior law and HB 1176.
- **Wired** into `state_property_tax_credits.yaml` (2024, 2025, 2026 blocks) so it feeds the taxsim_state_property_tax_credit umbrella (TAXSIM parity), like other state property-tax credits; note this umbrella does not currently flow into household_net_income.
- **Restored** `nd_renters_refund` to the **2026** block of `state_property_tax_credits.yaml`. It was present in 2024 and 2025 but was dropped from 2026 when the Indiana over-65 credit PR (#8308) created a fresh 2026 list — an accidental omission that silently zeroed the ND renter's refund in 2026 microsimulations. See note below.

## Note for reviewers

The `nd_renters_refund` restoration is an adjacent bug fix within the same ND rows of the aggregate. If the 2026 omission was in fact intentional, that one line can be dropped. (Separately, `pa_property_tax_or_rent_rebate` appears to have been dropped from the 2026 block the same way, but that is out of scope for this ND-focused PR.)

## Tests

`nd_primary_residence_credit.yaml` covers: above-cap (→ \$1,600), below-cap (→ property tax), the prior \$500 cap in 2024, renter with no property tax (→ \$0), non-ND resident (→ \$0), and 2026 (→ \$1,600).

## References

- [Primary Residence Credit — N.D. Office of State Tax Commissioner](https://www.tax.nd.gov/prc)
- [HB 1176 (2025) overview](https://ndlegis.gov/assembly/69-2025/regular/bill-overview/bo1176.html?bill_year=2025-2026)
- N.D.C.C. 57-02-08.9 (Primary residence credit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)