### PR TITLE
Hawaii: add 13% top income-tax bracket (SB 3125 / Act 24, 2026), effective TY2027

### DIFF
--- a/changelog.d/hi-act24-13pct-top-bracket.added.md
+++ b/changelog.d/hi-act24-13pct-top-bracket.added.md
@@ -1,0 +1,1 @@
+Hawaii Act 24 (S.B. 3125, SLH 2026) income tax rate schedules: 13% top bracket above $1,000,000 (joint and surviving spouse), $750,000 (head of household), and $500,000 (single and separate) with restructured 2027 and 2029 rates.

--- a/policyengine_us/parameters/gov/states/hi/tax/income/rates/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/hi/tax/income/rates/head_of_household.yaml
@@ -11,6 +11,7 @@ brackets:
       2029-01-01: 28_800
     rate:
       2018-01-01: 0.032
+      2027-01-01: 0.025
   - threshold:
       2018-01-01: 7_200
       2025-01-01: 21_600
@@ -18,6 +19,7 @@ brackets:
       2029-01-01: 36_000
     rate:
       2018-01-01: 0.055
+      2027-01-01: 0.05
   - threshold:
       2018-01-01: 14_400
       2025-01-01: 28_800
@@ -46,6 +48,7 @@ brackets:
       2029-01-01: 262_500
     rate:
       2018-01-01: 0.076
+      2029-01-01: 0.0825
   - threshold:
       2018-01-01: 54_000
       2025-01-01: 187_500
@@ -53,6 +56,8 @@ brackets:
       2029-01-01: 337_500
     rate:
       2018-01-01: 0.079
+      2027-01-01: 0.0825
+      2029-01-01: 0.09
   - threshold:
       2018-01-01: 72_000
       2025-01-01: 262_500
@@ -60,6 +65,8 @@ brackets:
       2029-01-01: 412_500
     rate:
       2018-01-01: 0.0825
+      2027-01-01: 0.09
+      2029-01-01: 0.1
   - threshold:
       2018-01-01: 225_000
       2025-01-01: 337_500
@@ -67,6 +74,8 @@ brackets:
       2029-01-01: 487_500
     rate:
       2018-01-01: 0.09
+      2027-01-01: 0.1
+      2029-01-01: 0.11
   - threshold:
       2018-01-01: 262_500
       2025-01-01: 412_500
@@ -74,6 +83,7 @@ brackets:
       2029-01-01: 600_000
     rate:
       2018-01-01: 0.1
+      2027-01-01: 0.11
   - threshold:
       2018-01-01: 300_000
       2025-01-01: 487_500
@@ -81,6 +91,13 @@ brackets:
       2029-01-01: 712_500
     rate:
       2018-01-01: 0.11
+  # S.B. 3125 C.D. 1 (Act 24, SLH 2026) adds a 13% bracket above $750,000
+  # for taxable years beginning after December 31, 2026.
+  - threshold:
+      2018-01-01: .inf
+      2027-01-01: 750_000
+    rate:
+      2027-01-01: 0.13
 
 metadata:
   threshold_unit: currency_USD
@@ -102,3 +119,7 @@ metadata:
       href: https://dev1-tax.hawaii.gov/forms/d_25table-on/d_25table-on_p13/
     - title: 2025 Hawaii N-11 Instructions Tax Rate Schedules
       href: https://files.hawaii.gov/tax/forms/current/n11ins.pdf#page=48
+    - title: S.B. 3125 C.D. 1 (Act 24, SLH 2026) Section 2, amending HRS Section 235-51 (b) - restructured rate schedule with a 13% top bracket for taxable years beginning after December 31, 2026 (effective date in Section 9)
+      href: https://data.capitol.hawaii.gov/sessions/session2026/bills/SB3125_CD1_.HTM
+    - title: S.B. 3125 measure status (Act 24, SLH 2026)
+      href: https://www.capitol.hawaii.gov/session/measure_indiv.aspx?billtype=SB&billnumber=3125

--- a/policyengine_us/parameters/gov/states/hi/tax/income/rates/joint.yaml
+++ b/policyengine_us/parameters/gov/states/hi/tax/income/rates/joint.yaml
@@ -12,6 +12,7 @@ brackets:
       2029-01-01: 38_400
     rate:
       2018-01-01: 0.032
+      2027-01-01: 0.025
   - threshold:
       2018-01-01: 9_600
       2025-01-01: 28_800
@@ -19,6 +20,7 @@ brackets:
       2029-01-01: 48_000
     rate:
       2018-01-01: 0.055
+      2027-01-01: 0.05
   - threshold:
       2018-01-01: 19_200
       2025-01-01: 38_400
@@ -47,6 +49,7 @@ brackets:
       2029-01-01: 350_000
     rate:
       2018-01-01: 0.076
+      2029-01-01: 0.0825
   - threshold:
       2018-01-01: 72_000
       2025-01-01: 250_000
@@ -54,6 +57,8 @@ brackets:
       2029-01-01: 450_000
     rate:
       2018-01-01: 0.079
+      2027-01-01: 0.0825
+      2029-01-01: 0.09
   - threshold:
       2018-01-01: 96_000
       2025-01-01: 350_000
@@ -61,6 +66,8 @@ brackets:
       2029-01-01: 550_000
     rate:
       2018-01-01: 0.0825
+      2027-01-01: 0.09
+      2029-01-01: 0.1
   - threshold:
       2018-01-01: 300_000
       2025-01-01: 450_000
@@ -68,6 +75,8 @@ brackets:
       2029-01-01: 650_000
     rate:
       2018-01-01: 0.09
+      2027-01-01: 0.1
+      2029-01-01: 0.11
   - threshold:
       2018-01-01: 350_000
       2025-01-01: 550_000
@@ -75,6 +84,7 @@ brackets:
       2029-01-01: 800_000
     rate:
       2018-01-01: 0.1
+      2027-01-01: 0.11
   - threshold:
       2018-01-01: 400_000
       2025-01-01: 650_000
@@ -82,6 +92,13 @@ brackets:
       2029-01-01: 950_000
     rate:
       2018-01-01: 0.11
+  # S.B. 3125 C.D. 1 (Act 24, SLH 2026) adds a 13% bracket above $1,000,000
+  # for taxable years beginning after December 31, 2026.
+  - threshold:
+      2018-01-01: .inf
+      2027-01-01: 1_000_000
+    rate:
+      2027-01-01: 0.13
 
 
 metadata:
@@ -104,3 +121,7 @@ metadata:
       href: https://dev1-tax.hawaii.gov/forms/d_25table-on/d_25table-on_p13/
     - title: 2025 Hawaii N-11 Instructions Tax Rate Schedules
       href: https://files.hawaii.gov/tax/forms/current/n11ins.pdf#page=48
+    - title: S.B. 3125 C.D. 1 (Act 24, SLH 2026) Section 2, amending HRS Section 235-51 (a) - restructured rate schedule with a 13% top bracket for taxable years beginning after December 31, 2026 (effective date in Section 9)
+      href: https://data.capitol.hawaii.gov/sessions/session2026/bills/SB3125_CD1_.HTM
+    - title: S.B. 3125 measure status (Act 24, SLH 2026)
+      href: https://www.capitol.hawaii.gov/session/measure_indiv.aspx?billtype=SB&billnumber=3125

--- a/policyengine_us/parameters/gov/states/hi/tax/income/rates/separate.yaml
+++ b/policyengine_us/parameters/gov/states/hi/tax/income/rates/separate.yaml
@@ -11,6 +11,7 @@ brackets:
       2029-01-01: 19_200
     rate:
       2018-01-01: 0.032
+      2027-01-01: 0.025
   - threshold:
       2018-01-01: 4_800
       2025-01-01: 14_400
@@ -18,6 +19,7 @@ brackets:
       2029-01-01: 24_000
     rate:
       2018-01-01: 0.055
+      2027-01-01: 0.05
   - threshold:
       2018-01-01: 9_600
       2025-01-01: 19_200
@@ -46,6 +48,7 @@ brackets:
       2029-01-01: 175_000
     rate:
       2018-01-01: 0.076
+      2029-01-01: 0.0825
   - threshold:
       2018-01-01: 36_000
       2025-01-01: 125_000
@@ -53,6 +56,8 @@ brackets:
       2029-01-01: 225_000
     rate:
       2018-01-01: 0.079
+      2027-01-01: 0.0825
+      2029-01-01: 0.09
   - threshold:
       2018-01-01: 48_000
       2025-01-01: 175_000
@@ -60,6 +65,8 @@ brackets:
       2029-01-01: 275_000
     rate:
       2018-01-01: 0.0825
+      2027-01-01: 0.09
+      2029-01-01: 0.1
   - threshold:
       2018-01-01: 150_000
       2025-01-01: 225_000
@@ -67,6 +74,8 @@ brackets:
       2029-01-01: 325_000
     rate:
       2018-01-01: 0.09
+      2027-01-01: 0.1
+      2029-01-01: 0.11
   - threshold:
       2018-01-01: 175_000
       2025-01-01: 275_000
@@ -74,6 +83,7 @@ brackets:
       2029-01-01: 400_000
     rate:
       2018-01-01: 0.1
+      2027-01-01: 0.11
   - threshold:
       2018-01-01: 200_000
       2025-01-01: 325_000
@@ -81,6 +91,13 @@ brackets:
       2029-01-01: 475_000
     rate:
       2018-01-01: 0.11
+  # S.B. 3125 C.D. 1 (Act 24, SLH 2026) adds a 13% bracket above $500,000
+  # for taxable years beginning after December 31, 2026.
+  - threshold:
+      2018-01-01: .inf
+      2027-01-01: 500_000
+    rate:
+      2027-01-01: 0.13
 
 metadata:
   threshold_unit: currency_USD
@@ -102,3 +119,7 @@ metadata:
       href: https://dev1-tax.hawaii.gov/forms/d_25table-on/d_25table-on_p13/
     - title: 2025 Hawaii N-11 Instructions Tax Rate Schedules
       href: https://files.hawaii.gov/tax/forms/current/n11ins.pdf#page=48
+    - title: S.B. 3125 C.D. 1 (Act 24, SLH 2026) Section 2, amending HRS Section 235-51 (c) - restructured rate schedule with a 13% top bracket for taxable years beginning after December 31, 2026 (effective date in Section 9)
+      href: https://data.capitol.hawaii.gov/sessions/session2026/bills/SB3125_CD1_.HTM
+    - title: S.B. 3125 measure status (Act 24, SLH 2026)
+      href: https://www.capitol.hawaii.gov/session/measure_indiv.aspx?billtype=SB&billnumber=3125

--- a/policyengine_us/parameters/gov/states/hi/tax/income/rates/single.yaml
+++ b/policyengine_us/parameters/gov/states/hi/tax/income/rates/single.yaml
@@ -11,6 +11,7 @@ brackets:
       2029-01-01: 19_200
     rate:
       2018-01-01: 0.032
+      2027-01-01: 0.025
   - threshold:
       2018-01-01: 4_800
       2025-01-01: 14_400
@@ -18,6 +19,7 @@ brackets:
       2029-01-01: 24_000
     rate:
       2018-01-01: 0.055
+      2027-01-01: 0.05
   - threshold:
       2018-01-01: 9_600
       2025-01-01: 19_200
@@ -46,6 +48,7 @@ brackets:
       2029-01-01: 175_000
     rate:
       2018-01-01: 0.076
+      2029-01-01: 0.0825
   - threshold:
       2018-01-01: 36_000
       2025-01-01: 125_000
@@ -53,6 +56,8 @@ brackets:
       2029-01-01: 225_000
     rate:
       2018-01-01: 0.079
+      2027-01-01: 0.0825
+      2029-01-01: 0.09
   - threshold:
       2018-01-01: 48_000
       2025-01-01: 175_000
@@ -60,6 +65,8 @@ brackets:
       2029-01-01: 275_000
     rate:
       2018-01-01: 0.0825
+      2027-01-01: 0.09
+      2029-01-01: 0.1
   - threshold:
       2018-01-01: 150_000
       2025-01-01: 225_000
@@ -67,6 +74,8 @@ brackets:
       2029-01-01: 325_000
     rate:
       2018-01-01: 0.09
+      2027-01-01: 0.1
+      2029-01-01: 0.11
   - threshold:
       2018-01-01: 175_000
       2025-01-01: 275_000
@@ -74,6 +83,7 @@ brackets:
       2029-01-01: 400_000
     rate:
       2018-01-01: 0.1
+      2027-01-01: 0.11
   - threshold:
       2018-01-01: 200_000
       2025-01-01: 325_000
@@ -81,6 +91,13 @@ brackets:
       2029-01-01: 475_000
     rate:
       2018-01-01: 0.11
+  # S.B. 3125 C.D. 1 (Act 24, SLH 2026) adds a 13% bracket above $500,000
+  # for taxable years beginning after December 31, 2026.
+  - threshold:
+      2018-01-01: .inf
+      2027-01-01: 500_000
+    rate:
+      2027-01-01: 0.13
 
 metadata:
   threshold_unit: currency_USD
@@ -102,3 +119,7 @@ metadata:
       href: https://dev1-tax.hawaii.gov/forms/d_25table-on/d_25table-on_p13/
     - title: 2025 Hawaii N-11 Instructions Tax Rate Schedules
       href: https://files.hawaii.gov/tax/forms/current/n11ins.pdf#page=48
+    - title: S.B. 3125 C.D. 1 (Act 24, SLH 2026) Section 2, amending HRS Section 235-51 (c) - restructured rate schedule with a 13% top bracket for taxable years beginning after December 31, 2026 (effective date in Section 9)
+      href: https://data.capitol.hawaii.gov/sessions/session2026/bills/SB3125_CD1_.HTM
+    - title: S.B. 3125 measure status (Act 24, SLH 2026)
+      href: https://www.capitol.hawaii.gov/session/measure_indiv.aspx?billtype=SB&billnumber=3125

--- a/policyengine_us/parameters/gov/states/hi/tax/income/rates/surviving_spouse.yaml
+++ b/policyengine_us/parameters/gov/states/hi/tax/income/rates/surviving_spouse.yaml
@@ -11,6 +11,7 @@ brackets:
       2029-01-01: 38_400
     rate:
       2018-01-01: 0.032
+      2027-01-01: 0.025
   - threshold:
       2018-01-01: 9_600
       2025-01-01: 28_800
@@ -18,6 +19,7 @@ brackets:
       2029-01-01: 48_000
     rate:
       2018-01-01: 0.055
+      2027-01-01: 0.05
   - threshold:
       2018-01-01: 19_200
       2025-01-01: 38_400
@@ -46,6 +48,7 @@ brackets:
       2029-01-01: 350_000
     rate:
       2018-01-01: 0.076
+      2029-01-01: 0.0825
   - threshold:
       2018-01-01: 72_000
       2025-01-01: 250_000
@@ -53,6 +56,8 @@ brackets:
       2029-01-01: 450_000
     rate:
       2018-01-01: 0.079
+      2027-01-01: 0.0825
+      2029-01-01: 0.09
   - threshold:
       2018-01-01: 96_000
       2025-01-01: 350_000
@@ -60,6 +65,8 @@ brackets:
       2029-01-01: 550_000
     rate:
       2018-01-01: 0.0825
+      2027-01-01: 0.09
+      2029-01-01: 0.1
   - threshold:
       2018-01-01: 300_000
       2025-01-01: 450_000
@@ -67,6 +74,8 @@ brackets:
       2029-01-01: 650_000
     rate:
       2018-01-01: 0.09
+      2027-01-01: 0.1
+      2029-01-01: 0.11
   - threshold:
       2018-01-01: 350_000
       2025-01-01: 550_000
@@ -74,6 +83,7 @@ brackets:
       2029-01-01: 800_000
     rate:
       2018-01-01: 0.1
+      2027-01-01: 0.11
   - threshold:
       2018-01-01: 400_000
       2025-01-01: 650_000
@@ -81,6 +91,13 @@ brackets:
       2029-01-01: 950_000
     rate:
       2018-01-01: 0.11
+  # S.B. 3125 C.D. 1 (Act 24, SLH 2026) adds a 13% bracket above $1,000,000
+  # for taxable years beginning after December 31, 2026.
+  - threshold:
+      2018-01-01: .inf
+      2027-01-01: 1_000_000
+    rate:
+      2027-01-01: 0.13
 
 metadata:
   threshold_unit: currency_USD
@@ -102,3 +119,7 @@ metadata:
       href: https://dev1-tax.hawaii.gov/forms/d_25table-on/d_25table-on_p13/
     - title: 2025 Hawaii N-11 Instructions Tax Rate Schedules
       href: https://files.hawaii.gov/tax/forms/current/n11ins.pdf#page=48
+    - title: S.B. 3125 C.D. 1 (Act 24, SLH 2026) Section 2, amending HRS Section 235-51 (a) - restructured rate schedule with a 13% top bracket for taxable years beginning after December 31, 2026 (effective date in Section 9)
+      href: https://data.capitol.hawaii.gov/sessions/session2026/bills/SB3125_CD1_.HTM
+    - title: S.B. 3125 measure status (Act 24, SLH 2026)
+      href: https://www.capitol.hawaii.gov/session/measure_indiv.aspx?billtype=SB&billnumber=3125

--- a/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/hi_income_tax_before_non_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/hi/tax/income/hi_income_tax_before_non_refundable_credits.yaml
@@ -19,3 +19,299 @@
     # First $4800 = $67.2
     # 3.2% of the next $200 = $6.4
     hi_income_tax_before_non_refundable_credits: 73.6
+
+# Act 24 (S.B. 3125 C.D. 1, SLH 2026) restructures the rate schedules for
+# taxable years beginning after December 31, 2026, adding a 13% top bracket.
+# TY2026 inertness tests: pre-2027 results must match the Act 46 (2024)
+# schedule exactly - the new bracket's threshold is infinite before 2027.
+- name: Single filer with $2,000,000 in 2026 is unaffected by Act 24
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 2_000_000
+    filing_status: SINGLE
+    state_code: HI
+  output:
+    #   1.40% * $9,600                       [$134.40]
+    # + 3.20% * ($14,400 - $9,600)           [$153.60]
+    # + 5.50% * ($19,200 - $14,400)          [$264.00]
+    # + 6.40% * ($24,000 - $19,200)          [$307.20]
+    # + 6.80% * ($36,000 - $24,000)          [$816.00]
+    # + 7.20% * ($48,000 - $36,000)          [$864.00]
+    # + 7.60% * ($125,000 - $48,000)         [$5,852.00]
+    # + 7.90% * ($175,000 - $125,000)        [$3,950.00]
+    # + 8.25% * ($225,000 - $175,000)        [$4,125.00]
+    # + 9.00% * ($275,000 - $225,000)        [$4,500.00]
+    # + 10.00% * ($325,000 - $275,000)       [$5,000.00]
+    # + 11.00% * ($2,000,000 - $325,000)     [$184,250.00]
+    # = $210,216.20
+    hi_income_tax_before_non_refundable_credits: 210_216.20
+
+- name: Joint filers with $2,000,000 in 2026 are unaffected by Act 24
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 2_000_000
+    filing_status: JOINT
+    state_code: HI
+  output:
+    #   1.40% * $19,200                      [$268.80]
+    # + 3.20% * ($28,800 - $19,200)          [$307.20]
+    # + 5.50% * ($38,400 - $28,800)          [$528.00]
+    # + 6.40% * ($48,000 - $38,400)          [$614.40]
+    # + 6.80% * ($72,000 - $48,000)          [$1,632.00]
+    # + 7.20% * ($96,000 - $72,000)          [$1,728.00]
+    # + 7.60% * ($250,000 - $96,000)         [$11,704.00]
+    # + 7.90% * ($350,000 - $250,000)        [$7,900.00]
+    # + 8.25% * ($450,000 - $350,000)        [$8,250.00]
+    # + 9.00% * ($550,000 - $450,000)        [$4,500.00 -> $9,000.00]
+    # + 10.00% * ($650,000 - $550,000)       [$10,000.00]
+    # + 11.00% * ($2,000,000 - $650,000)     [$148,500.00]
+    # = $200,432.40
+    hi_income_tax_before_non_refundable_credits: 200_432.40
+
+# TY2027 Act 24 schedule (statutory tables in S.B. 3125 C.D. 1 Section 2):
+# rates 1.40%, 2.50%, 5.00%, 6.40%, 6.80%, 7.20%, 7.60%, 8.25%, 9.00%,
+# 10.00%, 11.00%, and 13.00% above $1,000,000 (joint and surviving spouse),
+# $750,000 (head of household), or $500,000 (single and separate).
+- name: Joint filers just below the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 999_900
+    filing_status: JOINT
+    state_code: HI
+  output:
+    # Statutory base at $1,000,000 is $88,729 (see table below), so
+    # $88,729.20 - 11.00% * $100 = $88,718.20
+    hi_income_tax_before_non_refundable_credits: 88_718.20
+
+- name: Joint filers at the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 1_000_000
+    filing_status: JOINT
+    state_code: HI
+  output:
+    #   1.40% * $28,800                      [$403.20]
+    # + 2.50% * ($38,400 - $28,800)          [$240.00]
+    # + 5.00% * ($48,000 - $38,400)          [$480.00]
+    # + 6.40% * ($72,000 - $48,000)          [$1,536.00]
+    # + 6.80% * ($96,000 - $72,000)          [$1,632.00]
+    # + 7.20% * ($250,000 - $96,000)         [$11,088.00]
+    # + 7.60% * ($350,000 - $250,000)        [$7,600.00]
+    # + 8.25% * ($450,000 - $350,000)        [$8,250.00]
+    # + 9.00% * ($550,000 - $450,000)        [$9,000.00]
+    # + 10.00% * ($650,000 - $550,000)       [$10,000.00]
+    # + 11.00% * ($1,000,000 - $650,000)     [$38,500.00]
+    # = $88,729.20 (statute: "Over $1,000,000: $88,729.00 plus 13.00%")
+    hi_income_tax_before_non_refundable_credits: 88_729.20
+
+- name: Joint filers $100,000 above the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 1_100_000
+    filing_status: JOINT
+    state_code: HI
+  output:
+    # $88,729.20 + 13.00% * $100,000 = $101,729.20
+    hi_income_tax_before_non_refundable_credits: 101_729.20
+
+- name: Surviving spouse at the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 1_000_000
+    filing_status: SURVIVING_SPOUSE
+    state_code: HI
+  output:
+    # Same schedule as joint filers (HRS 235-51(a)): $88,729.20
+    hi_income_tax_before_non_refundable_credits: 88_729.20
+
+- name: Surviving spouse $100,000 above the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 1_100_000
+    filing_status: SURVIVING_SPOUSE
+    state_code: HI
+  output:
+    # $88,729.20 + 13.00% * $100,000 = $101,729.20
+    hi_income_tax_before_non_refundable_credits: 101_729.20
+
+- name: Head of household just below the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 749_900
+    filing_status: HEAD_OF_HOUSEHOLD
+    state_code: HI
+  output:
+    # Statutory base at $750,000 is $66,547 (see table below), so
+    # $66,546.90 - 11.00% * $100 = $66,535.90
+    hi_income_tax_before_non_refundable_credits: 66_535.90
+
+- name: Head of household at the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 750_000
+    filing_status: HEAD_OF_HOUSEHOLD
+    state_code: HI
+  output:
+    #   1.40% * $21,600                      [$302.40]
+    # + 2.50% * ($28,800 - $21,600)          [$180.00]
+    # + 5.00% * ($36,000 - $28,800)          [$360.00]
+    # + 6.40% * ($54,000 - $36,000)          [$1,152.00]
+    # + 6.80% * ($72,000 - $54,000)          [$1,224.00]
+    # + 7.20% * ($187,500 - $72,000)         [$8,316.00]
+    # + 7.60% * ($262,500 - $187,500)        [$5,700.00]
+    # + 8.25% * ($337,500 - $262,500)        [$6,187.50]
+    # + 9.00% * ($412,500 - $337,500)        [$6,750.00]
+    # + 10.00% * ($487,500 - $412,500)       [$7,500.00]
+    # + 11.00% * ($750,000 - $487,500)       [$28,875.00]
+    # = $66,546.90 (statute: "Over $750,000: $66,547.00 plus 13.00%")
+    hi_income_tax_before_non_refundable_credits: 66_546.90
+
+- name: Head of household $100,000 above the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 850_000
+    filing_status: HEAD_OF_HOUSEHOLD
+    state_code: HI
+  output:
+    # $66,546.90 + 13.00% * $100,000 = $79,546.90
+    hi_income_tax_before_non_refundable_credits: 79_546.90
+
+- name: Single filer just below the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 499_900
+    filing_status: SINGLE
+    state_code: HI
+  output:
+    # Statutory base at $500,000 is $44,365 (see table below), so
+    # $44,364.60 - 11.00% * $100 = $44,353.60
+    hi_income_tax_before_non_refundable_credits: 44_353.60
+
+- name: Single filer at the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 500_000
+    filing_status: SINGLE
+    state_code: HI
+  output:
+    #   1.40% * $14,400                      [$201.60]
+    # + 2.50% * ($19,200 - $14,400)          [$120.00]
+    # + 5.00% * ($24,000 - $19,200)          [$240.00]
+    # + 6.40% * ($36,000 - $24,000)          [$768.00]
+    # + 6.80% * ($48,000 - $36,000)          [$816.00]
+    # + 7.20% * ($125,000 - $48,000)         [$5,544.00]
+    # + 7.60% * ($175,000 - $125,000)        [$3,800.00]
+    # + 8.25% * ($225,000 - $175,000)        [$4,125.00]
+    # + 9.00% * ($275,000 - $225,000)        [$4,500.00]
+    # + 10.00% * ($325,000 - $275,000)       [$5,000.00]
+    # + 11.00% * ($500,000 - $325,000)       [$19,250.00]
+    # = $44,364.60 (statute: "Over $500,000: $44,365.00 plus 13.00%")
+    hi_income_tax_before_non_refundable_credits: 44_364.60
+
+- name: Single filer $100,000 above the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 600_000
+    filing_status: SINGLE
+    state_code: HI
+  output:
+    # $44,364.60 + 13.00% * $100,000 = $57,364.60
+    hi_income_tax_before_non_refundable_credits: 57_364.60
+
+- name: Separate filer at the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 500_000
+    filing_status: SEPARATE
+    state_code: HI
+  output:
+    # Same schedule as single filers (HRS 235-51(c)): $44,364.60
+    hi_income_tax_before_non_refundable_credits: 44_364.60
+
+- name: Separate filer $100,000 above the 13% threshold in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 600_000
+    filing_status: SEPARATE
+    state_code: HI
+  output:
+    # $44,364.60 + 13.00% * $100,000 = $57,364.60
+    hi_income_tax_before_non_refundable_credits: 57_364.60
+
+- name: Joint filers in the restructured 2.50% and 5.00% brackets in 2027
+  period: 2027
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 100_000
+    filing_status: JOINT
+    state_code: HI
+  output:
+    #   1.40% * $28,800                      [$403.20]
+    # + 2.50% * ($38,400 - $28,800)          [$240.00]
+    # + 5.00% * ($48,000 - $38,400)          [$480.00]
+    # + 6.40% * ($72,000 - $48,000)          [$1,536.00]
+    # + 6.80% * ($96,000 - $72,000)          [$1,632.00]
+    # + 7.20% * ($100,000 - $96,000)         [$288.00]
+    # = $4,579.20 (statute base at $96,000 is $4,291.00)
+    hi_income_tax_before_non_refundable_credits: 4_579.20
+
+# TY2029 Act 24 schedule: the 7.60% band is also removed and the widened
+# Act 24 thresholds apply; the 13% bracket thresholds are unchanged.
+- name: Joint filers above the 13% threshold in 2029
+  period: 2029
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 1_100_000
+    filing_status: JOINT
+    state_code: HI
+  output:
+    #   1.40% * $38,400                      [$537.60]
+    # + 2.50% * ($48,000 - $38,400)          [$240.00]
+    # + 5.00% * ($72,000 - $48,000)          [$1,200.00]
+    # + 6.40% * ($96,000 - $72,000)          [$1,536.00]
+    # + 6.80% * ($250,000 - $96,000)         [$10,472.00]
+    # + 7.20% * ($350,000 - $250,000)        [$7,200.00]
+    # + 8.25% * ($450,000 - $350,000)        [$8,250.00]
+    # + 9.00% * ($550,000 - $450,000)        [$9,000.00]
+    # + 10.00% * ($650,000 - $550,000)       [$10,000.00]
+    # + 11.00% * ($1,000,000 - $650,000)     [$38,500.00]
+    # + 13.00% * ($1,100,000 - $1,000,000)   [$13,000.00]
+    # = $99,935.60 (statute: "Over $1,000,000: $86,936.00 plus 13.00%")
+    hi_income_tax_before_non_refundable_credits: 99_935.60
+
+- name: Single filer above the 13% threshold in 2029
+  period: 2029
+  absolute_error_margin: 1
+  input:
+    hi_taxable_income: 600_000
+    filing_status: SINGLE
+    state_code: HI
+  output:
+    #   1.40% * $19,200                      [$268.80]
+    # + 2.50% * ($24,000 - $19,200)          [$120.00]
+    # + 5.00% * ($36,000 - $24,000)          [$600.00]
+    # + 6.40% * ($48,000 - $36,000)          [$768.00]
+    # + 6.80% * ($125,000 - $48,000)         [$5,236.00]
+    # + 7.20% * ($175,000 - $125,000)        [$3,600.00]
+    # + 8.25% * ($225,000 - $175,000)        [$4,125.00]
+    # + 9.00% * ($275,000 - $225,000)        [$4,500.00]
+    # + 10.00% * ($325,000 - $275,000)       [$5,000.00]
+    # + 11.00% * ($500,000 - $325,000)       [$19,250.00]
+    # + 13.00% * ($600,000 - $500,000)       [$13,000.00]
+    # = $56,467.80 (statute: "Over $500,000: $43,468.00 plus 13.00%")
+    hi_income_tax_before_non_refundable_credits: 56_467.80


### PR DESCRIPTION
Fixes #9051

## Summary

Encodes **Act 24, SLH 2026 (S.B. 3125 C.D. 1)**, signed 2026-05-21, in the Hawaii baseline rate schedules, effective for taxable years beginning after December 31, 2026 (Section 9(1) of the act). This is enacted law, so it is a baseline parameter change (not `gov/contrib`).

**Statutory citations:**
- Act 24 / S.B. 3125 C.D. 1 Section 2, amending HRS §235-51(a), (b), (c): https://data.capitol.hawaii.gov/sessions/session2026/bills/SB3125_CD1_.HTM
- Measure status: https://www.capitol.hawaii.gov/session/measure_indiv.aspx?billtype=SB&billnumber=3125
- Effective date: Section 9(1) — "Part I shall apply to taxable years beginning after December 31, 2026."

## New 13% top bracket (TY2027+)

| Filing status | 13% threshold |
|---|---|
| Joint | $1,000,000 |
| Surviving spouse | $1,000,000 |
| Head of household | $750,000 |
| Single | $500,000 |
| Separate | $500,000 |

Encoded as a new bracket `[12]` in each of the five rate files, inert before 2027: its threshold is `.inf` until 2027-01-01 (same pattern as Maryland's 2025 top brackets), with the 13% rate keyed at 2027-01-01.

## Discrepancy vs. issue #9051: Act 24 replaces the scheduled 2027/2029 tables, not just the top

Issue #9051 asked only for a new `[12]` bracket and said the Act 46 (2024) 2027 schedule is retained, flagging one anomaly to "reconcile against the primary Act 24 text at PR time": the statute says tax at $1,000,000 (joint) is **$88,729**, while the model's Act 46 schedule gives **$85,244**.

Reconciliation against the enrolled C.D. 1 text resolves this: it is not a rounding difference. Section 2 **brackets (repeals) the Act 46 tables for TY2027+ and TY2029+ and underscores (enacts) replacement tables** (Ramseyer convention confirmed by Section 8 of the act). Relative to Act 46, the replacement tables:

- cut the 3.20% rate to **2.50%** and the 5.50% rate to **5.00%** (TY2027+);
- remove the **7.90%** band (TY2027+) and additionally the **7.60%** band (TY2029+), shifting the 8.25%–11% rates down accordingly, so the 11% band runs from $650,000/$487,500/$325,000 up to the new top thresholds;
- add the **13%** bracket above $1,000,000 / $750,000 / $500,000 (same thresholds in both the TY2027 and TY2029 tables).

Under the replacement TY2027 joint schedule, tax at $1,000,000 computes to exactly the statutory base:
403.20 (1.4% × 28,800) + 240 (2.5% × 9,600) + 480 (5% × 9,600) + 1,536 (6.4% × 24,000) + 1,632 (6.8% × 24,000) + 11,088 (7.2% × 154,000) + 7,600 (7.6% × 100,000) + 8,250 (8.25% × 100,000) + 9,000 (9% × 100,000) + 10,000 (10% × 100,000) + 38,500 (11% × 350,000) = **$88,729.20** ✔

Encoding this PR only as "append a 13% bracket" would have left every TY2027+ liability above $28,800 (joint) / $21,600 (HoH) / $14,400 (single) wrong, so the full Section 2 schedules are encoded. **All encoded schedules were verified programmatically against every base amount in the statutory tables (55 boundary values across 5 filing statuses × 2 effective years) and match exactly.**

## Encoding

No existing threshold value is touched. The statute's 12-bracket (2027) and 11-bracket (2029) schedules map onto the existing 12 bracket slots by adding date-keyed **rate** values at 2027-01-01/2029-01-01; the repealed Act 46 upper boundaries ($800k/$950k joint, etc.) remain in place as zero-effect splits inside the 11% band (equal rates on both sides), which keeps the diff additive and pre-2027 behavior **bit-identical: the new bracket's threshold is infinite before 2027-01-01, and no pre-2027 value changes.**

## Boundary arithmetic in tests

Hand-computed expected values (full per-bracket arithmetic is in the test comments):

| Status | TY2026 ($2M) | TY2027 thr−$100 | TY2027 at thr | TY2027 thr+$100k | TY2029 thr+$100k |
|---|---|---|---|---|---|
| Joint | 200,432.40 | 88,718.20 | 88,729.20 | 101,729.20 | 99,935.60 |
| Surviving spouse | — | — | 88,729.20 | 101,729.20 | — |
| Head of household | — | 66,535.90 | 66,546.90 | 79,546.90 | — |
| Single | 210,216.20 | 44,353.60 | 44,364.60 | 57,364.60 | 56,467.80 (600k) |
| Separate | — | — | 44,364.60 | 57,364.60 | — |

TY2026 inertness tests pin the pre-Act-24 (Act 46) schedule at $2M for single and joint; a TY2027 joint test at $100,000 pins the restructured 2.50%/5.00% lower brackets.

## Test results

- Targeted file (`hi_income_tax_before_non_refundable_credits.yaml`): **20 passed** (2 pre-existing + 18 new)
- Full Hawaii baseline suite (`tests/policy/baseline/gov/states/hi`): **426 passed**
- Hawaii contrib suite: **12 passed**
- `make format` / ruff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
