### PR TITLE
Adopt corrected BLS SPM thresholds via spm-calculator 0.4.0

### DIFF
--- a/changelog.d/changed/spm-calculator-corrected-thresholds.md
+++ b/changelog.d/changed/spm-calculator-corrected-thresholds.md
@@ -1,0 +1,1 @@
+Adopt the corrected SPM thresholds BLS published on July 17, 2026 via spm-calculator 0.4.0: full-precision 2005-2024 reference thresholds replace the pre-correction values (which contained hand-entry errors of up to 8% for 2019-2023), shifting SPM threshold, poverty, and poverty-gap levels for all modeled years; reform-impact deltas are largely unaffected.

--- a/policyengine_us/tests/policy/baseline/household/income/spm_unit/test_spm_unit_spm_threshold.py
+++ b/policyengine_us/tests/policy/baseline/household/income/spm_unit/test_spm_unit_spm_threshold.py
@@ -1,14 +1,16 @@
 """Regression tests for the spm_unit_spm_threshold formula.
 
 Verifies that:
-1. Historical published years (2015-2024) match the Census Bureau's
-   published Betson reference thresholds exactly (via spm-calculator).
+1. Historical published years (2005-2024) match the corrected BLS
+   reference thresholds exactly (via spm-calculator >= 0.4.0, which
+   packages the full-precision series BLS reissued on 2026-07-17).
 2. Post-published years uprate via PolicyEngine's ``gov.bls.cpi.cpi_u``
    parameter.
 3. Composition and tenure changes between periods flow through to the
    threshold while applying the unit-specific geographic adjustment.
 4. The Betson three-parameter equivalence scale is applied (a 2A2C
-   reference family at the renter national base equals 39430 in 2024).
+   reference family at the renter national base equals 39,219.89 in
+   2024 under the corrected series).
 """
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "microdf-python>=1.0.0",
     "pandas>=2.0",
     "policyengine-core>=3.26.5",
-    "spm-calculator>=0.2.0",
+    "spm-calculator>=0.4.0",
     "tables>=3.9",
     "tqdm>=4.67.1",
 ]


### PR DESCRIPTION
## Context

BLS [reissued corrected 2019–2024 SPM thresholds](https://www.bls.gov/pir/spm/spm_thresholds_2024_correction.htm) on July 17, 2026 after finding errors in its threshold-generation code ([Census statement](https://www.census.gov/newsroom/press-releases/2026/statement-on-supplemental-poverty-measure.html)); Census re-releases SPM estimates before the September report. Auditing against the correction also found that spm-calculator ≤0.3.1 shipped hand-entered values matching **no BLS or Census publication** for 2019–2023 (errors up to 8% — several times the BLS correction's ≤1.6%). Full analysis: [spm-calculator#32](https://github.com/PolicyEngine/spm-calculator/pull/32) and its [docs/bls-2026-correction.md](https://github.com/PolicyEngine/spm-calculator/blob/max/bls-2026-threshold-correction/docs/bls-2026-correction.md).

## Changes

- Bump `spm-calculator` to `>=0.4.0`: `spm_unit_spm_threshold` now draws the corrected full-precision series (2005–2024) through `HISTORICAL_THRESHOLDS`, with 2025+ uprating off the corrected 2024 base.
- Update the threshold regression-test docstrings; the assertions themselves are dynamic against `HISTORICAL_THRESHOLDS` and now verify the corrected values across 2005–2024.

## Impact

- **Levels shift for all modeled years**: SPM thresholds, poverty rates, deep poverty, and poverty gaps. Largest changes are for 2019–2020 and 2022–2023, where the previous package values were furthest from any published series; 2024-based forecast years move by −0.5% to +0.9% depending on tenure.
- **Reform-impact deltas largely unaffected** — thresholds are identical between baseline and reform runs; only near-threshold crossings move.
- Raw ASEC `SPM_POVTHRESHOLD` columns in survey datasets remain pre-correction until Census re-releases the SPM research files; expect `spm_threshold_match`-style validations against current ASEC vintages to show sub-1% deltas until then (we lead Census here, intentionally).

## Verification

Local run against spm-calculator 0.4.0 (built from the release branch): `test_spm_unit_spm_threshold.py` 6/6, full `spm_unit` baseline suite 31/31.

**Draft until [spm-calculator#32](https://github.com/PolicyEngine/spm-calculator/pull/32) merges and 0.4.0 publishes to PyPI** — CI cannot resolve the pin before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
