### PR TITLE
Guard remaining MD local tax variables against unknown counties

### DIFF
--- a/changelog.d/md-local-unknown-county.fixed.md
+++ b/changelog.d/md-local-unknown-county.fixed.md
@@ -1,0 +1,1 @@
+Fixed crashes in the Maryland local tax variables md_applicable_local_tax_rate and md_flat_rate_county_tax for Maryland households whose county is unknown, by falling back to the same default county used elsewhere.

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_applicable_local_tax_rate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_applicable_local_tax_rate.yaml
@@ -48,3 +48,23 @@
         county_str: FREDERICK_COUNTY_MD
   output:
     md_applicable_local_tax_rate: 0.0296
+
+- name: Allegany County uses its flat rate (2025)
+  period: 2025
+  absolute_error_margin: 0.0001
+  input:
+    state_code_str: MD
+    county_str: ALLEGANY_COUNTY_MD
+  output:
+    md_applicable_local_tax_rate: 0.0303
+
+- name: Unknown county in an MD household falls back to Allegany County (issue #8975)
+  period: 2025
+  absolute_error_margin: 0.0001
+  input:
+    state_code_str: MD
+    county_str: UNKNOWN
+  output:
+    # gov.local.md.flat_rate has no UNKNOWN key; the formula falls back to
+    # ALLEGANY_COUNTY_MD. Before the fix this raised ParameterNotFoundError.
+    md_applicable_local_tax_rate: 0.0303

--- a/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_flat_rate_county_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/tax/income/local/md_flat_rate_county_tax.yaml
@@ -1,0 +1,23 @@
+- name: Allegany County MD flat rate county tax baseline (2025)
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    state_code_str: MD
+    county_str: ALLEGANY_COUNTY_MD
+    md_taxable_income: 30_000
+  output:
+    # 3.03% Allegany rate * 30,000 = 909
+    md_flat_rate_county_tax: 909
+
+- name: Unknown county in an MD household falls back to Allegany County (issue #8975)
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    state_code_str: MD
+    county_str: UNKNOWN
+    md_taxable_income: 30_000
+  output:
+    # gov.local.md.flat_rate has no UNKNOWN key; the formula falls back to
+    # ALLEGANY_COUNTY_MD, so this must equal the Allegany baseline above.
+    # Before the fix this raised ParameterNotFoundError instead of computing.
+    md_flat_rate_county_tax: 909

--- a/policyengine_us/variables/gov/states/md/tax/income/local/md_applicable_local_tax_rate.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/md_applicable_local_tax_rate.py
@@ -19,7 +19,11 @@ class md_applicable_local_tax_rate(Variable):
         # Guard against non-MD counties in microsimulation:
         # defined_for masks results but doesn't prevent formula execution.
         in_md = tax_unit.household("state_code_str", period) == "MD"
-        safe_county = where(in_md, county, "ALLEGANY_COUNTY_MD")
+        # Fall back to a default MD county when the county is unknown/unmapped
+        # (County.UNKNOWN is the default), since gov.local.md.flat_rate has no
+        # UNKNOWN key and would otherwise raise ParameterNotFoundError. The
+        # non-MD path already falls back to the same default county.
+        safe_county = where(in_md & (county != "UNKNOWN"), county, "ALLEGANY_COUNTY_MD")
 
         p = parameters(period).gov.local.md
         flat_rate = p.flat_rate[safe_county]

--- a/policyengine_us/variables/gov/states/md/tax/income/local/md_flat_rate_county_tax.py
+++ b/policyengine_us/variables/gov/states/md/tax/income/local/md_flat_rate_county_tax.py
@@ -17,7 +17,11 @@ class md_flat_rate_county_tax(Variable):
         # Guard against non-MD counties in microsimulation
         # defined_for masks results but doesn't prevent formula execution
         in_md = tax_unit.household("state_code_str", period) == "MD"
-        safe_county = where(in_md, county, "ALLEGANY_COUNTY_MD")
+        # Fall back to a default MD county when the county is unknown/unmapped
+        # (County.UNKNOWN is the default), since gov.local.md.flat_rate has no
+        # UNKNOWN key and would otherwise raise ParameterNotFoundError. The
+        # non-MD path already falls back to the same default county.
+        safe_county = where(in_md & (county != "UNKNOWN"), county, "ALLEGANY_COUNTY_MD")
 
         p = parameters(period).gov.local.md.flat_rate
         flat_rate = p[safe_county]


### PR DESCRIPTION
Extends #9116 (issue #8975) — same crash class, remaining instances.

## Problem

`md_applicable_local_tax_rate` and `md_flat_rate_county_tax` carry the identical unguarded pattern that #9116 fixed in `md_withheld_income_tax`:

```python
safe_county = where(in_md, county, "ALLEGANY_COUNTY_MD")   # guards non-MD only
flat_rate = p.flat_rate[safe_county]                       # UNKNOWN key -> crash
```

An MD household whose `county` resolves to `County.UNKNOWN` (the default when `county_fips` is unmapped/absent) raises `ParameterNotFoundError: The parameter 'gov.local.md.flat_rate.UNKNOWN' was not found`, crashing any computation of MD local income tax. The #8975 harness only hit the SALT-withholding chain, so these two siblings survived that report; verified pre-fix on this branch that the new UNKNOWN test case raises exactly that error.

## Fix

Extend the same guard used by #9116 to both variables:

```python
safe_county = where(in_md & (county != "UNKNOWN"), county, "ALLEGANY_COUNTY_MD")
```

No modeling-convention change: UNKNOWN falls back to the same default county the non-MD path already uses.

## Tests

- New `md_flat_rate_county_tax.yaml`: Allegany baseline (3.03% × $30,000 = $909, hand-checked) + UNKNOWN case pinned equal to it (raised `ParameterNotFoundError` before the fix).
- `md_applicable_local_tax_rate.yaml`: Allegany baseline (0.0303) + UNKNOWN case pinned equal.
- Local run: MD local dir 19/19; full `gov/states/md/tax/income` 189/189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
