### PR TITLE
Restore 51 orphaned changelog fragments into their true release sections

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,6 +58,30 @@ jobs:
             echo "::error::No valid changelog fragment found. Add one like: changelog.d/${{ github.head_ref }}.fixed.md"
             exit 1
           fi
+      - name: Validate changelog.d tree
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Tree-state guard: fragments at invalid paths (type subdirectories,
+          # missing .<type>. suffix) are silently ignored by towncrier and
+          # bump_version.py, so their entries never reach CHANGELOG.md (#9149).
+          # The changed-files check above only sees files touched by the PR;
+          # this step keeps the whole tree clean so strays cannot accumulate.
+          invalid=0
+          while IFS= read -r f; do
+            if [ "$f" = "changelog.d/.gitkeep" ]; then
+              continue
+            fi
+            if [[ ! "$f" =~ ^changelog\.d/[^/]+\.(breaking|added|changed|fixed|removed)\.md$ ]]; then
+              echo "::error file=${f}::Fragment at an invalid path (towncrier will ignore it). Use changelog.d/<name>.<type>.md at the top level; no type subdirectories."
+              invalid=1
+            fi
+          done < <(git ls-files -- changelog.d)
+
+          if [ "$invalid" -ne 0 ]; then
+            exit 1
+          fi
   BundleMetadataContract:
     name: Validate bundle metadata contract
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,7 @@
 
 ### Changed
 
-- - Dataset extension no longer deep-copies the full dataset per projected year; under pandas copy-on-write, carried-forward columns share base-year buffers, cutting extension time ~11x (about 21s to 2s on the full Populace 2024 dataset) with bit-identical output. `USSingleYearDataset.copy(deep=False)` falls back to a deep copy when copy-on-write is unavailable, so isolation is guaranteed on all pandas versions.
+- Dataset extension no longer deep-copies the full dataset per projected year; under pandas copy-on-write, carried-forward columns share base-year buffers, cutting extension time ~11x (about 21s to 2s on the full Populace 2024 dataset) with bit-identical output. `USSingleYearDataset.copy(deep=False)` falls back to a deep copy when copy-on-write is unavailable, so isolation is guaranteed on all pandas versions.
   - Require pandas >= 3.0 on Python >= 3.11 (pandas >= 2.0 retained for Python 3.9/3.10). This floor is stricter than the code requires — the runtime fallback keeps pandas 2.x fully correct — and is a deliberate choice to guarantee the fast path and pandas-3 CI coverage; downstream environments on Python >= 3.11 will be upgraded to pandas 3.
   - Note for downstream code: under pandas 3, arrays loaded from datasets into simulation holders are read-only views; in-place mutation of `holder.get_array(...)` results (e.g. `arr[mask] = x`) now raises `ValueError` where it previously worked. Copy the array first if mutation is needed.
   - Cap numpy below 2.0 on Python 3.9, where PyTables 3.9.x wheels are built against numpy 1.x; without the cap, every `pd.HDFStore` call on Python 3.9 fails with a binary-incompatibility error (pre-existing breakage surfaced by the new compat-leg tests).
@@ -207,7 +207,7 @@
 
 ### Fixed
 
-- - Require policyengine-core >= 3.30.1 so behavioral-response measurement branches record real baseline and reform marginal tax rates; the substitution and capital-gains channels were inert under earlier cores. Adds an end-to-end regression test.
+- Require policyengine-core >= 3.30.1 so behavioral-response measurement branches record real baseline and reform marginal tax rates; the substitution and capital-gains channels were inert under earlier cores. Adds an end-to-end regression test.
 
 
 ## [1.775.10] - 2026-07-20
@@ -291,14 +291,14 @@
 
 ### Fixed
 
-- - Applied Washington's capital gains 9.9% tier only from 2025; ESSB 5813 (Ch. 421, Laws of 2025) imposes the additional 2.9% over $1,000,000 beginning January 1, 2025, and the rate was a flat 7% in 2022-2024.
+- Applied Washington's capital gains 9.9% tier only from 2025; ESSB 5813 (Ch. 421, Laws of 2025) imposes the additional 2.9% over $1,000,000 beginning January 1, 2025, and the rate was a flat 7% in 2022-2024.
 
 
 ## [1.774.6] - 2026-07-16
 
 ### Fixed
 
-- - Raised the Vermont CSRS/military retirement exemption thresholds by $5,000 for 2025 per Act No. 51 (2025), Sec. 3 (32 V.S.A. § 5830e(b)), matching the Social Security thresholds updated in #8853.
+- Raised the Vermont CSRS/military retirement exemption thresholds by $5,000 for 2025 per Act No. 51 (2025), Sec. 3 (32 V.S.A. § 5830e(b)), matching the Social Security thresholds updated in #8853.
 
 
 ## [1.774.5] - 2026-07-16
@@ -326,7 +326,7 @@
 
 ### Fixed
 
-- - Kept the Arkansas MFJ two-or-more-dependents low-income tax table rows added for 2024-2025 out of earlier years; the published tables end at $32,200 (2021) through $34,100 (2023), so incomes above the cutoff use the regular tax table.
+- Kept the Arkansas MFJ two-or-more-dependents low-income tax table rows added for 2024-2025 out of earlier years; the published tables end at $32,200 (2021) through $34,100 (2023), so incomes above the cutoff use the regular tax table.
 - Keep each spouse's own Delaware personal credit in their own Filing Status 4 column per the PIT-RES line 27a example, allocating only dependent credits between columns, so the post-credit filing-status election no longer favors combined-separate filing through an impermissible credit shift.
 
 
@@ -334,7 +334,7 @@
 
 ### Fixed
 
-- - Corrected the Arkansas 2023 bracket-adjustment column: added the missing $89,901-$90,000 row, encoded the three intentionally $200-wide ranges, and removed duplicated 91,701/91,801 thresholds that doubled the reduction.
+- Corrected the Arkansas 2023 bracket-adjustment column: added the missing $89,901-$90,000 row, encoded the three intentionally $200-wide ranges, and removed duplicated 91,701/91,801 thresholds that doubled the reduction.
 
 
 ## [1.774.0] - 2026-07-16
@@ -500,7 +500,7 @@
 
 ### Fixed
 
-- - Hardened ACA ZIP3 parsing so missing, nonnumeric, leading-zero, and ZIP+4 ZIP codes parse correctly instead of silently failing SLCSP rating-area lookups.
+- Hardened ACA ZIP3 parsing so missing, nonnumeric, leading-zero, and ZIP+4 ZIP codes parse correctly instead of silently failing SLCSP rating-area lookups.
 
 
 ## [1.767.0] - 2026-07-07
@@ -521,7 +521,7 @@
 
 ### Fixed
 
-- - Honored the IRC § 21(e)(4) separated-taxpayer exception in the South Carolina child and dependent care credit.
+- Honored the IRC § 21(e)(4) separated-taxpayer exception in the South Carolina child and dependent care credit.
   - Stopped the Idaho and Georgia contributed child tax credit reforms from applying in years before their in_effect activation date.
   - Computed the Kentucky, Maine, and Vermont child and dependent care credits from the pre-OBBBA federal IRC § 21 credit for 2026, matching each state's static conformity to the Internal Revenue Code as of December 31, 2024.
   - Reduced the California, Idaho, and Virginia child and dependent care benefit bases by employer-provided dependent care benefits excluded under IRC § 129, matching each state's form treatment and the federal IRC § 21(c) reduction.
@@ -531,7 +531,7 @@
 
 ### Fixed
 
-- - Corrected the Colorado age 55-64 Social Security subtraction to allow the full taxable Social Security amount when AGI is at or below the filing-status threshold, per HB24-1142 (effective 2025).
+- Corrected the Colorado age 55-64 Social Security subtraction to allow the full taxable Social Security amount when AGI is at or below the filing-status threshold, per HB24-1142 (effective 2025).
   - Updated Kentucky CCAP 85% SMI income limits to DCC-113 R.12/24 (effective 2025-10-01).
   - Fixed the SNAP ABAWD dependent-child gate to key on any household member under the age threshold, per 7 CFR 273.24(c)(4), and removed the duplicate dead exemption branch.
 - The NYC School Tax Credit now computes through a formula so household output shows only the final credit rather than its fixed and rate-reduction components.
@@ -541,14 +541,14 @@
 
 ### Fixed
 
-- - Aligned Florida TCA payment standard, income tests, earned income disregard, and minimum issuance with the DCF ESS Program Policy Manual and Appendix A-5.
+- Aligned Florida TCA payment standard, income tests, earned income disregard, and minimum issuance with the DCF ESS Program Policy Manual and Appendix A-5.
 
 
 ## [1.766.2] - 2026-07-06
 
 ### Fixed
 
-- - Fixed the ACA 700% FPL cliff contrib reform to reuse the baseline ACA coverage and premium-paying gate, so Basic Health Program, Oregon Healthier Oregon, VA/CHAMPVA, and other minimum-essential-coverage exclusions and the below-FPL immigration exception apply to the reform.
+- Fixed the ACA 700% FPL cliff contrib reform to reuse the baseline ACA coverage and premium-paying gate, so Basic Health Program, Oregon Healthier Oregon, VA/CHAMPVA, and other minimum-essential-coverage exclusions and the below-FPL immigration exception apply to the reform.
 
 
 ## [1.766.1] - 2026-07-06
@@ -569,7 +569,7 @@
 
 ### Fixed
 
-- - Added the Maine EITC childless age expansion (36 M.R.S. Sec. 5219-S) so filers aged 18-24 without a qualifying child receive the credit.
+- Added the Maine EITC childless age expansion (36 M.R.S. Sec. 5219-S) so filers aged 18-24 without a qualifying child receive the credit.
   - Corrected the 2025 Maine sales tax fairness credit base amount to $215 for joint, head of household, and surviving spouse filers.
 
 
@@ -577,7 +577,7 @@
 
 ### Fixed
 
-- - Reduced the federal Child and Dependent Care Credit dollar limit by employer-provided dependent care benefits excluded under IRC section 129, as required by section 21(c) and Form 2441 Part III, and added the One Big Beautiful Bill Act increase to the section 129 exclusion cap.
+- Reduced the federal Child and Dependent Care Credit dollar limit by employer-provided dependent care benefits excluded under IRC section 129, as required by section 21(c) and Form 2441 Part III, and added the One Big Beautiful Bill Act increase to the section 129 exclusion cap.
 
 
 ## [1.765.4] - 2026-07-06
@@ -591,7 +591,7 @@
 
 ### Fixed
 
-- - California AMT no longer double-adds disallowed itemized deductions; Schedule P (540) Part I now adds regular taxable income plus specific AMT adjustments minus the restored itemized deductions limitation (line 18), instead of adding the full pre-limitation itemized deductions.
+- California AMT no longer double-adds disallowed itemized deductions; Schedule P (540) Part I now adds regular taxable income plus specific AMT adjustments minus the restored itemized deductions limitation (line 18), instead of adding the full pre-limitation itemized deductions.
   - Arizona property tax credit now selects the higher Table 2 credit schedule for any claimant living with one or more other persons (including a non-spouse cohabitant), matching ARS 43-1072(A)(3)(b), rather than only for married couples and cohabitating spouses.
   - Louisiana FITAP now rounds the grant deficit down to a whole dollar and pays no grant when the rounded deficit is below $10, per DCFS manual B-641-1-FITAP.
   - Nevada TANF now rounds the monthly benefit down to a whole dollar and issues no regular benefit below $10, per Eligibility and Payments Manual A-660.12.
@@ -608,7 +608,7 @@
 
 ### Fixed
 
-- - Exempted post-retirement-age distributions from eligible Pennsylvania employer retirement plans (401(k), 403(b), SEP, Keogh) from PA taxable compensation, matching the existing IRA treatment.
+- Exempted post-retirement-age distributions from eligible Pennsylvania employer retirement plans (401(k), 403(b), SEP, Keogh) from PA taxable compensation, matching the existing IRA treatment.
   - Moved the New Jersey 529 (NJBEST) contribution deduction from gross-income subtractions to taxable-income deductions so it no longer shifts the gross-income filing threshold.
 
 
@@ -645,7 +645,7 @@
 
 ### Fixed
 
-- - Migrated 156 partner YAML test fixtures from the derived `employment_income` input key to the actual `employment_income_before_lsr` input, fixing a latent bug where TANF and other earned-income-list programs silently saw $0 earnings in the `build_from_dict` test path; repinned the 17 output values this revealed as wrong across 8 fixture files (Head Start, school meals, Massachusetts EAEDC and TAFDC, Oregon SNAP).
+- Migrated 156 partner YAML test fixtures from the derived `employment_income` input key to the actual `employment_income_before_lsr` input, fixing a latent bug where TANF and other earned-income-list programs silently saw $0 earnings in the `build_from_dict` test path; repinned the 17 output values this revealed as wrong across 8 fixture files (Head Start, school meals, Massachusetts EAEDC and TAFDC, Oregon SNAP).
 
 
 ## [1.764.2] - 2026-07-06
@@ -788,7 +788,7 @@
 
 ### Fixed
 
-- - Added explicit 2026 values to Nebraska, Maine, and Rhode Island income tax parameters, and 2024-2025 values to New York's itemized deduction phase-out threshold, that had been frozen by a misplaced uprating block (#8905).
+- Added explicit 2026 values to Nebraska, Maine, and Rhode Island income tax parameters, and 2024-2025 values to New York's itemized deduction phase-out threshold, that had been frozen by a misplaced uprating block (#8905).
 
 
 ## [1.756.7] - 2026-07-05
@@ -802,7 +802,7 @@
 
 ### Fixed
 
-- - Added Saver's Credit joint AGI rate thresholds for 2024, 2025, and 2026 from IRS Notices 2023-75, 2024-80, and 2025-67.
+- Added Saver's Credit joint AGI rate thresholds for 2024, 2025, and 2026 from IRS Notices 2023-75, 2024-80, and 2025-67.
 - Fixed the 2020 unemployment compensation exclusion to require AGI strictly below $150,000.
 
 
@@ -810,7 +810,7 @@
 
 ### Fixed
 
-- - Fixed the Indiana EITC to use the current-year federal EITC for childless filers as well as filers with children, matching Schedule IN-EIC Section A, which applies the 10% match to all filers.
+- Fixed the Indiana EITC to use the current-year federal EITC for childless filers as well as filers with children, matching Schedule IN-EIC Section A, which applies the 10% match to all filers.
 - Backfilled the `state_code` enum from a `state_code_str`-only household input so every state-dependent variable resolves the intended state instead of the California default.
 
 
@@ -833,7 +833,7 @@
 ### Fixed
 
 - Included non-Schedule-D capital gain distributions in gross income, the preferential-rate capital gains base, and net investment income.
-- - Treated people denied Medicaid by work requirements as ineligible for ACA marketplace premium payment and premium tax credits.
+- Treated people denied Medicaid by work requirements as ineligible for ACA marketplace premium payment and premium tax credits.
 
 
 ## [1.756.1] - 2026-07-05
@@ -878,7 +878,7 @@
 - California AMT (Schedule P Line 4) no longer adds back acquisition home mortgage interest, matching the federal AMT treatment.
 - Use the federally loss-limited net capital gain in the Delaware pension exclusion eligible-income basket.
 - Corrected the Virginia per-person adjusted gross income used by the Spouse Tax Adjustment to attribute each Virginia subtraction (Social Security, railroad retirement, unemployment, US government interest, military and disability subtractions, and the age deduction) to the spouse who received the income, preventing the adjustment from being wrongly granted to couples where one spouse only has Virginia-exempt income.
-- - Fix the Vermont retirement-income exemption eligibility gate to use the Social Security phase-out threshold for Social Security filers.
+- Fix the Vermont retirement-income exemption eligibility gate to use the Social Security phase-out threshold for Social Security filers.
 - Compute the Indiana EITC for filers with children from the current-year federal EITC, per Schedule IN-EIC Section B, instead of a frozen 2023 IRC snapshot.
 - Limited the Missouri state-income-tax add-back to the federal SALT deduction after the OBBBA cap phase-down.
 - Exclude general sales tax from the New York itemized deduction per NY Tax Law section 615(c)(1).
@@ -938,7 +938,7 @@
 
 ### Added
 
-- - Excluded children's earned income from Kansas TANF gross-income and countable income per KEESM 6410.
+- Excluded children's earned income from Kansas TANF gross-income and countable income per KEESM 6410.
   - Added a Kansas TANF earned income deduction for the care of an incapacitated person per K.A.R. 30-4-111(b)(3).
 
 
@@ -965,14 +965,14 @@
 
 ### Fixed
 
-- - Fixed CHIP FCEP eligibility so an undocumented pregnant parent is not denied the unborn-child CHIP option solely due to immigration status.
+- Fixed CHIP FCEP eligibility so an undocumented pregnant parent is not denied the unborn-child CHIP option solely due to immigration status.
 
 
 ## [1.753.3] - 2026-07-01
 
 ### Changed
 
-- - Add FY2026 county-level HUD Fair Market Rents so simulations at period 2026 use FY2026 values, falling back to the nearest earlier bundled year for any county missing from the queried year.
+- Add FY2026 county-level HUD Fair Market Rents so simulations at period 2026 use FY2026 values, falling back to the nearest earlier bundled year for any county missing from the queried year.
   - Align HUD annual income with 24 CFR 5.609 by counting additional sources, excluding children's and full-time-student dependents' earned income and foster members' income, and no longer counting capital gains or retirement-account distributions.
 
 
@@ -1022,7 +1022,7 @@
 
 ### Added
 
-- - Modeled the SNAP student employment and training (7 CFR 273.5(b)(11)) and work incentive program (7 CFR 273.5(b)(4)) placement exemptions via the new `is_snap_employment_training_student` and `is_snap_work_incentive_student` inputs, combined as `is_snap_employment_training_or_work_incentive_student`.
+- Modeled the SNAP student employment and training (7 CFR 273.5(b)(11)) and work incentive program (7 CFR 273.5(b)(4)) placement exemptions via the new `is_snap_employment_training_student` and `is_snap_work_incentive_student` inputs, combined as `is_snap_employment_training_or_work_incentive_student`.
 
 
 ## [1.751.2] - 2026-07-01
@@ -1236,7 +1236,7 @@ No significant changes.
 
 ### Changed
 
-- - Switch the default US dataset to the certified Populace build (`populace_us_2024`), replacing the Enhanced CPS, and support loading datasets from Hugging Face dataset repositories via `hf://datasets/` URLs.
+- Switch the default US dataset to the certified Populace build (`populace_us_2024`), replacing the Enhanced CPS, and support loading datasets from Hugging Face dataset repositories via `hf://datasets/` URLs.
 
 
 ## [1.739.0] - 2026-06-19
@@ -1363,7 +1363,7 @@ No significant changes.
 
 ### Added
 
-- - Added the Florida School Readiness Program (child care subsidy).
+- Added the Florida School Readiness Program (child care subsidy).
 - Add Hawaii Child Care Assistance Program (CCAP / Child Care Subsidy).
 - Add Iowa Child Care Assistance (CCA / CCAP) - 3-tier CCDF child care subsidy with full provider rate matrix and sliding/percentage copays.
 - Add Idaho Child Care Program benefits.
@@ -1384,7 +1384,7 @@ No significant changes.
 ### Fixed
 
 - Fixed California SSI state supplement payment standards for disabled recipients identified by SSI disability criteria.
-- - Split partnership and S-corporation income into separate person-level inputs, and rename partnership self-employment income to partnership net earnings from self-employment.
+- Split partnership and S-corporation income into separate person-level inputs, and rename partnership self-employment income to partnership net earnings from self-employment.
 
 
 ## [1.727.0] - 2026-06-14
@@ -1467,21 +1467,24 @@ No significant changes.
 
 ### Added
 
-- - Add an Illinois SB3567 (104th General Assembly) contributed reform, opt-in via `gov.contrib.states.il.sb3567.in_effect`, that boosts the child tax credit for low-AGI filers.
+- Add an Illinois SB3567 (104th General Assembly) contributed reform, opt-in via `gov.contrib.states.il.sb3567.in_effect`, that boosts the child tax credit for low-AGI filers.
 - Added the Kentucky Homestead Exemption property tax reduction.
+- Add selected Marketplace plan categories and ACA cost-sharing reduction actuarial value variables.
+- End New York's expanded Basic Health Program income limit after the 2026 waiver termination.
 
 ### Fixed
 
 - Apply the Montana Elderly Homeowner/Renter Credit multiplier to household-level gross income and include the full Social Security amount.
 - Zero the New Jersey pre-credit liability before refundable credits flow through when AGI is at or below the filing threshold.
 - Correct Indiana TANF benefit payments to use the IC 12-14-2-5 maximum benefit and add the post-2025 gross/net income eligibility screens.
+- Fixed New York Child Health Plus premiums above 400 percent FPL.
 
 
 ## [1.721.4] - 2026-06-08
 
 ### Fixed
 
-- - Fixed federal alimony above-the-line deductions, Pennsylvania retirement income exclusions, and Ohio retirement credit regression coverage.
+- Fixed federal alimony above-the-line deductions, Pennsylvania retirement income exclusions, and Ohio retirement credit regression coverage.
 - Updated Colorado Temporary Assistance for Needy Families grant standards for the July 2025 current-law amounts.
 
 
@@ -1696,7 +1699,9 @@ No significant changes.
 
 ## [1.710.6] - 2026-05-27
 
-No significant changes.
+### Fixed
+
+- Add a Medicaid community engagement exclusion input for American Indian or Alaska Native status.
 
 
 ## [1.710.5] - 2026-05-27
@@ -1704,6 +1709,7 @@ No significant changes.
 ### Fixed
 
 - Apply rate cap before deducting copay in DC, NJ, SC, RI, PA, ME, MA, VA, and DE child care subsidy formulas, so the family copay is properly deducted from the state's max reimbursement when expenses exceed the cap.
+- Fix SNAP work-requirement treatment for per-person disqualifications and OBBBA ABAWD Indian exemptions.
 
 
 ## [1.710.4] - 2026-05-27
@@ -1715,17 +1721,24 @@ No significant changes.
 
 ## [1.710.3] - 2026-05-27
 
-No significant changes.
+### Fixed
+
+- Made `meets_ssi_disability_criteria` input-only so simulations use data-provided SSA disability-screen imputations instead of falling back to broad disability status.
+- Removed `ssi_federal_fiscal_year_outlays`; SSI formulas remain calendar-year oriented, with reusable payment-date helpers available in `policyengine_us.tools.ssi`.
 
 
 ## [1.710.2] - 2026-05-27
 
-No significant changes.
+### Added
+
+- Added section 1115 minimum essential coverage adults to Medicaid work requirement applicability.
 
 
 ## [1.710.1] - 2026-05-27
 
-No significant changes.
+### Fixed
+
+- Derive monthly hours worked from last-week hours for Medicaid work requirements.
 
 
 ## [1.710.0] - 2026-05-27
@@ -1775,14 +1788,26 @@ No significant changes.
 
 ## [1.706.16] - 2026-05-25
 
-No significant changes.
+### Added
+
+- Added the Mississippi Working Disabled Medicaid buy-in pathway.
+- Added Mississippi Healthier Mississippi Waiver Medicaid eligibility.
+
+### Fixed
+
+- Modeled SSI-recipient Medicaid eligibility for Section 209(b) states.
+- Add explicit Medicare Savings Program fiscal accounting for MSP-only beneficiaries.
 
 
 ## [1.706.15] - 2026-05-25
 
+### Added
+
+- Added Medicaid community engagement pass-through eligibility for SNAP and TANF work-compliance determinations.
+
 ### Changed
 
-- - Made Medicaid cost if enrolled data-backed and used Medicaid enrollment, rather than the Medicaid dollar value, for categorical eligibility checks.
+- Made Medicaid cost if enrolled data-backed and used Medicaid enrollment, rather than the Medicaid dollar value, for categorical eligibility checks.
 
 ### Fixed
 
@@ -1791,37 +1816,51 @@ No significant changes.
 
 ## [1.706.14] - 2026-05-25
 
-No significant changes.
+### Fixed
+
+- Treat the FLSA overtime premium as a data-backed input instead of calculating it from annual hours and wages, and expose CPS occupation inputs used to construct it.
 
 
 ## [1.706.13] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Fixed the CHIP child maximum age parameter unit and replaced the package description placeholder.
 
 
 ## [1.706.12] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Added a codified Tax Reform Code reference for the Pennsylvania income tax rate.
 
 
 ## [1.706.11] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Fixed the Connecticut EITC qualifying child bonus to require Connecticut EITC eligibility.
 
 
 ## [1.706.10] - 2026-05-24
 
-No significant changes.
+### Changed
+
+- Alphabetized TANF non-cash gross income limit state entries.
 
 
 ## [1.706.9] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Added the Mass.gov guidance reference for Massachusetts Senior Circuit Breaker income sources.
 
 
 ## [1.706.8] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Updated the income sources documentation example to use the current microsimulation API.
 
 
 ## [1.706.7] - 2026-05-24
@@ -1829,26 +1868,36 @@ No significant changes.
 ### Fixed
 
 - Fixed `RuntimeWarning: invalid value encountered in divide` in `qbid_amount` when the QBI phaseout length parameter is zero. The unguarded `(taxinc_less_qbid - po_start) / po_length` is now `np.divide(..., where=po_length > 0)` with a fully-phased-out fallback. Resolves the QBI source of the divide warnings tracked in #8216.
+- Deprecated the legacy `has_marketplace_health_coverage` input and added ACA PTC regression coverage for reported Marketplace coverage flags.
 
 
 ## [1.706.6] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Add a code-health test for non-vectorized built-in sum calls over entity variables.
 
 
 ## [1.706.5] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Make future-year contrib reform tests robust to CPI forecast updates.
+- Fix Michigan homestead property tax credit eligibility for filers above the total household resources limit.
 
 
 ## [1.706.4] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Update Alaska Permanent Fund Dividend and energy relief amounts for 2025 and 2026.
 
 
 ## [1.706.3] - 2026-05-24
 
-No significant changes.
+### Added
+
+- Added an SSA disability-screen variable for data-backed SSI disability modeling.
 
 
 ## [1.706.2] - 2026-05-24
@@ -1860,7 +1909,9 @@ No significant changes.
 
 ## [1.706.1] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Enforced the section 415(c) annual additions limit on self-employed pension contributions.
 
 
 ## [1.706.0] - 2026-05-24
@@ -1872,17 +1923,23 @@ No significant changes.
 
 ## [1.705.23] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Fixed the DC property tax credit applying outside DC.
 
 
 ## [1.705.22] - 2026-05-24
 
-No significant changes.
+### Added
+
+- Added the Minnesota homeowner Homestead Credit Refund.
 
 
 ## [1.705.21] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Enforce the combined traditional and Roth IRA contribution limit.
 
 
 ## [1.705.20] - 2026-05-24
@@ -1902,7 +1959,9 @@ No significant changes.
 
 ## [1.705.17] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- State payroll wage bases are now organized by state program.
 
 
 ## [1.705.16] - 2026-05-24
@@ -1917,57 +1976,80 @@ No significant changes.
 
 ## [1.705.14] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Split Pennsylvania refundable credits from state income tax before refundable credits.
 
 
 ## [1.705.13] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Added Minnesota Paid Leave employee contributions to employee payroll taxes.
 
 
 ## [1.705.12] - 2026-05-24
 
-No significant changes.
+### Fixed
+
+- Added Pennsylvania employee unemployment compensation withholding to employee payroll taxes.
 
 
 ## [1.705.11] - 2026-05-23
 
-No significant changes.
+### Fixed
+
+- Fixed New Mexico modified gross income to include retirement account distributions.
 
 
 ## [1.705.10] - 2026-05-23
 
-No significant changes.
+### Added
+
+- Add explicit New Mexico, South Carolina, and West Virginia 529 plan contribution deductions.
 
 
 ## [1.705.9] - 2026-05-23
 
-No significant changes.
+### Fixed
+
+- Fixed Oklahoma's Child Care/Child Tax Credit to include federal non-refundable Child Tax Credit amounts used against federal income tax.
 
 
 ## [1.705.8] - 2026-05-23
 
-No significant changes.
+### Fixed
+
+- Fix long-run Social Security benefit aging to use gross Social Security benefits instead of taxable Social Security income.
 
 
 ## [1.705.7] - 2026-05-23
 
-No significant changes.
+### Fixed
+
+- Fixed Oklahoma sales tax relief credit gross income to net capital gains before applying the positive-only rule.
 
 
 ## [1.705.6] - 2026-05-23
 
-No significant changes.
+### Fixed
+
+- Fixed New Jersey filing-threshold zero-out logic in state income tax variables.
+- Fixed Montana joint capital gains tax threshold application.
 
 
 ## [1.705.5] - 2026-05-23
 
-No significant changes.
+### Added
+
+- Added a TAXSIM-compatible total FICA output variable.
 
 
 ## [1.705.4] - 2026-05-23
 
-No significant changes.
+### Fixed
+
+- State payroll taxes now use program-specific wage bases for pre-tax payroll deductions.
 
 
 ## [1.705.3] - 2026-05-23
@@ -1977,7 +2059,9 @@ No significant changes.
 
 ## [1.705.2] - 2026-05-23
 
-No significant changes.
+### Fixed
+
+- California now adds back Health Savings Account contributions for state income tax and payroll-tax wage bases.
 
 
 ## [1.705.1] - 2026-05-22
@@ -2003,7 +2087,9 @@ No significant changes.
 
 ## [1.703.2] - 2026-05-22
 
-No significant changes.
+### Fixed
+
+- Monthlyized federal SSI payments, SSI living arrangements, and state SSI supplements, added a fiscal-year SSI outlay variable, and marked countable resource balances as stock variables.
 
 
 ## [1.703.1] - 2026-05-21
@@ -2035,7 +2121,9 @@ No significant changes.
 
 ## [1.701.1] - 2026-05-21
 
-No significant changes.
+### Fixed
+
+- Keep the SSI substantial gainful activity screen separate from the data-backed SSI disability criteria variable and preserve data-backed SSI disability criteria across future analysis years.
 
 
 ## [1.701.0] - 2026-05-21
@@ -2054,7 +2142,9 @@ No significant changes.
 
 ## [1.700.1] - 2026-05-20
 
-No significant changes.
+### Added
+
+- Backfill HHS State Median Income parameter with FY2018 through FY2021 historical values.
 
 
 ## [1.700.0] - 2026-05-19
@@ -2062,10 +2152,12 @@ No significant changes.
 ### Added
 
 - Add statutory American Opportunity Credit student eligibility inputs and compute eligibility from those inputs.
+- Add a taxable Roth conversions input for tax-only retirement conversion modeling.
 
 ### Changed
 
 - Reintroduce age-specific labor supply response multipliers without changing the legacy scalar income elasticity path, and fix the labor-supply-response zero guard so nonzero primary or secondary substitution elasticities are not skipped.
+- Removed non-geographic guards from input variables so they remain pure data inputs, aligned CHIP take-up with other take-up input flags, removed the obsolete CHIP take-up seed/rate controls, and added checks preventing input variables from using formulas, adds, subtracts, or non-geographic `defined_for` gates.
 
 ### Fixed
 
@@ -2073,6 +2165,7 @@ No significant changes.
 - Count SSTB self-employment income in Social Security, state and benefit income definitions, and mixed-category QBID allocation.
 - Fixed Idaho's OBBBA Schedule 1-A deduction conformity after 2028.
 - Fix EITC earned income calculations for self-employment loss netting.
+- Add the missing FY2025 North Carolina SNAP telephone utility allowance.
 
 
 ## [1.699.1] - 2026-05-19
@@ -2105,6 +2198,7 @@ No significant changes.
 ### Added
 
 - YAML tests under tests/policy/baseline/partners/ that fail CI when a PR would change calculation results for any household API partner, surfaced as a standalone "Household API Partners" CI check. Includes (1) customer fixture mirrors for Amplifi, Impactica, and MyFriendBen, (2) analytics_coverage/ with 81 per-signature test cases grouped by state (one per unique input-variable shape sent through the production API), and (3) analytics_coverage/edge_cases/ with 642 boundary cases organized as federal/{category}/{program}/ (tax_credits, nutrition, healthcare, childcare, cash, housing, utility, composition) and state/{xx}/{program}.yaml. Cases target binding thresholds — income at FPL boundaries, age cutoffs, asset limits, immigration status, household composition — using state-aware values (e.g., per-state SNAP BBCE multipliers).
+- Add the District of Columbia Senior Citizen or Disabled Property Owner Tax Relief.
 
 
 ## [1.696.0] - 2026-05-19
@@ -2603,7 +2697,7 @@ No significant changes.
 
 ### Added
 
-- - Added 2026 ACA lowest-cost bronze plan (`lcbp`) rating-area premiums and bronze companion variables.
+- Added 2026 ACA lowest-cost bronze plan (`lcbp`) rating-area premiums and bronze companion variables.
 
 
 ## [1.667.1] - 2026-04-25

--- a/changelog.d/added/7548.md
+++ b/changelog.d/added/7548.md
@@ -1,1 +1,0 @@
-Add explicit New Mexico, South Carolina, and West Virginia 529 plan contribution deductions.

--- a/changelog.d/added/7946.md
+++ b/changelog.d/added/7946.md
@@ -1,1 +1,0 @@
-Add a taxable Roth conversions input for tax-only retirement conversion modeling.

--- a/changelog.d/added/8188.md
+++ b/changelog.d/added/8188.md
@@ -1,1 +1,0 @@
-Add selected Marketplace plan categories and ACA cost-sharing reduction actuarial value variables.

--- a/changelog.d/added/8194.md
+++ b/changelog.d/added/8194.md
@@ -1,1 +1,0 @@
-Add the District of Columbia Senior Citizen or Disabled Property Owner Tax Relief.

--- a/changelog.d/added/8271.md
+++ b/changelog.d/added/8271.md
@@ -1,1 +1,0 @@
-Added section 1115 minimum essential coverage adults to Medicaid work requirement applicability.

--- a/changelog.d/added/8294.md
+++ b/changelog.d/added/8294.md
@@ -1,1 +1,0 @@
-Added a TAXSIM-compatible total FICA output variable.

--- a/changelog.d/added/8349.md
+++ b/changelog.d/added/8349.md
@@ -1,1 +1,0 @@
-End New York's expanded Basic Health Program income limit after the 2026 waiver termination.

--- a/changelog.d/added/8355.md
+++ b/changelog.d/added/8355.md
@@ -1,1 +1,0 @@
-Backfill HHS State Median Income parameter with FY2018 through FY2021 historical values.

--- a/changelog.d/added/8397.md
+++ b/changelog.d/added/8397.md
@@ -1,1 +1,0 @@
-Added the Minnesota homeowner Homestead Credit Refund.

--- a/changelog.d/added/8441.md
+++ b/changelog.d/added/8441.md
@@ -1,1 +1,0 @@
-Added the Mississippi Working Disabled Medicaid buy-in pathway.

--- a/changelog.d/added/8442.md
+++ b/changelog.d/added/8442.md
@@ -1,1 +1,0 @@
-Added Mississippi Healthier Mississippi Waiver Medicaid eligibility.

--- a/changelog.d/added/issue-8267-medicaid-ce-pass-through.md
+++ b/changelog.d/added/issue-8267-medicaid-ce-pass-through.md
@@ -1,1 +1,0 @@
-Added Medicaid community engagement pass-through eligibility for SNAP and TANF work-compliance determinations.

--- a/changelog.d/added/ssa-disability-screen.md
+++ b/changelog.d/added/ssa-disability-screen.md
@@ -1,1 +1,0 @@
-Added an SSA disability-screen variable for data-backed SSI disability modeling.

--- a/changelog.d/alphabetize-tanf-gross-income-limits.md
+++ b/changelog.d/alphabetize-tanf-gross-income-limits.md
@@ -1,1 +1,0 @@
-- Alphabetized TANF non-cash gross income limit state entries.

--- a/changelog.d/changelog-repair.fixed.md
+++ b/changelog.d/changelog-repair.fixed.md
@@ -1,0 +1,1 @@
+Restored 52 changelog entries from 51 orphaned changelog.d fragments (type subdirectories and missing type suffixes, all merged 2026-05-19 to 2026-05-27) into the CHANGELOG.md sections of the releases that first shipped them, removed the orphaned fragments, and fixed 32 pre-existing double-bullet formatting artifacts.

--- a/changelog.d/chip-age-unit-package-description.md
+++ b/changelog.d/chip-age-unit-package-description.md
@@ -1,1 +1,0 @@
-- Fixed the CHIP child maximum age parameter unit and replaced the package description placeholder.

--- a/changelog.d/ct-eitc-bonus-eligibility.md
+++ b/changelog.d/ct-eitc-bonus-eligibility.md
@@ -1,1 +1,0 @@
-- Fixed the Connecticut EITC qualifying child bonus to require Connecticut EITC eligibility.

--- a/changelog.d/fixed/1030.md
+++ b/changelog.d/fixed/1030.md
@@ -1,1 +1,0 @@
-Added the Mass.gov guidance reference for Massachusetts Senior Circuit Breaker income sources.

--- a/changelog.d/fixed/1272.md
+++ b/changelog.d/fixed/1272.md
@@ -1,1 +1,0 @@
-Added a codified Tax Reform Code reference for the Pennsylvania income tax rate.

--- a/changelog.d/fixed/6035.md
+++ b/changelog.d/fixed/6035.md
@@ -1,1 +1,0 @@
-Update Alaska Permanent Fund Dividend and energy relief amounts for 2025 and 2026.

--- a/changelog.d/fixed/6975.md
+++ b/changelog.d/fixed/6975.md
@@ -1,1 +1,0 @@
-Fixed Oklahoma sales tax relief credit gross income to net capital gains before applying the positive-only rule.

--- a/changelog.d/fixed/7321.md
+++ b/changelog.d/fixed/7321.md
@@ -1,1 +1,0 @@
-Add a code-health test for non-vectorized built-in sum calls over entity variables.

--- a/changelog.d/fixed/7391.md
+++ b/changelog.d/fixed/7391.md
@@ -1,1 +1,0 @@
-Make future-year contrib reform tests robust to CPI forecast updates.

--- a/changelog.d/fixed/7492.md
+++ b/changelog.d/fixed/7492.md
@@ -1,1 +1,0 @@
-Derive monthly hours worked from last-week hours for Medicaid work requirements.

--- a/changelog.d/fixed/7920.md
+++ b/changelog.d/fixed/7920.md
@@ -1,1 +1,0 @@
-Updated the income sources documentation example to use the current microsimulation API.

--- a/changelog.d/fixed/7968.md
+++ b/changelog.d/fixed/7968.md
@@ -1,1 +1,0 @@
-Monthlyized federal SSI payments, SSI living arrangements, and state SSI supplements, added a fiscal-year SSI outlay variable, and marked countable resource balances as stock variables.

--- a/changelog.d/fixed/7985.md
+++ b/changelog.d/fixed/7985.md
@@ -1,1 +1,0 @@
-Add the missing FY2025 North Carolina SNAP telephone utility allowance.

--- a/changelog.d/fixed/8097.md
+++ b/changelog.d/fixed/8097.md
@@ -1,1 +1,0 @@
-Fixed New York Child Health Plus premiums above 400 percent FPL.

--- a/changelog.d/fixed/8187.md
+++ b/changelog.d/fixed/8187.md
@@ -1,1 +1,0 @@
-Deprecated the legacy `has_marketplace_health_coverage` input and added ACA PTC regression coverage for reported Marketplace coverage flags.

--- a/changelog.d/fixed/8239.md
+++ b/changelog.d/fixed/8239.md
@@ -1,1 +1,0 @@
-Fixed Oklahoma's Child Care/Child Tax Credit to include federal non-refundable Child Tax Credit amounts used against federal income tax.

--- a/changelog.d/fixed/8241.md
+++ b/changelog.d/fixed/8241.md
@@ -1,1 +1,0 @@
-Fix Michigan homestead property tax credit eligibility for filers above the total household resources limit.

--- a/changelog.d/fixed/8336.md
+++ b/changelog.d/fixed/8336.md
@@ -1,1 +1,0 @@
-Fix long-run Social Security benefit aging to use gross Social Security benefits instead of taxable Social Security income.

--- a/changelog.d/fixed/8343.md
+++ b/changelog.d/fixed/8343.md
@@ -1,1 +1,0 @@
-Fixed New Jersey filing-threshold zero-out logic in state income tax variables.

--- a/changelog.d/fixed/8344.md
+++ b/changelog.d/fixed/8344.md
@@ -1,1 +1,0 @@
-Fixed Montana joint capital gains tax threshold application.

--- a/changelog.d/fixed/8376.md
+++ b/changelog.d/fixed/8376.md
@@ -1,1 +1,0 @@
-California now adds back Health Savings Account contributions for state income tax and payroll-tax wage bases.

--- a/changelog.d/fixed/8379.md
+++ b/changelog.d/fixed/8379.md
@@ -1,1 +1,0 @@
-State payroll taxes now use program-specific wage bases for pre-tax payroll deductions.

--- a/changelog.d/fixed/8388.md
+++ b/changelog.d/fixed/8388.md
@@ -1,1 +1,0 @@
-Enforce the combined traditional and Roth IRA contribution limit.

--- a/changelog.d/fixed/8389.md
+++ b/changelog.d/fixed/8389.md
@@ -1,1 +1,0 @@
-Enforced the section 415(c) annual additions limit on self-employed pension contributions.

--- a/changelog.d/fixed/8395.md
+++ b/changelog.d/fixed/8395.md
@@ -1,1 +1,0 @@
-Fixed New Mexico modified gross income to include retirement account distributions.

--- a/changelog.d/fixed/8401.md
+++ b/changelog.d/fixed/8401.md
@@ -1,1 +1,0 @@
-Added Minnesota Paid Leave employee contributions to employee payroll taxes.

--- a/changelog.d/fixed/8405.md
+++ b/changelog.d/fixed/8405.md
@@ -1,1 +1,0 @@
-Split Pennsylvania refundable credits from state income tax before refundable credits.

--- a/changelog.d/fixed/8406.md
+++ b/changelog.d/fixed/8406.md
@@ -1,1 +1,0 @@
-Added Pennsylvania employee unemployment compensation withholding to employee payroll taxes.

--- a/changelog.d/fixed/8443.md
+++ b/changelog.d/fixed/8443.md
@@ -1,1 +1,0 @@
-Modeled SSI-recipient Medicaid eligibility for Section 209(b) states.

--- a/changelog.d/fixed/8496.md
+++ b/changelog.d/fixed/8496.md
@@ -1,1 +1,0 @@
-Add explicit Medicare Savings Program fiscal accounting for MSP-only beneficiaries.

--- a/changelog.d/fixed/dc-ptc-state-gate.md
+++ b/changelog.d/fixed/dc-ptc-state-gate.md
@@ -1,1 +1,0 @@
-Fixed the DC property tax credit applying outside DC.

--- a/changelog.d/fixed/fsla-overtime-input.md
+++ b/changelog.d/fixed/fsla-overtime-input.md
@@ -1,1 +1,0 @@
-Treat the FLSA overtime premium as a data-backed input instead of calculating it from annual hours and wages, and expose CPS occupation inputs used to construct it.

--- a/changelog.d/fixed/medicaid-ce-exclusions.md
+++ b/changelog.d/fixed/medicaid-ce-exclusions.md
@@ -1,1 +1,0 @@
-Add a Medicaid community engagement exclusion input for American Indian or Alaska Native status.

--- a/changelog.d/fixed/snap-work-requirement-issues.md
+++ b/changelog.d/fixed/snap-work-requirement-issues.md
@@ -1,1 +1,0 @@
-Fix SNAP work-requirement treatment for per-person disqualifications and OBBBA ABAWD Indian exemptions.

--- a/changelog.d/fixed/ssi-disability-input-only.md
+++ b/changelog.d/fixed/ssi-disability-input-only.md
@@ -1,2 +1,0 @@
-- Made `meets_ssi_disability_criteria` input-only so simulations use data-provided SSA disability-screen imputations instead of falling back to broad disability status.
-- Removed `ssi_federal_fiscal_year_outlays`; SSI formulas remain calendar-year oriented, with reusable payment-date helpers available in `policyengine_us.tools.ssi`.

--- a/changelog.d/fixed/ssi-disability-sga.md
+++ b/changelog.d/fixed/ssi-disability-sga.md
@@ -1,1 +1,0 @@
-Keep the SSI substantial gainful activity screen separate from the data-backed SSI disability criteria variable and preserve data-backed SSI disability criteria across future analysis years.

--- a/changelog.d/fixed/state-payroll-wage-base-organization.md
+++ b/changelog.d/fixed/state-payroll-wage-base-organization.md
@@ -1,1 +1,0 @@
-State payroll wage bases are now organized by state program.

--- a/changelog.d/pure-leaf-inputs.md
+++ b/changelog.d/pure-leaf-inputs.md
@@ -1,1 +1,0 @@
-- Removed non-geographic guards from input variables so they remain pure data inputs, aligned CHIP take-up with other take-up input flags, removed the obsolete CHIP take-up seed/rate controls, and added checks preventing input variables from using formulas, adds, subtracts, or non-geographic `defined_for` gates.


### PR DESCRIPTION
Fixes #9149.

## What this does

**Commit 1 — historical repair.** Restores the 52 changelog entries from the 51 orphaned `changelog.d/` fragments (47 in type subdirectories + 4 top-level missing the `.<type>.` suffix; one file carried two entries) into the `CHANGELOG.md` sections of the releases that actually first shipped them, then deletes the orphans. Also fixes 32 pre-existing `- - ` double-bullet artifacts (fragments that carried their own leading dash, doubled by towncrier). Formatting-only for existing entries — no released entry's text was altered.

**Commit 2 — enforcement.** Adds a tree-state step to the `Check changelog fragment` job: any tracked file under `changelog.d/` that isn't `.gitkeep` or a top-level `<name>.<type>.md` now fails CI. The existing check only inspects PR-changed files, which is how the orphans accumulated between the towncrier migration (#7488) and the path-validation check (2026-05-27). Landing enforcement in the same PR as the cleanup makes the invariant atomic.

## Why historical repair (vs. dumping into the next release, or writing off)

All 50 orphan-adding commits shipped **only** the orphan — none had a valid fragment alongside — so these entries are the sole changelog record of ~51 changes released in May 2026 (verified: sampled orphan content appears nowhere in any released CHANGELOG.md). Renaming them into live fragments would misdate them ~2 months and force a spurious minor bump from the 13 `added` entries; deleting them would preserve a permanent gap in the public record. Adjudicated with a second-model review (sol) concurring on repair + same-PR enforcement.

## Method and verification

- Mapping: each orphan's adding commit → first `Update PolicyEngine US` bump commit on main's first-parent chain → the version stamped in that commit's `pyproject.toml`. Entry type = the original author's declaration (the subdirectory name; the 4 suffixless classified from content, noted below).
- Insertion preserves the canonical heading order (Breaking changes/Added/Changed/Fixed/Removed), creates missing headings in position, appends after the last bullet of an existing heading, and removes `No significant changes.` from any section gaining content.
- Receipts: script run is **deterministic and idempotent** (first run `inserted=52`; rerun `inserted=0 already-present=52`); post-repair structure checks: 0 sections with heading-order violations or duplicate headings, 0 sections mixing `No significant changes.` with content, 0 remaining `- - ` artifacts; `towncrier build --draft` renders normally against the repaired file (prepend pipeline unaffected).
- Suffixless classifications: `alphabetize-tanf-gross-income-limits` → Changed, `chip-age-unit-package-description` → Fixed, `ct-eitc-bonus-eligibility` → Fixed, `pure-leaf-inputs` → Changed.

<details><summary>Full fragment → release mapping (51 files, 52 entries)</summary>


| Fragment | Type | Added by | PR/commit subject | Restored under | Result |
|---|---|---|---|---|---|
| `changelog.d/added/7548.md` | added | `a4be56977c` | Add NM, SC, and WV 529 plan deductions | 1.705.10 | inserted |
| `changelog.d/added/7946.md` | added | `20927f088e` | Add a tax-only Roth conversion input (#7946) | 1.700.0 | inserted |
| `changelog.d/added/8188.md` | added | `07acc70c80` | Add ACA cost-sharing reduction actuarial values | 1.722.0 | inserted |
| `changelog.d/added/8194.md` | added | `3830c85a8c` | Add DC senior disabled property tax relief | 1.697.0 | inserted |
| `changelog.d/added/8271.md` | added | `6ef6346b3c` | Add Medicaid 1115 adult work requirement scope (#8505) | 1.710.2 | inserted |
| `changelog.d/added/8294.md` | added | `29affcd12c` | Add TAXSIM total FICA output (#8383) | 1.705.5 | inserted |
| `changelog.d/added/8349.md` | added | `07be47bda1` | Update NY Essential Plan expansion after 2026 waiver termination | 1.722.0 | inserted |
| `changelog.d/added/8355.md` | added | `96c878259b` | Backfill HHS SMI parameter with FY2018, FY2020, and FY2021 historical values | 1.700.1 | inserted |
| `changelog.d/added/8397.md` | added | `f397006735` | Add Minnesota Homestead Credit Refund (#8417) | 1.705.22 | inserted |
| `changelog.d/added/8441.md` | added | `a339a03a5f` | Add Mississippi working disabled Medicaid buy-in | 1.706.16 | inserted |
| `changelog.d/added/8442.md` | added | `d3c35b978d` | Add Mississippi Healthier Medicaid waiver eligibility | 1.706.16 | inserted |
| `changelog.d/added/issue-8267-medicaid-ce-pass-through.md` | added | `d5b8379b2f` | Add Medicaid CE SNAP TANF pass-through | 1.706.15 | inserted |
| `changelog.d/added/ssa-disability-screen.md` | added | `fa2594a08f` | Add SSI disability criteria input (#8398) | 1.706.3 | inserted |
| `changelog.d/fixed/1030.md` | fixed | `6c5eaa554b` | Cite Massachusetts Senior Circuit Breaker income guidance (#8436) | 1.706.9 | inserted |
| `changelog.d/fixed/1272.md` | fixed | `7857196824` | Cite Pennsylvania income tax rate code (#8435) | 1.706.12 | inserted |
| `changelog.d/fixed/6035.md` | fixed | `17f66dd22b` | Update Alaska PFD amounts (#8421) | 1.706.4 | inserted |
| `changelog.d/fixed/6975.md` | fixed | `e2a06f4d25` | Fix OK STC capital gains gross income | 1.705.7 | inserted |
| `changelog.d/fixed/7321.md` | fixed | `f6b062c420` | Add vectorized sum code-health test (#8426) | 1.706.6 | inserted |
| `changelog.d/fixed/7391.md` | fixed | `d6ddcd7991` | Harden contrib reform tests against CPI updates (#8425) | 1.706.5 | inserted |
| `changelog.d/fixed/7492.md` | fixed | `cb3625f94f` | Derive monthly hours worked from last week (#8507) | 1.710.1 | inserted |
| `changelog.d/fixed/7920.md` | fixed | `6a1b962176` | Update income sources docs example (#8434) | 1.706.8 | inserted |
| `changelog.d/fixed/7968.md` | fixed | `ca6f5a6b66` | Monthlyize SSI payments and resource stocks (#8375) | 1.703.2 | inserted |
| `changelog.d/fixed/7985.md` | fixed | `53089b51bc` | Add NC FY2025 SNAP phone allowance (#7985) | 1.700.0 | inserted |
| `changelog.d/fixed/8097.md` | fixed | `510dfab734` | Fix NY Child Health Plus full-premium tier | 1.722.0 | inserted |
| `changelog.d/fixed/8187.md` | fixed | `dc37dbb601` | Deprecate legacy Marketplace coverage input (#8432) | 1.706.7 | inserted |
| `changelog.d/fixed/8239.md` | fixed | `1e187b5567` | Fix Oklahoma child credit federal CTC match | 1.705.9 | inserted |
| `changelog.d/fixed/8241.md` | fixed | `886022254b` | Fix Michigan homestead property tax credit income limit (#8424) | 1.706.5 | inserted |
| `changelog.d/fixed/8336.md` | fixed | `f2b90af06a` | Fix Social Security benefit aging uprater (#8381) | 1.705.8 | inserted |
| `changelog.d/fixed/8343.md` | fixed | `eb27050230` | Fix NJ and MT state tax edge cases | 1.705.6 | inserted |
| `changelog.d/fixed/8344.md` | fixed | `eb27050230` | Fix NJ and MT state tax edge cases | 1.705.6 | inserted |
| `changelog.d/fixed/8376.md` | fixed | `c55e08465c` | Fix California HSA wage addback (#8378) | 1.705.2 | inserted |
| `changelog.d/fixed/8379.md` | fixed | `203913f016` | Fix state payroll tax wage bases | 1.705.4 | inserted |
| `changelog.d/fixed/8388.md` | fixed | `9013c73de8` | Enforce IRA contribution limits (#8416) | 1.705.21 | inserted |
| `changelog.d/fixed/8389.md` | fixed | `f261de7bfa` | Cap self-employed pension contributions (#8419) | 1.706.1 | inserted |
| `changelog.d/fixed/8395.md` | fixed | `00e0f0e62f` | Fix NM modified gross income retirement distributions | 1.705.11 | inserted |
| `changelog.d/fixed/8401.md` | fixed | `571740b137` | Add Minnesota Paid Leave employee payroll tax (#8408) | 1.705.13 | inserted |
| `changelog.d/fixed/8405.md` | fixed | `26310eb13e` | Split Pennsylvania refundable credits (#8409) | 1.705.14 | inserted |
| `changelog.d/fixed/8406.md` | fixed | `742d9e4f04` | Add Pennsylvania employee UC payroll tax (#8407) | 1.705.12 | inserted |
| `changelog.d/fixed/8443.md` | fixed | `887bed9cc9` | Model SSI Medicaid eligibility in 209b states | 1.706.16 | inserted |
| `changelog.d/fixed/8496.md` | fixed | `d613be6605` | Add MSP fiscal accounting | 1.706.16 | inserted |
| `changelog.d/fixed/dc-ptc-state-gate.md` | fixed | `b0f124abfb` | Limit DC property tax credit to DC (#8418) | 1.705.23 | inserted |
| `changelog.d/fixed/fsla-overtime-input.md` | fixed | `c5a4dfbf2f` | Make FLSA overtime premium a data input (#8429) | 1.706.14 | inserted |
| `changelog.d/fixed/medicaid-ce-exclusions.md` | fixed | `e71157a6a0` | Add Medicaid CE exclusion inputs (#8377) | 1.710.6 | inserted |
| `changelog.d/fixed/snap-work-requirement-issues.md` | fixed | `eb6ff02979` | Fix SNAP work requirement issues (#8372) | 1.710.5 | inserted |
| `changelog.d/fixed/ssi-disability-input-only.md` | fixed | `1c0bd159a5` | Make SSI disability criteria input-only (#8428) | 1.710.3 | inserted,inserted |
| `changelog.d/fixed/ssi-disability-sga.md` | fixed | `99f65ffd4d` | Keep SSI SGA screen separate from disability criteria (#8365) | 1.701.1 | inserted |
| `changelog.d/fixed/state-payroll-wage-base-organization.md` | fixed | `6671586661` | Organize state payroll wage bases by program (#8382) | 1.705.17 | inserted |
| `changelog.d/alphabetize-tanf-gross-income-limits.md` | changed | `2b01631b62` | Alphabetize TANF gross income limits (#8439) | 1.706.10 | inserted |
| `changelog.d/chip-age-unit-package-description.md` | fixed | `f66aba808c` | Fix CHIP age unit and package description (#8437) | 1.706.13 | inserted |
| `changelog.d/ct-eitc-bonus-eligibility.md` | fixed | `4ff151180e` | Fix Connecticut EITC bonus eligibility (#8438) | 1.706.11 | inserted |
| `changelog.d/pure-leaf-inputs.md` | changed | `e58b53d3b3` | Make input variables pure leaves (#8162) | 1.700.0 | inserted |

</details>

<details><summary>Repair script (one-time, run from repo root)</summary>

```python
#!/usr/bin/env python3
"""One-time historical repair: insert orphaned changelog.d fragments into the
CHANGELOG.md sections of the releases that actually first shipped them.

Deterministic and idempotent: reruns insert nothing. Fails loudly on any
unmapped orphan, missing release section, or count mismatch.
Outputs a markdown mapping table (for the PR body) to stdout.
"""

import glob
import re
import subprocess
import sys
from pathlib import Path

REPO = Path.cwd()
HEADING_ORDER = ["Breaking changes", "Added", "Changed", "Fixed", "Removed"]
TYPE_TO_HEADING = {
    "breaking": "Breaking changes",
    "added": "Added",
    "changed": "Changed",
    "fixed": "Fixed",
    "removed": "Removed",
}
# The four suffixless top-level orphans, classified from their content.
SUFFIXLESS = {
    "changelog.d/alphabetize-tanf-gross-income-limits.md": "changed",
    "changelog.d/chip-age-unit-package-description.md": "fixed",
    "changelog.d/ct-eitc-bonus-eligibility.md": "fixed",
    "changelog.d/pure-leaf-inputs.md": "changed",
}


def run(*args: str) -> str:
    return subprocess.run(args, check=True, capture_output=True, text=True).stdout


def orphan_files() -> list[tuple[str, str]]:
    files: list[tuple[str, str]] = []
    for type_dir in ("added", "fixed"):
        for path in sorted(glob.glob(f"changelog.d/{type_dir}/*.md")):
            files.append((path, type_dir))
    for path, type_ in SUFFIXLESS.items():
        if Path(path).exists():
            files.append((path, type_))
    return files


def entry_texts(path: str) -> list[str]:
    """A fragment is usually one entry, but a file whose lines each start with
    '- ' carries multiple entries; keep them as separate bullets."""
    raw_lines = [l.strip() for l in Path(path).read_text().strip().splitlines()]
    raw_lines = [l for l in raw_lines if l]
    if len(raw_lines) > 1 and all(l.startswith("- ") for l in raw_lines):
        return [re.sub(r"^-\s+", "", l).strip() for l in raw_lines]
    text = re.sub(r"^-\s+", "", " ".join(raw_lines)).strip()
    return [text]


def adding_commit(path: str) -> str:
    out = run("git", "log", "--diff-filter=A", "--format=%H", "--", path)
    shas = out.split()
    if not shas:
        sys.exit(f"FATAL: no adding commit for {path}")
    return shas[-1]  # oldest add


def first_bump_after(sha: str, cache: dict[str, str]) -> str:
    if sha in cache:
        return cache[sha]
    out = run(
        "git", "rev-list", "--first-parent", "--reverse", "--format=%H %s",
        f"^{sha}", "upstream/main",
    )
    for line in out.splitlines():
        if line.startswith("commit "):
            continue
        commit, _, subject = line.partition(" ")
        if subject.strip() == "Update PolicyEngine US":
            cache[sha] = commit
            return commit
    sys.exit(f"FATAL: no version-bump commit found after {sha}")


def bump_version(bump_sha: str, cache: dict[str, str]) -> str:
    if bump_sha in cache:
        return cache[bump_sha]
    toml = run("git", "show", f"{bump_sha}:pyproject.toml")
    m = re.search(r'^version\s*=\s*"([^"]+)"', toml, re.M)
    if not m:
        sys.exit(f"FATAL: no version in pyproject.toml at {bump_sha}")
    cache[bump_sha] = m.group(1)
    return m.group(1)


def insert(lines: list[str], version: str, heading: str, bullet: str) -> str:
    """Insert bullet under `### {heading}` in section `## [{version}]`.
    Returns 'inserted' or 'already-present'. Mutates lines."""
    sec_start = None
    for i, line in enumerate(lines):
        if line.startswith(f"## [{version}] - "):
            sec_start = i
            break
    if sec_start is None:
        sys.exit(f"FATAL: no CHANGELOG section for version {version}")
    sec_end = len(lines)
    for i in range(sec_start + 1, len(lines)):
        if lines[i].startswith("## ["):
            sec_end = i
            break
    if bullet in lines[sec_start:sec_end]:
        return "already-present"
    # A section gaining real content must drop its "No significant changes." line.
    for i in range(sec_end - 1, sec_start, -1):
        if lines[i] == "No significant changes.":
            del lines[i]
            if i < len(lines) and lines[i] == "" and lines[i - 1] == "":
                del lines[i]
    # Recompute section end after possible deletion.
    sec_end = len(lines)
    for i in range(sec_start + 1, len(lines)):
        if lines[i].startswith("## ["):
            sec_end = i
            break
    # Find the heading inside the section.
    head_idx = None
    for i in range(sec_start + 1, sec_end):
        if lines[i] == f"### {heading}":
            head_idx = i
            break
    if head_idx is not None:
        # Append after the last bullet of this heading's block.
        j = head_idx + 1
        last_bullet = None
        while j < sec_end and not lines[j].startswith("### "):
            if lines[j].startswith("- "):
                last_bullet = j
            j += 1
        insert_at = (last_bullet + 1) if last_bullet is not None else head_idx + 2
        lines.insert(insert_at, bullet)
        return "inserted"
    # Create the heading at its canonical position among existing headings.
    rank = HEADING_ORDER.index(heading)
    insert_at = None
    for i in range(sec_start + 1, sec_end):
        if lines[i].startswith("### "):
            existing = lines[i][4:]
            if existing in HEADING_ORDER and HEADING_ORDER.index(existing) > rank:
                insert_at = i
                break
    if insert_at is None:
        insert_at = sec_end - 1  # before the trailing blanks preceding next section
        while insert_at > sec_start and lines[insert_at - 1] == "":
            insert_at -= 1
        # keep exactly one blank line between previous content and new heading
        lines[insert_at:insert_at] = ["", f"### {heading}", "", bullet]
        return "inserted"
    lines[insert_at:insert_at] = [f"### {heading}", "", bullet, ""]
    return "inserted"


def main() -> None:
    changelog = REPO / "CHANGELOG.md"
    lines = changelog.read_text().splitlines()
    bump_cache: dict[str, str] = {}
    version_cache: dict[str, str] = {}
    rows = []
    inserted = present = bullets_total = 0
    orphans = orphan_files()
    for path, type_ in orphans:
        texts = entry_texts(path)
        if not texts or not all(texts):
            sys.exit(f"FATAL: empty fragment {path}")
        sha = adding_commit(path)
        bump = first_bump_after(sha, bump_cache)
        version = bump_version(bump, version_cache)
        heading = TYPE_TO_HEADING[type_]
        subject = run("git", "log", "-1", "--format=%s", sha).strip()
        results = []
        for text in texts:
            bullets_total += 1
            result = insert(lines, version, heading, f"- {text}")
            results.append(result)
            if result == "inserted":
                inserted += 1
            else:
                present += 1
        rows.append((path, type_, sha[:10], subject, version, ",".join(results)))
    # Repair pre-existing "- - " double-bullet artifacts (fragments that
    # carried their own leading dash, doubled by towncrier).
    double_bullets = 0
    for i, line in enumerate(lines):
        if line.startswith("- - "):
            lines[i] = line[2:]
            double_bullets += 1
    changelog.write_text("\n".join(lines) + "\n")
    print(
        f"orphans={len(orphans)} bullets={bullets_total} inserted={inserted} "
        f"already-present={present} double-bullets-fixed={double_bullets}\n"
    )
    print("| Fragment | Type | Added by | PR/commit subject | Restored under | Result |")
    print("|---|---|---|---|---|---|")
    for path, type_, sha, subject, version, result in rows:
        subject = subject.replace("|", "\\|")
        print(f"| `{path}` | {type_} | `{sha}` | {subject} | {version} | {result} |")
    if inserted + present != bullets_total:
        sys.exit("FATAL: count mismatch")


if __name__ == "__main__":
    main()
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
