### PR TITLE
Fix Rhode Island 2026 income tax parameters

### DIFF
--- a/changelog.d/ri-2026-income-tax-parameters.fixed.md
+++ b/changelog.d/ri-2026-income-tax-parameters.fixed.md
@@ -1,0 +1,1 @@
+Correct Rhode Island's 2026 personal income tax brackets, exemption, and deduction phase-out parameters using Division of Taxation Advisory ADV 2025-22.

--- a/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/phase_out/increment.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/phase_out/increment.yaml
@@ -5,6 +5,7 @@ values:
   2023-01-01: 6_700
   2024-01-01: 7_050
   2025-01-01: 7_250
+  2026-01-01: 7_450
 
 metadata:
   unit: currency-USD
@@ -16,6 +17,8 @@ metadata:
       type: downwards
       interval: 50
   reference:
+    - title: Rhode Island Division of Taxation Advisory ADV 2025-22
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=1
     # Legal code specifies $5,000 starting in 2011.
     - title: R.I. Gen. Laws § 44-30-2.6 (B), (III)
       href: https://law.justia.com/codes/rhode-island/title-44/chapter-44-30/part-i/section-44-30-2-6/

--- a/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/phase_out/start.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/phase_out/start.yaml
@@ -5,6 +5,7 @@ values:
   2023-01-01: 233_750
   2024-01-01: 246_450
   2025-01-01: 254_250
+  2026-01-01: 261_000
 
 metadata:
   unit: currency-USD
@@ -16,6 +17,8 @@ metadata:
       type: downwards
       interval: 50
   reference:
+    - title: Rhode Island Division of Taxation Advisory ADV 2025-22
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=1
     # Legal code specifies $175,000 starting in 2011.
     - title: R.I. Gen. Laws § 44-30-2.6 (c), (3), (B), (III)
       href: https://law.justia.com/codes/rhode-island/title-44/chapter-44-30/part-i/section-44-30-2-6/

--- a/policyengine_us/parameters/gov/states/ri/tax/income/exemption/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/exemption/amount.yaml
@@ -5,6 +5,7 @@ values:
   2023-01-01: 4_700
   2024-01-01: 4_950
   2025-01-01: 5_100
+  2026-01-01: 5_250
 
 metadata:
   unit: currency-USD
@@ -16,6 +17,8 @@ metadata:
       type: downwards
       interval: 50
   reference:
+    - title: Rhode Island Division of Taxation Advisory ADV 2025-22
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=1
     - title: 2025 RI-1040 Instructions page I-5
       href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=5
     # The tax form points to this worksheet: Exemption Worksheet for RI-1040NR, Page 1, line 6)

--- a/policyengine_us/parameters/gov/states/ri/tax/income/exemption/reduction/increment.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/exemption/reduction/increment.yaml
@@ -5,6 +5,7 @@ values:
   2023-01-01: 6_700
   2024-01-01: 7_050
   2025-01-01: 7_250
+  2026-01-01: 7_450
 
 metadata:
   unit: currency-USD
@@ -16,6 +17,8 @@ metadata:
       type: downwards
       interval: 50
   reference:
+    - title: Rhode Island Division of Taxation Advisory ADV 2025-22
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=1
     - title: 2025 RI-1040 Instructions page I-5
       href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=5
     # The tax form points to this worksheet: Exemption Worksheet for RI-1040NR, Page 1, line 6)

--- a/policyengine_us/parameters/gov/states/ri/tax/income/exemption/reduction/start.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/exemption/reduction/start.yaml
@@ -5,6 +5,7 @@ values:
   2023-01-01: 233_750
   2024-01-01: 246_450
   2025-01-01: 254_250
+  2026-01-01: 261_000
 
 metadata:
   unit: currency-USD
@@ -16,6 +17,8 @@ metadata:
       type: downwards
       interval: 50
   reference:
+    - title: Rhode Island Division of Taxation Advisory ADV 2025-22
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=1
     - title: 2025 RI-1040 Instructions page I-5
       href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=5
     # The tax form points to this worksheet: Exemption Worksheet for RI-1040NR, Page 1, line 6)

--- a/policyengine_us/parameters/gov/states/ri/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/rate.yaml
@@ -6,6 +6,8 @@ metadata:
   period: year
   label: Rhode Island income tax rate
   reference:
+    - title: Rhode Island Division of Taxation Advisory ADV 2025-22
+      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf#page=2
     - title: Rhode Island Tax Rate Schedule - 2025
       href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=13
     - title: Rhode Island Tax Rate Schedule - 2024
@@ -31,6 +33,7 @@ brackets:
         2023-01-01: 73_450
         2024-01-01: 77_450
         2025-01-01: 79_900
+        2026-01-01: 82_050
       metadata:
         uprating:
           parameter: gov.irs.uprating
@@ -46,6 +49,7 @@ brackets:
         2023-01-01: 166_950
         2024-01-01: 176_050
         2025-01-01: 181_650
+        2026-01-01: 186_450
       metadata:
         uprating:
           parameter: gov.irs.uprating

--- a/policyengine_us/tests/core/test_state_indexed_frozen_parameters.py
+++ b/policyengine_us/tests/core/test_state_indexed_frozen_parameters.py
@@ -118,6 +118,19 @@ def test_ri_2026_standard_deduction(status, value):
     assert amount[status] == value
 
 
+def test_ri_2026_income_tax_parameters():
+    p = _p("2026-01-01").gov.states.ri.tax.income
+    rates = SYSTEM.parameters.gov.states.ri.tax.income.rate
+
+    assert rates.brackets[1].threshold("2026-01-01") == 82_050
+    assert rates.brackets[2].threshold("2026-01-01") == 186_450
+    assert p.exemption.amount == 5_250
+    assert p.exemption.reduction.start == 261_000
+    assert p.exemption.reduction.increment == 7_450
+    assert p.deductions.standard.phase_out.start == 261_000
+    assert p.deductions.standard.phase_out.increment == 7_450
+
+
 # --- New York: 2024 and 2025 itemized-deduction phase-out applicable amount ----
 # NY Tax Law 615 conforms to the pre-TCJA federal 26 U.S.C. 68 applicable amount,
 # which NY continues to inflation-adjust. This parameter is not currently consumed

--- a/policyengine_us/tests/policy/baseline/contrib/states/ri/high_earner_tax/ri_high_earner_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/contrib/states/ri/high_earner_tax/ri_high_earner_tax.yaml
@@ -9,9 +9,8 @@
 # The baseline tax below these tests also moved: gov/states/ri/tax/income/
 # rate.yaml's bracket thresholds ($79,900 @ bracket[1] / $181,650 @ bracket[2]
 # in 2025) were frozen by the same #8905 bug and are now gov.irs.uprating
-# projections ($84,100 / $191,300 for 2027) -- RI's own rate-schedule
-# references only cover through 2025, so this is also a projection pending
-# RI's 2027 publication, not yet a published figure.
+# projections ($84,450 / $192,000 for 2027) from RI's official 2026
+# thresholds -- this remains a projection pending RI's 2027 publication.
 
 - name: RI high earner tax - income below threshold (no surtax)
   period: 2027
@@ -32,8 +31,8 @@
         state_code: RI
   output:
     # Income below the 2027 threshold - only baseline tax applies, surtax = 0.
-    # Baseline: .0375*84,100 + .0475*(191,300-84,100) + .0599*(500,000-191,300) = 26,736.88
-    ri_income_tax_before_non_refundable_credits: 26_736.88
+    # Baseline: .0375*84,450 + .0475*(192,000-84,450) + .0599*(500,000-192,000) = 26,724.70
+    ri_income_tax_before_non_refundable_credits: 26_724.70
 
 - name: RI high earner tax - income above threshold
   period: 2027
@@ -53,12 +52,12 @@
         members: [person1]
         state_code: RI
   output:
-    # Baseline tax (41,711.88) + 3% surtax on income above the 2027 threshold
+    # Baseline tax (41,699.70) + 3% surtax on income above the 2027 threshold
     # (gov.irs.uprating-projected from $640,000 @ 2026 to $659,050 @ 2027)
-    # Baseline: .0375*84,100 + .0475*(191,300-84,100) + .0599*(750,000-191,300) = 41,711.88
+    # Baseline: .0375*84,450 + .0475*(192,000-84,450) + .0599*(750,000-192,000) = 41,699.70
     # Surtax: (750,000 - 659,050) * 0.03 = 90,950 * 0.03 = 2,728.5
-    # Total: 41,711.88 + 2,728.5 = 44,440.38
-    ri_income_tax_before_non_refundable_credits: 44_440.38
+    # Total: 41,699.70 + 2,728.5 = 44,428.20
+    ri_income_tax_before_non_refundable_credits: 44_428.20
 
 - name: RI high earner tax - income well above threshold
   period: 2027
@@ -78,12 +77,12 @@
         members: [person1]
         state_code: RI
   output:
-    # Baseline tax (56,686.88) + 3% surtax on income above the 2027 threshold
+    # Baseline tax (56,674.70) + 3% surtax on income above the 2027 threshold
     # (gov.irs.uprating-projected from $640,000 @ 2026 to $659,050 @ 2027)
-    # Baseline: .0375*84,100 + .0475*(191,300-84,100) + .0599*(1,000,000-191,300) = 56,686.88
+    # Baseline: .0375*84,450 + .0475*(192,000-84,450) + .0599*(1,000,000-192,000) = 56,674.70
     # Surtax: (1,000,000 - 659,050) * 0.03 = 340,950 * 0.03 = 10,228.5
-    # Total: 56,686.88 + 10,228.5 = 66,915.38
-    ri_income_tax_before_non_refundable_credits: 66_915.38
+    # Total: 56,674.70 + 10,228.5 = 66,903.20
+    ri_income_tax_before_non_refundable_credits: 66_903.20
 
 - name: RI high earner tax - reform not in effect
   period: 2027
@@ -104,5 +103,5 @@
         state_code: RI
   output:
     # Reform not in effect - only baseline tax applies (no surtax)
-    # Baseline: .0375*84,100 + .0475*(191,300-84,100) + .0599*(750,000-191,300) = 41,711.88
-    ri_income_tax_before_non_refundable_credits: 41_711.88
+    # Baseline: .0375*84,450 + .0475*(192,000-84,450) + .0599*(750,000-192,000) = 41,699.70
+    ri_income_tax_before_non_refundable_credits: 41_699.70

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/deductions/standard/ri_standard_deduction_applicable_percentage.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/deductions/standard/ri_standard_deduction_applicable_percentage.yaml
@@ -45,3 +45,27 @@
     ri_agi: 400_000
   output:
     ri_standard_deduction_applicable_percentage: 0
+
+- name: RI 2026 standard deduction is fully allowed at the phase-out start
+  period: 2026
+  input:
+    state_code: RI
+    ri_agi: 261_000
+  output:
+    ri_standard_deduction_applicable_percentage: 1
+
+- name: RI 2026 standard deduction begins phasing out above the start
+  period: 2026
+  input:
+    state_code: RI
+    ri_agi: 261_001
+  output:
+    ri_standard_deduction_applicable_percentage: 0.8
+
+- name: RI 2026 standard deduction is fully phased out above the published range
+  period: 2026
+  input:
+    state_code: RI
+    ri_agi: 290_801
+  output:
+    ri_standard_deduction_applicable_percentage: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/exemption/ri_exemptions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/exemption/ri_exemptions.yaml
@@ -108,3 +108,30 @@
     exemptions_count: 3
   output:
     ri_exemptions: 0
+
+- name: RI 2026 exemptions use the official amount at the phase-out start
+  period: 2026
+  input:
+    state_code: RI
+    ri_agi: 261_000
+    exemptions_count: 2
+  output:
+    ri_exemptions: 10_500
+
+- name: RI 2026 exemptions begin phasing out above the start
+  period: 2026
+  input:
+    state_code: RI
+    ri_agi: 261_001
+    exemptions_count: 2
+  output:
+    ri_exemptions: 8_400
+
+- name: RI 2026 exemptions are fully phased out above the published range
+  period: 2026
+  input:
+    state_code: RI
+    ri_agi: 290_801
+    exemptions_count: 2
+  output:
+    ri_exemptions: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/integration.yaml
@@ -265,9 +265,7 @@
     ri_high_earner_tax: 2_500
     ri_social_security_modification: 10_000
     # Baseline tax uses gov/states/ri/tax/income/rate.yaml's bracket
-    # thresholds, gov.irs.uprating-projected for 2027 (#8905 unfroze this
-    # parameter's sibling-of-values `uprating:` block; RI's own rate-schedule
-    # references only cover through 2025, so this is a projection pending
-    # RI's 2027 publication): 71,661.88 before credits, + 2,500 surtax,
-    # - 330 CTC = 73,831.88
-    ri_income_tax: 73_831.88
+    # thresholds, gov.irs.uprating-projected for 2027 from the official 2026
+    # thresholds (84,450 / 192,000): 71,649.70 before credits, + 2,500 surtax,
+    # - 330 CTC = 73,819.70.
+    ri_income_tax: 73_819.70

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/ri_high_earner_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/ri_high_earner_tax.yaml
@@ -44,15 +44,13 @@
     ri_taxable_income: 1_250_000
   output:
     # Baseline tax uses gov/states/ri/tax/income/rate.yaml's bracket
-    # thresholds, gov.irs.uprating-projected for 2027 (#8905 unfroze this
-    # parameter's sibling-of-values `uprating:` block; RI's own rate-schedule
-    # references only cover through 2025, so this is a projection pending
-    # RI's 2027 publication):
-    # .0375*84,100 + .0475*(191,300-84,100) + .0599*(1,250,000-191,300) = 71,661.88
+    # thresholds, gov.irs.uprating-projected for 2027 from the official 2026
+    # thresholds:
+    # .0375*84,450 + .0475*(192,000-84,450) + .0599*(1,250,000-192,000) = 71,649.70
     # + 1% high-earner surtax on income above the (explicit, unaffected)
     # $1,000,000 2027 threshold: (1,250,000 - 1,000,000) * 0.01 = 2,500
-    # Total: 71,661.88 + 2,500 = 74,161.88
-    ri_income_tax_before_non_refundable_credits: 74_161.88
+    # Total: 71,649.70 + 2,500 = 74,149.70
+    ri_income_tax_before_non_refundable_credits: 74_149.70
 
 - name: Rhode Island high-income surtax does not apply at the threshold
   period: 2027

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/ri_income_tax_before_non_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/tax/income/ri_income_tax_before_non_refundable_credits.yaml
@@ -22,3 +22,27 @@
   output:
     # (70,000 - 66,200) * 0.0475 + 66,200 * 0.0375
     ri_income_tax_before_non_refundable_credits: 2_663
+
+- name: 2026 first bracket ceiling
+  period: 2026
+  input:
+    state_code: RI
+    ri_taxable_income: 82_050
+  output:
+    ri_income_tax_before_non_refundable_credits: 3_076.875
+
+- name: 2026 second bracket
+  period: 2026
+  input:
+    state_code: RI
+    ri_taxable_income: 100_000
+  output:
+    ri_income_tax_before_non_refundable_credits: 3_929.50
+
+- name: 2026 top bracket
+  period: 2026
+  input:
+    state_code: RI
+    ri_taxable_income: 200_000
+  output:
+    ri_income_tax_before_non_refundable_credits: 8_847.52


### PR DESCRIPTION
## Summary

- add the official TY2026 Rhode Island personal-income-tax bracket thresholds from Division of Taxation Advisory ADV 2025-22
- add the advisory’s 2026 exemption amount and standard-deduction/exemption phase-out values
- pin schedule and phase-out boundary behavior with focused tests
- update six ordinary 2027 expectations because their uprating projection now starts from the official 2026 bracket anchor

This corrects the underlying PolicyEngine parameter tree; it does not add an oracle-specific override or case-based workaround.

Official source: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-11/ADV_2025_22_Inflation_Adjustments.pdf

## Checks

- `UV_NO_SYNC=1 make format`
- `pytest -c pyproject.toml -q policyengine_us/tests/core/test_state_indexed_frozen_parameters.py` (28 passed)
- full `policyengine-core test policyengine_us/tests/policy/baseline/gov/states/ri/tax/income -c policyengine_us` with parent pytest config isolated (161 passed before adding six additional boundary cases)
- focused new exemption and standard-deduction phase-out cases (23 passed total in the two files)
- contributed RI high-earner reform fixture (4 passed)
- independent review after the CI-driven fixture update: clean, no actionable findings

No partner contract test was changed.