### PR TITLE
Update CLAUDE.md skill references to current plugin skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,11 @@ At the START of each session, ask the user:
 1. "Yes, load skills" (Recommended) - Load pattern skills for code quality
 2. "No, skip" - Proceed without loading skills
 
-**If Option 1 selected, load ALL of these:**
-- /policyengine-code-style
-- /policyengine-parameter-patterns
-- /policyengine-period-patterns
-- /policyengine-testing-patterns
-- /policyengine-variable-patterns
+**If Option 1 selected, load ALL of these** (from the `policyengine-claude` plugin):
+- /complete:policyengine-model-development (variable, parameter, period, and testing patterns)
+- /complete:policyengine-standards (code style, formatting, changelog, PR workflow)
+
+If these skills are unavailable (plugin not installed), skip loading and proceed.
 
 ---
 

--- a/changelog.d/remove-stale-skill-references.changed.md
+++ b/changelog.d/remove-stale-skill-references.changed.md
@@ -1,0 +1,1 @@
+Update CLAUDE.md skill-loading instructions to reference current policyengine-claude plugin skills instead of removed skill names.


### PR DESCRIPTION
## Summary

Removes the five stale skill names from the "MANDATORY FIRST ACTION" block in `CLAUDE.md` and points the skill-loading prompt at the current `policyengine-claude` plugin equivalents.

Fixes #9143

## Problem

The block instructed agents to load five skills that no longer exist (`/policyengine-code-style`, `/policyengine-parameter-patterns`, `/policyengine-period-patterns`, `/policyengine-testing-patterns`, `/policyengine-variable-patterns`), producing five "Unknown skill" errors at the start of every session.

## Changes

- Replace the five stale names with the consolidated plugin skills:
  - `/complete:policyengine-model-development` — variable, parameter, period, and testing patterns
  - `/complete:policyengine-standards` — code style, formatting, changelog, PR workflow
- Add a fallback line so sessions without the plugin installed skip loading instead of erroring.

`AGENTS.md` needs no change — it has no skill references (it defers to `CLAUDE.md`).

## Test plan

- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)