### PR TITLE
Fix broken and mislabeled FTB references in CA parameter files

### DIFF
--- a/changelog.d/ca-reference-housekeeping.fixed.md
+++ b/changelog.d/ca-reference-housekeeping.fixed.md
@@ -1,0 +1,1 @@
+Fix broken and mislabeled FTB reference links in California CalEITC and Foster Youth Tax Credit parameter files.

--- a/policyengine_us/parameters/gov/states/ca/tax/income/credits/earned_income/phase_out/final/end.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/credits/earned_income/phase_out/final/end.yaml
@@ -14,8 +14,8 @@ metadata:
       href: https://www.ftb.ca.gov/forms/2022/2022-3514-instructions.html
     - title: California Form 3514 instructions (2023)
       href: https://www.ftb.ca.gov/forms/2023/2023-3514-instructions.html
-    - title: California Form 3514 instructions (2024)
-      href: https://www.ftb.ca.gov/forms/2024/2024-3514-instructions.html
+    - title: 2024 California Earned Income Tax Credit Booklet
+      href: https://www.ftb.ca.gov/forms/2024/2024-3514-booklet.html
     - title: 2025 California Earned Income Tax Credit Booklet
       href: https://www.ftb.ca.gov/forms/2025/2025-3514-booklet.html
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/ca/tax/income/credits/foster_youth/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/credits/foster_youth/amount.yaml
@@ -32,7 +32,7 @@ metadata:
     - title: 2022 California Earned Income Tax Credit Form
       href: https://www.ftb.ca.gov/forms/2022/2022-3514.pdf#page=4
     - title: 2023 California Earned Income Tax Credit Form
-      href: https://www.ftb.ca.gov/forms/2022/2022-3514.pdf#page=4
+      href: https://www.ftb.ca.gov/forms/2023/2023-3514.pdf#page=4
   # The legal code specifies the amount as $1,176 multiplied by the CalEITC adjustment factor ($1,000 in 2021).
   # Since the base value is adjusted annually with inflation.
   # For accuracy, we use the final product as the parameter value 

--- a/policyengine_us/parameters/gov/states/ca/tax/income/credits/foster_youth/phase_out/increment.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/credits/foster_youth/phase_out/increment.yaml
@@ -12,7 +12,7 @@ metadata:
     - title: 2022 California Earned Income Tax Credit Form
       href: https://www.ftb.ca.gov/forms/2022/2022-3514.pdf#page=4
     - title: 2023 California Earned Income Tax Credit Form
-      href: https://www.ftb.ca.gov/forms/2022/2022-3514.pdf#page=4
+      href: https://www.ftb.ca.gov/forms/2023/2023-3514.pdf#page=4
   # The legal code provides the pre-adjustment value  
     - title: California Revenue and Taxation Code (R&TC) Section 17052.2(a)(2)(C)(i)
       href: https://casetext.com/statute/california-codes/california-revenue-and-taxation-code/division-2-other-taxes/part-10-personal-income-tax/chapter-2-imposition-of-tax/section-170522-foster-youth-tax-credit-for-qualified-taxpayers#:~:text=Section%2017052.2%20%2D%20Foster%20youth%20tax%20credit%20for%20qualified%20taxpayers%20(a,determined%20under%20paragraph%20(2)

--- a/uv.lock
+++ b/uv.lock
@@ -2974,7 +2974,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.773.1"
+version = "1.773.2"
 source = { editable = "." }
 dependencies = [
     { name = "microdf-python" },


### PR DESCRIPTION
## Summary

Reference-only housekeeping from the CA parameter verification (partially addresses #9050). No parameter values change.

## Changes

- `credits/earned_income/phase_out/final/end.yaml`: the 2024 Form 3514 instructions link 404s (FTB folded 2024+ instructions into the booklet page) — now cites the 2024 booklet, matching the sibling reference in `eligibility/max_investment_income.yaml`.
- `credits/foster_youth/amount.yaml` and `credits/foster_youth/phase_out/increment.yaml`: references titled "2023 California Earned Income Tax Credit Form" pointed at the 2022 PDF — now point at `2023-3514.pdf#page=4`.

## Not included (stays open in #9050)

The $1 boundary-convention item on the 2024 CalEITC earnings cap (stored 31,950 vs the booklet's "less than $31,951"): normalizing it is a value change that shifts the 2024 final-phase-out interpolation slightly, so it needs a test-impact check and shouldn't ride along with link fixes.

## Checklist

- [x] Changelog entry created
- [x] `make format` run
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)