### PR TITLE
Add the published KFF 2026 ACA benchmark premium, keeping the extension on the pre-jump trend

### DIFF
--- a/changelog.d/aca-benchmark-2026-actual.changed.md
+++ b/changelog.d/aca-benchmark-2026-actual.changed.md
@@ -1,0 +1,1 @@
+Add the published KFF 2026 national average benchmark premium ($625) to the ACA benchmark uprating index, keeping the long-run extension on the pre-2026 growth trend so the one-off jump does not compound.

--- a/policyengine_us/parameters/gov/aca/benchmark_premium_uprating.yaml
+++ b/policyengine_us/parameters/gov/aca/benchmark_premium_uprating.yaml
@@ -3,7 +3,7 @@ metadata:
   unit: currency-USD
   label: ACA benchmark premium uprating
   reference:
-    - title: KFF Marketplace Average Benchmark Premiums, 2014-2025
+    - title: KFF Marketplace Average Benchmark Premiums, 2014-2026
       href: https://www.kff.org/affordable-care-act/state-indicator/marketplace-average-benchmark-premiums/
 values:
   # Historical KFF data - actual national average SLCSP premiums
@@ -19,5 +19,7 @@ values:
   2023-01-01: 456
   2024-01-01: 477
   2025-01-01: 497
-  # Values for 2026-2100 are set programmatically in uprating_extensions.py
-  # based on 2024-2025 growth rate
+  2026-01-01: 625
+  # Values for 2027-2100 are set programmatically in uprating_extensions.py.
+  # The published 2026 actual is 25.8% above 2025; the extension treats that
+  # as a one-off level shift and keeps long-run growth at the 2024-2025 trend.

--- a/policyengine_us/parameters/uprating_extensions.py
+++ b/policyengine_us/parameters/uprating_extensions.py
@@ -1,6 +1,7 @@
 """Unified script to extend all uprating factors through 2100."""
 
 import math
+from typing import Optional, Tuple
 
 from policyengine_us.model_api import *
 from policyengine_core.periods import instant
@@ -112,6 +113,7 @@ def extend_parameter_values(
     end_year: int,
     period_month: int = 1,
     period_day: int = 1,
+    growth_years: Optional[Tuple[int, int]] = None,
 ) -> None:
     """
     Extend a parameter's values from last_projected_year to end_year using
@@ -123,11 +125,18 @@ def extend_parameter_values(
         end_year: The year to extend values through
         period_month: The month for the period (default 1 for January)
         period_day: The day for the period (default 1)
+        growth_years: Optional (earlier, later) pair to measure the growth
+            rate between, instead of the last two projected years — used
+            when the final actual embeds a one-off level shift that should
+            not compound in the long-run extension.
     """
     # Calculate the growth rate from the last two years of projections
     date_format = f"-{period_month:02d}-{period_day:02d}"
-    second_to_last_value = parameter(f"{last_projected_year - 1}{date_format}")
-    last_value = parameter(f"{last_projected_year}{date_format}")
+    if growth_years is None:
+        growth_years = (last_projected_year - 1, last_projected_year)
+    earlier_year, later_year = growth_years
+    second_to_last_value = parameter(f"{earlier_year}{date_format}")
+    last_value = parameter(f"{later_year}{date_format}")
     growth_rate = last_value / second_to_last_value
 
     # Apply growth rate for years beyond projections
@@ -422,13 +431,16 @@ def set_all_uprating_parameters(parameters: ParameterNode) -> ParameterNode:
         period_day=1,
     )
 
-    # ACA benchmark premium uprating (January values, last projection year 2025)
+    # ACA benchmark premium uprating (January values, last actual 2026).
+    # The published 2026 actual is 25.8% above 2025; keep long-run growth
+    # at the 2024-2025 trend so the one-off jump does not compound.
     extend_parameter_values(
         parameters.gov.aca.benchmark_premium_uprating,
-        last_projected_year=2025,
+        last_projected_year=2026,
         end_year=END_YEAR,
         period_month=1,
         period_day=1,
+        growth_years=(2024, 2025),
     )
 
     # CMS per-capita out-of-pocket medical spending (January values, last

--- a/policyengine_us/tests/policy/baseline/gov/aca/test_benchmark_premium_uprating.py
+++ b/policyengine_us/tests/policy/baseline/gov/aca/test_benchmark_premium_uprating.py
@@ -1,0 +1,20 @@
+"""The ACA benchmark premium index carries the published 2026 actual and
+extends at the pre-2026 trend (#9092)."""
+
+from policyengine_us.system import system
+
+
+def test_2026_benchmark_premium_is_published_actual():
+    uprating = system.parameters.gov.aca.benchmark_premium_uprating
+    # KFF national average benchmark (SLCSP) premium for 2026.
+    assert uprating("2026-01-01") == 625
+
+
+def test_extension_keeps_pre_jump_trend():
+    # The 2026 jump is a one-off level shift: long-run growth stays at the
+    # 2024-2025 trend rather than compounding the jump.
+    uprating = system.parameters.gov.aca.benchmark_premium_uprating
+    trend = uprating("2025-01-01") / uprating("2024-01-01")
+    for year in (2027, 2028):
+        implied = uprating(f"{year}-01-01") / uprating(f"{year - 1}-01-01")
+        assert abs(implied - trend) < 1e-9


### PR DESCRIPTION
Fixes #9092.

Adds `2026-01-01: 625` to `gov/aca/benchmark_premium_uprating.yaml` — the published KFF national average benchmark (SLCSP) premium for 2026, verified against the KFF indicator page this session (2024 $477 / 2025 $497 / 2026 $625). The previous extension extrapolated ~$518 for 2026 from the 2024→2025 growth rate.

**Extension design:** the 2026 actual is 25.8% above 2025 — a one-off level shift. `extend_parameter_values` gains an optional `growth_years` pair, and the ACA call pins long-run growth to the 2024→2025 trend (+4.19%/yr) from the new 2026 base, so the jump raises the level without compounding: index 625 → 651.21 (2027) → 678.51 (2028).

**Downstream: no change.** `state_rating_area_cost.yaml` (the index's only consumer) has explicit values through 2026-01-01, and the 2027+ uprating ratio idx(t)/idx(2026) is identical before and after — verified computationally (TX rating area 1: 535 / 557.43 / 580.80 for 2026-28, byte-identical) and empirically (ACA tree 278/278, partner tree 630/630, both unchanged).

**Tests:** new `test_benchmark_premium_uprating.py` pins the 2026 actual (fails on main: 517.84 ≠ 625) and the trend-preservation property of the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)