### PR TITLE
Add Indiana supplemental homestead credit (SEA 1, 2025)

### DIFF
--- a/changelog.d/in-supplemental-homestead-credit.added.md
+++ b/changelog.d/in-supplemental-homestead-credit.added.md
@@ -1,0 +1,1 @@
+Add the Indiana supplemental homestead credit (Senate Enrolled Act 1, 2025), the lesser of 10% of homestead property tax or $300, from 2026.

--- a/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
@@ -172,6 +172,7 @@ values:
     - dc_senior_disabled_property_tax_relief
     - il_property_tax_credit
     - in_over_65_property_tax_credit
+    - in_supplemental_homestead_credit
     - ma_senior_circuit_breaker
     - me_property_tax_fairness_credit
     - mi_homestead_property_tax_credit

--- a/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/cap.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/cap.yaml
@@ -1,4 +1,4 @@
-description: Indiana caps its supplemental homestead credit at this amount.
+description: Indiana limits its supplemental homestead credit to this amount.
 values:
   2026-01-01: 300
 metadata:
@@ -6,7 +6,7 @@ metadata:
   period: year
   label: Indiana supplemental homestead credit cap
   reference:
-    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c)
-      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
+    - title: Senate Enrolled Act 1 (2025), SEC. 74 (page 124), adding IC 6-1.1-20.6-7.7(c)
+      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf#page=124
     - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
-      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2
+      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=9

--- a/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/cap.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/cap.yaml
@@ -1,0 +1,12 @@
+description: Indiana caps its supplemental homestead credit at this amount.
+values:
+  2026-01-01: 300
+metadata:
+  unit: currency-USD
+  period: year
+  label: Indiana supplemental homestead credit cap
+  reference:
+    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c) - lesser of 10% of liability or $300
+      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
+    - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
+      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2

--- a/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/cap.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/cap.yaml
@@ -6,7 +6,7 @@ metadata:
   period: year
   label: Indiana supplemental homestead credit cap
   reference:
-    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c) - lesser of 10% of liability or $300
+    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c)
       href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
     - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
       href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2

--- a/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/rate.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/rate.yaml
@@ -6,7 +6,7 @@ metadata:
   period: year
   label: Indiana supplemental homestead credit rate
   reference:
-    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c)
-      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
+    - title: Senate Enrolled Act 1 (2025), SEC. 74 (page 124), adding IC 6-1.1-20.6-7.7(c)
+      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf#page=124
     - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
-      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2
+      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=9

--- a/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/rate.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/rate.yaml
@@ -1,0 +1,12 @@
+description: Indiana provides its supplemental homestead credit as this share of the homestead property tax liability, up to a cap.
+values:
+  2026-01-01: 0.1
+metadata:
+  unit: /1
+  period: year
+  label: Indiana supplemental homestead credit rate
+  reference:
+    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c) - lesser of 10% of liability or $300
+      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
+    - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
+      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2

--- a/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/rate.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/supplemental_homestead_credit/rate.yaml
@@ -1,4 +1,4 @@
-description: Indiana provides its supplemental homestead credit as this share of the homestead property tax liability, up to a cap.
+description: Indiana provides its supplemental homestead credit as this share of the homestead property tax liability.
 values:
   2026-01-01: 0.1
 metadata:
@@ -6,7 +6,7 @@ metadata:
   period: year
   label: Indiana supplemental homestead credit rate
   reference:
-    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c) - lesser of 10% of liability or $300
+    - title: Senate Enrolled Act 1 (2025), SEC. 74, adding IC 6-1.1-20.6-7.7(c)
       href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
     - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
       href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/in_supplemental_homestead_credit_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/in_supplemental_homestead_credit_in_aggregate.yaml
@@ -1,0 +1,52 @@
+# Guards that in_supplemental_homestead_credit flows through the
+# state_property_tax_credits umbrella (taxsim_state_property_tax_credit) from
+# 2026, stacking with the over-65 credit, and is excluded in 2025 by the
+# year-keyed list (the standalone variable has no in_effect gate, so only the
+# list protects earlier years).
+
+- name: 2026 umbrella stacks the supplemental homestead credit with the over-65 credit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 66
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status:
+          2024: SINGLE
+          2026: SINGLE
+        adjusted_gross_income:
+          2024: 30_000
+          2026: 30_000
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    # Supplemental: 10% of 2,000 = 200. Over-65: $150 (senior, 2024 AGI 30,000
+    # under the limit, homeowner). Umbrella = 350.
+    in_supplemental_homestead_credit: 200
+    in_over_65_property_tax_credit: 150
+    taxsim_state_property_tax_credit: 350
+
+- name: 2025 umbrella excludes the supplemental homestead credit
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    # The credit is only in the 2026 list block, so the umbrella is 0 in 2025
+    # even though the standalone variable would extrapolate a nonzero value.
+    taxsim_state_property_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.yaml
@@ -3,8 +3,9 @@
 # or $300, for taxes first due and payable in 2026 and after. No age or income
 # limit.
 
-- name: 2026 homeowner below the cap receives 10% of property tax
+- name: Case 1, 2026 homeowner below the cap receives 10% of property tax.
   period: 2026
+  absolute_error_margin: 0.01
   input:
     people:
       person1:
@@ -19,8 +20,9 @@
   output:
     in_supplemental_homestead_credit: 200
 
-- name: 2026 homeowner at the $3,000 liability boundary receives the $300 cap
+- name: Case 2, 2026 homeowner at the $3,000 liability boundary receives the $300 cap.
   period: 2026
+  absolute_error_margin: 0.01
   input:
     people:
       person1:
@@ -35,8 +37,9 @@
   output:
     in_supplemental_homestead_credit: 300
 
-- name: 2026 homeowner above the cap is limited to $300
+- name: Case 3, 2026 homeowner above the cap is limited to $300.
   period: 2026
+  absolute_error_margin: 0.01
   input:
     people:
       person1:
@@ -51,8 +54,9 @@
   output:
     in_supplemental_homestead_credit: 300
 
-- name: 2026 renter with no real estate taxes receives no credit
+- name: Case 4, 2026 renter with no real estate taxes receives no credit.
   period: 2026
+  absolute_error_margin: 0.01
   input:
     people:
       person1:
@@ -67,8 +71,9 @@
   output:
     in_supplemental_homestead_credit: 0
 
-- name: 2026 non-Indiana homeowner receives no credit
+- name: Case 5, 2026 non-Indiana homeowner receives no credit.
   period: 2026
+  absolute_error_margin: 0.01
   input:
     people:
       person1:

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.yaml
@@ -87,3 +87,23 @@
         state_code: MN
   output:
     in_supplemental_homestead_credit: 0
+
+- name: Case 6, 2026 multi-person tax unit is capped once per return.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        real_estate_taxes: 1_500
+      person2:
+        real_estate_taxes: 1_500
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IN
+  output:
+    # 10% of the combined $3,000 is $300, exactly the cap, for the tax unit.
+    in_supplemental_homestead_credit: 300

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.yaml
@@ -1,0 +1,84 @@
+# Indiana supplemental homestead credit (Senate Enrolled Act 1, 2025;
+# IC 6-1.1-20.6-7.7): the lesser of 10% of the homestead property tax liability
+# or $300, for taxes first due and payable in 2026 and after. No age or income
+# limit.
+
+- name: 2026 homeowner below the cap receives 10% of property tax
+  period: 2026
+  input:
+    people:
+      person1:
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_supplemental_homestead_credit: 200
+
+- name: 2026 homeowner at the $3,000 liability boundary receives the $300 cap
+  period: 2026
+  input:
+    people:
+      person1:
+        real_estate_taxes: 3_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_supplemental_homestead_credit: 300
+
+- name: 2026 homeowner above the cap is limited to $300
+  period: 2026
+  input:
+    people:
+      person1:
+        real_estate_taxes: 5_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_supplemental_homestead_credit: 300
+
+- name: 2026 renter with no real estate taxes receives no credit
+  period: 2026
+  input:
+    people:
+      person1:
+        real_estate_taxes: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_supplemental_homestead_credit: 0
+
+- name: 2026 non-Indiana homeowner receives no credit
+  period: 2026
+  input:
+    people:
+      person1:
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    in_supplemental_homestead_credit: 0

--- a/policyengine_us/variables/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class in_supplemental_homestead_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Indiana supplemental homestead credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf",
+        "https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2",
+    )
+    defined_for = StateCode.IN
+
+    def formula(tax_unit, period, parameters):
+        # Senate Enrolled Act 1 (2025) adds IC 6-1.1-20.6-7.7, a supplemental
+        # homestead credit equal to the lesser of 10% of the homestead property
+        # tax liability or $300, for taxes first due and payable in 2026 and
+        # after. No age or income limit; homeowners only, so renters (with no
+        # real estate taxes) receive zero.
+        p = (
+            parameters(period)
+            .gov.states["in"]
+            .tax.property.supplemental_homestead_credit
+        )
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+        return min_(p.rate * property_tax, p.cap)

--- a/policyengine_us/variables/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.py
@@ -8,8 +8,8 @@ class in_supplemental_homestead_credit(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf",
-        "https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2",
+        "https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf#page=124",
+        "https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=9",
     )
     defined_for = StateCode.IN
 
@@ -18,10 +18,13 @@ class in_supplemental_homestead_credit(Variable):
         # homestead credit equal to the lesser of 10% of the homestead property
         # tax liability or $300, for taxes first due and payable in 2026 and
         # after. No age or income limit; homeowners only, so renters (with no
-        # real estate taxes) receive zero. real_estate_taxes is used as a proxy
-        # for the homestead-only property tax liability, since PE has no
-        # homestead-specific real-estate-tax variable; the effect is bounded by
-        # the $300 cap.
+        # real estate taxes) receive zero.
+        # Modeling approximations, all bounded by the $300 cap: eligibility is
+        # proxied by real_estate_taxes > 0 rather than the IC 6-1.1-12-37
+        # homestead standard deduction qualification; the base is total
+        # real_estate_taxes rather than the homestead-only liability (PE has no
+        # homestead-specific variable); and subsection (d)'s exclusion of
+        # referendum-approved taxes from the base is not modeled.
         p = (
             parameters(period)
             .gov.states["in"]

--- a/policyengine_us/variables/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/property/supplemental_homestead_credit/in_supplemental_homestead_credit.py
@@ -18,7 +18,10 @@ class in_supplemental_homestead_credit(Variable):
         # homestead credit equal to the lesser of 10% of the homestead property
         # tax liability or $300, for taxes first due and payable in 2026 and
         # after. No age or income limit; homeowners only, so renters (with no
-        # real estate taxes) receive zero.
+        # real estate taxes) receive zero. real_estate_taxes is used as a proxy
+        # for the homestead-only property tax liability, since PE has no
+        # homestead-specific real-estate-tax variable; the effect is bounded by
+        # the $300 cap.
         p = (
             parameters(period)
             .gov.states["in"]


### PR DESCRIPTION
## Summary

Adds Indiana's **Supplemental Homestead Credit**, created by [Senate Enrolled Act 1 (2025)](https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf) (P.L.68-2025), SEC. 74, adding **IC 6-1.1-20.6-7.7**.

The credit is the **lesser of 10% of the homestead property tax liability or \$300**, for property taxes first due and payable in **2026 and after**. There is **no age or income limit**; it applies to owner-occupied homesteads. It is modeled as `min(0.10 × real_estate_taxes, $300)`, so renters (with no real estate taxes) receive \$0.

## Changes

- **New variable** `in_supplemental_homestead_credit` (`TaxUnit`, `defined_for = StateCode.IN`) = `min(rate × real_estate_taxes, cap)`.
- **New parameters** under `gov.states.in.tax.property.supplemental_homestead_credit`: `rate` (10%) and `cap` (\$300), both from 2026.
- **Wired** into the 2026 block of `state_property_tax_credits.yaml`, alongside the existing `in_over_65_property_tax_credit`.

## Scope

SEA 1 created several property-tax credits. This PR adds the flagship **supplemental homestead credit** (universal to homesteaders, no income test). For context on the others:
- The **Over-65 \$150 credit** (IC 6-1.1-51.3-1) is **already implemented** as `in_over_65_property_tax_credit` (#8308).
- The **Blind/Disabled \$125 credit** (IC 6-1.1-51.3-2) is a possible follow-up.
- The SEA 1 **veteran credits were repealed** by HEA 1427-2025 (veterans keep their pre-existing deductions), so they are intentionally not modeled.

## Tests

`in_supplemental_homestead_credit.yaml` covers: below-cap (\$2,000 → \$200), the \$3,000 liability boundary (→ \$300 cap), above-cap (\$5,000 → \$300), renter with no property tax (→ \$0), and non-IN resident (→ \$0).

## References

- [Senate Enrolled Act 1 (2025), enrolled text](https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf) — SEC. 74, IC 6-1.1-20.6-7.7(c)
- [Indiana DLGF memo — Legislation Affecting Deductions, Exemptions, and Credits](https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)