### PR TITLE
Restore Pennsylvania property tax or rent rebate to 2026 aggregate

### DIFF
--- a/changelog.d/restore-pa-property-tax-rebate-2026.fixed.md
+++ b/changelog.d/restore-pa-property-tax-rebate-2026.fixed.md
@@ -1,0 +1,1 @@
+Restore the Pennsylvania property tax or rent rebate to the 2026 state property tax credit aggregate, from which it was accidentally dropped.

--- a/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
@@ -184,6 +184,7 @@ values:
     - nm_property_tax_rebate
     - ny_real_property_tax_credit
     - ok_ptc
+    - pa_property_tax_or_rent_rebate
     - ri_property_tax_credit
     - ut_homeowner_renter_relief
     - vt_renter_credit

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/pa_property_tax_or_rent_rebate_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/pa_property_tax_or_rent_rebate_in_aggregate.yaml
@@ -1,0 +1,23 @@
+# Guards against pa_property_tax_or_rent_rebate being dropped from the 2026
+# state property tax credits aggregate again (it was accidentally removed and is
+# restored by this PR). The underlying rebate parameters carry their 2025 values
+# forward, so a qualifying 2026 household must flow through the year-keyed list.
+
+- name: PA rebate flows into the aggregate in 2026
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 65
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        adjusted_gross_income: 8_550
+    households:
+      household:
+        members: [person1]
+        state_code: PA
+  output:
+    pa_property_tax_or_rent_rebate: 1_000
+    taxsim_state_property_tax_credit: 1_000


### PR DESCRIPTION
## Summary

Restores `pa_property_tax_or_rent_rebate` to the **2026** block of `state_property_tax_credits.yaml`.

It was present in the 2025 block but was dropped from the 2026 block when the Indiana over-65 credit PR (#8308) created a fresh 2026 list — the same accidental merge collision that dropped `nd_renters_refund` (restored separately in #8996). The omission silently zeroed the Pennsylvania Property Tax/Rent Rebate in 2026 microsimulations.

## Why this is correct

The Property Tax/Rent Rebate is an ongoing program with no 2026 sunset. Its parameters (amount schedule, income limit) carry their 2025 values forward, so restoring it to the 2026 aggregate makes it compute exactly as it did in 2025 — which is the intended behavior.

## Changes

- Add `pa_property_tax_or_rent_rebate` back to the 2026 block (alphabetical position, matching 2025).

No new variables or parameters — this is purely the accidentally-dropped aggregate entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)