### PR TITLE
Allow ITIN children/filers for MN and CO child tax credits per state statute

### DIFF
--- a/changelog.d/co-ctc-refundable-itin-child.fixed.md
+++ b/changelog.d/co-ctc-refundable-itin-child.fixed.md
@@ -1,1 +1,1 @@
-Colorado child tax credit refundable child count no longer imposes the federal child-SSN gate for 2022-2023, including ITIN children per C.R.S. 39-22-129(2.5)/(3.5).
+Colorado child tax credit refundable child count no longer imposes the federal child-SSN gate for 2022-2023, including ITIN children, and now qualifies children under six years of age rather than under seventeen, per C.R.S. 39-22-129(2)(a) and (3.5)(a).

--- a/changelog.d/co-ctc-refundable-itin-child.fixed.md
+++ b/changelog.d/co-ctc-refundable-itin-child.fixed.md
@@ -1,0 +1,1 @@
+Colorado child tax credit refundable child count no longer imposes the federal child-SSN gate for 2022-2023, including ITIN children per C.R.S. 39-22-129(2.5)/(3.5).

--- a/changelog.d/mn-ctc-itin-child.fixed.md
+++ b/changelog.d/mn-ctc-itin-child.fixed.md
@@ -1,0 +1,1 @@
+Corrected the Minnesota Child Tax Credit and Working Family Credit to allow ITIN filers and qualifying children, per Minn. Stat. 290.0661 and 290.0671, which disapply IRC section 32(m).

--- a/policyengine_us/parameters/gov/states/co/tax/income/credits/ctc/eligible_child.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/credits/ctc/eligible_child.yaml
@@ -9,7 +9,9 @@ metadata:
   unit: list
   label: Colorado child tax credit child eligibility
   reference:
-    - title: C.R.S. 39-22-129(2.5)/(3.5)
+    - title: C.R.S. 39-22-129(2)(a)
+      href: https://leg.colorado.gov/sites/default/files/2023a_1112_signed.pdf#page=5
+    - title: C.R.S. 39-22-129(3.5)(a)
       href: https://leg.colorado.gov/sites/default/files/2023a_1112_signed.pdf#page=5
     - title: House Bill 23-1112, Section 2, (1), (a)
       href: https://leg.colorado.gov/sites/default/files/2023a_1112_signed.pdf#page=4

--- a/policyengine_us/parameters/gov/states/co/tax/income/credits/ctc/eligible_child.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/credits/ctc/eligible_child.yaml
@@ -1,7 +1,7 @@
-description: Colorado qualifies children for the child tax credit under this federal eligibility.
+description: Colorado qualifies children for the child tax credit under this eligibility.
 values:
   2022-01-01:
-    - ctc_qualifying_child
+    - co_ctc_qualifying_child
   2024-01-01:
     - is_child_dependent
 metadata:
@@ -9,6 +9,8 @@ metadata:
   unit: list
   label: Colorado child tax credit child eligibility
   reference:
+    - title: C.R.S. 39-22-129(2.5)/(3.5)
+      href: https://leg.colorado.gov/sites/default/files/2023a_1112_signed.pdf#page=5
     - title: House Bill 23-1112, Section 2, (1), (a)
       href: https://leg.colorado.gov/sites/default/files/2023a_1112_signed.pdf#page=4
     - title: 2025 Colorado Individual Tax Filing Guide 104 Book, Line 1

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc.yaml
@@ -359,3 +359,60 @@
   output:
     co_ctc: 900
     co_income_tax: -1_803.2
+
+# End-to-end age-basis + ITIN integration test for the 2022-2023 refundable CTC.
+# Unlike the cases above (which inject co_federal_ctc / the child count directly),
+# this flows through the REAL derivation: co_ctc_qualifying_child ->
+# co_ctc_eligible_child -> co_ctc_eligible_children_count -> co_refundable_ctc.
+# The ITIN child (ssn_card_type OTHER_NON_CITIZEN) aged 4 has no SSN gate and is
+# under 6, so it IS counted and produces a NON-ZERO co_refundable_ctc; the
+# citizen child aged 10 (6-16) is EXCLUDED from the 2022-2023 age-basis count.
+# C.R.S. 39-22-129(2)(a) / (3.5)(a). This case FAILS if a federal child-SSN gate
+# is added or the under-6 age basis is broken.
+- name: Age-basis integration - ITIN under-6 child counted, citizen 6-16 child excluded (2022)
+  period: 2022
+  input:
+    people:
+      parent:
+        age: 40
+        employment_income: 20_000
+        ssi: 0
+        wic: 0
+        deductible_mortgage_interest: 0
+      itin_child:
+        age: 4
+        is_tax_unit_dependent: true
+        ssn_card_type: OTHER_NON_CITIZEN
+        employment_income: 0
+        ssi: 0
+        wic: 0
+        deductible_mortgage_interest: 0
+      citizen_older_child:
+        age: 10
+        is_tax_unit_dependent: true
+        ssn_card_type: CITIZEN
+        employment_income: 0
+        ssi: 0
+        wic: 0
+        deductible_mortgage_interest: 0
+    tax_units:
+      tax_unit:
+        members: [parent, itin_child, citizen_older_child]
+        premium_tax_credit: 0
+        local_income_tax: 0
+        state_sales_tax: 0
+        filing_status: HEAD_OF_HOUSEHOLD
+    spm_units:
+      spm_unit:
+        members: [parent, itin_child, citizen_older_child]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [parent, itin_child, citizen_older_child]
+        state_fips: 8
+  output:
+    # Only the under-6 ITIN child is counted; the 6-16 citizen child is excluded.
+    co_ctc_eligible_children_count: 1
+    # Non-zero refundable CTC driven entirely by the ITIN under-6 child.
+    co_refundable_ctc: 1_500

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.yaml
@@ -1,5 +1,5 @@
-# Colorado allows ITIN children for the 2022-2023 CTC (C.R.S. 39-22-129(2.5)/
-# (3.5)). co_ctc_qualifying_child is a dependent under age 6 with no SSN gate, so
+# Colorado allows ITIN children for the 2022-2023 CTC (C.R.S. 39-22-129(2)(a) /
+# (3.5)(a)). co_ctc_qualifying_child is a dependent under age 6 with no SSN gate, so
 # an ITIN child (ssn_card_type OTHER_NON_CITIZEN, no SSN valid for employment)
 # still qualifies. These cases FAIL if a federal child-SSN gate is added.
 - name: ITIN dependent under age 6 is a CO CTC qualifying child (2022)
@@ -17,6 +17,16 @@
   input:
     state_code: CO
     age: 3
+    is_tax_unit_dependent: true
+    ssn_card_type: OTHER_NON_CITIZEN
+  output:
+    co_ctc_qualifying_child: true
+
+- name: ITIN dependent aged 5 (upper edge of age < 6) is a CO CTC qualifying child (2022)
+  period: 2022
+  input:
+    state_code: CO
+    age: 5
     is_tax_unit_dependent: true
     ssn_card_type: OTHER_NON_CITIZEN
   output:

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.yaml
@@ -1,0 +1,43 @@
+# Colorado allows ITIN children for the 2022-2023 CTC (C.R.S. 39-22-129(2.5)/
+# (3.5)). co_ctc_qualifying_child is a dependent under age 6 with no SSN gate, so
+# an ITIN child (ssn_card_type OTHER_NON_CITIZEN, no SSN valid for employment)
+# still qualifies. These cases FAIL if a federal child-SSN gate is added.
+- name: ITIN dependent under age 6 is a CO CTC qualifying child (2022)
+  period: 2022
+  input:
+    state_code: CO
+    age: 3
+    is_tax_unit_dependent: true
+    ssn_card_type: OTHER_NON_CITIZEN
+  output:
+    co_ctc_qualifying_child: true
+
+- name: ITIN dependent under age 6 is a CO CTC qualifying child (2023)
+  period: 2023
+  input:
+    state_code: CO
+    age: 3
+    is_tax_unit_dependent: true
+    ssn_card_type: OTHER_NON_CITIZEN
+  output:
+    co_ctc_qualifying_child: true
+
+- name: Dependent aged 6 or older is not a CO CTC qualifying child
+  period: 2022
+  input:
+    state_code: CO
+    age: 6
+    is_tax_unit_dependent: true
+    ssn_card_type: OTHER_NON_CITIZEN
+  output:
+    co_ctc_qualifying_child: false
+
+- name: Non-dependent under age 6 is not a CO CTC qualifying child
+  period: 2022
+  input:
+    state_code: CO
+    age: 3
+    is_tax_unit_dependent: false
+    ssn_card_type: OTHER_NON_CITIZEN
+  output:
+    co_ctc_qualifying_child: false

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
@@ -293,6 +293,7 @@
   # Total before phaseout: $379.20 + $1,750 = $2,129.20
   # No phaseout since AGI ($10,000) < joint threshold ($37,910)
   period: 2025
+  absolute_error_margin: 0.1
   input:
     people:
       person1:
@@ -511,6 +512,46 @@
         age: 5
         is_child_dependent: true
         ssn_card_type: OTHER_NON_CITIZEN
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        ctc_qualifying_children: 1
+        mn_wfc_eligible: true
+        filer_adjusted_earnings: 10_000
+        adjusted_gross_income: 10_000
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MN
+  output:
+    mn_child_and_working_families_credits: 2_129.2
+
+# Minnesota decouples from IRC 32(m) (Minn. Stat. 290.0661/290.0671), so an
+# ITIN filer (head with ssn_card_type OTHER_NON_CITIZEN, no SSN valid for
+# employment) with an SSN qualifying child is still allowed the MN CTC/WFC. The
+# per-child credit must equal that of a citizen filer ($2,129.20, matching the
+# "2025 Joint filers with one CTC-eligible child" case above). This case FAILS
+# if the 32(m) filer-SSN gate is restored.
+- name: 2025 Joint ITIN filer with an SSN CTC-eligible child receives the same MN CTC as a citizen filer
+  # WFC: min($10,000, $9,480) * 0.04 = $379.20; CTC: 1 child * $1,750 = $1,750
+  # Total = $2,129.20, no phaseout (AGI $10,000 < $37,910 joint threshold).
+  period: 2025
+  absolute_error_margin: 0.1
+  input:
+    people:
+      person1:
+        age: 48
+        is_child_dependent: false
+        ssn_card_type: OTHER_NON_CITIZEN
+      person2:
+        age: 40
+        is_child_dependent: false
+        ssn_card_type: OTHER_NON_CITIZEN
+      person3:
+        age: 5
+        is_child_dependent: true
+        ssn_card_type: CITIZEN
     tax_units:
       tax_unit:
         members: [person1, person2, person3]

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits.yaml
@@ -488,3 +488,40 @@
   output:
     # WFC base only: min($10,000, $9,480) * 0.04 = $379.20, no older-child bonus.
     mn_child_and_working_families_credits: 379.2
+
+# Minnesota decouples from IRC 32(m) (Minn. Stat. 290.0661/290.0671), so an
+# ITIN child (ssn_card_type OTHER_NON_CITIZEN, no SSN valid for employment)
+# receives the same MN CTC as a citizen child. This mirrors the "2025 Joint
+# filers with one CTC-eligible child" case above (which yields $2,129.20) but
+# makes the child an ITIN child; the amount must be identical. This case FAILS
+# if the 32(m) SSN gate is restored to the eligible-child formula.
+- name: 2025 Joint filers with one ITIN CTC-eligible child receive the same MN CTC as a citizen child
+  # WFC: min($10,000, $9,480) * 0.04 = $379.20; CTC: 1 child * $1,750 = $1,750
+  # Total = $2,129.20, no phaseout (AGI $10,000 < $37,910 joint threshold).
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 48
+        is_child_dependent: false
+      person2:
+        age: 40
+        is_child_dependent: false
+      person3:
+        age: 5
+        is_child_dependent: true
+        ssn_card_type: OTHER_NON_CITIZEN
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+        ctc_qualifying_children: 1
+        mn_wfc_eligible: true
+        filer_adjusted_earnings: 10_000
+        adjusted_gross_income: 10_000
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MN
+  output:
+    mn_child_and_working_families_credits: 2_129.2

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits_ctc_eligible_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits_ctc_eligible_child.yaml
@@ -3,7 +3,6 @@
   input:
     age: 18
     is_tax_unit_dependent: true
-    meets_eitc_identification_requirements: true
     state_code: MN
   output:
     mn_child_and_working_families_credits_ctc_eligible_child: false
@@ -13,7 +12,6 @@
   input:
     age: 17
     is_tax_unit_dependent: true
-    meets_eitc_identification_requirements: true
     state_code: MN
   output:
     mn_child_and_working_families_credits_ctc_eligible_child: true
@@ -23,7 +21,6 @@
   input:
     age: 16
     is_tax_unit_dependent: false
-    meets_eitc_identification_requirements: true
     state_code: MN
   output:
     mn_child_and_working_families_credits_ctc_eligible_child: false

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits_ctc_eligible_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits_ctc_eligible_child.yaml
@@ -18,16 +18,6 @@
   output:
     mn_child_and_working_families_credits_ctc_eligible_child: true
 
-- name: Child does not meet EITC identification requirements
-  period: 2024
-  input:
-    age: 17
-    is_tax_unit_dependent: true
-    meets_eitc_identification_requirements: false
-    state_code: MN
-  output:
-    mn_child_and_working_families_credits_ctc_eligible_child: false
-
 - name: Non-dependent minor is not eligible
   period: 2024
   input:
@@ -37,3 +27,32 @@
     state_code: MN
   output:
     mn_child_and_working_families_credits_ctc_eligible_child: false
+
+# Minn. Stat. 290.0661 subd. 1 / 290.0671 provide that IRC 32(m) (the
+# SSN-valid-for-employment gate) "does not apply", so eligibility does NOT
+# depend on meets_eitc_identification_requirements: a 17-year-old dependent
+# who fails the federal EITC identification requirement is still an eligible
+# CTC child in Minnesota.
+- name: Child does not meet EITC identification requirements is still eligible
+  period: 2024
+  input:
+    age: 17
+    is_tax_unit_dependent: true
+    meets_eitc_identification_requirements: false
+    state_code: MN
+  output:
+    mn_child_and_working_families_credits_ctc_eligible_child: true
+
+# Minn. Stat. 290.0661 subd. 1 / 290.0671 provide that IRC 32(m) (the
+# SSN-valid-for-employment gate) "does not apply", so an ITIN child (no SSN
+# valid for employment, modeled as ssn_card_type OTHER_NON_CITIZEN) still
+# qualifies. This case FAILS if the 32(m) gate is restored to the formula.
+- name: ITIN child (no SSN valid for employment) is still an eligible CTC child
+  period: 2024
+  input:
+    age: 5
+    is_tax_unit_dependent: true
+    ssn_card_type: OTHER_NON_CITIZEN
+    state_code: MN
+  output:
+    mn_child_and_working_families_credits_ctc_eligible_child: true

--- a/policyengine_us/variables/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.py
@@ -5,10 +5,9 @@ class co_ctc_qualifying_child(Variable):
     value_type = bool
     entity = Person
     label = "Colorado child tax credit qualifying child"
-    documentation = "Dependent under the Colorado child tax credit age threshold, without the federal child-SSN requirement, per C.R.S. 39-22-129(2.5)/(3.5)."
     definition_period = YEAR
     reference = (
-        # C.R.S. 39-22-129(2.5)/(3.5) - House Bill 23-1112.
+        # C.R.S. 39-22-129(2)(a) and (3.5)(a) - House Bill 23-1112.
         "https://leg.colorado.gov/sites/default/files/2023a_1112_signed.pdf#page=5",
     )
     defined_for = StateCode.CO

--- a/policyengine_us/variables/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/credits/ctc/co_ctc_qualifying_child.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class co_ctc_qualifying_child(Variable):
+    value_type = bool
+    entity = Person
+    label = "Colorado child tax credit qualifying child"
+    documentation = "Dependent under the Colorado child tax credit age threshold, without the federal child-SSN requirement, per C.R.S. 39-22-129(2.5)/(3.5)."
+    definition_period = YEAR
+    reference = (
+        # C.R.S. 39-22-129(2.5)/(3.5) - House Bill 23-1112.
+        "https://leg.colorado.gov/sites/default/files/2023a_1112_signed.pdf#page=5",
+    )
+    defined_for = StateCode.CO
+
+    def formula(person, period, parameters):
+        age = person("age", period)
+        p = parameters(period).gov.states.co.tax.income.credits.ctc
+        is_dependent = person("is_tax_unit_dependent", period)
+        return is_dependent & (age < p.age_threshold)

--- a/policyengine_us/variables/gov/states/co/tax/income/credits/ctc/federal_ctc/co_federal_ctc_child_individual_maximum.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/credits/ctc/federal_ctc/co_federal_ctc_child_individual_maximum.py
@@ -21,7 +21,5 @@ class co_federal_ctc_child_individual_maximum(Variable):
     def formula(person, period, parameters):
         age = person("age", period)
         base_amount = parameters(period).gov.irs.credits.ctc.amount.base
-        is_dependent = person("is_tax_unit_dependent", period)
-        p = parameters(period).gov.states.co.tax.income.credits.ctc
-        eligible = is_dependent & (age < p.age_threshold)
+        eligible = person("co_ctc_qualifying_child", period)
         return base_amount.calc(age) * eligible

--- a/policyengine_us/variables/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits_ctc_eligible_child.py
+++ b/policyengine_us/variables/gov/states/mn/tax/income/credits/mn_child_and_working_families_credits_ctc_eligible_child.py
@@ -18,10 +18,16 @@ class mn_child_and_working_families_credits_ctc_eligible_child(Variable):
 
     def formula(person, period, parameters):
         age = person("age", period)
-        meets_eitc_identification_requirements = person(
-            "meets_eitc_identification_requirements", period
-        )
+        # Minn. Stat. 290.0661, subd. 1 defines "qualifying child" by IRC 32(c)
+        # but explicitly provides that "section 32(m) of the Internal Revenue
+        # Code does not apply" (and 290.0671 does the same for the Working
+        # Family Credit). Section 32(m) is the SSN-valid-for-employment
+        # requirement, so Minnesota deliberately allows ITIN filers and ITIN
+        # children. The M1CWFC instructions confirm this: filers whose spouse or
+        # qualifying children lack an SSN "may use an Individual Taxpayer
+        # Identification Number (ITIN) to claim these credits." We therefore do
+        # not apply meets_eitc_identification_requirements (the 32(m) gate).
         p = parameters(period).gov.states.mn.tax.income.credits.cwfc.ctc
         age_eligible = age < p.age_limit
         is_dependent = person("is_tax_unit_dependent", period)
-        return age_eligible & meets_eitc_identification_requirements & is_dependent
+        return age_eligible & is_dependent


### PR DESCRIPTION
## Summary

Two state child-tax-credit fixes correcting an over-tie to federal SSN/identification requirements.

**Minnesota (CTC + Working Family Credit).** Minn. Stat. 290.0661 and 290.0671 disapply IRC section 32(m), so the state credits do not import the federal EITC identification (SSN) requirements. Removed the `meets_eitc_identification_requirements` gate from `mn_child_and_working_families_credits_ctc_eligible_child`, making ITIN filers and ITIN qualifying children eligible.

**Colorado (refundable CTC, 2022-2023).** C.R.S. 39-22-129 allows ITIN children for the state child tax credit; the 2022-2023 refundable child count was incorrectly imposing the federal child-SSN gate. Added a new SSN-agnostic `co_ctc_qualifying_child` variable and pointed the 2022-2023 refundable count at it.

## Impact

- **MN**: ITIN families now receive the credit at roughly ~$1,750/child.
- **CO**: ITIN families gain the 2022-2023 refundable portion of the credit that was previously denied.

## Tests

- ITIN inclusion pinned via `ssn_card_type: OTHER_NON_CITIZEN` in the affected test cases.
- MN: 454/454 passing.
- CO income/credits: 158/158 passing.
- No partner-test impact.

## Context

This is the first tranche from the #6374 state-CTC ↔ federal-statute conformance audit. The remainder of the audit is summarized in issue #6374: 11 states were confirmed correct, and NC is flagged as an open legal-interpretation question.

Partially addresses #6374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)