### PR TITLE
Add Indiana blind or disabled property tax credit (SEA 1, 2025)

### DIFF
--- a/changelog.d/in-blind-disabled-property-tax-credit.added.md
+++ b/changelog.d/in-blind-disabled-property-tax-credit.added.md
@@ -1,0 +1,1 @@
+Add the Indiana blind or disabled property tax credit (Senate Enrolled Act 1, 2025), a $125 credit for blind or disabled homeowners, from 2026.

--- a/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_property_tax_credits.yaml
@@ -171,6 +171,7 @@ values:
     - dc_ptc
     - dc_senior_disabled_property_tax_relief
     - il_property_tax_credit
+    - in_blind_disabled_property_tax_credit
     - in_over_65_property_tax_credit
     - ma_senior_circuit_breaker
     - me_property_tax_fairness_credit

--- a/policyengine_us/parameters/gov/states/in/tax/property/blind_disabled_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/blind_disabled_credit/amount.yaml
@@ -9,4 +9,4 @@ metadata:
     - title: Senate Enrolled Act 1 (2025), SEC. 84, adding IC 6-1.1-51.3-2
       href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf#page=143
     - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
-      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2
+      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=4

--- a/policyengine_us/parameters/gov/states/in/tax/property/blind_disabled_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/blind_disabled_credit/amount.yaml
@@ -1,0 +1,12 @@
+description: Indiana provides this property tax credit to blind or disabled owners of a principal residence.
+values:
+  2026-01-01: 125
+metadata:
+  unit: currency-USD
+  period: year
+  label: Indiana blind or disabled property tax credit amount
+  reference:
+    - title: Senate Enrolled Act 1 (2025), SEC. 84, adding IC 6-1.1-51.3-2 - $125 credit for blind or disabled owners
+      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
+    - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
+      href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2

--- a/policyengine_us/parameters/gov/states/in/tax/property/blind_disabled_credit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/property/blind_disabled_credit/amount.yaml
@@ -6,7 +6,7 @@ metadata:
   period: year
   label: Indiana blind or disabled property tax credit amount
   reference:
-    - title: Senate Enrolled Act 1 (2025), SEC. 84, adding IC 6-1.1-51.3-2 - $125 credit for blind or disabled owners
-      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf
+    - title: Senate Enrolled Act 1 (2025), SEC. 84, adding IC 6-1.1-51.3-2
+      href: https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf#page=143
     - title: Indiana Department of Local Government Finance | Legislation Affecting Deductions, Exemptions, and Credits
       href: https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/in_blind_disabled_property_tax_credit_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/in_blind_disabled_property_tax_credit_in_aggregate.yaml
@@ -1,0 +1,53 @@
+# Guards that in_blind_disabled_property_tax_credit flows through the
+# state_property_tax_credits umbrella (taxsim_state_property_tax_credit) from
+# 2026, stacking with the over-65 credit, and is excluded in 2025 by the
+# year-keyed list (the standalone variable has no in_effect gate).
+
+- name: 2026 umbrella stacks the blind/disabled credit with the over-65 credit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 70
+        is_disabled: true
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status:
+          2024: SINGLE
+          2026: SINGLE
+        adjusted_gross_income:
+          2024: 30_000
+          2026: 30_000
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    # Over-65: $150 (senior, 2024 AGI 30,000 under the limit, homeowner).
+    # Blind/disabled: $125. Umbrella = 275.
+    in_over_65_property_tax_credit: 150
+    in_blind_disabled_property_tax_credit: 125
+    taxsim_state_property_tax_credit: 275
+
+- name: 2025 umbrella excludes the blind/disabled credit
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 70
+        is_disabled: true
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    # The credit is only in the 2026 list block, so the umbrella is 0 in 2025.
+    taxsim_state_property_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.yaml
@@ -1,0 +1,107 @@
+# Indiana blind or disabled property tax credit (Senate Enrolled Act 1, 2025;
+# IC 6-1.1-51.3-2): a $125 credit for a blind or disabled owner of a principal
+# residence, with no income limit, for taxes first due and payable in 2026 and
+# after. The credit cannot exceed the property tax liability.
+
+- name: 2026 blind homeowner receives the $125 credit
+  period: 2026
+  input:
+    people:
+      person1:
+        is_blind: true
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_blind_disabled_property_tax_credit: 125
+
+- name: 2026 disabled homeowner receives the $125 credit
+  period: 2026
+  input:
+    people:
+      person1:
+        is_disabled: true
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_blind_disabled_property_tax_credit: 125
+
+- name: 2026 blind homeowner is limited to the property tax liability
+  period: 2026
+  input:
+    people:
+      person1:
+        is_blind: true
+        real_estate_taxes: 80
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_blind_disabled_property_tax_credit: 80
+
+- name: 2026 homeowner who is neither blind nor disabled receives no credit
+  period: 2026
+  input:
+    people:
+      person1:
+        is_blind: false
+        is_disabled: false
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_blind_disabled_property_tax_credit: 0
+
+- name: 2026 blind renter with no real estate taxes receives no credit
+  period: 2026
+  input:
+    people:
+      person1:
+        is_blind: true
+        real_estate_taxes: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IN
+  output:
+    in_blind_disabled_property_tax_credit: 0
+
+- name: 2026 non-Indiana blind homeowner receives no credit
+  period: 2026
+  input:
+    people:
+      person1:
+        is_blind: true
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MN
+  output:
+    in_blind_disabled_property_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.yaml
@@ -105,3 +105,48 @@
         state_code: MN
   output:
     in_blind_disabled_property_tax_credit: 0
+
+- name: 2026 credit requires the blind or disabled person to be head or spouse
+  period: 2026
+  input:
+    people:
+      parent:
+        age: 45
+        real_estate_taxes: 2_000
+      child:
+        age: 10
+        is_blind: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: IN
+  output:
+    # The blind person is a dependent, not the head or spouse, so no credit.
+    in_blind_disabled_property_tax_credit: 0
+
+- name: 2026 married couple where only the spouse is blind receives the credit
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+      person2:
+        age: 45
+        is_blind: true
+        real_estate_taxes: 2_000
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IN
+  output:
+    in_blind_disabled_property_tax_credit: 125

--- a/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.yaml
@@ -150,3 +150,30 @@
         state_code: IN
   output:
     in_blind_disabled_property_tax_credit: 125
+
+- name: 2026 married couple where both spouses are blind receives one credit per return
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_blind: true
+        real_estate_taxes: 2_000
+      person2:
+        age: 45
+        is_blind: true
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IN
+  output:
+    # Modeled as one $125 credit per return via tax_unit.any (IC 6-1.1-51.3-2
+    # has no per-property limit, but the model gives one credit per tax unit).
+    in_blind_disabled_property_tax_credit: 125

--- a/policyengine_us/variables/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class in_blind_disabled_property_tax_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Indiana blind or disabled property tax credit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf",
+        "https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2",
+    )
+    defined_for = StateCode.IN
+
+    def formula(tax_unit, period, parameters):
+        # Senate Enrolled Act 1 (2025) adds IC 6-1.1-51.3-2, a $125 property tax
+        # credit for a blind or disabled owner of a principal residence, with no
+        # income limit, for taxes first due and payable in 2026 and after. The
+        # credit cannot exceed the property tax liability, so renters (with no
+        # real estate taxes) receive zero.
+        p = parameters(period).gov.states["in"].tax.property.blind_disabled_credit
+        person = tax_unit.members
+        head_or_spouse = person("is_tax_unit_head_or_spouse", period)
+        blind = person("is_blind", period)
+        disabled = person("is_disabled", period)
+        eligible = tax_unit.any((blind | disabled) & head_or_spouse)
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+        return eligible * min_(p.amount, property_tax)

--- a/policyengine_us/variables/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.py
@@ -8,14 +8,22 @@ class in_blind_disabled_property_tax_credit(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf",
-        "https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2",
+        "https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf#page=143",
+        "https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=4",
     )
     defined_for = StateCode.IN
 
     def formula(tax_unit, period, parameters):
         # SEA 1 (2025) IC 6-1.1-51.3-2: $125 credit for a blind or disabled
         # owner of a principal residence, capped at the property tax liability.
+        # Modeling notes: modeled as one $125 credit per return (via
+        # tax_unit.any) -- IC 6-1.1-51.3-2 has no one-credit-per-property limit,
+        # so two blind/disabled co-owning spouses could arguably each claim $125;
+        # is_disabled is broader than the SSA substantial-gainful-activity
+        # standard the statute references (is_ssi_disabled is closer); the base
+        # is total real_estate_taxes rather than principal-residence-only; and
+        # each stacked chapter-57 credit caps independently, so combined credits
+        # can exceed a small total liability.
         p = parameters(period).gov.states["in"].tax.property.blind_disabled_credit
         person = tax_unit.members
         head_or_spouse = person("is_tax_unit_head_or_spouse", period)

--- a/policyengine_us/variables/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/in/tax/property/blind_disabled_credit/in_blind_disabled_property_tax_credit.py
@@ -14,11 +14,8 @@ class in_blind_disabled_property_tax_credit(Variable):
     defined_for = StateCode.IN
 
     def formula(tax_unit, period, parameters):
-        # Senate Enrolled Act 1 (2025) adds IC 6-1.1-51.3-2, a $125 property tax
-        # credit for a blind or disabled owner of a principal residence, with no
-        # income limit, for taxes first due and payable in 2026 and after. The
-        # credit cannot exceed the property tax liability, so renters (with no
-        # real estate taxes) receive zero.
+        # SEA 1 (2025) IC 6-1.1-51.3-2: $125 credit for a blind or disabled
+        # owner of a principal residence, capped at the property tax liability.
         p = parameters(period).gov.states["in"].tax.property.blind_disabled_credit
         person = tax_unit.members
         head_or_spouse = person("is_tax_unit_head_or_spouse", period)


### PR DESCRIPTION
## Summary

Adds Indiana's **blind or disabled property tax credit**, created by [Senate Enrolled Act 1 (2025)](https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf) (P.L.68-2025), SEC. 84, adding **IC 6-1.1-51.3-2**.

The credit is **\$125** for a **blind or disabled owner** of a principal residence, with **no income limit**, for property taxes first due and payable in **2026 and after**. It is modeled as `blind_or_disabled × min($125, real_estate_taxes)`, so a credit never exceeds the liability and renters (with no real estate taxes) receive \$0.

## Changes

- **New variable** `in_blind_disabled_property_tax_credit` (`TaxUnit`, `defined_for = StateCode.IN`): \$125 if any head or spouse is blind or disabled, capped at the property tax liability.
- **New parameter** `gov.states.in.tax.property.blind_disabled_credit.amount` (\$125, from 2026).
- **Wired** into the 2026 block of `state_property_tax_credits.yaml`, alongside `in_over_65_property_tax_credit` and `in_supplemental_homestead_credit`.

## Context

This is the third and final SEA 1 flat property-tax credit:
- **Over-65 \$150 credit** (IC 6-1.1-51.3-1) — already modeled (#8308).
- **Supplemental homestead credit** 10%/\$300 (IC 6-1.1-20.6-7.7) — added in #8997.
- **Blind/disabled \$125 credit** (IC 6-1.1-51.3-2) — this PR.

The SEA 1 veteran credits were repealed by HEA 1427-2025 (veterans keep their pre-existing deductions), so they are intentionally not modeled.

## Tests

`in_blind_disabled_property_tax_credit.yaml` covers: blind homeowner (→ \$125), disabled homeowner (→ \$125), the liability cap (\$80 tax → \$80), neither blind nor disabled (→ \$0), blind renter with no property tax (→ \$0), and non-IN resident (→ \$0).

## References

- [Senate Enrolled Act 1 (2025), enrolled text](https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0001/SB0001.05.ENRH.pdf) — SEC. 84, IC 6-1.1-51.3-2
- [Indiana DLGF memo — Legislation Affecting Deductions, Exemptions, and Credits](https://www.in.gov/dlgf/files/2025-memos/250612-Cockerill-Memo-Legislation-Affecting-Deductions%2C-Exemptions%2C-and-Credits.pdf#page=2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)