### PR TITLE
Fix incorrect medicaid_rating_area lookup comment

### DIFF
--- a/changelog.d/medicaid-rating-area-comment.fixed.md
+++ b/changelog.d/medicaid-rating-area-comment.fixed.md
@@ -1,0 +1,1 @@
+Corrected the medicaid_rating_area lookup comment to match the code (county first, then three-digit zip code fallback, defaulting to 1).

--- a/policyengine_us/variables/input/geography.py
+++ b/policyengine_us/variables/input/geography.py
@@ -97,7 +97,7 @@ class medicaid_rating_area(Variable):
     def formula(household, period, parameters):
         three_digit_zip_code = household("three_digit_zip_code", period)
         county = household("county_str", period)
-        # Try a lookup on zip code, fill missing values with a lookup on county, fill missing with zero.
+        # Try a lookup on county, fill missing values with a lookup on three-digit zip code, fill missing with 1.
         df = pd.DataFrame(
             {
                 "location": county,


### PR DESCRIPTION
Fixes #5713.

The comment in `medicaid_rating_area` (`policyengine_us/variables/input/geography.py`) said:

> Try a lookup on zip code, fill missing values with a lookup on county, fill missing with zero.

But the code does the reverse order and a different default: it looks up the **county** first, falls back to the **three-digit zip code** for unmatched rows, and defaults any remaining missing values to **1** (`.fillna(1)`), not 0. Corrected the comment to match the code. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)