### PR TITLE
Fix SNAP student parent Exception 5 for single non-student parents

### DIFF
--- a/changelog.d/snap-parent-exception-5.fixed.md
+++ b/changelog.d/snap-parent-exception-5.fixed.md
@@ -1,0 +1,1 @@
+Fixed the SNAP student parent exception so a single parent responsible for a child under six qualifies for Exception 5 without being a full-time student.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/student/meets_snap_parent_exception.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/student/meets_snap_parent_exception.yaml
@@ -71,7 +71,7 @@
   output:
     meets_snap_parent_exception: [true, false]
 
-- name: Single parent with child under 6 but NOT full-time student does not meet exception
+- name: Single parent with child under 6 but NOT full-time student meets exception 5
   period: 2024
   input:
     people:
@@ -88,7 +88,7 @@
       spm_unit:
         members: [parent, child]
   output:
-    meets_snap_parent_exception: [false, false]
+    meets_snap_parent_exception: [true, false]
 
 - name: Single parent with child exactly 12 does not meet exception even if full-time student
   period: 2024

--- a/policyengine_us/variables/gov/usda/snap/eligibility/student/meets_snap_parent_exception.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/student/meets_snap_parent_exception.py
@@ -30,13 +30,17 @@ class meets_snap_parent_exception(Variable):
             household_member_ages < p.single_parent
         )
 
-        # Two-parent households need child under 6
-        # Single parent households need child under 12, enrolled full-time
         is_full_time_student = person("is_full_time_college_student", period)
-        parent_exception_requirement = where(
-            parent_count > 1,
-            has_child_under_two_parent_limit,
-            has_child_under_single_parent_limit & is_full_time_student,
+        # Exception 5: any parent responsible for a child under 6 (the
+        # two-parent age limit); no full-time enrollment requirement.
+        exception_5 = has_child_under_two_parent_limit
+        # Exception 8: single parent enrolled full-time, responsible for a
+        # child under 12 (the single-parent age limit).
+        exception_8 = (
+            (parent_count == 1)
+            & has_child_under_single_parent_limit
+            & is_full_time_student
         )
+        parent_exception_requirement = exception_5 | exception_8
 
         return is_parent & parent_exception_requirement


### PR DESCRIPTION
Fixes #8134.

`meets_snap_parent_exception` used `where(parent_count > 1, exception_5, exception_8_gated_on_full_time_student)`, routing **single** parents down a branch that requires full-time student status. This wrongly denied statutory **Exception 5** (7 USC 2015(e)(5)) — a parent responsible for a child under 6 qualifies with **no** full-time enrollment requirement — to single, non-student parents.

**Fix:** compute the two exceptions independently and union them:
```python
exception_5 = has_child_under_two_parent_limit  # child < 6, any parent
exception_8 = (parent_count == 1) & has_child_under_single_parent_limit & is_full_time_student
return is_parent & (exception_5 | exception_8)
```

**Test:** the existing "single parent with child under 6 but NOT full-time student" case was pinned to the wrong `[false, false]`; corrected to `[true, false]`. Two-parent (Exception 5) and single-parent-full-time (Exception 8) cases unchanged. File: 18/18 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)