### PR TITLE
Fix mortgage interest deduction for person-level input and missing balances

### DIFF
--- a/changelog.d/mortgage-interest-person-level-fallback.fixed.md
+++ b/changelog.d/mortgage-interest-person-level-fallback.fixed.md
@@ -1,0 +1,1 @@
+Fixed the federal mortgage interest deduction to use person-level home_mortgage_interest when the structured tax-unit inputs are absent, and to treat mortgage interest with no specified balance as fully deductible instead of non-deductible.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/deductible_mortgage_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/deductible_mortgage_interest.yaml
@@ -67,3 +67,42 @@
   output:
     deductible_mortgage_interest_tax_unit: 0
     non_deductible_mortgage_interest_tax_unit: 0
+
+- name: Person-level home mortgage interest is deductible when no structural inputs are provided
+  period: 2024
+  input:
+    people:
+      head:
+        home_mortgage_interest: 10_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+        tax_unit_itemizes: true
+        standard_deduction: 0
+  output:
+    deductible_mortgage_interest_tax_unit: 10_000
+    interest_deduction: 10_000
+    mortgage_interest: 10_000
+
+- name: Structural interest with no reported balance is fully deductible
+  period: 2024
+  input:
+    filing_status: SINGLE
+    tax_unit_itemizes: true
+    standard_deduction: 0
+    first_home_mortgage_interest: 10_000
+  output:
+    deductible_mortgage_interest_tax_unit: 10_000
+
+- name: Regression guard - post-TCJA balance above the cap is still limited
+  period: 2024
+  input:
+    filing_status: SINGLE
+    tax_unit_itemizes: true
+    standard_deduction: 0
+    first_home_mortgage_balance: 900_000
+    first_home_mortgage_interest: 45_000
+    first_home_mortgage_origination_year: 2018
+  output:
+    deductible_mortgage_interest_tax_unit: 37_500

--- a/policyengine_us/variables/household/expense/tax_unit/mortgage_interest_structure.py
+++ b/policyengine_us/variables/household/expense/tax_unit/mortgage_interest_structure.py
@@ -104,7 +104,20 @@ class home_mortgage_interest_tax_unit(Variable):
     label = "Tax unit home mortgage interest"
     unit = USD
     definition_period = YEAR
-    adds = ["first_home_mortgage_interest", "second_home_mortgage_interest"]
+    documentation = (
+        "Total home mortgage interest, taken from the structured first/second "
+        "mortgage inputs when provided, otherwise falling back to the reported "
+        "person-level home mortgage interest."
+    )
+
+    def formula(tax_unit, period, parameters):
+        structured_interest = add(
+            tax_unit,
+            period,
+            ["first_home_mortgage_interest", "second_home_mortgage_interest"],
+        )
+        reported_interest = add(tax_unit, period, ["home_mortgage_interest"])
+        return where(structured_interest > 0, structured_interest, reported_interest)
 
 
 class deductible_mortgage_interest_tax_unit(Variable):
@@ -122,12 +135,12 @@ class deductible_mortgage_interest_tax_unit(Variable):
     def formula(tax_unit, period, parameters):
         first_balance = tax_unit("first_home_mortgage_balance", period)
         second_balance = tax_unit("second_home_mortgage_balance", period)
-        first_interest = tax_unit("first_home_mortgage_interest", period)
-        second_interest = tax_unit("second_home_mortgage_interest", period)
         first_year = tax_unit("first_home_mortgage_origination_year", period)
         second_year = tax_unit("second_home_mortgage_origination_year", period)
         total_balance = first_balance + second_balance
-        total_interest = first_interest + second_interest
+        # Falls back to reported person-level interest when the structured
+        # first/second inputs are absent.
+        total_interest = tax_unit("home_mortgage_interest_tax_unit", period)
 
         filing_status = tax_unit("filing_status", period)
         p = parameters(period).gov.irs.deductions.itemized.interest.mortgage
@@ -151,7 +164,10 @@ class deductible_mortgage_interest_tax_unit(Variable):
             first_balance, second_balance, first_cap, second_cap
         )
 
-        deductible_share = np.zeros_like(total_balance)
+        # When no acquisition-debt balance is provided, assume the mortgage is
+        # within the statutory caps and fully deductible, rather than treating a
+        # $0 balance as making the interest entirely non-deductible.
+        deductible_share = np.ones_like(total_balance)
         mask = total_balance > 0
         deductible_share[mask] = np.minimum(
             1, limited_balance[mask] / total_balance[mask]


### PR DESCRIPTION
Fixes #9004 (reported by @jindal-git).

Two related defects in the federal mortgage-interest deduction:
1. **Person-level input ignored** — `home_mortgage_interest_tax_unit` only summed the structured `first_home_mortgage_interest` / `second_home_mortgage_interest`, so a household with only person-level `home_mortgage_interest` got `$0` deductible.
2. **Missing-balance fallback** — with interest provided but the balance defaulting to `$0`, `deductible_share` was `0`, making the interest entirely non-deductible.

**Fix:**
- `home_mortgage_interest_tax_unit` now falls back to the reported person-level `home_mortgage_interest` when the structured inputs are absent, and `deductible_mortgage_interest_tax_unit` uses it so the fallback flows into the deduction;
- `deductible_share` defaults to fully deductible when no acquisition-debt balance is provided (assume within the §163 caps), instead of `$0`.

The `balance > 0` cap logic is unchanged, so real acquisition-debt limits still apply.

**Microsim impact: none.** The national `deductible_mortgage_interest` aggregate is identical before/after ($254.853B, 2024) — the enhanced-CPS microdata provides structured interest *and* balances, so neither fallback triggers in simulation. The fix only affects household inputs that supply person-level interest or omit the balance (the reported household-calculator scenarios).

**Tests:** person-level fallback → $10k deductible; structural interest with no balance → $10k; post-TCJA over-cap balance still limited to $37.5k; "no inputs → $0" unchanged. 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)