### PR TITLE
Key pre-2023 Iowa CDCC percentage on net income, not taxable income

### DIFF
--- a/changelog.d/fix-ia-cdcc-net-income.fixed.md
+++ b/changelog.d/fix-ia-cdcc-net-income.fixed.md
@@ -1,0 +1,1 @@
+Key the pre-2023 Iowa child and dependent care credit percentage on net income (IA 1040 line 26) rather than taxable income, and restore the pre-2021 45,000 dollar credit cutoff.

--- a/policyengine_us/parameters/gov/states/ia/tax/income/credits/child_care/fraction.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/credits/child_care/fraction.yaml
@@ -7,15 +7,17 @@ metadata:
   label: Iowa CDCC fraction
   reference:
   - title: Iowa Admin. Code r. 701-304.15 (Iowa Code § 422.12C), percentage schedule by net income (pre- and post-2021 columns)
+    href: https://www.legis.iowa.gov/docs/iac/rule/701.304.15.pdf
+  - title: Iowa Admin. Code r. 701-304.15 (Cornell LII mirror)
     href: https://www.law.cornell.edu/regulations/iowa/Iowa-Code-r-701-304.15
   - title: 2021 IA1040 Iowa Income Tax Return, Line 60
     href: https://revenue.iowa.gov/sites/default/files/2022-01/IA1040%2841-001%29.pdf#page=2
-  - title: 2021 IA1040 Income Tax Return instructions
-    href: https://revenue.iowa.gov/sites/default/files/2023-01/2021%20Expanded%20Instructions_010323.pdf#page=86
+  - title: 2021 IA1040 Expanded Instructions, Line 60 worksheet (printed page 86)
+    href: https://taxsim.nber.org/historical_state_tax_forms/IA/2021/2021%20Expanded%20Instructions_0.pdf#page=87
   - title: 2022 IA1040 Iowa Income Tax Return, Line 60
     href: https://revenue.iowa.gov/sites/default/files/2023-01/2022IA1040%2841001%29.pdf#page=2
-  - title: 2022 IA1040 Income Tax Return instructions
-    href: https://revenue.iowa.gov/sites/default/files/2023-03/2022%20Expanded%20Instructions_022023.pdf#page=86
+  - title: 2022 IA1040 Expanded Instructions, Line 60 worksheet (printed page 86)
+    href: https://taxsim.nber.org/historical_state_tax_forms/IA/2022/2022%20Expanded%20Instructions_022023.pdf#page=86
   - title: 2024 IA1040 Iowa Income Tax Return Instruction, Line 24
     href: https://revenue.iowa.gov/media/4152/download?inline#page=43
   - title: 2025 IA 1040 Expanded Instructions, Child & Dependent Care Credit

--- a/policyengine_us/parameters/gov/states/ia/tax/income/credits/child_care/fraction.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/credits/child_care/fraction.yaml
@@ -1,4 +1,4 @@
-description: Iowa has a child/dependent care credit that is a taxable-income-based fraction of the federal credit.
+description: Iowa provides a child/dependent care credit equal to this fraction of the federal credit, based on net income before 2023 and taxable income thereafter.
 metadata:
   period: year
   type: single_amount
@@ -6,6 +6,8 @@ metadata:
   amount_unit: /1
   label: Iowa CDCC fraction
   reference:
+  - title: Iowa Admin. Code r. 701-304.15 (Iowa Code § 422.12C), percentage schedule by net income (pre- and post-2021 columns)
+    href: https://www.law.cornell.edu/regulations/iowa/Iowa-Code-r-701-304.15
   - title: 2021 IA1040 Iowa Income Tax Return, Line 60
     href: https://revenue.iowa.gov/sites/default/files/2022-01/IA1040%2841-001%29.pdf#page=2
   - title: 2021 IA1040 Income Tax Return instructions
@@ -21,30 +23,37 @@ metadata:
 
 brackets:
   - threshold:
-      2021-01-01: -.inf
+      2006-01-01: -.inf
     amount:
-      2021-01-01: 0.75
+      2006-01-01: 0.75
   - threshold:
-      2021-01-01: 10_000
+      2006-01-01: 10_000
     amount:
-      2021-01-01: 0.65
+      2006-01-01: 0.65
   - threshold:
-      2021-01-01: 20_000
+      2006-01-01: 20_000
     amount:
-      2021-01-01: 0.55
+      2006-01-01: 0.55
   - threshold:
-      2021-01-01: 25_000
+      2006-01-01: 25_000
     amount:
-      2021-01-01: 0.50
+      2006-01-01: 0.50
   - threshold:
-      2021-01-01: 35_000
+      2006-01-01: 35_000
     amount:
-      2021-01-01: 0.40
+      2006-01-01: 0.40
   - threshold:
-      2021-01-01: 40_000
+      2006-01-01: 40_000
     amount:
+      2006-01-01: 0.30
+  - threshold:
+      2006-01-01: 45_000
+    amount:
+      # r. 701-304.15: $45,000-$90,000 band is "No Credit" before 2021,
+      # 30% for tax years beginning on or after January 1, 2021.
+      2006-01-01: 0.0
       2021-01-01: 0.30
   - threshold:
-      2021-01-01: 90_000
+      2006-01-01: 90_000
     amount:
-      2021-01-01: 0.0
+      2006-01-01: 0.0

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
@@ -1,8 +1,10 @@
 - name: IA cdcc unit test 1
+  # Pre-2023 the percentage is keyed on net income (IA 1040 line 26),
+  # per the Line 60 worksheet and r. 701-304.15.
   period: 2021
   input:
     cdcc_potential: 1_000
-    ia_taxable_income: 9_999.99
+    ia_net_income: 9_999.99
     state_code: IA
   output:
     ia_cdcc: 750
@@ -11,7 +13,7 @@
   period: 2022
   input:
     cdcc_potential: 1_000
-    ia_taxable_income: 40_000
+    ia_net_income: 40_000
     state_code: IA
   output:
     ia_cdcc: 300
@@ -20,10 +22,62 @@
   period: 2022
   input:
     cdcc_potential: 1_000
-    ia_taxable_income: 90_000
+    ia_net_income: 90_000
     state_code: IA
   output:
     ia_cdcc: 0
+
+- name: IA cdcc denied above 90k net income even when taxable income is below (taxsim #1108)
+  # TaxAct Child Credits worksheet for the policyengine-taxsim#1108
+  # record: line 2 (net income, line 26 A+B) = 97,058 -> decimal
+  # 0.000000 -> line 60 = 0, even though taxable income (80,303,
+  # after the federal-tax and standard deductions) is under 90k.
+  period: 2021
+  absolute_error_margin: 1
+  input:
+    people:
+      head:
+        age: 41
+        employment_income: 94_286
+        taxable_interest_income: 2_773
+      child:
+        age: 10
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        tax_unit_childcare_expenses: 2_707
+    spm_units:
+      spm_unit:
+        members: [head, child]
+    households:
+      household:
+        members: [head, child]
+        state_code: IA
+  output:
+    ia_net_income: [97_059, 0]
+    ia_cdcc: 0
+
+- name: IA cdcc 45k-90k band gives no credit before 2021
+  # r. 701-304.15: "$45,000 or more but less than $90,000" is
+  # "No Credit" for tax years before January 1, 2021 (the 30% band
+  # extension to 90k starts in 2021).
+  period: 2020
+  input:
+    cdcc_potential: 1_000
+    ia_net_income: 50_000
+    state_code: IA
+  output:
+    ia_cdcc: 0
+
+- name: IA cdcc 40k-45k band still 30 percent before 2021
+  period: 2020
+  input:
+    cdcc_potential: 1_000
+    ia_net_income: 44_000
+    state_code: IA
+  output:
+    ia_cdcc: 300
 
 - name: 2023+ IA CDCC uses ia_taxable_income_consolidated (75% bracket)
   # Post-HF 2317 (2023+) IA tax base is federal taxable income, so the

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_cdcc.yaml
@@ -58,6 +58,48 @@
     ia_net_income: [97_059, 0]
     ia_cdcc: 0
 
+- name: IA cdcc 45k threshold gets 30 percent from 2021
+  # r. 701-304.15 2021+ column: "$45,000 or more but less than $90,000" is 30%.
+  period: 2021
+  input:
+    cdcc_potential: 1_000
+    ia_net_income: 45_000
+    state_code: IA
+  output:
+    ia_cdcc: 300
+
+- name: IA cdcc 45k-90k band mid-point 30 percent from 2021
+  period: 2021
+  input:
+    cdcc_potential: 1_000
+    ia_net_income: 60_000
+    state_code: IA
+  output:
+    ia_cdcc: 300
+
+- name: IA cdcc combines both spouses net income for the 90k cutoff
+  # 2021 Expanded Instructions p. 86: "If you are married, your net income
+  # and the net income of your spouse must be combined to determine if you
+  # qualify"; worksheet line 2 is line 26 columns A and B. Each spouse is
+  # under 90k but the combined 100k is over.
+  period: 2021
+  input:
+    people:
+      head:
+        ia_net_income: 50_000
+      spouse:
+        ia_net_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        cdcc_potential: 1_000
+    households:
+      household:
+        members: [head, spouse]
+        state_code: IA
+  output:
+    ia_cdcc: 0
+
 - name: IA cdcc 45k-90k band gives no credit before 2021
   # r. 701-304.15: "$45,000 or more but less than $90,000" is
   # "No Credit" for tax years before January 1, 2021 (the 30% band

--- a/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_cdcc.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_cdcc.py
@@ -17,13 +17,13 @@ class ia_cdcc(Variable):
     defined_for = StateCode.IA
 
     def formula(tax_unit, period, parameters):
-        # Pre-2023: Iowa's tax base used net income (the legacy joint /
-        # indiv path that the dynamically generated ia_taxable_income
-        # resolves to).
+        # Pre-2023: the percentage table is keyed on Iowa net income
+        # (IA 1040 line 26, columns A and B combined), per the Line 60
+        # worksheet and Iowa Admin. Code r. 701-304.15.
         federal_cdcc = tax_unit("cdcc_potential", period)
-        taxable_income = tax_unit("ia_taxable_income", period)
+        net_income = add(tax_unit, period, ["ia_net_income"])
         p = parameters(period).gov.states.ia.tax.income
-        return federal_cdcc * p.credits.child_care.fraction.calc(taxable_income)
+        return federal_cdcc * p.credits.child_care.fraction.calc(net_income)
 
     def formula_2023(tax_unit, period, parameters):
         # The 2022 Iowa tax reform (HF 2317) shifted Iowa's tax base to
@@ -34,4 +34,6 @@ class ia_cdcc(Variable):
         federal_cdcc = tax_unit("cdcc_potential", period)
         taxable_income = tax_unit("ia_taxable_income_consolidated", period)
         p = parameters(period).gov.states.ia.tax.income
-        return federal_cdcc * p.credits.child_care.fraction.calc(taxable_income)
+        return federal_cdcc * p.credits.child_care.fraction.calc(
+            taxable_income
+        )

--- a/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_cdcc.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/credits/ia_cdcc.py
@@ -34,6 +34,4 @@ class ia_cdcc(Variable):
         federal_cdcc = tax_unit("cdcc_potential", period)
         taxable_income = tax_unit("ia_taxable_income_consolidated", period)
         p = parameters(period).gov.states.ia.tax.income
-        return federal_cdcc * p.credits.child_care.fraction.calc(
-            taxable_income
-        )
+        return federal_cdcc * p.credits.child_care.fraction.calc(taxable_income)


### PR DESCRIPTION
Fixes #9140. Originating report: PolicyEngine/policyengine-taxsim#1108.

## What

- `ia_cdcc` (pre-2023 formula): look the percentage up against **net income** (IA 1040 line 26, columns A and B combined, via `ia_net_income`) instead of `ia_taxable_income` (line 38, after the federal-tax and standard deductions). The 2023+ formula is unchanged — the post-HF 2317 instructions key on taxable income ("Only taxpayers with Iowa taxable income of less than $90,000…", 2025 Expanded Instructions).
- `fraction.yaml`: date the bracket values from 2006 and add the $45,000 bracket so the pre-2021 schedule ("$45,000 or more but less than $90,000 — No Credit", r. 701-304.15) no longer inherits the 2021 band expansion by backward fill. Adds the rule as a reference.
- Tests: pre-2023 unit tests re-keyed on `ia_net_income`; new integration test from the taxsim #1108 TaxAct return (net income $97,058 → credit $0 even though taxable income is $80,303); new pre-2021 boundary tests (50k → 0, 44k → 30%).

## Evidence

2021 IA 1040 Expanded Instructions, Line 60 (p. 86):

> Only taxpayers with a net income of less than $90,000 are eligible to take one of these refundable credits. […] The percentages are based on your Iowa net income on line 26. […] 2. If total of line 26 of the IA 1040, columns A and B, is: […] $90,000 and over: not eligible for credit

[Iowa Admin. Code r. 701-304.15](https://www.law.cornell.edu/regulations/iowa/Iowa-Code-r-701-304.15) (implements Iowa Code § 422.12C): schedule "on the basis of the net incomes of the taxpayers"; $45,000–$90,000 band is "No Credit" before 2021 and 30% for tax years beginning on or after January 1, 2021; "$90,000 or more — No Credit" in both columns.

## Verification

On the taxsim #1108 record (2021 HoH, $94,286 wages + $2,773 interest, $2,707 childcare): `ia_cdcc` 406.01 → **0**, IA tax 4,313.37 → **4,719.40** vs TaxAct's 4,721 (tax-table rounding). Full IA suite: 411 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)