### PR TITLE
Update SNAP uprating index with published CPI-U actuals through June 2026

### DIFF
--- a/changelog.d/refresh-snap-uprating-actuals.changed.md
+++ b/changelog.d/refresh-snap-uprating-actuals.changed.md
@@ -1,0 +1,1 @@
+Update the SNAP uprating index with published CPI-U actuals for June 2024, 2025, and 2026, raising projected FY2027 COLAs to +3.5% year-over-year; later years remain CBO forecasts.

--- a/policyengine_us/parameters/gov/usda/snap/uprating.yaml
+++ b/policyengine_us/parameters/gov/usda/snap/uprating.yaml
@@ -5,10 +5,10 @@ values:
   2021-10-01: 271.696 # 2021-06.
   2022-10-01: 296.311 # 2022-06.
   2023-10-01: 305.109 # 2023-06.
+  2024-10-01: 314.175 # 2024-06.
+  2025-10-01: 322.561 # 2025-06.
+  2026-10-01: 333.952 # 2026-06.
   # Forecasts from CBO's Q2 forecasts.
-  2024-10-01: 313.7 # 2024Q2
-  2025-10-01: 321.2 # 2025Q2
-  2026-10-01: 328.4 # 2026Q2
   2027-10-01: 335.5 # 2027Q2
   2028-10-01: 342.7 # 2028Q2
   2029-10-01: 350.3 # 2029Q2
@@ -25,5 +25,7 @@ metadata:
   reference:
     - title: 7 U.S. Code § 2012(u)(4)
       href: https://www.law.cornell.edu/uscode/text/7/2012#u_4
+    - title: BLS Consumer Price Index for All Urban Consumers (CPI-U), all items, U.S. city average, not seasonally adjusted (CUUR0000SA0)
+      href: https://data.bls.gov/timeseries/CUUR0000SA0
     - title: CBO Economic Projections, February 2024.
       href: https://www.cbo.gov/publication/59710

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_excess_shelter_expense_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_excess_shelter_expense_deduction.yaml
@@ -85,3 +85,24 @@
   output:
     # cap at 701, 
     snap_excess_shelter_expense_deduction: 700
+
+- name: FY2027 shelter cap uprates the FY2026 value by June 2026 over June 2025 CPI-U actuals.
+  period: 2027-01
+  absolute_error_margin: 0.01
+  input:
+    housing_cost:
+      2027: 12_000
+  output:
+    # 744 * 333.952 / 322.561
+    snap_excess_shelter_expense_deduction: 770.27
+
+- name: FY2027 homeless shelter deduction uprates the FY2026 value by June 2026 over June 2025 CPI-U actuals.
+  period: 2027-01
+  absolute_error_margin: 0.01
+  input:
+    state_code: TX
+    is_homeless: true
+    housing_cost: 1
+  output:
+    # 198.99 * 333.952 / 322.561
+    snap_excess_shelter_expense_deduction: 206.02

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_limited_utility_allowance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_limited_utility_allowance.yaml
@@ -115,3 +115,16 @@
   output:
     snap_limited_utility_allowance: 0
     # AZ had no LUA in FY2019 (main.yaml = 0, not in by_household_size states list)
+
+- name: FY2027 Texas limited utility allowance uprates the FY2026 value by June 2026 over June 2025 CPI-U actuals.
+  period: 2027-01
+  absolute_error_margin: 0.01
+  input:
+    snap_utility_allowance_type: LUA
+    snap_utility_region_str: TX
+    spm_unit_size: 1
+    electricity_expense: 20
+    phone_expense: 20
+  output:
+    # 400 * 333.952 / 322.561
+    snap_limited_utility_allowance: 414.13

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_standard_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_standard_deduction.yaml
@@ -56,3 +56,23 @@
     state_group: HI
   output:
     snap_standard_deduction: 250
+
+- name: FY2027 standard deduction uprates the FY2026 value by June 2026 over June 2025 CPI-U actuals.
+  period: 2027-01
+  absolute_error_margin: 0.01
+  input:
+    spm_unit_size: 4
+    state_group: CONTIGUOUS_US
+  output:
+    # 223 * 333.952 / 322.561
+    snap_standard_deduction: 230.88
+
+- name: FY2027 standard deduction for a one-person household.
+  period: 2027-01
+  absolute_error_margin: 0.01
+  input:
+    spm_unit_size: 1
+    state_group: CONTIGUOUS_US
+  output:
+    # 209 * 333.952 / 322.561
+    snap_standard_deduction: 216.38

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_max_allotment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_max_allotment.yaml
@@ -1,0 +1,38 @@
+- name: FY2026 max allotment for a 4-person contiguous-US household (explicit FY2026 COLA value).
+  period: 2026-01
+  input:
+    snap_region_str: CONTIGUOUS_US
+    snap_unit_size: 4
+  output:
+    snap_max_allotment: 994
+
+- name: FY2027 max allotment uprates the FY2026 value by June 2026 over June 2025 CPI-U actuals.
+  period: 2027-01
+  absolute_error_margin: 0.01
+  input:
+    snap_region_str: CONTIGUOUS_US
+    snap_unit_size: 4
+  output:
+    # 994 * 333.952 / 322.561
+    snap_max_allotment: 1029.1
+
+- name: FY2027 max allotment for a 1-person household.
+  period: 2027-01
+  absolute_error_margin: 0.01
+  input:
+    snap_region_str: CONTIGUOUS_US
+    snap_unit_size: 1
+  output:
+    # 298 * 333.952 / 322.561
+    snap_max_allotment: 308.52
+
+- name: FY2028 max allotment retains the CBO forecast index level over the June 2025 actual base.
+  period: 2027-11
+  absolute_error_margin: 0.01
+  input:
+    snap_region_str:
+      2027: CONTIGUOUS_US
+    snap_unit_size: 4
+  output:
+    # 994 * 335.5 / 322.561
+    snap_max_allotment: 1033.87

--- a/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/amplifi/2026.yaml
@@ -110,7 +110,7 @@
       spm_unit:
         ca_tanf: 0.0
         ca_tanf_eligible: false
-        snap: 2360.52
+        snap: 2392.44
         is_snap_eligible: true
         lifeline: 228.0
         is_lifeline_eligible: true
@@ -260,7 +260,7 @@
       spm_unit:
         ca_tanf: 0.0
         ca_tanf_eligible: false
-        snap: 1908.29
+        snap: 1942.26
         is_snap_eligible: true
         lifeline: 228.0
         is_lifeline_eligible: true
@@ -411,7 +411,7 @@
       spm_unit:
         ca_tanf: 13280.0
         ca_tanf_eligible: true
-        snap: 4124.09
+        snap: 4157.17
         is_snap_eligible: true
         lifeline: 228.0
         is_lifeline_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ca.yaml
@@ -75,9 +75,9 @@
         # 2,191.00 (SUA 663 < half of pre-shelter net, so no shelter deduction)
         # <= 2,220.83 Jan-Sep limit -> eligible all year. EC = floor(2,191) x
         # 0.3 = 657.30 -> 785 - 657.30 = 127.70/month Jan-Sep; Oct-Dec: net
-        # 2,186.32 -> EC 655.80 -> 802.60 - 655.80 = 146.80.
-        # Annual = 9 x 127.70 + 3 x 146.80 = 1,589.70.
-        snap: 1_589.69
+        # 2,183.62 -> EC 654.90 -> 812.72 - 654.90 = 157.82.
+        # Annual = 9 x 127.70 + 3 x 157.82 = 1,622.76.
+        snap: 1622.76
         is_snap_eligible: true
 - name: snap_ca_net_income_at_fy2026_net_limit_36447 (ca)
   period: 2026
@@ -142,9 +142,9 @@
         # At the binding CA net limit: net = 36,447/12 x 0.8 - 209 = 2,220.80,
         # just under the Jan-Sep limit of 26,650/12 = 2,220.83 -> eligible.
         # EC = floor(2,220) x 0.3 = 666.00 -> 785 - 666.00 = 119.00/month
-        # Jan-Sep; Oct-Dec: net 2,216.12 -> EC 664.80 -> 802.60 - 664.80 =
-        # 137.80. Annual = 9 x 119.00 + 3 x 137.80 = 1,484.40.
-        snap: 1_484.39
+        # Jan-Sep; Oct-Dec: net 2,213.42 -> EC 663.90 -> 812.72 - 663.90 =
+        # 148.82. Annual = 9 x 119.00 + 3 x 148.82 = 1,517.46.
+        snap: 1517.46
         is_snap_eligible: true
 - name: snap_ca_net_income_above_net_limit_all_year_38000 (ca)
   period: 2026
@@ -208,7 +208,7 @@
       spm_unit:
         # Deliberate ineligible-side pin of CA's net-test route: net =
         # 38,000/12 x 0.8 - 209 = 2,324.33 exceeds the net limit in every
-        # month (Jan-Sep 2,220.83; Oct-Dec: 2,319.65 > 2,276.67), and the
+        # month (Jan-Sep 2,220.83; Oct-Dec: 2,316.95 > 2,276.67), and the
         # federal 130% gross test also fails (ratio 1.43), so the unit is
         # ineligible all year. In a no-net-test 200% state this income would
         # be eligible.
@@ -280,7 +280,7 @@
         # fully counted; from April the head is excluded (size 2) and their
         # earnings count at the 2/3 prorated share under 7 CFR
         # 273.11(c)(2)-(3), raising the benefit relative to full counting.
-        snap: 2_162.22
+        snap: 2186.94
         is_snap_eligible: true
 - name: snap_ca_head_immigration_undocumented_calworks_interaction (ca)
   period: 2026
@@ -346,5 +346,5 @@
         # 2, the CalWORKs grant excludes the head from the AU but counts in
         # full as unit-level unearned income, and the head's earnings count
         # at the 2/3 prorated share under 7 CFR 273.11(c)(2)-(3).
-        snap: 3_002.22
+        snap: 3026.94
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/co.yaml
@@ -69,8 +69,8 @@
         # Jan-Sep: pre-shelter net = 46,000/12 x 0.8 - 209 = 2,857.67; shelter
         # expense = 1,500 housing + 594 CO SUA = 2,094 - 1,428.83 = 665.17 ->
         # net = 2,192.50 -> EC 657.60 -> 785 - 657.60 = 127.40/month; Oct-Dec:
-        # 802.60 - 655.50 = 147.10. Annual = 9 x 127.40 + 3 x 147.10 = 1,587.90.
-        snap: 1_587.89
+        # 812.72 - 654.30 = 158.42. Annual = 9 x 127.40 + 3 x 158.42 = 1,621.86.
+        snap: 1621.86
         is_snap_eligible: true
 - name: snap_income_above_200_pct_bbce_limit_54740 (co)
   period: 2026

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/federal.yaml
@@ -4,9 +4,9 @@
 # (sizes 1-4), standard deduction $209 (sizes 1-3) / $223 (size 4), shelter cap
 # $744, TX SUA $445, TX LUA $400, earned income deduction 20%, expected food
 # contribution 30% of floored net income, minimum allotment 8% of the 1-person
-# maximum. Oct-Dec 2026 use uprated FY2027 values: max $304.68/$558.24/$802.60/
-# $1,016.28, standard deduction $213.68/$228.00, shelter cap $760.68 (SUA is not
-# uprated; LUA is, to $408.97).
+# maximum. Oct-Dec 2026 use uprated FY2027 values: max $308.52/$565.28/$812.72/
+# $1,029.10, standard deduction $216.38/$230.88, shelter cap $770.27 (SUA is not
+# uprated; LUA is, to $414.13).
 # SNAP compares income to the poverty guideline in effect at the preceding
 # Oct 1 (snap_fpg): Jan-Sep 2026 use the 2025 FPG (1p $15,650 / 2p $21,150 /
 # 3p $26,650), Oct-Dec 2026 use the 2026 FPG (1p $15,960 / 2p $21,640 /
@@ -82,9 +82,9 @@
         # shelter expense = 1,500 housing + 445 SUA (heating/cooling expense present)
         # = 1,945 - 0.5 x 2,715.80 = 587.10 (< 744 cap); net = 2,128.70 ->
         # contribution = floor(2,128) x 0.3 = 638.40 -> 785 - 638.40 = 146.60/month.
-        # Oct-Dec: std ded 213.68 -> net 2,121.68 -> EC 636.30 -> 802.60 - 636.30
-        # = 166.30/month. Annual = 9 x 146.60 + 3 x 166.30 = 1,818.30.
-        snap: 1_818.29
+        # Oct-Dec: std ded 216.38 -> net 2,117.63 -> EC 635.10 -> 812.72 - 635.10
+        # = 177.62/month. Annual = 9 x 146.60 + 3 x 177.62 = 1,852.26.
+        snap: 1852.26
         is_snap_eligible: true
 - name: snap_income_at_fy2026_bbce_gross_limit_43972 (federal)
   period: 2026
@@ -152,9 +152,9 @@
         # limit 1.65 x 26,650 / 12 = 3,664.38 -> still eligible.
         # Jan-Sep: pre-shelter net = 3,664.33 x 0.8 - 209 = 2,722.47; shelter =
         # 1,945 - 1,361.23 = 583.77 -> net = 2,138.70 -> EC 641.40 ->
-        # 785 - 641.40 = 143.60/month. Oct-Dec: 802.60 - 639.30 = 163.30/month.
-        # Annual = 9 x 143.60 + 3 x 163.30 = 1,782.30.
-        snap: 1_782.29
+        # 785 - 641.40 = 143.60/month. Oct-Dec: 812.72 - 638.10 = 174.62/month.
+        # Annual = 9 x 143.60 + 3 x 174.62 = 1,816.26.
+        snap: 1816.26
         is_snap_eligible: true
 - name: snap_income_above_bbce_gross_limit_all_year_45178 (federal)
   period: 2026
@@ -275,8 +275,8 @@
         # Zero-income childless couple pins the 2-person maximum allotment
         # directly (no TANF/SSI confound; weekly_hours_worked_before_lsr defaults
         # to 40, so work requirements are met). Net income 0 -> contribution 0 ->
-        # benefit = max allotment: 9 x 546 + 3 x 558.24 = 6,588.72.
-        snap: 6_588.72
+        # benefit = max allotment: 9 x 546 + 3 x 565.28 = 6,609.84.
+        snap: 6609.85
         is_snap_eligible: true
 - name: snap_minimum_allotment_single_adult_20k (federal)
   period: 2026
@@ -320,8 +320,8 @@
         # contribution 337.20 exceeds the 1-person maximum (298), so the normal
         # allotment is negative and the minimum allotment applies (8% of the
         # 1-person maximum, units of 1-2 people only): Jan-Sep 0.08 x 298 =
-        # 23.84/month; Oct-Dec 0.08 x 304.68 = 24.37/month. Annual = 287.67.
-        snap: 287.68
+        # 23.84/month; Oct-Dec 0.08 x 308.52 = 24.68/month. Annual = 288.60.
+        snap: 288.61
         is_snap_eligible: true
 - name: snap_single_elderly_65_ssi_counts_as_unearned_income (federal)
   period: 2026
@@ -364,10 +364,10 @@
         # Zero-income aged-65 single receives SSI (2026 federal benefit rate
         # $994/month), which counts as SNAP unearned income:
         # Jan-Sep: net = 994 - 209 = 785 -> EC 235.50 -> 298 - 235.50 =
-        # 62.50/month. Oct-Dec: net = 994 - 213.68 = 780.32 -> EC floor(780) x
-        # 0.3 = 234.00 -> 304.68 - 234.00 = 70.68/month.
-        # Annual = 9 x 62.50 + 3 x 70.68 = 774.54.
-        snap: 774.54
+        # 62.50/month. Oct-Dec: net = 994 - 216.38 = 777.62 -> EC floor(777) x
+        # 0.3 = 233.10 -> 308.52 - 233.10 = 75.42/month.
+        # Annual = 9 x 62.50 + 3 x 75.42 = 788.76.
+        snap: 788.77
         is_snap_eligible: true
 - name: snap_childless_couple_20k (federal)
   period: 2026
@@ -418,10 +418,10 @@
     spm_units:
       spm_unit:
         # 2-person baseline: net = 20,000/12 x 0.8 - 209 = 1,124.33 -> EC 337.20
-        # -> 546 - 337.20 = 208.80/month Jan-Sep; Oct-Dec: net 1,119.65 -> EC
-        # 335.70 -> 558.24 - 335.70 = 222.54. Annual = 9 x 208.80 + 3 x 222.54
-        # = 2,546.82. (Also the benchmark for the excluded-immigrant cases below.)
-        snap: 2_546.82
+        # -> 546 - 337.20 = 208.80/month Jan-Sep; Oct-Dec: net 1,116.95 -> EC
+        # 334.80 -> 565.28 - 334.80 = 230.48. Annual = 9 x 208.80 + 3 x 230.48
+        # = 2,570.64. (Also the benchmark for the excluded-immigrant cases below.)
+        snap: 2570.64
         is_snap_eligible: true
 - name: snap_single_parent_1_child_15k_mid_phase_out (federal)
   period: 2026
@@ -474,10 +474,10 @@
     spm_units:
       spm_unit:
         # Mid-phase-out partial benefit: net = 15,000/12 x 0.8 - 209 = 791.00 ->
-        # EC 237.30 -> 546 - 237.30 = 308.70/month Jan-Sep; Oct-Dec: net 786.32
-        # -> EC 235.80 -> 558.24 - 235.80 = 322.44. Annual = 9 x 308.70 +
-        # 3 x 322.44 = 3,745.62. (TX TANF is 0 at this income.)
-        snap: 3_745.62
+        # EC 237.30 -> 546 - 237.30 = 308.70/month Jan-Sep; Oct-Dec: net 783.62
+        # -> EC 234.90 -> 565.28 - 234.90 = 330.38. Annual = 9 x 308.70 +
+        # 3 x 330.38 = 3,769.44. (TX TANF is 0 at this income.)
+        snap: 3769.44
         is_snap_eligible: true
 - name: snap_size_4_couple_2_children_20k (federal)
   period: 2026
@@ -553,9 +553,9 @@
       spm_unit:
         # Size 4 uses the higher standard deduction ($223): net = 1,666.67 x 0.8
         # - 223 = 1,110.33 -> EC 333.00 -> 994 - 333.00 = 661.00/month Jan-Sep;
-        # Oct-Dec: net 1,105.33 -> EC 331.50 -> 1,016.28 - 331.50 = 684.78.
-        # Annual = 9 x 661.00 + 3 x 684.78 = 8,003.34.
-        snap: 8_003.34
+        # Oct-Dec: net 1,102.46 -> EC 330.60 -> 1,029.10 - 330.60 = 698.50.
+        # Annual = 9 x 661.00 + 3 x 698.50 = 8,044.50.
+        snap: 8044.51
         is_snap_eligible: true
 - name: snap_shelter_deduction_capped_non_elderly (federal)
   period: 2026
@@ -613,9 +613,9 @@
         # pre-shelter net = 24,000/12 x 0.8 - 209 = 1,391.00; shelter expense =
         # 1,200 housing + 445 SUA = 1,645 - 0.5 x 1,391 = 949.50 -> capped at
         # 744 -> net = 647.00 -> EC 194.10 -> 546 - 194.10 = 351.90/month
-        # Jan-Sep; Oct-Dec (cap 760.68): 558.24 - 187.50 = 370.74.
-        # Annual = 9 x 351.90 + 3 x 370.74 = 4,279.32.
-        snap: 4_279.32
+        # Jan-Sep; Oct-Dec (cap 770.27): 565.28 - 183.90 = 381.38.
+        # Annual = 9 x 351.90 + 3 x 381.38 = 4,311.24.
+        snap: 4311.24
         is_snap_eligible: true
 - name: snap_shelter_deduction_uncapped_elderly (federal)
   period: 2026
@@ -672,9 +672,9 @@
         # Same unit as the previous case but the head is 60+, so the shelter
         # deduction is NOT capped: full 949.50 deducted -> net = 1,391.00 -
         # 949.50 = 441.50 -> EC 132.30 -> 546 - 132.30 = 413.70/month Jan-Sep;
-        # Oct-Dec: net 434.48 -> EC 130.20 -> 558.24 - 130.20 = 428.04.
-        # Annual = 9 x 413.70 + 3 x 428.04 = 5,007.42 (vs 4,279.32 capped).
-        snap: 5_007.42
+        # Oct-Dec: net 430.43 -> EC 129.00 -> 565.28 - 129.00 = 436.28.
+        # Annual = 9 x 413.70 + 3 x 436.28 = 5,032.14 (vs 4,311.24 capped).
+        snap: 5032.15
         is_snap_eligible: true
 - name: snap_head_immigration_lpr (federal)
   period: 2026
@@ -738,9 +738,9 @@
       spm_unit:
         # LPR head remains a full unit member post-OBBB (size 3): net =
         # 1,666.67 x 0.8 - 209 = 1,124.33 -> EC 337.20 -> 785 - 337.20 =
-        # 447.80/month Jan-Sep; Oct-Dec: 802.60 - 335.70 = 466.90.
-        # Annual = 9 x 447.80 + 3 x 466.90 = 5,430.90.
-        snap: 5_430.89
+        # 447.80/month Jan-Sep; Oct-Dec: 812.72 - 334.80 = 477.92.
+        # Annual = 9 x 447.80 + 3 x 477.92 = 5,463.96.
+        snap: 5463.97
         is_snap_eligible: true
 - name: snap_head_immigration_refugee_excluded_post_obbb (federal)
   period: 2026
@@ -807,9 +807,9 @@
         # allotment 546) and their earnings count at the 2/3 prorated share
         # under 7 CFR 273.11(c)(2)-(3) (TX prorates): counted earnings
         # 1,111.11/mo, net income 679.89 -> EC = floor(679.89) x 0.3 = 203.70
-        # -> 546 - 203.70 = 342.30/month Jan-Sep; Oct-Dec (FY2027): 558.24 -
-        # 202.50 = 355.74. Annual = 9 x 342.30 + 3 x 355.74 = 4,147.92.
-        snap: 4_147.92
+        # -> 546 - 203.70 = 342.30/month Jan-Sep; Oct-Dec (FY2027): 565.28 -
+        # 201.60 = 363.68. Annual = 9 x 342.30 + 3 x 363.68 = 4,171.74.
+        snap: 4171.75
         is_snap_eligible: true
 - name: snap_head_immigration_undocumented_excluded (federal)
   period: 2026
@@ -873,8 +873,8 @@
       spm_unit:
         # Undocumented head is excluded from the unit (size 2) with earnings
         # counted at the 2/3 prorated share; identical arithmetic to the
-        # refugee case: annual = 9 x 342.30 + 3 x 355.74 = 4,147.92.
-        snap: 4_147.92
+        # refugee case: annual = 9 x 342.30 + 3 x 363.68 = 4,171.74.
+        snap: 4171.75
         is_snap_eligible: true
 - name: snap_abawd_zero_hours_fails_work_requirements (federal)
   period: 2026
@@ -969,9 +969,9 @@
         # general-requirement compliance, flipping the unit to eligible
         # (without it this person is ineligible). Benefit: net = 13,000/12 -
         # 20% - 209 = 657.67 -> EC 197.10 -> 298 - 197.10 = 100.90/month
-        # Jan-Sep; Oct-Dec: 304.68 - 195.60 = 109.08.
-        # Annual = 9 x 100.90 + 3 x 109.08 = 1,235.34.
-        snap: 1_235.34
+        # Jan-Sep; Oct-Dec: 308.52 - 195.00 = 113.52.
+        # Annual = 9 x 100.90 + 3 x 113.52 = 1,248.66.
+        snap: 1248.67
         is_snap_eligible: true
 - name: snap_ineligible_student_sole_member (federal)
   period: 2026
@@ -1149,9 +1149,9 @@
         # TANF cash ($2,400/year override): TANF receipt confers categorical
         # eligibility, overriding the failed asset test. TANF also counts as
         # unearned income ($200/month): net = 1,124.33 + 200 = 1,324.33 -> EC
-        # 397.20 -> 785 - 397.20 = 387.80/month Jan-Sep; Oct-Dec: 802.60 -
-        # 395.70 = 406.90. Annual = 9 x 387.80 + 3 x 406.90 = 4,710.90.
-        snap: 4_710.89
+        # 397.20 -> 785 - 397.20 = 387.80/month Jan-Sep; Oct-Dec: 812.72 -
+        # 394.80 = 417.92. Annual = 9 x 387.80 + 3 x 417.92 = 4,743.96.
+        snap: 4743.97
         is_snap_eligible: true
 - name: snap_partner_override_snap_earned_and_unearned_income (federal)
   period: 2026
@@ -1222,9 +1222,9 @@
         # (2,400/year) inputs replace the model's own aggregation, so SNAP sees
         # earned 1,250/month (not the 1,500 implied by employment income) and
         # unearned 200/month. Net = 1,250 - 250 (20%) + 200 - 209 = 991.00 ->
-        # EC 297.30 -> 785 - 297.30 = 487.70/month Jan-Sep; Oct-Dec: 802.60 -
-        # 295.80 = 506.80. Annual = 9 x 487.70 + 3 x 506.80 = 5,909.70.
-        snap: 5_909.69
+        # EC 297.30 -> 785 - 297.30 = 487.70/month Jan-Sep; Oct-Dec: 812.72 -
+        # 294.90 = 517.82. Annual = 9 x 487.70 + 3 x 517.82 = 5,942.76.
+        snap: 5942.77
         is_snap_eligible: true
 - name: snap_negative_self_employment_income_robustness (federal)
   period: 2026
@@ -1280,10 +1280,10 @@
         # Robustness: a $6,000 self-employment LOSS does not offset wages in
         # SNAP earned income (floored at zero), so the benefit equals the
         # wages-only case: net = 18,000/12 x 0.8 - 209 = 991.00 -> EC 297.30 ->
-        # 546 - 297.30 = 248.70/month Jan-Sep; Oct-Dec: 558.24 - 295.80 =
-        # 262.44. Annual = 9 x 248.70 + 3 x 262.44 = 3,025.62 (no benefit
+        # 546 - 297.30 = 248.70/month Jan-Sep; Oct-Dec: 565.28 - 294.90 =
+        # 270.38. Annual = 9 x 248.70 + 3 x 270.38 = 3,049.44 (no benefit
         # inflation from negative income).
-        snap: 3_025.62
+        snap: 3049.44
         is_snap_eligible: true
 - name: snap_2025_single_parent_2_children_20k (federal)
   period: 2025
@@ -1423,9 +1423,9 @@
         # expense inputs) select TX's Limited Utility Allowance ($400 FY2026)
         # instead of the SUA: shelter expense = 600 housing + 400 LUA = 1,000 -
         # 0.5 x 1,124.33 = 437.83 (uncapped) -> net = 686.50 -> EC 205.80 ->
-        # 785 - 205.80 = 579.20/month Jan-Sep; Oct-Dec (LUA uprated to 408.97):
-        # 802.60 - 201.00 = 601.60. Annual = 9 x 579.20 + 3 x 601.60 = 7,017.60.
-        snap: 7_017.59
+        # 785 - 205.80 = 579.20/month Jan-Sep; Oct-Dec (LUA uprated to 414.13):
+        # 812.72 - 198.30 = 614.42. Annual = 9 x 579.20 + 3 x 614.42 = 7,056.06.
+        snap: 7056.07
         is_snap_eligible: true
 
 - name: snap_ineligible_student_income_excluded_mixed_household (federal)
@@ -1484,5 +1484,5 @@
         # their $10,000 earnings are excluded entirely and the unit size is 1;
         # the 130%-FPG gross test passes only because of the exclusion, and
         # the unit receives the 1-2 person minimum allotment.
-        snap: 287.68
+        snap: 288.61
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/il.yaml
@@ -69,7 +69,7 @@
         # - 209 = 1,124.33; shelter expense = 600 housing + 546 = 1,146 -
         # 562.17 = 583.83 (below the 744 cap, so the IL SUA value is fully
         # visible) -> net = 540.50 -> EC 162.00 -> 785 - 162.00 = 623.00/month;
-        # Oct-Dec: 802.60 - 159.90 = 642.70.
-        # Annual = 9 x 623.00 + 3 x 642.70 = 7,535.10.
-        snap: 7_535.09
+        # Oct-Dec: 812.72 - 158.70 = 654.02.
+        # Annual = 9 x 623.00 + 3 x 654.02 = 7,569.06.
+        snap: 7569.06
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ks.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ks.yaml
@@ -59,10 +59,10 @@
         # Monthly gross 27,395/12 = 2,282.92 vs Jan-Sep limit 1.3 x 21,150/12
         # = 2,291.25 -> passes the federal gross test all year (Oct-Dec limit
         # 2,344.33). Net = 2,282.92 x 0.8 - 209 = 1,617.33 -> EC 485.10 ->
-        # 546 - 485.10 = 60.90/month Jan-Sep; Oct-Dec: net 1,612.65 -> EC
-        # 483.60 -> 558.24 - 483.60 = 74.64.
-        # Annual = 9 x 60.90 + 3 x 74.64 = 772.02.
-        snap: 772.02
+        # 546 - 485.10 = 60.90/month Jan-Sep; Oct-Dec: net 1,609.95 -> EC
+        # 482.70 -> 565.28 - 482.70 = 82.58.
+        # Annual = 9 x 60.90 + 3 x 82.58 = 795.84.
+        snap: 795.84
         is_snap_eligible: true
 - name: snap_couple_income_at_fy2026_gross_limit_27495 (ks)
   period: 2026
@@ -115,9 +115,9 @@
         # Exactly at the binding FY2026 limit: 27,495 = 1.3 x 21,150 -> gross
         # ratio 1.30 -> still eligible. Net = 2,291.25 x 0.8 - 209 = 1,624.00
         # -> EC 487.20 -> 546 - 487.20 = 58.80/month Jan-Sep; Oct-Dec: net
-        # 1,619.32 -> EC 485.70 -> 558.24 - 485.70 = 72.54.
-        # Annual = 9 x 58.80 + 3 x 72.54 = 746.82.
-        snap: 746.82
+        # 1,616.62 -> EC 484.80 -> 565.28 - 484.80 = 80.48.
+        # Annual = 9 x 58.80 + 3 x 80.48 = 770.64.
+        snap: 770.64
         is_snap_eligible: true
 - name: snap_couple_income_above_gross_limit_all_year_28232 (ks)
   period: 2026
@@ -284,7 +284,7 @@
         # higher elderly/disabled asset limit ($4,500) applies, so $4,000
         # passes and the age-59/60 asset distinction is observable (0 vs
         # positive). Net = 20,000/12 x 0.8 - 209 = 1,124.33 -> EC 337.20 ->
-        # 546 - 337.20 = 208.80/month Jan-Sep; Oct-Dec: 558.24 - 335.70 =
-        # 222.54. Annual = 9 x 208.80 + 3 x 222.54 = 2,546.82.
-        snap: 2_546.82
+        # 546 - 337.20 = 208.80/month Jan-Sep; Oct-Dec: 565.28 - 334.80 =
+        # 230.48. Annual = 9 x 208.80 + 3 x 230.48 = 2,570.64.
+        snap: 2570.64
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ma.yaml
@@ -69,9 +69,9 @@
         # Jan-Sep: pre-shelter net = 2,857.67; shelter expense = 1,500 housing
         # + 914 MA SUA = 2,414 - 1,428.83 = 985.17 -> capped at 744 -> net =
         # 2,113.67 -> EC 633.90 -> 785 - 633.90 = 151.10/month; Oct-Dec (cap
-        # 760.68): 802.60 - 627.60 = 175.00.
-        # Annual = 9 x 151.10 + 3 x 175.00 = 1,884.90.
-        snap: 1_884.89
+        # 770.27): 812.72 - 624.00 = 188.72.
+        # Annual = 9 x 151.10 + 3 x 188.72 = 1,926.06.
+        snap: 1926.06
         is_snap_eligible: true
 - name: snap_income_above_200_pct_bbce_limit_54740 (ma)
   period: 2026
@@ -205,5 +205,5 @@
   output:
     spm_units:
       spm_unit:
-        snap: 3_815.82
+        snap: 3840.54
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/nc.yaml
@@ -70,9 +70,9 @@
         # selects the SUA (NC 3-person: $768). Jan-Sep: pre-shelter net =
         # 2,857.67; shelter expense = 1,500 + 768 = 2,268 - 1,428.83 = 839.17
         # -> capped at 744 -> net = 2,113.67 -> EC 633.90 -> 785 - 633.90 =
-        # 151.10/month; Oct-Dec (cap 760.68): 802.60 - 627.60 = 175.00.
-        # Annual = 9 x 151.10 + 3 x 175.00 = 1,884.90.
-        snap: 1_884.89
+        # 151.10/month; Oct-Dec (cap 770.27): 812.72 - 624.00 = 188.72.
+        # Annual = 9 x 151.10 + 3 x 188.72 = 1,926.06.
+        snap: 1926.06
         is_snap_eligible: true
 - name: snap_income_above_200_pct_bbce_limit_54740 (nc)
   period: 2026
@@ -275,5 +275,5 @@
         # The full $1,666.67/month passes the gross screens and the benefit
         # is computed from the 2/3-prorated income, matching the TX
         # prorate-state baseline.
-        snap: 4_147.92
+        snap: 4171.75
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/wa.yaml
@@ -71,9 +71,9 @@
         # WA SUA = 2,015 - 1,428.83 = 586.17 -> net = 2,271.50, which is ABOVE
         # the regular 100%-FPG net limit (2,220.83) - WA's BBCE has no net
         # test, so the unit is still eligible. EC 681.30 -> 785 - 681.30 =
-        # 103.70/month; Oct-Dec: 802.60 - 679.20 = 123.40.
-        # Annual = 9 x 103.70 + 3 x 123.40 = 1,303.50.
-        snap: 1_303.49
+        # 103.70/month; Oct-Dec: 812.72 - 678.00 = 134.72.
+        # Annual = 9 x 103.70 + 3 x 134.72 = 1,337.46.
+        snap: 1337.46
         is_snap_eligible: true
 - name: snap_income_above_200_pct_bbce_limit_54740 (wa)
   period: 2026

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ca.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ca.yaml
@@ -170,7 +170,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -372,7 +372,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -752,7 +752,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 10398.24
+        snap: 10448.41
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -1124,7 +1124,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 7947.54
+        snap: 7990.51
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -1323,7 +1323,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -1517,7 +1517,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -1706,7 +1706,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 7947.54
+        snap: 7990.51
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -1907,7 +1907,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -2092,7 +2092,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 7947.54
+        snap: 7990.51
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -2486,7 +2486,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 7947.54
+        snap: 7990.51
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -2678,7 +2678,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -2878,7 +2878,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -3066,7 +3066,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 7947.54
+        snap: 7990.51
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -3450,7 +3450,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 7947.54
+        snap: 7990.51
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -3640,7 +3640,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 10398.24
+        snap: 10448.41
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -3838,7 +3838,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -4032,7 +4032,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -4224,7 +4224,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 10398.24
+        snap: 10448.41
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -4415,7 +4415,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 10398.24
+        snap: 10448.41
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -4799,7 +4799,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -5187,7 +5187,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 10398.24
+        snap: 10448.41
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -5377,7 +5377,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 10398.24
+        snap: 10448.41
     people:
       head:
         ca_ala_general_assistance_eligible_person: false
@@ -5562,7 +5562,7 @@
         la_general_relief: 0.0
         la_general_relief_eligible: false
         lifeline: 228.0
-        snap: 7947.54
+        snap: 7990.51
     people:
       head:
         ca_ala_general_assistance_eligible_person: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/co.yaml
@@ -214,7 +214,7 @@
         lifeline: 111.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_16 (13 reqs, +8 dupes)
   period: 2026
   absolute_error_margin: 0.1
@@ -613,7 +613,7 @@
         lifeline: 111.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_92 (3 reqs, +1 dupes)
   period: 2026
   absolute_error_margin: 0.1
@@ -900,7 +900,7 @@
         lifeline: 111.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_124 (2 reqs, +1 dupes)
   period: 2026
   absolute_error_margin: 0.1

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/federal.yaml
@@ -90,7 +90,7 @@
         is_medicaid_eligible: true
     spm_units:
       spm_unit:
-        snap: 1282.14
+        snap: 1323.31
 - name: signature_8 (25 reqs, +2 dupes)
   period: 2026
   absolute_error_margin: 0.1
@@ -353,7 +353,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         is_wic_eligible: false
@@ -515,7 +515,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         is_wic_eligible: false
@@ -618,7 +618,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         is_wic_eligible: false
@@ -845,7 +845,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 5775.84
+        snap: 5826.01
     people:
       head:
         is_wic_eligible: false
@@ -953,7 +953,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 5775.84
+        snap: 5826.01
     people:
       head:
         is_wic_eligible: false
@@ -1149,7 +1149,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         is_wic_eligible: false
@@ -1349,7 +1349,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         is_wic_eligible: false
@@ -1650,7 +1650,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         is_wic_eligible: false
@@ -1761,7 +1761,7 @@
     spm_units:
       spm_unit:
         is_snap_eligible: true
-        snap: 3713.94
+        snap: 3756.91
     people:
       head:
         is_wic_eligible: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/il.yaml
@@ -267,7 +267,7 @@
         lifeline: 111.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_71 (4 reqs)
   period: 2026
   absolute_error_margin: 0.1
@@ -518,7 +518,7 @@
         lifeline: 111.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_102 (2 reqs)
   period: 2026
   absolute_error_margin: 0.1
@@ -1777,4 +1777,4 @@
         lifeline: 111.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/ma.yaml
@@ -253,7 +253,7 @@
         ma_tafdc: 13516.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_55 (4 reqs)
   period: 2026
   absolute_error_margin: 0.1
@@ -494,7 +494,7 @@
         ma_tafdc: 13516.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_111 (2 reqs, +1 dupes)
   period: 2026
   absolute_error_margin: 0.1
@@ -973,7 +973,7 @@
         ma_tafdc: 13516.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_174 (1 reqs)
   period: 2026
   absolute_error_margin: 0.1

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/nc.yaml
@@ -196,7 +196,7 @@
         nc_tanf: 1564.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_49 (5 reqs, +9 dupes)
   period: 2026
   absolute_error_margin: 0.1
@@ -561,7 +561,7 @@
         nc_tanf: 1564.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_140 (1 reqs)
   period: 2026
   absolute_error_margin: 0.1
@@ -926,4 +926,4 @@
         nc_tanf: 1564.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/tx.yaml
@@ -270,7 +270,7 @@
         lifeline: 153.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
         tanf: 0.0
         tx_ccs: 3335.28
         tx_tanf: 0.0
@@ -523,7 +523,7 @@
         lifeline: 153.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
         tanf: 0.0
         tx_ccs: 3335.28
         tx_tanf: 0.0
@@ -1280,7 +1280,7 @@
         lifeline: 153.0
         school_meal_daily_subsidy: 7.15
         school_meal_tier: 0
-        snap: 11994.84
+        snap: 12033.31
         tanf: 0.0
         tx_ccs: 3335.28
         tx_tanf: 0.0

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/wa.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/signatures/wa.yaml
@@ -153,7 +153,7 @@
     spm_units:
       spm_unit:
         lifeline: 111.0
-        snap: 11994.84
+        snap: 12033.31
 - name: signature_9 (25 reqs, +8 dupes)
   period: 2026
   absolute_error_margin: 0.1
@@ -282,7 +282,7 @@
     spm_units:
       spm_unit:
         lifeline: 111.0
-        snap: 11994.84
+        snap: 12033.31
     people:
       head:
         ssi: 0.0
@@ -424,7 +424,7 @@
     spm_units:
       spm_unit:
         lifeline: 111.0
-        snap: 11994.84
+        snap: 12033.31
     people:
       head:
         ssi: 0.0


### PR DESCRIPTION
Fixes #9088.

## What

Replaces the three published-but-still-forecast entries in `gov/usda/snap/uprating.yaml` with BLS actuals (CPI-U NSA all items, `CUUR0000SA0`, June value per the file's `# YYYY-06.` convention; retrieved from the BLS API 2026-07-19):

| Entry | Was (CBO Feb 2024 forecast) | Now (BLS actual) |
|---|---|---|
| `2024-10-01` | 313.7 | 314.175 (June 2024) |
| `2025-10-01` | 321.2 | 322.561 (June 2025) |
| `2026-10-01` | 328.4 | 333.952 (June 2026) |

`2027-10-01` and later remain CBO February-2024 forecasts pending a baseline refresh. Adds the BLS series reference to the parameter metadata.

## Downstream effect

FY2026 values are explicit (FY2026 COLA memo), so nothing changes before 2026-10-01. From 2026-10-01, projected FY2027 values for everything uprated by this index — `max_allotment`, the standard deduction, the excess shelter cap, the homeless shelter deduction, and the limited/single utility allowances — grow **+3.53% y/y (333.952/322.561) instead of +2.24% (328.4/321.2)**, since June 2026 CPI came in 1.69% above CBO's early-2024 forecast level. Contiguous-US examples (computed from the model):

| Parameter (monthly) | FY2026 | FY2027 before | FY2027 after |
|---|---|---|---|
| Max allotment, 4-person | 994 | 1,016.28 | 1,029.10 |
| Standard deduction, 1–3-person | 209 | 213.68 | 216.38 |
| Excess shelter cap | 744 | 760.68 | 770.27 |
| Homeless shelter deduction | 198.99 | 203.45 | 206.02 |

Two notes:

- Because the FY2028 forecast level (335.5) is retained over the higher June-2025 actual base, implied FY2028 growth compresses to +0.46%; the new FY2028 test case pins this choice explicitly. A CBO-baseline refresh of the forecast tail is follow-up work (the repo's CPI files are already on the February 2026 baseline).
- `asset_test/limit.yaml` references this index but its file-level `uprating:` metadata is silently inert (values live under children without `propagate_metadata_to_children`), so asset limits are unaffected — flagged in #9089, the FY2027 COLA tracking issue.

## Tests

- New `snap_max_allotment.yaml` tests: FY2026 explicit guard, FY2027 uprated values, and the FY2028 forecast-retention pin.
- New FY2027 cases for the standard deduction, shelter cap, homeless deduction, and TX limited utility allowance.
- Discrimination verified in the strong form: with the old forecast values patched back, exactly these 8 new cases fail; with the actuals, the full SNAP tree passes (463 tests).

## Partner contract tests

The change moves Oct–Dec 2026 SNAP amounts, so 87 of 630 partner contract cases (amplifi 2026 yearly totals, analytics_coverage signatures and SNAP edge cases; all 630 pass pre-change) were recalibrated per the partner-test protocol — three-question gate run with Max and approved (team and partner notification handled by Max). Only the changed `snap@2026` pins were touched (87 single-line value edits), and the edge-case files' documented FY2027 arithmetic was recomputed from model outputs, not hand-derived. Partner tree passes 630/630 after recalibration.

## Follow-ups

- #9089 — encode official FY2027 COLA values when USDA publishes the memo (~August 2026).
- Sweep of the other uprating indices (BLS CPI monthly actuals end August 2025 in `gov/bls/cpi/*`; HHS uprating has published-actual entries still on forecast) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
