### PR TITLE
Close out state CTC federal-conformance audit (NC/CO/UT)

### DIFF
--- a/changelog.d/ctc-audit-nc-co-ut-followup.changed.md
+++ b/changelog.d/ctc-audit-nc-co-ut-followup.changed.md
@@ -1,0 +1,1 @@
+Add regression and boundary tests for the state CTC federal-conformance audit (NC ITIN-filer child deduction, CO rate-branch flip date) and cite the Utah CTC statute.

--- a/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/co/tax/income/credits/ctc/co_ctc.yaml
@@ -416,3 +416,18 @@
     co_ctc_eligible_children_count: 1
     # Non-zero refundable CTC driven entirely by the ITIN under-6 child.
     co_refundable_ctc: 1_500
+
+# Boundary guard for the ctc_matched_federal_credit flip date (2022-01-01 true ->
+# 2024-01-01 false). 2023 must still use the rate x co_federal_ctc branch, not the
+# 2024+ flat-per-child branch. Mirrors the 2022 single/agi=25k/federal=1_000 case.
+# HB23-1112; ctc_matched_federal_credit.yaml.
+- name: In 2023, single filer, agi = 25_000, federal ctc = 1_000, rate branch still active - co_ctc = 600
+  period: 2023
+  input:
+    state_code: CO
+    adjusted_gross_income: 25_000
+    co_federal_ctc: 1_000
+    filing_status: SINGLE
+    age: 5
+  output:
+    co_ctc: 600

--- a/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_child_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nc/tax/income/deductions/nc_child_deduction.yaml
@@ -57,3 +57,33 @@
     ctc_qualifying_children: 1
   output:
     nc_child_deduction: 2_000 * 1
+
+# Regression guard for the #6374 NC resolution: NC is a static IRC-conformity state
+# (conformed to the Code as of Jan 1, 2023, N.C. Gen. Stat. 105-228.90(b)(1b)), so it
+# does NOT import the OBBBA (July 2025) filer-SSN gate on section 24. An ITIN filer
+# whose qualifying child has a valid SSN still receives the NC child deduction, because
+# nc_child_deduction keys on ctc_qualifying_children (child-SSN gate only), not the
+# federal filer-SSN gate. Fails if a filer-SSN gate is ever propagated into the NC count.
+- name: NC child deduction counts an SSN-holding child of an ITIN filer in 2025
+  period: 2025
+  input:
+    people:
+      parent:
+        age: 40
+        ssn_card_type: OTHER_NON_CITIZEN  # ITIN filer, no SSN
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+        ssn_card_type: CITIZEN            # child has a valid SSN
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+        adjusted_gross_income: 25_000
+    households:
+      household:
+        members: [parent, child]
+        state_code: NC
+  output:
+    ctc_qualifying_children: 1
+    nc_child_deduction: 3_000

--- a/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc_potential.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/credits/child_tax_credit/ut_ctc_potential.py
@@ -7,6 +7,7 @@ class ut_ctc_potential(Variable):
     label = "Utah Child Tax Credit"
     unit = USD
     definition_period = YEAR
+    reference = "https://le.utah.gov/xcode/Title59/Chapter10/59-10-S1047.html"
     defined_for = StateCode.UT
 
     def formula(tax_unit, period, parameters):


### PR DESCRIPTION
## What

Closes out the state CTC ↔ federal-conformance audit (#6374) by resolving its three remaining watch-items. Two are verification/regression-only (no behavior change); one adds a missing reference.

### NC — regression test (no code change)
The audit's open question was whether NC's "allowed the federal §24 credit" language re-imports the OBBBA (July 2025) **filer**-SSN gate. It does not: NC is a **static IRC-conformity** state, conformed to the Code **as of Jan 1, 2023** (N.C. Gen. Stat. §105-228.90(b)(1b)), and NCDOR's TY2025 guidance confirms NC does not conform to OBBBA for 2025. §24's child-SSN rule (TCJA, 2018) is in the Jan-1-2023 Code and is correctly imported via `ctc_qualifying_children`; the filer-SSN rule (2025) is not. This PR adds a regression test: a 2025 ITIN filer whose qualifying child has a valid SSN still receives the NC child deduction. It fails if a filer-SSN gate is ever propagated into the NC count.

### CO — boundary test (no code change)
`co_ctc` selects between `rate × co_federal_ctc` (2022–2023) and a flat per-child amount (2024+) via `ctc_matched_federal_credit` (true → false at 2024-01-01). The existing unit tests jumped from 2022 to 2024, leaving the flip date unguarded. Verified the 2022 tests correctly exercise the rate branch (no mismatch — the watch-item was a false alarm), and added a **2023** case pinning the rate branch is still active in 2023.

### UT — missing reference
`ut_ctc_potential.py` had no `reference`. Added Utah Code §59-10-1047 (the statute the surrounding parameters already cite).

## Testing
- NC `nc_child_deduction.yaml`: 7 passed
- CO `co_ctc.yaml`: 28 passed
- UT `ut_ctc.yaml`: 14 passed

Fixes #6374.

The two remaining audit notes are indefinite watch-items with no action needed today: GA/ID cite §24(c) (the definition subsection, silent on SSNs) with no evidence either state intends ITIN eligibility — revisit only if a DOR confirms coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
