### PR TITLE
Add missing defined_for state gate to dc_ctc

### DIFF
--- a/changelog.d/fix-dc-ctc-defined-for.fixed.md
+++ b/changelog.d/fix-dc-ctc-defined-for.fixed.md
@@ -1,0 +1,1 @@
+The DC Child Tax Credit now applies only to DC households: `dc_ctc` was missing `defined_for = StateCode.DC`, so from 2026 (when it joined `gov.states.household.state_ctcs`) it computed for households in any state and leaked into `taxsim_state_ctc` and its deprecated `state_ctc` alias (see #9079).

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/ctc/dc_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/ctc/dc_ctc.yaml
@@ -150,6 +150,58 @@
     # $45,000 excess = 45 increments * $50 = $2,250 phase-out exceeds $1,000 base
     dc_ctc: 0
 
+- name: 2026 non-DC household with otherwise-qualifying children gets no DC CTC
+  period: 2026
+  input:
+    people:
+      parent:
+        age: 30
+        employment_income: 30_000
+      child1:
+        age: 10
+        is_tax_unit_dependent: true
+      child2:
+        age: 14
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child1, child2]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [parent, child1, child2]
+        state_code: OR
+  output:
+    dc_ctc: 0
+    # No state CTC component applies to this household, so the
+    # umbrella must be zero (guards against ungated components).
+    taxsim_state_ctc: 0
+
+- name: 2026 DC household credit flows through the state CTC umbrella
+  period: 2026
+  input:
+    people:
+      parent:
+        age: 30
+        employment_income: 30_000
+      child1:
+        age: 10
+        is_tax_unit_dependent: true
+      child2:
+        age: 14
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child1, child2]
+        filing_status: SINGLE
+    households:
+      household:
+        members: [parent, child1, child2]
+        state_code: DC
+  output:
+    dc_ctc: 2_000
+    taxsim_state_ctc: 2_000
+
 - name: 2026 child over 18 not eligible
   period: 2026
   input:

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/federal.yaml
@@ -252,7 +252,7 @@
         income_tax: -7169.5
         income_tax_before_credits: 1580.0
         state_cdcc: 679.4
-        state_ctc: 2000.0
+        state_ctc: 0.0
         state_eitc: 0.0
         state_income_tax: 0.0
         state_income_tax_before_refundable_credits: 0.0

--- a/policyengine_us/variables/gov/states/dc/tax/income/credits/ctc/dc_ctc.py
+++ b/policyengine_us/variables/gov/states/dc/tax/income/credits/ctc/dc_ctc.py
@@ -9,6 +9,7 @@ class dc_ctc(Variable):
     unit = USD
     definition_period = YEAR
     reference = "https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.17"
+    defined_for = StateCode.DC
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.dc.tax.income.credits.ctc


### PR DESCRIPTION
Fixes #9079.

`dc_ctc` had no `defined_for`, so it computed a nonzero DC Child Tax Credit for households in any state. Since #7996 added it to `gov.states.household.state_ctcs` (2026-01-01), the leak flowed into `taxsim_state_ctc` and its deprecated `state_ctc` alias for every non-DC household with children under 18 — e.g. an Oregon single parent with two qualifying children picked up a phantom $2,000 in 2026. All 20 other components in the umbrella list are state-gated; `dc_ctc` was the only one missing a gate.

## Changes

- Add `defined_for = StateCode.DC` to `dc_ctc` (one line).
- Regression tests in `dc_ctc.yaml`: a differential pair of otherwise-identical OR/DC households (single parent, $30k employment income, children aged 10 and 14) asserting `dc_ctc: 0` and `taxsim_state_ctc: 0` for the Oregon household, and `dc_ctc: 2_000` flowing through to `taxsim_state_ctc: 2_000` for the DC household. The Oregon case's umbrella assertion also guards against any future ungated component for this household shape.

## Notes

- Test children are aged 10 and 14 (DC-qualifying: under 18; Oregon requires under 6) so the `taxsim_state_ctc: 0` assertion is independent of Oregon Kids' Credit parameters. The issue repro's ages (2 and 4) now legitimately earn `or_ctc` at $30k on current main after #9076, so a bare zero umbrella assertion with those ages would be wrong.
- Verified the regression test discriminates: without the gate, the Oregon case fails with `dc_ctc = 2_000`.
- Existing DC CTC YAML tests all provide `state_code: DC` and pass unchanged; the full `tests/policy/baseline/gov/states/dc/tax/income` directory passes (112 tests).
- Blast radius: `dc_ctc`'s only other consumer is DC's own refundable-credits list feeding `dc_income_tax`, which is already DC-gated, so DC household outputs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
