### PR TITLE
Fix would_claim_wic straggler breaking the baseline suite on main

### DIFF
--- a/changelog.d/fix-wic-would-claim-straggler.fixed.md
+++ b/changelog.d/fix-wic-would-claim-straggler.fixed.md
@@ -1,0 +1,1 @@
+Update the June 2026 WIC CVB test to the takes_up_wic_if_eligible take-up flag, fixing the baseline suite on main after the would_claim_wic rename.

--- a/policyengine_us/tests/policy/baseline/gov/usda/wic/wic.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/wic/wic.yaml
@@ -78,6 +78,6 @@
   input:
     wic_food_package_str: CHILD_24_59_MONTHS
     is_wic_eligible: true
-    would_claim_wic: true
+    takes_up_wic_if_eligible: true
   output:
     wic: 60.42


### PR DESCRIPTION
## Summary

Fixes a broken `main`: the "June 2026 child package value uses the observed CPI-U" test added by #9102 sets `would_claim_wic: true`, but #9041 renamed that variable to `takes_up_wic_if_eligible`. #9102 was authored and CI-tested against a pre-#9041 base, so the incompatibility only materialized on `main` after both merged — every branch on current main now fails the `Full Suite - Baseline (ssa-usda)` shard on this case.

One-line fix: use `takes_up_wic_if_eligible: true` (the sibling test case in the same file added by #9102 already uses the new name).

## Verification

- [x] Local run of `policyengine_us/tests/policy/baseline/gov/usda/wic/wic.yaml`: 9 passed, 0 failed
- [ ] CI passes

Unblocks CI for all open PRs on current main (e.g. #9112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)