### PR TITLE
Apply basic income disability supplement to blind people

### DIFF
--- a/changelog.d/ubi-disability-supplement-blind.fixed.md
+++ b/changelog.d/ubi-disability-supplement-blind.fixed.md
@@ -1,0 +1,1 @@
+Applied the basic income disability supplement to blind people in household simulations by including is_blind alongside is_ssi_disabled.

--- a/policyengine_us/tests/policy/baseline/contrib/ubi_center/basic_income_before_phase_out.yaml
+++ b/policyengine_us/tests/policy/baseline/contrib/ubi_center/basic_income_before_phase_out.yaml
@@ -122,3 +122,37 @@
         is_married: false
   output:
     basic_income_before_phase_out: 12_000
+
+- name: Disability supplement applies to a blind person (issue 3523)
+  period: 2022
+  input:
+    gov.contrib.ubi_center.basic_income.amount.person.disability: 6_000
+    people:
+      blind_adult:
+        age: 40
+        is_blind: true
+        is_ssi_disabled: false
+      nondisabled_adult:
+        age: 40
+        is_blind: false
+        is_ssi_disabled: false
+    tax_units:
+      tax_unit:
+        members: [blind_adult, nondisabled_adult]
+  output:
+    basic_income_before_phase_out: 6_000
+
+- name: Disability supplement not double-counted for a blind and disabled person
+  period: 2022
+  input:
+    gov.contrib.ubi_center.basic_income.amount.person.disability: 6_000
+    people:
+      blind_and_disabled_adult:
+        age: 40
+        is_blind: true
+        is_ssi_disabled: true
+    tax_units:
+      tax_unit:
+        members: [blind_and_disabled_adult]
+  output:
+    basic_income_before_phase_out: 6_000

--- a/policyengine_us/variables/contrib/ubi_center/basic_income/basic_income_before_phase_out.py
+++ b/policyengine_us/variables/contrib/ubi_center/basic_income/basic_income_before_phase_out.py
@@ -28,8 +28,10 @@ class basic_income_before_phase_out(Variable):
         fpg = tax_unit("tax_unit_fpg", period)
         fpg_amount = p.amount.tax_unit.fpg_percent * fpg
 
-        # Disability amount
-        disabled = person("is_ssi_disabled", period)
+        # Disability amount. Blind people are treated as disabled for this
+        # supplement; is_blind is settable directly on households, unlike the
+        # microdata-only blindness capture in is_ssi_disabled (see issue #3523).
+        disabled = person("is_ssi_disabled", period) | person("is_blind", period)
         disabled_amount = tax_unit.sum(disabled * p.amount.person.disability)
         base_amount = (
             total_flat_amount + applicable_amount_by_age + fpg_amount + disabled_amount


### PR DESCRIPTION
Fixes #3523.

The basic income disability supplement in `basic_income_before_phase_out` keyed off `is_ssi_disabled`, which does not consider blindness. Blindness is only captured in the microdata (set directly in `cps.py`), so in **household** simulations a blind person was denied the disability supplement — as reported in #3523.

**Change:** base the supplement count on `is_ssi_disabled | is_blind`. `is_blind` is a settable person-level input, so it now works directly on the household page (no `ssi_reported > 0` workaround needed).

**Tests** (appended to `basic_income_before_phase_out.yaml`):
- a blind, non-`ssi_disabled` adult receives the disability supplement;
- a blind **and** disabled adult is not double-counted (the OR yields one supplement).

Verified locally: 9/9 in the file and 17/17 across the `ubi_center` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)