### PR TITLE
Stop double-phasing Vermont's 2025 income-based military retirement exclusion

### DIFF
--- a/changelog.d/vt-military-retirement-double-phase.fixed.md
+++ b/changelog.d/vt-military-retirement-double-phase.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Vermont retirement income exemption so the 2025 income-based U.S. military retirement exclusion is not phased a second time through the CSRS band, and is no longer denied to military retirees with AGI above the CSRS threshold.

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/agi/subtractions/vt_retirement_income_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/agi/subtractions/vt_retirement_income_exemption.yaml
@@ -272,3 +272,70 @@
   output:
     # AGI 70,000 = new full-exclusion threshold (was 65,000 pre-Act 51): full 10,000
     vt_retirement_income_exemption: 10_000
+
+# Act 51 (2025) 32 V.S.A. 5830e(d): income-based military pension exemption with
+# its own $125k-$175k phase-out. When the military exclusion is the chosen one it
+# must NOT also run through the CSRS $55k-$65k single phase-out band, and must not
+# be zeroed by the CSRS-end ($65k) AGI eligibility gate (issue pe-us #9069).
+- name: VT 2025 single military retiree fully excluded at 60k AGI (below 125k full-exemption threshold, no double-phase)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      person:
+        age: 66
+        military_retirement_pay: 30_000
+        employment_income: 60_000  # military_retirement_pay is not itself wired into AGI
+    tax_units:
+      tax_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code: VT
+  output:
+    # AGI 60,000 < 125,000 -> FULL military exclusion (was 30,000 x 0.50 CSRS ratio before the fix)
+    vt_military_retirement_income_based_exemption: 30_000
+    vt_retirement_income_exemption: 30_000
+
+- name: VT 2025 single military retiree fully excluded at 100k AGI (above CSRS-end gate but below 125k threshold)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      person:
+        age: 66
+        military_retirement_pay: 30_000
+        employment_income: 100_000  # military_retirement_pay is not itself wired into AGI
+    tax_units:
+      tax_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code: VT
+  output:
+    # AGI 100,000 > CSRS-end $65k gate but < 125,000 -> FULL military exclusion (was $0 before the fix)
+    vt_military_retirement_income_based_exemption: 30_000
+    vt_retirement_income_exemption: 30_000
+
+- name: VT 2025 single military retiree half excluded at 150k AGI (midpoint of 125k-175k phase-out band)
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    people:
+      person:
+        age: 66
+        military_retirement_pay: 30_000
+        employment_income: 150_000  # military_retirement_pay is not itself wired into AGI
+    tax_units:
+      tax_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code: VT
+  output:
+    # AGI 150,000: ratio (175,000 - 150,000) / 50,000 = 0.50 -> 30,000 x 0.50 = 15,000
+    vt_military_retirement_income_based_exemption: 15_000
+    vt_retirement_income_exemption: 15_000

--- a/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/subtractions/retirement_income_exemption/vt_retirement_income_exemption.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/subtractions/retirement_income_exemption/vt_retirement_income_exemption.py
@@ -73,5 +73,16 @@ class vt_retirement_income_exemption(Variable):
         partial_exemption_ratio = min_(partial_exemption_ratio, 1)
         # Calculate parital exemption amount
         partial_exemption = chosen_retirement_income * partial_exemption_ratio
-        # Return final exemption amount based on eligibility status
-        return where(partial_qualified, partial_exemption, chosen_retirement_income)
+        csrs_or_ss_exemption = where(
+            partial_qualified, partial_exemption, chosen_retirement_income
+        )
+        # The 2025 income-based military exclusion (32 V.S.A. 5830e(d)) has its own
+        # $125k-$175k phase-out inside vt_military_retirement_income_based_exemption,
+        # so when it is the chosen exclusion it bypasses the CSRS reduction band
+        # rather than being phased a second time.
+        use_military = ~use_ss & (
+            vt_military_retirement_pay_exclusion == chosen_retirement_income
+        )
+        military_income_based = p.military_retirement.income_based_structure.in_effect
+        bypass_csrs_band = use_military & military_income_based
+        return where(bypass_csrs_band, chosen_retirement_income, csrs_or_ss_exemption)

--- a/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/subtractions/retirement_income_exemption/vt_retirement_income_exemption_eligible.py
+++ b/policyengine_us/variables/gov/states/vt/tax/income/adjusted_gross_income/subtractions/retirement_income_exemption/vt_retirement_income_exemption_eligible.py
@@ -61,6 +61,15 @@ class vt_retirement_income_exemption_eligible(Variable):
         )
         # The agi should below threshold
         agi_qualified = agi < reduction_end
+        # The 2025 income-based military exclusion (32 V.S.A. 5830e(d)) carries its
+        # own $125k-$175k phase-out, so it does not use the CSRS-end AGI gate; a
+        # high-AGI military retiree stays eligible (the exclusion itself returns 0
+        # above $175k).
+        use_military = ~use_ss & (
+            vt_military_retirement_pay_exclusion == chosen_retirement_income
+        )
+        military_income_based = p.military_retirement.income_based_structure.in_effect
+        agi_qualified = where(use_military & military_income_based, True, agi_qualified)
         # Both qualified then the filer is qualified for vermont retirement
         # income exemption
         return retirement_income_qualified & agi_qualified


### PR DESCRIPTION
Fixes #9069 (found by @hua7450 during the VT Act 51 CSRS-threshold review).

Act 51 (2025) rewrote 32 V.S.A. §5830e(d) to give U.S. military retirement / survivor benefit income its **own** AGI thresholds (full exclusion ≤ $125k, proportional phase-out $125k–$175k, for any filing status). That phase-out is implemented in `vt_military_retirement_income_based_exemption`.

But the top-level `vt_retirement_income_exemption` then applied the **CSRS reduction band** ($55k–$65k single / $70k–$80k joint) on top of the chosen military exclusion — **double-phasing** — and `vt_retirement_income_exemption_eligible` required `AGI < CSRS end`, so any 2025 military retiree above ~$65k/$80k got **$0**.

**Fix:** when the chosen exclusion is the military one and `income_based_structure.in_effect` (2025+), bypass both the CSRS reduction band and the CSRS-end eligibility gate — the §5830e(d) $125k/$175k phase-out already lives inside the military exclusion. §5830e(e)'s one-exclusion-per-taxpayer limit is unaffected (the `max_()` still picks a single exclusion).

**Verified** (2025 single filer, $30k military pay):
| AGI | Before | After (Act 51) |
|---|---|---|
| $60,000 | $15k (military × 0.5 CSRS ratio) | **$30,000** full |
| $100,000 | $0 (failed CSRS gate) | **$30,000** full |
| $150,000 | $0 | **$15,000** (50% of $125k–$175k band) |

Boundary tests added; VT retirement file 21/21, VT income dir 176/176. Social Security, CSRS, and pre-2025 cap-based military paths are unchanged (the bypass is scoped to `use_military & income_based`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)