### PR TITLE
Add Delaware unemployment compensation exclusion for 2020-2021 (30 Del. C. § 1106(b)(10))

### DIFF
--- a/changelog.d/de-unemployment-exclusion.fixed.md
+++ b/changelog.d/de-unemployment-exclusion.fixed.md
@@ -1,0 +1,1 @@
+Delaware now excludes unemployment compensation received in 2020 and 2021 from Delaware AGI, per 30 Del. C. § 1106(b)(10).

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
@@ -4,6 +4,10 @@ values:
     - de_pension_exclusion # (3)
     - taxable_social_security # (4)
     - us_govt_interest_person
+    # Unemployment compensation received in calendar years 2020 and 2021,
+    # to the extent included in federal AGI, is excluded under
+    # 30 Del. C. § 1106(b)(10) (HB 65 of 2021; HB 285 of 2022).
+    - taxable_unemployment_compensation # (10)
     # The elderly or disabled income exclusion is computed separately
     # - de_elderly_or_disabled_income_exclusion # (2)
   2022-01-01:
@@ -16,6 +20,10 @@ metadata:
   unit: list
   period: year
   label: Delaware adjusted gross income subtractions
-  references: 
+  references:
   - title: Delaware Code, § 1106 Modifcations (b)
     href: https://delcode.delaware.gov/title30/c011/sc02/index.html
+  - title: Delaware HB 285 (151st General Assembly), amending 30 Del. C. § 1106(b)(10)
+    href: https://legis.delaware.gov/BillDetail/79061
+  - title: 2021 Delaware Resident Individual Income Tax Return (PIT-RES) Instructions, Line 7
+    href: https://revenuefiles.delaware.gov/2021/PIT-RES_TY21_2021-01_Instructions.pdf

--- a/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml
@@ -406,3 +406,60 @@
   output:
     de_files_separately: true
     de_income_tax: 59.155
+
+- name: 2021 unemployment compensation excluded from Delaware AGI (30 Del. C. § 1106(b)(10))
+  # From TaxAct-derived example in issue #9065: single filer, age 42,
+  # $22,791.92 wages plus $12,240 unemployment compensation. Delaware
+  # excludes unemployment compensation received in 2020-2021 from DE AGI
+  # (2021 PIT-RES Line 7), so DE AGI equals wages only. Ground truth from
+  # TaxAct: pre-credit tax $718 (tax tables), personal credit $110,
+  # tax $608. PolicyEngine's continuous rate schedule yields $609.01;
+  # the ~$1 residual is tax-table rounding.
+  period: 2021
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        age: 42
+        employment_income: 22_791.92
+        unemployment_compensation: 12_240
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: DE
+  output:
+    de_agi_indiv: 22_791.92
+    de_taxable_income_indv: 19_541.92
+    de_income_tax: 608
+
+- name: 2022 unemployment compensation not excluded from Delaware AGI (exclusion expired)
+  # 30 Del. C. § 1106(b)(10) covers unemployment benefits received in
+  # calendar years 2020 and 2021 only, so the same household in 2022
+  # includes the full $12,240 of unemployment compensation in DE AGI.
+  period: 2022
+  absolute_error_margin: 2
+  input:
+    people:
+      person1:
+        age: 42
+        employment_income: 22_791.92
+        unemployment_compensation: 12_240
+        is_tax_unit_head: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: DE
+  output:
+    de_subtractions: 0
+    de_agi_indiv: 35_031.92
+    de_taxable_income_indv: 31_781.92
+    de_income_tax: 1_267.40


### PR DESCRIPTION
## Summary

Delaware excludes unemployment benefits received in calendar years 2020 and 2021, to the extent included in federal adjusted gross income, from Delaware AGI. PolicyEngine US omitted this subtraction, so 2021 Delaware returns with unemployment compensation overstated Delaware AGI and tax. This PR adds `taxable_unemployment_compensation` to the Delaware subtractions list for tax year 2021.

Fixes #9065. Origin: PolicyEngine/policyengine-taxsim#1097 (DE 2021 single filer with $22,791.92 wages and $12,240 UI: PolicyEngine computed $1,267.40 vs TaxAct $608).

## Statute

- 30 Del. C. § 1106(b)(10), added by HB 65 (2021) and amended by [HB 285](https://legis.delaware.gov/BillDetail/79061) (signed 2022-01-27): "The amount of any unemployment benefits received in calendar years 2020 and 2021, to the extent included in federal adjusted gross income" ([current code text](https://delcode.delaware.gov/title30/c011/sc02/index.html))
- Implemented on Line 7 of the [2021 PIT-RES instructions](https://revenuefiles.delaware.gov/2021/PIT-RES_TY21_2021-01_Instructions.pdf)

## Root cause

`parameters/gov/states/de/tax/income/subtractions/subtractions.yaml` listed only the pension exclusion, taxable Social Security, and US government interest for 2021.

## What changed

- Added `taxable_unemployment_compensation` (person-level; equals unemployment compensation included in federal AGI, which handles the 2020 ARPA $10,200 federal exclusion interaction) to the 2021-01-01 subtractions list, with statute and form references. The existing 2022-01-01 list omits it, so the exclusion expires on schedule.
- Added two integration tests in `tests/policy/baseline/gov/states/de/tax/income/integration.yaml`:
  - 2021 single filer, age 42, $22,791.92 wages + $12,240 UI: `de_agi_indiv` $22,791.92, `de_taxable_income_indv` $19,541.92, `de_income_tax` $608 (TaxAct ground truth; PolicyEngine's continuous rate schedule yields $609.01 vs the form's rounded tax-table $608, within the file's existing $2 margin)
  - 2022 same household: full $12,240 UI included in DE AGI ($35,031.92), `de_subtractions` $0, `de_income_tax` $1,267.40

## Tax year 2020

The statute also covers unemployment benefits received in calendar year 2020, but the Delaware subtractions parameter (and DE AGI pipeline generally) is only defined from 2021-01-01, so this PR adds the exclusion for 2021 only. If Delaware coverage is later extended to 2020, the subtraction should be included there as well.

## Test evidence

- `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/de/tax/income/integration.yaml -c policyengine_us`: 13 passed (including the 2 new tests)
- `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/de -c policyengine_us`: 323 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)