### PR TITLE
Apply rent-equivalent property tax factor in Arizona property tax credit (Form 140PTC line 13)

### DIFF
--- a/changelog.d/az-ptc-rent-factor.fixed.md
+++ b/changelog.d/az-ptc-rent-factor.fixed.md
@@ -1,0 +1,1 @@
+Weight rent by an assumed landlord property tax factor (0.15, matching TAXSIM) instead of counting 100% of rent as property taxes paid in the Arizona property tax credit, per ARS 43-1072(B) and Form 140PTC line 13.

--- a/policyengine_us/parameters/gov/states/az/tax/income/credits/property_tax/rent_property_tax_rate.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/credits/property_tax/rent_property_tax_rate.yaml
@@ -1,0 +1,16 @@
+description: Arizona counts this fraction of rent as property taxes paid under its property tax credit; this rate is a modeling assumption, as Arizona applies the landlord-specific property tax factor from Form 201 rather than a statutory fraction.
+metadata:
+  unit: /1
+  period: year
+  label: Arizona property tax credit rent property tax rate
+  reference:
+    - title: 43-1072. Earned credit for property taxes; residents sixty-five years of age or older - (B), (C)
+      href: https://www.azleg.gov/viewdocument/?docName=https://www.azleg.gov/ars/43/01072.htm
+    - title: 2021 Property Tax Refund (Credit) Claim Form 140PTC - Lines 13-15
+      href: https://azdor.gov/sites/default/files/2023-09/FORMS_INDIVIDUAL_2021_140PTC-f.pdf#page=1
+    - title: 2022 Renter's Certificate of Property Taxes Paid Form 201 - Part 3
+      href: https://azdor.gov/sites/default/files/2023-03/FORMS_INDIVIDUAL_2022_201_f.pdf#page=1
+    # The 0.15 rate matches the assumption applied in NBER TAXSIM, as no
+    # statutory rate exists; the actual factor varies by landlord.
+values:
+  2021-01-01: 0.15

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_property_tax_credit.yaml
@@ -8,7 +8,40 @@
     real_estate_taxes: 0
     rent: 1_000
   output:
+    # Taxes paid: 0.15 * 1,000 = 150, above the $123 table amount.
     az_property_tax_credit: 123
+
+# Form 140PTC line 13: a renter's property taxes paid equal rent multiplied
+# by the landlord's property tax factor (Form 201), modeled as 0.15.
+# Integration case from issue 9064: Table 1 amount is 457 at $1,919.59 of
+# income, but taxes paid are only 0.15 * 856.96 = 128.54.
+- name: renter credit is capped at rent times the property tax factor
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    state_code: AZ
+    cohabitating_spouses: false
+    age: 79
+    az_property_tax_credit_income: 1_919.59
+    az_property_tax_credit_eligible: true
+    real_estate_taxes: 0
+    rent: 856.96
+  output:
+    az_property_tax_credit: 128.54
+
+# Homeowner property taxes count in full; only rent is weighted.
+- name: homeowner real estate taxes count at 100 percent alongside weighted rent
+  period: 2021
+  input:
+    state_code: AZ
+    cohabitating_spouses: false
+    az_property_tax_credit_income: 1_900
+    az_property_tax_credit_eligible: true
+    real_estate_taxes: 300
+    rent: 1_000
+  output:
+    # Taxes paid: 300 + 0.15 * 1,000 = 450, below the $457 table amount.
+    az_property_tax_credit: 450
 
 - name: filer at 50 meets criteria
   period: 2023

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/property_tax_credit/az_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/property_tax_credit/az_property_tax_credit.py
@@ -10,7 +10,6 @@ class az_property_tax_credit(Variable):
     defined_for = "az_property_tax_credit_eligible"
 
     def formula(tax_unit, period, parameters):
-        person = tax_unit.members
         p = parameters(period).gov.states.az.tax.income.credits.property_tax
         income = tax_unit("az_property_tax_credit_income", period)
 
@@ -34,8 +33,13 @@ class az_property_tax_credit(Variable):
             p.amount.living_alone.calc(income),
         )
 
-        # Rent counts equally to property taxes.
-        property_tax_plus_rent = add(tax_unit, period, ["real_estate_taxes", "rent"])
-        # property_tax and rent are equally weighted
+        # ARS 43-1072(B): the credit is the lesser of the table amount and
+        # property taxes paid. For renters, taxes paid is rent multiplied by
+        # the landlord's property tax factor from Form 201 (Form 140PTC line
+        # 13); the rent_property_tax_rate parameter approximates this
+        # landlord-specific factor.
+        real_estate_taxes = add(tax_unit, period, ["real_estate_taxes"])
+        rent = add(tax_unit, period, ["rent"])
+        property_taxes_paid = real_estate_taxes + p.rent_property_tax_rate * rent
 
-        return min_(cap, property_tax_plus_rent)
+        return min_(cap, property_taxes_paid)


### PR DESCRIPTION
Fixes #9064

## Summary

`az_property_tax_credit` counted 100% of rent as property taxes paid, so the ARS 43-1072(B) "lesser of" cap effectively never bound for renters (full rent almost always exceeds the $502 table maximum). Per Form 140PTC line 13, a renter's property taxes paid equal rent multiplied by the landlord's property tax factor from Form 201.

## Changes

- New parameter `gov.states.az.tax.income.credits.property_tax.rent_property_tax_rate` (0.15 from 2021).
- Formula now computes `min_(table_amount, real_estate_taxes + rent_property_tax_rate × rent)`; homeowner property taxes still count in full.
- Tests: the issue's TAXSIM-derived integration case (2021, single, age 79, income $1,919.59, rent $856.96 → credit $128.54 instead of $457), a mixed homeowner+renter case (300 + 0.15 × 1,000 = 450, below the $457 table amount), and an updated existing renter case with the cap still binding.

## Modeling assumption (flagged for reviewers)

Arizona has **no statutory rent fraction** — the actual factor is landlord-specific via Form 201 (business property tax ÷ total rents). The 0.15 value matches the assumption NBER TAXSIM applies and is documented as an assumption in the parameter description. This mirrors existing rent-equivalent parameters (e.g., Montana's `rent_equivalent_tax_rate`).

## Tests

All 474 AZ tests pass (`policyengine-core test policyengine_us/tests/policy/baseline/gov/states/az -c policyengine_us`).

Origin: PolicyEngine/policyengine-taxsim#1098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)