### PR TITLE
Branch Idaho aged/disabled credit vs deduction to pick the better option

### DIFF
--- a/changelog.d/id-aged-disabled-credit-deduction-branch.fixed.md
+++ b/changelog.d/id-aged-disabled-credit-deduction-branch.fixed.md
@@ -1,0 +1,1 @@
+Branched the Idaho aged or disabled credit versus deduction choice to select whichever yields lower Idaho income tax, instead of always taking the credit.

--- a/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/id_receives_aged_or_disabled_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/id/tax/income/id_receives_aged_or_disabled_credit.yaml
@@ -1,0 +1,83 @@
+# End-to-end tests for the credit-vs-deduction chooser. These cases do NOT
+# set id_receives_aged_or_disabled_credit as an input, so the new formula runs
+# and compares Idaho income tax under each branch (mirroring the Delaware EITC
+# get_branch() pattern).
+#
+# Under Idaho law the $100/person aged-or-disabled credit is refundable, while
+# the $1,000/person deduction only reduces AGI. Idaho's post-2022 tax rate is a
+# flat 5.8% (2023), 5.695% (2024), 5.3% (2025), so a $1,000 deduction is worth
+# at most ~$58/person, always less than the $100 credit. The credit therefore
+# wins for every household with a positive liability, and (being refundable)
+# also pays out when there is no liability. A "deduction wins" outcome is not
+# reachable under current Idaho rates; the chooser still exists as the correct
+# lower-tax comparison and keeps the credit on ties (preserving the prior
+# always-credit default).
+
+- name: Credit wins - low income, refundable credit pays where deduction is worthless
+  period: 2023
+  input:
+    people:
+      head:
+        age: 45
+        employment_income: 8_000
+      disabled_dependent:
+        age: 10
+        is_disabled: true
+        share_of_care_and_support_costs_paid_by_tax_filer: 1
+    tax_units:
+      tax_unit:
+        members: [head, disabled_dependent]
+    households:
+      household:
+        members: [head, disabled_dependent]
+        state_code: ID
+  output:
+    id_aged_or_disabled_credit_eligible_person: [false, true]
+    id_receives_aged_or_disabled_credit: true
+    id_aged_or_disabled_credit: 100
+    id_aged_or_disabled_deduction: 0
+    id_income_tax: -100
+
+- name: Credit wins - positive liability, credit beats deduction at Idaho flat rate
+  period: 2023
+  input:
+    people:
+      head:
+        age: 45
+        employment_income: 80_000
+      disabled_dependent:
+        age: 10
+        is_disabled: true
+        share_of_care_and_support_costs_paid_by_tax_filer: 1
+    tax_units:
+      tax_unit:
+        members: [head, disabled_dependent]
+    households:
+      household:
+        members: [head, disabled_dependent]
+        state_code: ID
+  output:
+    id_receives_aged_or_disabled_credit: true
+    id_aged_or_disabled_credit: 100
+    id_aged_or_disabled_deduction: 0
+
+- name: No eligible person - both credit and deduction are zero
+  period: 2023
+  input:
+    people:
+      head:
+        age: 45
+        employment_income: 30_000
+      child:
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [head, child]
+    households:
+      household:
+        members: [head, child]
+        state_code: ID
+  output:
+    id_aged_or_disabled_credit_eligible_person: [false, false]
+    id_aged_or_disabled_credit: 0
+    id_aged_or_disabled_deduction: 0

--- a/policyengine_us/variables/gov/states/id/tax/income/id_income_tax_if_receiving_aged_or_disabled_credit.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/id_income_tax_if_receiving_aged_or_disabled_credit.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class id_income_tax_if_receiving_aged_or_disabled_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = (
+        "Idaho income tax if claiming the aged or disabled credit over the deduction"
+    )
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.ID
+
+    def formula(tax_unit, period, parameters):
+        simulation = tax_unit.simulation
+        branch = simulation.get_branch("id_receives_aged_or_disabled_credit_branch")
+        branch.set_input(
+            "id_receives_aged_or_disabled_credit",
+            period,
+            np.ones((tax_unit.count,), dtype=bool),
+        )
+        return branch.calculate("id_income_tax", period)

--- a/policyengine_us/variables/gov/states/id/tax/income/id_income_tax_if_receiving_aged_or_disabled_deduction.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/id_income_tax_if_receiving_aged_or_disabled_deduction.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class id_income_tax_if_receiving_aged_or_disabled_deduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = (
+        "Idaho income tax if claiming the aged or disabled deduction over the credit"
+    )
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.ID
+
+    def formula(tax_unit, period, parameters):
+        simulation = tax_unit.simulation
+        branch = simulation.get_branch("id_receives_aged_or_disabled_deduction_branch")
+        branch.set_input(
+            "id_receives_aged_or_disabled_credit",
+            period,
+            np.zeros((tax_unit.count,), dtype=bool),
+        )
+        return branch.calculate("id_income_tax", period)

--- a/policyengine_us/variables/gov/states/id/tax/income/id_receives_aged_or_disabled_credit.py
+++ b/policyengine_us/variables/gov/states/id/tax/income/id_receives_aged_or_disabled_credit.py
@@ -10,3 +10,15 @@ class id_receives_aged_or_disabled_credit(Variable):
     reference = "https://legislature.idaho.gov/statutesrules/idstat/title63/t63ch30/sect63-3025d/"
     defined_for = StateCode.ID
     default_value = True
+
+    def formula(tax_unit, period, parameters):
+        tax_if_credit = tax_unit(
+            "id_income_tax_if_receiving_aged_or_disabled_credit", period
+        )
+        tax_if_deduction = tax_unit(
+            "id_income_tax_if_receiving_aged_or_disabled_deduction", period
+        )
+        # id_income_tax is a liability net of refundable credits, so the more
+        # beneficial option yields lower Idaho income tax. Ties keep the credit,
+        # preserving the prior default.
+        return tax_if_credit <= tax_if_deduction


### PR DESCRIPTION
Fixes #3380.

Idaho lets a filer supporting an aged (65+) or disabled person claim **either** a $100/person refundable credit **or** a $1,000/person deduction, not both (Idaho Code 63-3025D(1)). `id_receives_aged_or_disabled_credit` had **no formula** and hardcoded `default_value = True`, so the model always took the credit.

**Fix:** add a chooser that compares Idaho income tax under each option and picks whichever yields lower tax, mirroring the Delaware EITC `get_branch()` pattern:
- new `id_income_tax_if_receiving_aged_or_disabled_credit` / `..._deduction` (each branches, sets the gate, returns branch `id_income_tax`);
- `id_receives_aged_or_disabled_credit` now returns `tax_if_credit <= tax_if_deduction` (credit kept on ties). `default_value = True` is retained so existing tests that pin the gate as input are unaffected.

**Note on current impact:** under Idaho's current flat rate a $1,000 deduction is worth ≤ ~$58/person, always less than the $100 refundable credit, so the chooser currently always selects the credit — **no current household outcome changes**. This corrects the structure and future-proofs it against rate/parameter changes (the issue explicitly asked for the branching).

**Verification:** new end-to-end chooser tests (3/3); ID income-tax dir 192/192; the `get_branch()` branch variables vectorize cleanly over the full microdata (87k records, no NaN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)