### PR TITLE
Apply Rhode Island pre-2015 partial EITC refundability

### DIFF
--- a/changelog.d/ri-partial-eitc-refundability.fixed.md
+++ b/changelog.d/ri-partial-eitc-refundability.fixed.md
@@ -1,0 +1,1 @@
+Applied Rhode Island's pre-2015 partial (15%) refundability of the earned income tax credit amount exceeding the tax liability.

--- a/policyengine_us/parameters/gov/states/ri/tax/income/credits/eitc/refundable_percent.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/credits/eitc/refundable_percent.yaml
@@ -1,5 +1,6 @@
-description: Rhode Island refunds this share of the earned income tax credit that exceeds the tax liability.
+description: Rhode Island provides this share of the earned income tax credit exceeding the tax liability as a refund.
 values:
+  # Taxable years before 2015. Start date unknown. RI's refundable share was historically lower (10%) in the mid-2000s.
   2014-01-01: 0.15
   2015-01-01: 1
 metadata:
@@ -7,9 +8,9 @@ metadata:
   period: year
   label: Rhode Island refundable EITC share
   reference:
-    - title: R.I. Gen. Laws § 44-30-2.6.(c)(2)(N)
+    - title: R.I. Gen. Laws § 44-30-2.6.(c)(2)(N)(2)
       href: https://webserver.rilegislature.gov/Statutes/TITLE44/44-30/44-I/44-30-2.6.htm
     - title: 2014 Form RI-1040 - RI Schedule EIC
-      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/forms/2014/Income/2014-1040_h.pdf
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/forms/2014/Income/2014-1040_h.pdf#page=2
     - title: 2015 Form RI-1040 - RI Schedule EIC
       href: https://tax.ri.gov/sites/g/files/xkgbur541/files/forms/2015/Income/2015-1040_hhh.pdf#page=2

--- a/policyengine_us/parameters/gov/states/ri/tax/income/credits/eitc/refundable_percent.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/credits/eitc/refundable_percent.yaml
@@ -1,0 +1,15 @@
+description: Rhode Island refunds this share of the earned income tax credit that exceeds the tax liability.
+values:
+  2014-01-01: 0.15
+  2015-01-01: 1
+metadata:
+  unit: /1
+  period: year
+  label: Rhode Island refundable EITC share
+  reference:
+    - title: R.I. Gen. Laws § 44-30-2.6.(c)(2)(N)
+      href: https://webserver.rilegislature.gov/Statutes/TITLE44/44-30/44-I/44-30-2.6.htm
+    - title: 2014 Form RI-1040 - RI Schedule EIC
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/forms/2014/Income/2014-1040_h.pdf
+    - title: 2015 Form RI-1040 - RI Schedule EIC
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/forms/2015/Income/2015-1040_hhh.pdf#page=2

--- a/policyengine_us/parameters/gov/states/ri/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/credits/refundable.yaml
@@ -1,14 +1,14 @@
 description: Rhode Island provides these refundable income tax credits.
 values:
   2021-01-01:
-    - ri_eitc
+    - ri_refundable_eitc
     - ri_property_tax_credit
     - ri_child_tax_rebate
   2022-01-01:
-    - ri_eitc
+    - ri_refundable_eitc
     - ri_property_tax_credit
   2027-01-01:
-    - ri_eitc
+    - ri_refundable_eitc
     - ri_property_tax_credit
     - ri_ctc
 

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/eitc/ri_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/eitc/ri_refundable_eitc.yaml
@@ -33,3 +33,39 @@
     ri_income_tax_before_refundable_credits: 500
   output:
     ri_refundable_eitc: 600
+
+- name: Pre-2015, zero liability with positive EITC, only 15% is refundable
+  period: 2014
+  input:
+    state_code: RI
+    ri_eitc: 600
+    ri_income_tax_before_refundable_credits: 0
+  output:
+    ri_refundable_eitc: 90
+
+- name: 2015+, zero liability with positive EITC, fully refundable
+  period: 2015
+  input:
+    state_code: RI
+    ri_eitc: 600
+    ri_income_tax_before_refundable_credits: 0
+  output:
+    ri_refundable_eitc: 600
+
+- name: Pre-2015, EITC exactly equal to liability (boundary, no excess)
+  period: 2014
+  input:
+    state_code: RI
+    ri_eitc: 500
+    ri_income_tax_before_refundable_credits: 500
+  output:
+    ri_refundable_eitc: 500
+
+- name: 2015+, EITC exactly equal to liability (boundary, no excess)
+  period: 2015
+  input:
+    state_code: RI
+    ri_eitc: 500
+    ri_income_tax_before_refundable_credits: 500
+  output:
+    ri_refundable_eitc: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/eitc/ri_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/credits/eitc/ri_refundable_eitc.yaml
@@ -1,0 +1,35 @@
+- name: Pre-2015, EITC fully within liability (excess zero, no partial refund)
+  period: 2014
+  input:
+    state_code: RI
+    ri_eitc: 500
+    ri_income_tax_before_refundable_credits: 600
+  output:
+    ri_refundable_eitc: 500
+
+- name: Pre-2015, EITC exceeds liability, only 15% of excess is refundable
+  period: 2014
+  input:
+    state_code: RI
+    ri_eitc: 600
+    ri_income_tax_before_refundable_credits: 500
+  output:
+    ri_refundable_eitc: 515
+
+- name: 2015+, EITC fully within liability equals ri_eitc
+  period: 2015
+  input:
+    state_code: RI
+    ri_eitc: 500
+    ri_income_tax_before_refundable_credits: 600
+  output:
+    ri_refundable_eitc: 500
+
+- name: 2015+, EITC exceeds liability, 100% of excess refundable
+  period: 2015
+  input:
+    state_code: RI
+    ri_eitc: 600
+    ri_income_tax_before_refundable_credits: 500
+  output:
+    ri_refundable_eitc: 600

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/integration.yaml
@@ -196,6 +196,45 @@
     ri_cdcc: 0
     ri_income_tax: -398
 
+# Locks the "no-op for covered years" claim behind PR #9123: for 2021+,
+# refundable_percent = 1, so ri_refundable_eitc == ri_eitc and the swap to
+# ri_refundable_eitc in refundable.yaml leaves 2015+ behavior unchanged. Low
+# earner produces a real federal EITC that matches at 15% (ri_eitc), is fully
+# refundable, and flows through ri_refundable_credits into a negative
+# ri_income_tax. Existing RI integration cases are high-income with ~zero EITC,
+# so this exercises the ri_eitc -> ri_refundable_eitc -> ri_income_tax chain.
+- name: 2023 RI low-earner HOH with 1 child - refundable EITC flows to negative income tax
+  absolute_error_margin: 0.01
+  period: 2023
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 18_000
+      child1:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, child1]
+        filing_status: HEAD_OF_HOUSEHOLD
+    spm_units:
+      spm_unit:
+        members: [person1, child1]
+        snap: 0
+        tanf: 0
+    households:
+      household:
+        members: [person1, child1]
+        state_code: RI
+  output:
+    # Federal EITC = 3,995; RI match = 15% -> ri_eitc = 599.25.
+    # 2023 refundable_percent = 1, so ri_refundable_eitc == ri_eitc, it flows
+    # through ri_refundable_credits, and with zero pre-credit liability drives
+    # ri_income_tax to -599.25.
+    ri_eitc: 599.25
+    ri_refundable_eitc: 599.25
+    ri_income_tax: -599.25
+
 - name: 2027 RI CTC and high-income surtax apply in the same tax unit
   absolute_error_margin: 0.01
   period: 2027

--- a/policyengine_us/variables/gov/states/ri/tax/income/credits/eitc/ri_refundable_eitc.py
+++ b/policyengine_us/variables/gov/states/ri/tax/income/credits/eitc/ri_refundable_eitc.py
@@ -1,0 +1,26 @@
+from policyengine_us.model_api import *
+
+
+class ri_refundable_eitc(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Rhode Island refundable earned income tax credit"
+    defined_for = StateCode.RI
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://webserver.rilegislature.gov/Statutes/TITLE44/44-30/44-I/44-30-2.6.htm"
+    )
+
+    def formula(tax_unit, period, parameters):
+        ri_eitc = tax_unit("ri_eitc", period)
+        tax_before_refundable_credits = tax_unit(
+            "ri_income_tax_before_refundable_credits", period
+        )
+        p = parameters(period).gov.states.ri.tax.income.credits.eitc
+        # The portion of the RI EITC up to the tax liability offsets tax
+        # dollar-for-dollar; only refundable_percent of the excess over the
+        # liability is refunded (100% from 2015, 15% before 2015).
+        non_refundable_portion = min_(ri_eitc, tax_before_refundable_credits)
+        excess_over_liability = ri_eitc - non_refundable_portion
+        return non_refundable_portion + p.refundable_percent * excess_over_liability


### PR DESCRIPTION
Fixes #5156.

The Rhode Island EITC was modeled as **fully refundable in every year**, but before 2015 only **15%** of the credit exceeding the tax liability was refundable. (RI made the EITC fully refundable alongside a match-rate cut — 25%→10% — in 2015; R.I. Gen. Laws §44-30-2.6(c)(2)(N).)

**Fix:**
- new `refundable_percent` parameter (0.15 before 2015, 1 from 2015);
- new `ri_refundable_eitc` = the liability-offsetting portion in full **plus** `refundable_percent × excess-over-liability`;
- use `ri_refundable_eitc` (instead of `ri_eitc`) in the refundable-credit list. `ri_eitc` remains the gross building block (still used by `state_eitcs`).

For 2015+ (`refundable_percent = 1`) this equals `ri_eitc` exactly, so **no current-year result changes** — RI baseline tests are unaffected (RI income dir 153/153). The pre-2015 rule is encoded correctly; it isn't wired into simulation until RI income tax is backdated before 2021 (a separate follow-up). Revives the intent of the stale-closed #5166.

**Tests:** pre-2015 (excess refunded at 15%) vs 2015+ (100%): 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)