### PR TITLE
Include pre-2019-divorce alimony in federal gross income

### DIFF
--- a/changelog.d/alimony-taxable-income.added.md
+++ b/changelog.d/alimony-taxable-income.added.md
@@ -1,0 +1,1 @@
+Included pre-2019-divorce alimony in federal gross income (and AGI), matching the payer-side deduction, via a new taxable_alimony_income variable.

--- a/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
+++ b/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
@@ -28,6 +28,8 @@ values:
     - miscellaneous_income
     # Listed separately on 1040 line 8g.
     - ak_permanent_fund_dividend
+    # Alimony from divorces executed before the TCJA cutoff (Schedule 1 line 2a).
+    - taxable_alimony_income
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/household/income/person/misc/taxable_alimony_income.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/misc/taxable_alimony_income.yaml
@@ -1,0 +1,78 @@
+- name: Pre-2019 divorce, alimony income is taxable to the recipient.
+  period: 2022
+  input:
+    divorce_year: 2015
+    alimony_income: 10_000
+  output:
+    taxable_alimony_income: 10_000
+
+- name: Post-2018 divorce, alimony income is not taxable to the recipient.
+  period: 2022
+  input:
+    divorce_year: 2020
+    alimony_income: 10_000
+  output:
+    taxable_alimony_income: 0
+
+- name: Default divorce year (2010) is pre-cutoff, so alimony is taxable.
+  period: 2022
+  input:
+    alimony_income: 10_000
+  output:
+    taxable_alimony_income: 10_000
+
+- name: 2018 divorce is pre-cutoff, so alimony is taxable.
+  period: 2022
+  input:
+    divorce_year: 2018
+    alimony_income: 10_000
+  output:
+    taxable_alimony_income: 10_000
+
+- name: 2019 divorce is at the cutoff, so alimony is not taxable.
+  period: 2022
+  input:
+    divorce_year: 2019
+    alimony_income: 10_000
+  output:
+    taxable_alimony_income: 0
+
+- name: Pre-2019 alimony income flows into federal gross income and AGI.
+  period: 2022
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        divorce_year: 2015
+        alimony_income: 10_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    taxable_alimony_income: 10_000
+    irs_gross_income: 10_000
+    adjusted_gross_income: 10_000
+
+- name: Post-2018 alimony income does not flow into federal gross income or AGI.
+  period: 2022
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        divorce_year: 2020
+        alimony_income: 10_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    taxable_alimony_income: 0
+    irs_gross_income: 0
+    adjusted_gross_income: 0

--- a/policyengine_us/variables/household/income/person/misc/taxable_alimony_income.py
+++ b/policyengine_us/variables/household/income/person/misc/taxable_alimony_income.py
@@ -1,0 +1,20 @@
+from policyengine_us.model_api import *
+
+
+class taxable_alimony_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Taxable alimony income"
+    unit = USD
+    documentation = "Alimony income included in gross income, for divorces executed before the TCJA cutoff year."
+    definition_period = YEAR
+    reference = "https://www.irs.gov/taxtopics/tc452"
+
+    def formula(person, period, parameters):
+        alimony_income = person("alimony_income", period)
+        divorce_year = person("divorce_year", period)
+        p = parameters(period).gov.irs.ald.alimony_expense
+        # Mirror the payer-side deduction: alimony from divorces before the TCJA
+        # cutoff (2019) is taxable to the recipient; later divorces are not.
+        taxable = p.divorce_year_threshold.calc(divorce_year)
+        return alimony_income * taxable


### PR DESCRIPTION
Fixes #4989.

Recipient `alimony_income` never entered federal gross income / AGI — it was **absent from `gov.irs.gross_income.sources`** and only fed `market_income`. This was asymmetric with the payer side, where `alimony_expense_ald` is deductible only for pre-2019 divorces (per TCJA §11051).

**Fix:** a new person-level `taxable_alimony_income` = `alimony_income` when the divorce predates the TCJA cutoff, reusing the **same** `gov.irs.ald.alimony_expense.divorce_year_threshold` parameter (< 2019 → taxable) as the payer-side deduction so the two stay symmetric. Added `taxable_alimony_income` to the gross-income sources list. Post-2018 alimony is correctly excluded.

**Tests:** divorce-year gating (2015/2018 taxable; 2019/2020 not; default 2010 taxable) and AGI flow (pre-2019 alimony $10k → `irs_gross_income`/`adjusted_gross_income` +$10k; post-2018 → +$0). 7/7 pass.

**Partner-facing note:** this is a genuine partner-facing AGI change for real filers with **pre-2019-divorce alimony** (their federal AGI now includes it, as it should). Partner **contract tests are unchanged** — every partner household sets `alimony_income: 0`, so `taxable_alimony_income` is 0 for them (verified: the alimony-referencing CA signature suite passes 29/29). Flagging for partner awareness since production results shift for affected households.

🤖 Generated with [Claude Code](https://claude.com/claude-code)