### PR TITLE
Fix md_withheld_income_tax crash for MD households with unknown county

### DIFF
--- a/changelog.d/md-withholding-unknown-county.fixed.md
+++ b/changelog.d/md-withholding-unknown-county.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash in md_withheld_income_tax for Maryland households whose county is unknown by falling back to a default Maryland county.

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/md_withheld_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/md_withheld_income_tax.yaml
@@ -33,3 +33,30 @@
     state_code: MD
   output:
     md_withheld_income_tax: 0
+
+- name: Allegany County MD baseline for the unknown-county fallback comparison
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    adjusted_gross_income_person: 5_000
+    filing_status: JOINT
+    state_code: MD
+    county_str: ALLEGANY_COUNTY_MD
+  output:
+    # State: single rates on (5,000 - 2,350 standard deduction) = 76
+    # Local: 3.05% Allegany rate * 2,650 = 80.825
+    md_withheld_income_tax: 156.825
+
+- name: Unknown county in an MD household falls back to Allegany County (issue #8975)
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    adjusted_gross_income_person: 5_000
+    filing_status: JOINT
+    state_code: MD
+    county_str: UNKNOWN
+  output:
+    # gov.local.md.flat_rate has no UNKNOWN key; the formula falls back to
+    # ALLEGANY_COUNTY_MD, so this must equal the Allegany baseline above.
+    # Before the fix this raised ParameterNotFoundError instead of computing.
+    md_withheld_income_tax: 156.825

--- a/policyengine_us/variables/gov/states/md/tax/income/md_withheld_income_tax.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/md_withheld_income_tax.py
@@ -23,7 +23,11 @@ class md_withheld_income_tax(Variable):
         # Guard against non-MD counties in microsimulation:
         # defined_for masks results but doesn't prevent formula execution.
         in_md = person.household("state_code_str", period) == "MD"
-        safe_county = where(in_md, county, "ALLEGANY_COUNTY_MD")
+        # Fall back to a default MD county when the county is unknown/unmapped
+        # (County.UNKNOWN is the default), since gov.local.md.flat_rate has no
+        # UNKNOWN key and would otherwise raise ParameterNotFoundError. The
+        # non-MD path already falls back to the same default county.
+        safe_county = where(in_md & (county != "UNKNOWN"), county, "ALLEGANY_COUNTY_MD")
         p_local = parameters(period).gov.local.md
         flat_rate_withheld = p_local.flat_rate[safe_county] * reduced_agi
         is_anne_arundel = county == "ANNE_ARUNDEL_COUNTY_MD"


### PR DESCRIPTION
Fixes #8975.

`md_withheld_income_tax` guarded **non-MD** households but not an **MD** household whose `county` resolves to `County.UNKNOWN` (the default when `county_fips` is unmapped/absent). Indexing `gov.local.md.flat_rate` with an `UNKNOWN` key raised `ParameterNotFoundError`, crashing the `income_tax → salt_deduction → state_and_local_sales_or_income_tax → md_withheld_income_tax` chain for such households in microsimulation.

**Fix:** fall back to a default MD county (`ALLEGANY_COUNTY_MD`) for unknown MD counties, mirroring the existing non-MD guard:
```python
safe_county = where(in_md & (county != "UNKNOWN"), county, "ALLEGANY_COUNTY_MD")
```

**Test:** added a case with `county_str: UNKNOWN` and AGI above the standard deduction (so the flat-rate indexing actually executes) asserting it equals the `ALLEGANY_COUNTY_MD` result (156.825). This case crashed before the fix. MD dir: 382/382 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)