### PR TITLE
Fix Missouri 2021 HoH exemption start date and federal income tax deduction base

### DIFF
--- a/changelog.d/fix-mo-2021-deductions.fixed.md
+++ b/changelog.d/fix-mo-2021-deductions.fixed.md
@@ -1,0 +1,1 @@
+Correct the Missouri head of household $1,400 additional exemption to start in 2022, when MO-1040 Line 15 first appeared (the 2018-2021 forms had no line for it), and stop netting the refundable CTC and 2021 refundable CDCC out of the federal income tax deduction base, per the MO-1040 Line 9 worksheet.

--- a/policyengine_us/parameters/gov/states/mo/tax/income/deductions/federal_income_tax/ignored_credits.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/deductions/federal_income_tax/ignored_credits.yaml
@@ -1,8 +1,28 @@
 description: Missouri ignores the following credits in federal income tax deduction calculations.
+# The MO-1040 Line 9 worksheet defines the base as 1040 Line 22 less the EIC
+# (Line 27), the refundable American Opportunity Credit (Line 29), Schedule 2
+# Part I Line 3, and the net premium tax credit (Schedule 3 Line 9). Credits
+# claimed on Line 28 (refundable CTC) and Line 30 (recovery rebate), and the
+# 2021 refundable CDCC (Schedule 3 Line 13g), never reduce Line 22, so they
+# are added back here. The worksheet does subtract the EIC, so its presence
+# in this list deviates from the form — see issue #9094.
 values:
   2018-01-01:
     - eitc
     - recovery_rebate_credit
+    - refundable_ctc
+  # The CDCC is a refundable credit only in 2021 (ARPA); in other years it
+  # already reduces income tax before refundable credits, so adding it back
+  # would overstate the base.
+  2021-01-01:
+    - eitc
+    - recovery_rebate_credit
+    - refundable_ctc
+    - cdcc
+  2022-01-01:
+    - eitc
+    - recovery_rebate_credit
+    - refundable_ctc
 metadata:
   unit: list
   label: Missouri ignored credits in federal income tax deduction
@@ -10,5 +30,7 @@ metadata:
   reference:
     - title: Revisor of Missouri Title X TAXATION AND REVENUE section 143.171
       href: https://revisor.mo.gov/main/OneSection.aspx?section=143.171&bid=49937&hl=federal+income+tax+deduction%u2044
-    - title: 2021 Form MO-1040 instructions, Line 9
+    - title: 2021 Form MO-1040 instructions, Line 9 worksheet
       href: https://dor.mo.gov/forms/MO-1040%20Instructions_2021.pdf#page=7
+    - title: 2024 Form MO-1040 instructions, Line 9 worksheet
+      href: https://dor.mo.gov/forms/MO-1040%20Instructions_2024.pdf#page=7

--- a/policyengine_us/parameters/gov/states/mo/tax/income/exemptions/head_of_household.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/exemptions/head_of_household.yaml
@@ -6,7 +6,15 @@ metadata:
   reference:
     - title: RSMo 143.161(2) — Head of household additional exemption
       href: https://www.revisor.mo.gov/main/OneSection.aspx?section=143.161
+    - title: 2021 MO-1040 Instructions (Line 15 is the long-term care insurance deduction; the booklet has no head of household exemption line)
+      href: https://dor.mo.gov/forms/MO-1040%20Instructions_2021.pdf#page=8
+    - title: 2022 MO-1040 Instructions, Line 15
+      href: https://dor.mo.gov/forms/MO-1040%20Instructions_2022.pdf#page=8
     - title: 2024 MO-1040 Instructions, Line 15
       href: https://dor.mo.gov/forms/MO-1040%20Instructions_2024.pdf#page=8
 values:
-  2021-01-01: 1_400
+  # The Department of Revenue provided no line for this exemption on the
+  # 2018-2021 forms; it (re)appeared as MO-1040 Line 15 on the 2022 form.
+  # Pre-2018 history, when the exemption was also claimable, is not modeled.
+  0000-01-01: 0
+  2022-01-01: 1_400

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_federal_income_tax_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_federal_income_tax_deduction.yaml
@@ -98,3 +98,36 @@
     # disable test:
     #mo_federal_income_tax_deduction: 678.4
     mo_adjusted_gross_income: 100_000
+
+- name: Refundable CTC does not reduce the deduction base (MO-1040 Line 9 is 1040 Line 22, undiminished by Line 28 — issue 9094)
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    # taxsim issue 1104 record - HoH, one child, $70,512.51 wages.
+    # Base is 121.50 + 2,800 recovery rebate + 3,000 refundable CTC = 5,921.50;
+    # times 15% (AGI between 50,001 and 100,000) = 888.23.
+    mo_adjusted_gross_income: 70_512.51
+    income_tax: 121.5
+    recovery_rebate_credit: 2_800
+    refundable_ctc: 3_000
+    eitc: 0
+    filing_status: HEAD_OF_HOUSEHOLD
+    state_code: MO
+  output:
+    mo_federal_income_tax_deduction: 888.23
+
+- name: 2021 refundable CDCC does not reduce the deduction base (Schedule 3 Line 13g is not in the Line 9 worksheet)
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    # Base is 1,000 + 500 = 1,500; times 25% (AGI between 25,001 and 50,000) = 375.
+    mo_adjusted_gross_income: 30_000
+    income_tax: 1_000
+    cdcc: 500
+    recovery_rebate_credit: 0
+    refundable_ctc: 0
+    eitc: 0
+    filing_status: SINGLE
+    state_code: MO
+  output:
+    mo_federal_income_tax_deduction: 375

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/integration_tests/mo_pension_and_ss_or_ssd.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/deductions/mo_pension_and_ss_or_ssd_deduction/integration_tests/mo_pension_and_ss_or_ssd.yaml
@@ -391,8 +391,13 @@
       household:
         members: [person1, person2, person3, person4, person5, person6]
         state_code: MO
-  output:  # expected results from patched TAXSIM35 2023-02-13 version
-    mo_income_tax: 3095.77
+  output:
+    # Patched TAXSIM35 2023-02-13 gave 3095.77, netting the fully refundable
+    # 2021 CTC out of the MO federal income tax deduction base. The MO-1040
+    # Line 9 worksheet bases the deduction on 1040 Line 22, which Line 28
+    # refundable credits never reduce (issue 9094, taxsim issue 1104), so
+    # the deduction is larger and the tax lower.
+    mo_income_tax: 3071.82
 
 - name: Tax unit with taxsimid 94115 in f21.its.csv and f21.ots.csv
   absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/exemptions/mo_head_of_household_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/exemptions/mo_head_of_household_exemption.yaml
@@ -38,13 +38,13 @@
   output:
     mo_head_of_household_exemption: 0
 
-- name: HoH filer in 2021 gets $1,400 exemption (statute in effect per RSMo 143.161(2))
+- name: HoH filer in 2021 gets no exemption (no line on the 2021 MO-1040; Line 15 first appeared on the 2022 form — issue 9093)
   period: 2021
   input:
     filing_status: HEAD_OF_HOUSEHOLD
     state_code: MO
   output:
-    mo_head_of_household_exemption: 1_400
+    mo_head_of_household_exemption: 0
 
 - name: HoH filer in 2022 gets $1,400 exemption
   period: 2022

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/tax_sim/mo_taxable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/tax_sim/mo_taxable_income.yaml
@@ -76,3 +76,29 @@
     # disable test:
     #mo_taxable_income: [74_860.5, 0, 0]
     age: [32, 32, 5]
+
+- name: Taxsim issue 1104 record - 2021 HoH, one child, 70,512.51 wages
+  period: 2021
+  absolute_error_margin: 0.05
+  input:
+    people:
+      person1:
+        age: 37
+        employment_income: 70_512.51
+        is_tax_unit_head: true
+      person2:
+        age: 10
+    tax_units:
+      tax_unit:
+        aca_ptc: 0
+        members: [person1, person2]
+    household:
+      members: [person1, person2]
+      state_code: MO
+  output:
+    # 2021 MO-1040 (TaxAct return in policyengine-taxsim#1104): AGI 70,512.51
+    # - 18,800 standard deduction
+    # - 888.23 federal income tax deduction (15% x 5,921.50 Line 22 tax,
+    #   undiminished by the fully refundable 2021 CTC)
+    # - no head of household exemption (no line on the 2021 form)
+    mo_taxable_income: [50_824.28, 0]

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/tax_sim/scenarios/mo_income_tax_by_family_structure.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/tax_sim/scenarios/mo_income_tax_by_family_structure.yaml
@@ -158,7 +158,9 @@
     income_tax: -7_940
     #taxsim output: $6,740 ("Income Tax Balance"), offset by $1,200 error.
     mo_adjusted_gross_income: [50_000, 0, 0]
-    # HoH gets $1,400 additional exemption per RSMo 143.161(2)
-    mo_taxable_income: [29_800, 0, 0]
-    #taxsim output: 30_681
+    # 50,000 - 18,800 standard deduction - 519 federal income tax deduction
+    # (15% x 3,460 Line 22 tax, undiminished by the refundable 2021 CTC).
+    # No head of household exemption: MO-1040 Line 15 first appeared on the
+    # 2022 form (issue 9093). Matches taxsim.
+    mo_taxable_income: [30_681, 0, 0]
     #taxsim output: 1_469.64


### PR DESCRIPTION
Fixes #9093
Fixes #9094

Surfaced by PolicyEngine/policyengine-taxsim#1104 (MO 2021 HoH, $70,512.51 wages, one child): PolicyEngine's MO taxable income was $49,874 vs $50,833 on the filed MO-1040.

## Changes

**1. Head of household $1,400 additional exemption starts in 2022, not 2021** (`exemptions/head_of_household.yaml`). RSMo 143.161(2) provides the exemption, but the Department of Revenue offered no line for it on the 2018–2021 forms — on the 2021 MO-1040, Line 15 is the long-term care insurance deduction, and "$1,400" appears nowhere in the 2021 booklet. The exemption (re)appeared as Line 15 on the 2022 form. Values are now `0000-01-01: 0`, `2022-01-01: 1_400` (pre-2018 history, when it was also claimable, stays out of scope).

**2. Refundable CTC (all years) and the 2021 refundable CDCC no longer reduce the federal income tax deduction base** (`deductions/federal_income_tax/ignored_credits.yaml`). The MO-1040 Line 9 worksheet defines the base as 1040 Line 22 less Lines 27/29, Schedule 2 Part I Line 3, and Schedule 3 Line 9 — credits on Line 28 (refundable CTC/ACTC), Line 30 (recovery rebate), and Schedule 3 Line 13g (2021 refundable CDCC) never touch Line 22. `cdcc` is added for 2021 only, the year it is in `gov.irs.credits.refundable`; adding it back in other years would overstate the base.

Not changed: `eitc` remains in the ignored list even though the worksheet subtracts the EIC ("Line 22 less Line 27a") — flagged as an open question in #9094.

## Validation

Against the #1104 record (2021, HoH, $70,512.51 wages, one child age 10):

| | Before | After | Filed MO-1040 |
|---|---|---|---|
| Federal income tax deduction | 438.23 | 888.23 | 888 |
| HoH exemption | 1,400 | 0 | — |
| MO taxable income | 49,874.28 | 50,824.28 | 50,833 |
| MO income tax | 2,506.08 | 2,557.38 | 2,558 |

Residual ~$9 of taxable income traces to the TaxAct federal return showing $8 of taxable interest despite no interest input, plus wage rounding.

Tests: flipped the 2021 HoH-exemption test to 0, added deduction unit tests for the refundable CTC and 2021 CDCC add-backs, and added the #1104 record as a taxsim integration test. All 21 MO tests in the touched files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
