### PR TITLE
Apply IA pension exclusion married cap as a combined limit

### DIFF
--- a/changelog.d/fix-ia-pension-exclusion-combined-cap.fixed.md
+++ b/changelog.d/fix-ia-pension-exclusion-combined-cap.fixed.md
@@ -1,0 +1,1 @@
+Apply the Iowa pension exclusion's married cap as a combined $12,000 limit prorated across eligible spouses, per the 2021 IA Expanded Instructions, instead of up to $12,000 per spouse.

--- a/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_pension_exclusion.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ia/tax/income/ia_pension_exclusion.yaml
@@ -117,3 +117,76 @@
         state_code: IA
   output:
     ia_pension_exclusion: [1_000, 7_000]
+
+- name: Married cap is a combined $12,000, prorated across eligible spouses (issue 9155, taxsim issue 1110)
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        ia_pension_exclusion_eligible: true
+        taxable_pension_income: 22_087
+      person2:
+        is_tax_unit_spouse: true
+        ia_pension_exclusion_eligible: true
+        taxable_pension_income: 22_087
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IA
+  output:
+    # Combined exclusion capped at 12,000, not 12,000 per spouse.
+    ia_pension_exclusion: [6_000, 6_000]
+
+- name: Single eligible spouse takes the full couple limit share (2021 Expanded Instructions p. 27, Example 2)
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        ia_pension_exclusion_eligible: false
+        taxable_pension_income: 10_000
+      person2:
+        is_tax_unit_spouse: true
+        ia_pension_exclusion_eligible: true
+        taxable_pension_income: 8_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IA
+  output:
+    # No per-spouse $6,000 sub-cap: the eligible spouse excludes all 8,000
+    # against the couple's combined 12,000 limit.
+    ia_pension_exclusion: [0, 8_000]
+
+- name: Combined cap prorated by each eligible spouse's pension share
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        ia_pension_exclusion_eligible: true
+        taxable_pension_income: 30_000
+      person2:
+        is_tax_unit_spouse: true
+        ia_pension_exclusion_eligible: true
+        taxable_pension_income: 10_000
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: IA
+  output:
+    # 12,000 x 30/40 and 12,000 x 10/40.
+    ia_pension_exclusion: [9_000, 3_000]

--- a/policyengine_us/variables/gov/states/ia/tax/income/net_income/ia_pension_exclusion.py
+++ b/policyengine_us/variables/gov/states/ia/tax/income/net_income/ia_pension_exclusion.py
@@ -8,15 +8,22 @@ class ia_pension_exclusion(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://revenue.iowa.gov/sites/default/files/2023-01/2021%20Expanded%20Instructions_010323.pdf#page=26",
+        "https://revenue.iowa.gov/sites/default/files/2023-01/2021%20Expanded%20Instructions_010323.pdf#page=27",
         "https://revenue.iowa.gov/sites/default/files/2023-03/2022%20Expanded%20Instructions_022023.pdf#page=26",
     )
     defined_for = "ia_pension_exclusion_eligible"
 
     def formula(person, period, parameters):
         p = parameters(period).gov.states.ia.tax.income.pension_exclusion
-        # determine pension exclusion amount
         pension = person("taxable_pension_income", period)
+        eligible = person("ia_pension_exclusion_eligible", period)
+        eligible_pension = pension * eligible
         filing_status = person.tax_unit("filing_status", period)
         exclusion_cap = p.maximum_amount[filing_status]
-        return min_(pension, exclusion_cap)
+        # The cap is a combined limit for the tax unit ("a married couple is
+        # allowed a combined exclusion of up to $12,000"); allocate it across
+        # eligible spouses in proportion to each one's pension income.
+        unit_eligible_pension = person.tax_unit.sum(eligible_pension)
+        unit_exclusion = min_(unit_eligible_pension, exclusion_cap)
+        denominator = where(unit_eligible_pension > 0, unit_eligible_pension, 1)
+        return eligible_pension / denominator * unit_exclusion


### PR DESCRIPTION
Fixes #9155

Surfaced by PolicyEngine/policyengine-taxsim#1110 (IA 2021, married separate-on-combined, ages 58/57, $44,174 of pensions split evenly between spouses).

## Changes

The 2021 IA Expanded Instructions (p. 27, the variable's own reference) make the married pension-exclusion cap a **combined** limit: "a married couple is allowed a combined exclusion of up to $12,000" (Example 2), limited to each eligible (55+/disabled) spouse's own pension, with no per-spouse $6,000 sub-cap.

`ia_pension_exclusion` previously applied `min(pension, maximum_amount[filing_status])` per person, letting each eligible spouse exclude up to $12,000 — $24,000 per couple. The formula now caps the tax-unit total of eligible pension at the filing-status maximum and prorates it across eligible spouses by pension share.

Inert for 2023+ (the cap is `.inf`). No parameter changes.

## Validation

Against the #1110 record (IA 1040: exclusion 6,000 + 6,000, net income 151,511, tax before credits 7,154 + 596 = 7,750, tax after exemption credits 7,670):

| | Before | After | IA 1040 |
|---|---|---|---|
| Pension exclusion | 24,000 | 12,000 | 12,000 |
| Net income | 139,511 | 151,511 | 151,511 |
| Tax before credits | 6,919.50 | 7,749.70 | 7,750 |
| Tax after exemption credits | 6,839.50 | 7,669.70 | 7,670 |

New tests: the #1110 both-spouses-over-cap case ([6,000, 6,000]), Example 2 from the instructions (single eligible spouse excludes the full $8,000), and uneven proration ([9,000, 3,000] on 30k/10k). All 10 tests in the file pass locally, including the 7 pre-existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
