### PR TITLE
Fix SNAP rounding for income limits and minimum allotment

### DIFF
--- a/changelog.d/fix-snap-rounding.fixed.md
+++ b/changelog.d/fix-snap-rounding.fixed.md
@@ -1,0 +1,1 @@
+Round SNAP monthly gross and net income eligibility standards up to the next whole dollar (7 CFR 273.9(a)(3)) and the minimum allotment to the nearest whole dollar (7 CFR 273.10(e)(2)(ii)(C)), matching USDA published values.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_gross_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_gross_income_test.yaml
@@ -29,3 +29,62 @@
     has_snap_elderly_disabled_member: true
   output:
     meets_snap_gross_income_test: true
+
+- name: Monthly gross standard rounds up to the next whole dollar
+  period: 2022
+  input:
+    # $1,302 per month against a $1,000.83 monthly poverty guideline;
+    # 130% of the guideline is $1,301.08, which 7 CFR 273.9(a)(3)(i)
+    # rounds up to $1,302.
+    snap_gross_test_income: 15_624
+    snap_fpg: 12_010
+  output:
+    meets_snap_gross_income_test: true
+
+- name: Income above the rounded monthly gross standard fails
+  period: 2022
+  input:
+    # $1,303 per month against the rounded $1,302 monthly standard.
+    snap_gross_test_income: 15_636
+    snap_fpg: 12_010
+  output:
+    meets_snap_gross_income_test: false
+
+- name: Missouri three-person household at the published FY 2026 gross limit passes
+  period: 2026-01
+  input:
+    people:
+      person1: {}
+      person2: {}
+      person3: {}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        # USDA FY 2026 gross monthly income limit for a household of three:
+        # 130% of the $26,650 annual poverty guideline / 12 = $2,887.08,
+        # rounded up to $2,888.
+        snap_gross_test_income: 2_888
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MO
+  output:
+    meets_snap_gross_income_test: true
+
+- name: Missouri three-person household just above the published FY 2026 gross limit fails
+  period: 2026-01
+  input:
+    people:
+      person1: {}
+      person2: {}
+      person3: {}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        snap_gross_test_income: 2_889
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MO
+  output:
+    meets_snap_gross_income_test: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_net_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_net_income_test.yaml
@@ -6,13 +6,75 @@
 - name: Income up to 100% meets test
   period: 2022
   input:
-    snap_net_income_fpg_ratio: 1
+    # $1,000 per month against a $1,000 monthly poverty guideline.
+    snap_net_income: 12_000
+    snap_fpg: 12_000
   output:
     meets_snap_net_income_test: true
 
 - name: Income above 100% fails test
   period: 2022
   input:
-    snap_net_income_fpg_ratio: 1.01
+    # $1,010 per month against a $1,000 monthly poverty guideline.
+    snap_net_income: 12_120
+    snap_fpg: 12_000
+  output:
+    meets_snap_net_income_test: false
+
+- name: Monthly net standard rounds up to the next whole dollar
+  period: 2022
+  input:
+    # $1,001 per month against a $1,000.83 monthly poverty guideline;
+    # 7 CFR 273.9(a)(3)(ii) rounds the monthly standard up to $1,001.
+    snap_net_income: 12_012
+    snap_fpg: 12_010
+  output:
+    meets_snap_net_income_test: true
+
+- name: Income above the rounded monthly net standard fails
+  period: 2022
+  input:
+    # $1,002 per month against the rounded $1,001 monthly standard.
+    snap_net_income: 12_024
+    snap_fpg: 12_010
+  output:
+    meets_snap_net_income_test: false
+
+- name: Missouri three-person household at the published FY 2026 net limit passes
+  period: 2026-01
+  input:
+    people:
+      person1: {}
+      person2: {}
+      person3: {}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        # USDA FY 2026 net monthly income limit for a household of three:
+        # $26,650 annual poverty guideline / 12 = $2,220.83, rounded up
+        # to $2,221.
+        snap_net_income: 2_221
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MO
+  output:
+    meets_snap_net_income_test: true
+
+- name: Missouri three-person household just above the published FY 2026 net limit fails
+  period: 2026-01
+  input:
+    people:
+      person1: {}
+      person2: {}
+      person3: {}
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+        snap_net_income: 2_222
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MO
   output:
     meets_snap_net_income_test: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/snap_work_requirement_disqualification_income_treatment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/snap_work_requirement_disqualification_income_treatment.yaml
@@ -66,8 +66,11 @@
     # exceed the 2-person limits. When the earner fails the ABAWD time
     # limit, 273.11(c)(2) counts half his income toward the remaining
     # 1-person unit, which qualifies: proration can create eligibility.
+    # The unit receives the minimum allotment, rounded to the nearest
+    # whole dollar per 7 CFR 273.10(e)(2)(ii)(C): $24 for the nine
+    # FY 2026 months plus $25 for the three uprated FY 2027 months.
     is_snap_eligible: true
-    snap: 288.61
+    snap: 291
 
 - name: Case 3, over-income household stays ineligible when the earner is sanctioned under the general work requirements.
   period: 2026

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_min_allotment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_min_allotment.yaml
@@ -73,3 +73,25 @@
     state_group: CONTIGUOUS_US
   output:
     snap_min_allotment: 40
+
+- name: FY 2025 minimum allotment rounds down to the nearest whole dollar
+  period: 2025-01
+  input:
+    spm_unit_size: 1
+    state_code: CA
+    state_group: CONTIGUOUS_US
+  output:
+    # 8% of the $292 one-person maximum allotment is $23.36, rounded to
+    # the nearest whole dollar per 7 CFR 273.10(e)(2)(ii)(C): $23.
+    snap_min_allotment: 23
+
+- name: FY 2026 minimum allotment rounds up to the nearest whole dollar
+  period: 2026-01
+  input:
+    spm_unit_size: 1
+    state_code: CA
+    state_group: CONTIGUOUS_US
+  output:
+    # 8% of the $298 one-person maximum allotment is $23.84, rounded to
+    # the nearest whole dollar per 7 CFR 273.10(e)(2)(ii)(C): $24.
+    snap_min_allotment: 24

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_min_allotment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_min_allotment.yaml
@@ -74,6 +74,18 @@
   output:
     snap_min_allotment: 40
 
+- name: Before Maryland's supplement took effect, Maryland follows the federal rules
+  period: 2016-01
+  input:
+    spm_unit_size: 1
+    md_snap_elderly_present: true
+    state_code_str: MD
+    state_group: CONTIGUOUS_US
+  output:
+    # 8% of the $194 one-person maximum allotment is $15.52, rounded to
+    # the nearest whole dollar: $16 (the USDA FY 2016 minimum benefit).
+    snap_min_allotment: 16
+
 - name: FY 2025 minimum allotment rounds down to the nearest whole dollar
   period: 2025-01
   input:

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/federal.yaml
@@ -319,9 +319,11 @@
         # Minimum allotment path: net = 20,000/12 x 0.8 - 209 = 1,124.33 ->
         # contribution 337.20 exceeds the 1-person maximum (298), so the normal
         # allotment is negative and the minimum allotment applies (8% of the
-        # 1-person maximum, units of 1-2 people only): Jan-Sep 0.08 x 298 =
-        # 23.84/month; Oct-Dec 0.08 x 308.52 = 24.68/month. Annual = 288.60.
-        snap: 288.61
+        # 1-person maximum, rounded to the nearest whole dollar per 7 CFR
+        # 273.10(e)(2)(ii)(C), units of 1-2 people only): Jan-Sep
+        # 0.08 x 298 = 23.84 -> 24/month; Oct-Dec 0.08 x 308.52 = 24.68 ->
+        # 25/month. Annual = 291.
+        snap: 291
         is_snap_eligible: true
 - name: snap_single_elderly_65_ssi_counts_as_unearned_income (federal)
   period: 2026
@@ -1483,6 +1485,7 @@
         # The ineligible student is a nonhousehold member (7 CFR 273.11(d)):
         # their $10,000 earnings are excluded entirely and the unit size is 1;
         # the 130%-FPG gross test passes only because of the exclusion, and
-        # the unit receives the 1-2 person minimum allotment.
-        snap: 288.61
+        # the unit receives the 1-2 person minimum allotment, rounded to the
+        # nearest whole dollar ($24/month Jan-Sep, $25/month Oct-Dec).
+        snap: 291
         is_snap_eligible: true

--- a/policyengine_us/tests/policy/contrib/snap/abolish_snap_net_income_test.yaml
+++ b/policyengine_us/tests/policy/contrib/snap/abolish_snap_net_income_test.yaml
@@ -1,7 +1,9 @@
 - name: Reform not in effect
   period: 2024
   input:
-    snap_net_income_fpg_ratio: 1.5
+    # $1,500 per month against a $1,000 monthly poverty guideline.
+    snap_net_income: 18_000
+    snap_fpg: 12_000
   output:
     meets_snap_net_income_test: false
 
@@ -10,6 +12,8 @@
   reforms: policyengine_us.reforms.snap.abolish_snap_net_income_test.abolish_snap_net_income_test
   input:
     gov.contrib.snap.abolish_net_income_test.in_effect: true
-    snap_net_income_fpg_ratio: 1.5
+    # $1,500 per month against a $1,000 monthly poverty guideline.
+    snap_net_income: 18_000
+    snap_fpg: 12_000
   output:
     meets_snap_net_income_test: true

--- a/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_gross_income_test.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_gross_income_test.py
@@ -16,10 +16,16 @@ class meets_snap_gross_income_test(Variable):
         p = parameters(period).gov.usda.snap.income.limit
         # The gross test uses state-specific income counting for certain
         # ineligible aliens (7 CFR 273.11(c)(3)(i)).
-        ratio = spm_unit("snap_gross_test_income_fpg_ratio", period)
+        income = spm_unit("snap_gross_test_income", period)
+        fpg = spm_unit("snap_fpg", period)
+        # 7 CFR 273.9(a)(3): the monthly standard is 130% of the poverty
+        # guideline divided by 12, rounded up to the next whole dollar.
+        # Pre-round to 4 decimals so float error on an exact whole-dollar
+        # standard cannot push the ceiling up an extra dollar.
+        limit = np.ceil(np.round(p.gross * fpg, 4))
         # Households with an elderly or disabled unit member are exempt
         # from the gross income test; excluded members are not household
         # members under the 7 CFR 271.2 definition, so they do not confer
         # this status.
         has_elderly_disabled = spm_unit("has_snap_elderly_disabled_member", period)
-        return has_elderly_disabled | (ratio <= p.gross)
+        return has_elderly_disabled | (income <= limit)

--- a/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_net_income_test.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/meets_snap_net_income_test.py
@@ -13,6 +13,12 @@ class meets_snap_net_income_test(Variable):
     )
 
     def formula(spm_unit, period, parameters):
-        net_income_limit_fpg = parameters(period).gov.usda.snap.income.limit.net
-        net_income_fpg = spm_unit("snap_net_income_fpg_ratio", period)
-        return net_income_fpg <= net_income_limit_fpg
+        p = parameters(period).gov.usda.snap.income.limit
+        net_income = spm_unit("snap_net_income", period)
+        fpg = spm_unit("snap_fpg", period)
+        # 7 CFR 273.9(a)(3): the monthly standard is the poverty guideline
+        # divided by 12, rounded up to the next whole dollar.
+        # Pre-round to 4 decimals so float error on an exact whole-dollar
+        # standard cannot push the ceiling up an extra dollar.
+        limit = np.ceil(np.round(p.net * fpg, 4))
+        return net_income <= limit

--- a/policyengine_us/variables/gov/usda/snap/snap_min_allotment.py
+++ b/policyengine_us/variables/gov/usda/snap/snap_min_allotment.py
@@ -23,7 +23,9 @@ class snap_min_allotment(Variable):
         # Minimum benefits only apply to households up to a certain size.
         size = spm_unit("snap_unit_size", period)
         eligible = size <= snap.min_allotment.maximum_household_size
-        min_allotment = eligible * min_allotment.rate * relevant_max_allotment
+        # 7 CFR 273.10(e)(2)(ii)(C): 8 percent of the one-person maximum
+        # allotment, rounded to the nearest whole dollar.
+        min_allotment = np.round(eligible * min_allotment.rate * relevant_max_allotment)
 
         # DC, NM, MD and NJ provide separate minimum allotment amounts
         state_code = spm_unit.household("state_code_str", period)


### PR DESCRIPTION
## Summary

PolicyEngine compared unrounded income-to-poverty ratios against 1.3 / 1.0 and paid an unrounded minimum allotment. USDA rounds both: monthly income eligibility standards round **up** to the next whole dollar, and the minimum allotment rounds to the **nearest** whole dollar. Households at exactly the published limit therefore failed the tests in PolicyEngine and received $0 instead of a positive benefit.

## Legal basis (verified against statute and regulation text)

| Change | Authority | Verbatim rule |
|---|---|---|
| Gross income limit: `ceil(1.3 × monthly FPG)` | [7 CFR 273.9(a)(3)(i)](https://www.law.cornell.edu/cfr/text/7/273.9) | "130 percent of the annual income poverty guidelines shall be divided by 12 to determine the monthly gross income standards, rounding the results upwards as necessary." |
| Net income limit: `ceil(monthly FPG)` | [7 CFR 273.9(a)(3)(ii)](https://www.law.cornell.edu/cfr/text/7/273.9) | "The annual income poverty guidelines shall be divided by 12 to determine the monthly net income eligibility standards, rounding the results upward as necessary." |
| Minimum allotment: `round(0.08 × one-person max)` | [7 CFR 273.10(e)(2)(ii)(C)](https://www.law.cornell.edu/cfr/text/7/273.10); [7 U.S.C. 2017(a)](https://www.law.cornell.edu/uscode/text/7/2017) | "The minimum benefit is 8 percent of the maximum allotment for a household of one, rounded to the nearest whole dollar." |

The statute (7 U.S.C. 2014(c)) contains no rounding rule for the income standards; the regulation supplies it.

## Verification against USDA published values

- FY 2026, household of 3, 48 states: gross limit $2,888 (from $2,887.08), net limit $2,221 (from $2,220.83) — both now reproduced exactly.
- Minimum allotment: FY 2025 $23 (8% × $292 = $23.36 rounds down) and FY 2026 $24 (8% × $298 = $23.84 rounds up) — pinning "nearest" in both directions; ceiling or flooring would each fail one year.
- `np.round` half-to-even is safe here: 8% of an integer allotment always has a fractional part that is a multiple of $0.04, so an exact 50-cent tie cannot occur.
- The limits pre-round to 4 decimals before the ceiling so float error on an exact whole-dollar standard (e.g., $2,600 for a household of 4 in FY 2025) cannot add a dollar.

## Implementation notes

- The income tests now compare monthly income against a rounded dollar limit instead of comparing unrounded ratios. `snap_fpg` stays unrounded because rounding does not commute with the 130% multiplication and `snap_fpg` also feeds BBCE.
- The gross-test exemption for households with an elderly or disabled member is unchanged.
- State minimum-allotment overrides (DC, MD, NJ) are unchanged.

## Known limitations (documented, not fixed here)

- **FY 2023 minimum allotment is $22 in PolicyEngine vs USDA's published $23.** USDA applies the statutory 8% to the unrounded thrifty food plan cost ($281.70 → $22.54 → $23), while this implementation applies the regulation's paraphrase to the rounded published maximum ($281 → $22.48 → $22). FY 2023 is the only year in FY 2019–2026 where the two bases diverge; matching it would require storing unrounded TFP costs.
- **Households of 9+**: the regulation rounds the per-person increment separately before adding it to the eight-person standard; this implementation ceilings the total, which can be $1 stricter (e.g., 10-person FY 2026 gross limit $7,032 vs USDA $7,033).
- **BBCE** (`meets_tanf_non_cash_*`) still compares unrounded ratios — same class of issue, left for a follow-up.

## Test plan

- Rewrote `meets_snap_net_income_test.yaml` to drive the formula through `snap_net_income` and `snap_fpg` (the ratio variable is no longer read by the formula but remains for BBCE).
- Added boundary tests at the published FY 2026 limits for a 3-person Missouri household (non-BBCE state, monthly period), passing at the limit and failing $1 above.
- Added synthetic round-up cases and the FY 2025/FY 2026 minimum-allotment nearest-dollar cases.
- Changelog fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)