### PR TITLE
Fix IN blind/disabled aggregate test for supplemental credit stacking

### DIFF
--- a/changelog.d/fix-in-aggregate-stacking-test.fixed.md
+++ b/changelog.d/fix-in-aggregate-stacking-test.fixed.md
@@ -1,0 +1,1 @@
+Fix the Indiana blind/disabled property tax credit aggregate test to account for the supplemental homestead credit (SEA 1) stacking in the umbrella.

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/in_blind_disabled_property_tax_credit_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/in_blind_disabled_property_tax_credit_in_aggregate.yaml
@@ -26,11 +26,14 @@
         members: [person1]
         state_code: IN
   output:
-    # Over-65: $150 (senior, 2024 AGI 30,000 under the limit, homeowner).
-    # Blind/disabled: $125. Umbrella = 275.
+    # A disabled senior homeowner qualifies for all three SEA 1 credits, which
+    # stack in the umbrella: over-65 $150 (senior, 2024 AGI 30,000 under the
+    # limit, homeowner) + blind/disabled $125 + supplemental homestead $200
+    # (10% of 2,000, capped at $300) = $475.
     in_over_65_property_tax_credit: 150
     in_blind_disabled_property_tax_credit: 125
-    taxsim_state_property_tax_credit: 275
+    in_supplemental_homestead_credit: 200
+    taxsim_state_property_tax_credit: 475
 
 - name: 2025 umbrella excludes the blind/disabled credit
   period: 2025


### PR DESCRIPTION
## Summary

Fixes the `Full Suite - Baseline (states-shard-4)` failure currently red on `main`.

The `in_blind_disabled_property_tax_credit_in_aggregate.yaml` 2026 case (a **disabled senior homeowner**) asserted `taxsim_state_property_tax_credit: 275` = over-65 `$150` + blind/disabled `$125`. That was correct when #9007 was written (rebased before #8997 merged), but now that the **supplemental homestead credit (#8997)** is also in the 2026 aggregate, the same household correctly qualifies for **all three** SEA 1 credits:

| Credit | Amount |
|--------|--------|
| Over-65 (IC 6-1.1-51.3-1) | $150 |
| Blind/disabled (IC 6-1.1-51.3-2) | $125 |
| Supplemental homestead (IC 6-1.1-20.6-7.7) | $200 (10% of $2,000) |
| **`taxsim_state_property_tax_credit`** | **$475** |

Updates the expected value `275 → 475` and adds the `in_supplemental_homestead_credit: 200` assertion. Verified that the sibling `in_supplemental_homestead_credit_in_aggregate.yaml` test is unaffected (its household is not blind/disabled, so the blind/disabled credit is $0 and its total stays $350).

The separate `Household API Partners` (CA) failure on main is unrelated — a policyengine-core issue tracked in #9045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)