### PR TITLE
Gate AZ Families Tax Rebate on after-credit tax liability per SB 1734

### DIFF
--- a/changelog.d/fix-az-rebate-liability-gate.fixed.md
+++ b/changelog.d/fix-az-rebate-liability-gate.fixed.md
@@ -1,0 +1,1 @@
+Gate the Arizona Families Tax Rebate on tax liability net of nonrefundable and refundable credits per SB 1734's definition, instead of tax before credits.

--- a/changelog.d/fix-az-rebate-liability-gate.fixed.md
+++ b/changelog.d/fix-az-rebate-liability-gate.fixed.md
@@ -1,1 +1,1 @@
-Gate the Arizona Families Tax Rebate on tax liability net of nonrefundable and refundable credits per SB 1734's definition, instead of tax before credits.
+Gate the Arizona Families Tax Rebate on tax liability net of nonrefundable and refundable credits per SB 1734's definition, instead of tax before credits, with the $1 minimum-liability threshold now set as a parameter rather than a hard-coded literal.

--- a/policyengine_us/parameters/gov/states/az/tax/income/rebate/min_tax_liability.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/rebate/min_tax_liability.yaml
@@ -1,0 +1,12 @@
+description: Arizona limits eligibility to filers with at least this tax liability under the Families Tax Rebate program.
+metadata:
+  period: year
+  unit: currency-USD
+  label: Arizona Families Tax Rebate minimum tax liability
+  reference:
+    - title: Arizona Families Tax Rebate
+      href: https://azdor.gov/individuals/arizona-families-tax-rebate
+    - title: SB 1734 (Laws 2023, ch. 147) Sec. 3.A.1
+      href: https://www.azleg.gov/legtext/56leg/1R/laws/0147.pdf#page=4
+values:
+  2021-01-01: 1

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_families_tax_rebate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_families_tax_rebate.yaml
@@ -265,6 +265,11 @@
     # credit reduce the balance to zero, plus the $50 refundable increased
     # excise tax credit. SB 1734 liability (after nonrefundable and
     # refundable credits) is below $1, so no rebate.
+    az_income_tax_before_refundable_credits: 0
+    az_increased_excise_tax_credit: 50
+    # The $50 refundable excise credit flows through to net AZ income tax,
+    # confirming the refundable-flow premise rather than leaving it in a comment.
+    az_income_tax: -50
     az_families_tax_rebate: 0
 
 - name: 2021 - After-credit liability of at least $1 keeps the rebate
@@ -291,3 +296,32 @@
   output:
     # Liability 51 - 50 = 1 >= $1: eligible for $250 (one dependent under 17).
     az_families_tax_rebate: 250
+
+- name: 2021 - Refundable excise credit drives after-credit liability below $1 - no rebate
+  period: 2021
+  input:
+    people:
+      filer:
+        age: 30
+        is_tax_unit_dependent: false
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+        az_income_tax_before_refundable_credits: 50.99
+        az_increased_excise_tax_credit: 50
+        az_property_tax_credit: 0
+    households:
+      household:
+        members: [filer, child]
+        state_code: AZ
+  output:
+    # After-credit liability 50.99 - 50 = 0.99 < $1, so no rebate. This pins
+    # the PR's central logic: the $50 REFUNDABLE excise credit is what pushes
+    # liability under $1. Dropping the refundable subtraction leaves 50.99 >= $1
+    # and would wrongly pay $250, so this case fails without it. Also closes the
+    # sub-$1 boundary (0.99 vs the 1.00 kept-rebate case above).
+    az_families_tax_rebate: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_families_tax_rebate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/tax/income/credits/az_families_tax_rebate.yaml
@@ -240,3 +240,54 @@
   output:
     # Non-Arizona residents do not receive Arizona rebate
     az_families_tax_rebate: 0
+
+- name: 2021 - Credits wipe out liability - no rebate (taxsim issue 1102, PE-US issue 9098)
+  period: 2021
+  input:
+    people:
+      filer:
+        age: 25
+        employment_income: 19_824.22
+        is_tax_unit_dependent: false
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        members: [filer, child]
+        state_code: AZ
+  output:
+    # Form 140: tax 26.53, dependent tax credit and family income tax
+    # credit reduce the balance to zero, plus the $50 refundable increased
+    # excise tax credit. SB 1734 liability (after nonrefundable and
+    # refundable credits) is below $1, so no rebate.
+    az_families_tax_rebate: 0
+
+- name: 2021 - After-credit liability of at least $1 keeps the rebate
+  period: 2021
+  input:
+    people:
+      filer:
+        age: 30
+        is_tax_unit_dependent: false
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [filer, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+        az_income_tax_before_refundable_credits: 51
+        az_increased_excise_tax_credit: 50
+        az_property_tax_credit: 0
+    households:
+      household:
+        members: [filer, child]
+        state_code: AZ
+  output:
+    # Liability 51 - 50 = 1 >= $1: eligible for $250 (one dependent under 17).
+    az_families_tax_rebate: 250

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/az_families_tax_rebate.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/az_families_tax_rebate.py
@@ -6,8 +6,10 @@ class az_families_tax_rebate(Variable):
     entity = TaxUnit
     label = "Arizona Families Tax Rebate"
     unit = USD
-    documentation = "https://azdor.gov/individuals/arizona-families-tax-rebate"
-    reference = "https://www.azleg.gov/legtext/56leg/1r/laws/0147.htm"
+    reference = (
+        "https://www.azleg.gov/legtext/56leg/1R/laws/0147.pdf#page=6",
+        "https://azdor.gov/individuals/arizona-families-tax-rebate",
+    )
     definition_period = YEAR
     defined_for = StateCode.AZ
 
@@ -17,14 +19,19 @@ class az_families_tax_rebate(Variable):
         # tax liability and having claimed dependents.
         p = parameters(period).gov.states.az.tax.income.rebate
 
-        # Check tax liability eligibility (at least $1). SB 1734 (Laws 2023,
-        # ch. 147, sec. 3.N.4) defines tax liability as tax "minus the sum of
-        # nonrefundable and refundable income tax credits claimed" under
-        # title 43, chapter 10, article 5 - i.e., after all credits. The
-        # rebate itself is a session-law payment, not an article 5 credit,
-        # so it is excluded here. (The statute's 2020/2019 fallback tests
-        # are not modelable from a single-year record; like TAXSIM, the
-        # 2021 liability proxies all three years.)
+        # Check tax liability eligibility (at least the statutory minimum).
+        # SB 1734 (Laws 2023, ch. 147, sec. 3.N.4) defines tax liability as
+        # tax "minus the sum of nonrefundable and refundable income tax
+        # credits claimed" under title 43, chapter 10, article 5 - i.e.,
+        # after all credits. The statute's definition also ADDS "any amount
+        # of recaptured income tax credits" and the taxpayer's Arizona small
+        # business (Form 140-SBI) income tax liability. Neither is modeled
+        # here: recapture is not modeled at all, and SBI income remains in
+        # regular taxable income, which approximates the combined liability.
+        # The rebate itself is a session-law payment, not an article 5
+        # credit, so it is excluded here. (The statute's 2020/2019 fallback
+        # tests are not modelable from a single-year record; like TAXSIM,
+        # the 2021 liability proxies all three years.)
         tax_after_non_refundable_credits = tax_unit(
             "az_income_tax_before_refundable_credits", period
         )
@@ -37,7 +44,7 @@ class az_families_tax_rebate(Variable):
             [c for c in refundable_credits if c != "az_families_tax_rebate"],
         )
         tax_liability = tax_after_non_refundable_credits - other_refundable_credits
-        has_tax_liability = tax_liability >= 1
+        has_tax_liability = tax_liability >= p.min_tax_liability
 
         person = tax_unit.members
         dependent = person("is_tax_unit_dependent", period)

--- a/policyengine_us/variables/gov/states/az/tax/income/credits/az_families_tax_rebate.py
+++ b/policyengine_us/variables/gov/states/az/tax/income/credits/az_families_tax_rebate.py
@@ -17,11 +17,27 @@ class az_families_tax_rebate(Variable):
         # tax liability and having claimed dependents.
         p = parameters(period).gov.states.az.tax.income.rebate
 
-        # Check tax liability eligibility (at least $1)
-        tax_before_credits = tax_unit(
-            "az_income_tax_before_non_refundable_credits", period
+        # Check tax liability eligibility (at least $1). SB 1734 (Laws 2023,
+        # ch. 147, sec. 3.N.4) defines tax liability as tax "minus the sum of
+        # nonrefundable and refundable income tax credits claimed" under
+        # title 43, chapter 10, article 5 - i.e., after all credits. The
+        # rebate itself is a session-law payment, not an article 5 credit,
+        # so it is excluded here. (The statute's 2020/2019 fallback tests
+        # are not modelable from a single-year record; like TAXSIM, the
+        # 2021 liability proxies all three years.)
+        tax_after_non_refundable_credits = tax_unit(
+            "az_income_tax_before_refundable_credits", period
         )
-        has_tax_liability = tax_before_credits >= 1
+        refundable_credits = parameters(
+            period
+        ).gov.states.az.tax.income.credits.refundable
+        other_refundable_credits = add(
+            tax_unit,
+            period,
+            [c for c in refundable_credits if c != "az_families_tax_rebate"],
+        )
+        tax_liability = tax_after_non_refundable_credits - other_refundable_credits
+        has_tax_liability = tax_liability >= 1
 
         person = tax_unit.members
         dependent = person("is_tax_unit_dependent", period)


### PR DESCRIPTION
Fixes #9098

Surfaced by PolicyEngine/policyengine-taxsim#1102 (AZ 2021 HoH, $19,824.22 wages, one dependent).

## Changes

SB 1734 (Laws 2023, ch. 147, §3) requires "a tax liability of at least $1" on the 2021 return for the Arizona Families Tax Rebate, and §3.N.4 defines the term as taxable income × rate **"minus the sum of nonrefundable and refundable income tax credits claimed"** under title 43, chapter 10, article 5. The ADOR FAQ says the same: credits reducing liability to zero in 2019–2021 → ineligible.

`az_families_tax_rebate` previously gated on `az_income_tax_before_non_refundable_credits >= 1` (tax before credits). It now gates on `az_income_tax_before_refundable_credits` minus the other refundable credits (excise and property tax credits; the rebate itself is a session-law payment, not an article 5 credit, so its exclusion is both non-circular and statutory).

The statute's 2020/2019 fallback tests are unmodelable from a single-year record; like TAXSIM, the 2021 liability proxies all three years (noted in a comment).

## Validation

Against the #1102 record (Form 140: tax 27, dependent credit 100, family income tax credit 80 → balance 0, excise credit 50 → $50 refund; TAXSIM refuses the rebate):

| | Before | After | TAXSIM / statute |
|---|---|---|---|
| az_families_tax_rebate | 250 | 0 | 0 (liability < $1) |
| az_income_tax | −300 | −50 | −50 |

New tests: the #1102 record (credits wipe liability → no rebate) and a boundary case (after-credit liability exactly $1 → rebate kept). All 10 tests in the file pass locally, including the 8 pre-existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
