### PR TITLE
Pin Michigan 2026 income tax rate

### DIFF
--- a/changelog.d/mi-2026-income-tax-rate.fixed.md
+++ b/changelog.d/mi-2026-income-tax-rate.fixed.md
@@ -1,0 +1,1 @@
+Pin Michigan's 2026 individual income tax rate to the official 4.25 percent annual determination.

--- a/policyengine_us/parameters/gov/states/mi/tax/income/rate.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/rate.yaml
@@ -6,6 +6,8 @@ values:
   2024-01-01: 0.0425
   # 2025 rate remains at 4.25% per Michigan Treasury notice
   2025-01-01: 0.0425
+  # 2026 rate remains at 4.25% per April 15, 2026 Michigan Treasury notice
+  2026-01-01: 0.0425
 metadata:
   period: year
   unit: /1
@@ -22,3 +24,5 @@ metadata:
     href: https://www.michigan.gov/taxes/questions/tax-faqs/income-tax-rate-change/income-tax-rate-change-overview
   - title: 2025 Tax Year Income Tax Rate for Individuals and Fiduciaries
     href: https://www.michigan.gov/treasury/reference/taxpayer-notices/2025-tax-year-income-tax-rate-for-individuals-and-fiduciaries
+  - title: 4.25% Income Tax Rate for Individuals and Fiduciaries in 2026 Tax Year
+    href: https://www.michigan.gov/treasury/reference/taxpayer-notices/2026/04/15/425-income-tax-rate-for-individuals-and-fiduciaries-in-2026-tax-year

--- a/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_income_tax_before_non_refundable_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mi/tax/income/mi_income_tax_before_non_refundable_credits.yaml
@@ -14,3 +14,11 @@
     state_code: MI
   output:
     mi_income_tax_before_non_refundable_credits: 0
+
+- name: 2026 Michigan income tax uses the official 4.25 percent rate
+  period: 2026
+  input:
+    mi_taxable_income: 20_000
+    state_code: MI
+  output:
+    mi_income_tax_before_non_refundable_credits: 850

--- a/policyengine_us/tests/test_parameter_files.py
+++ b/policyengine_us/tests/test_parameter_files.py
@@ -8,6 +8,7 @@ PARAMETERS_DIR = Path(__file__).resolve().parents[1] / "parameters"
 SOI_LONG_TERM_CAPITAL_GAINS_PATH = (
     PARAMETERS_DIR / "calibration/gov/irs/soi/long_term_capital_gains.yaml"
 )
+MI_INCOME_TAX_RATE_PATH = PARAMETERS_DIR / "gov/states/mi/tax/income/rate.yaml"
 SOI_LONG_TERM_CAPITAL_GAINS_ANCHORS = {
     date(2015, 1, 1): 733_313_255_000,
     date(2020, 1, 1): 1_063_500_316_000,
@@ -146,4 +147,13 @@ def test_soi_long_term_capital_gains_uses_latest_publication_1304_anchor():
     assert max(values) >= date(2023, 1, 1)
     assert parameter["metadata"]["reference"][0]["href"].endswith(
         "publication-1304-basic-tables-part-1"
+    )
+
+
+def test_mi_2026_income_tax_rate_uses_official_annual_determination():
+    parameter = yaml.safe_load(MI_INCOME_TAX_RATE_PATH.read_text())
+
+    assert parameter["values"][date(2026, 1, 1)] == 0.0425
+    assert parameter["metadata"]["reference"][-1]["href"].endswith(
+        "425-income-tax-rate-for-individuals-and-fiduciaries-in-2026-tax-year"
     )


### PR DESCRIPTION
## Summary

- add the official TY2026 Michigan individual income-tax rate determination as an explicit annual parameter anchor
- cite the Michigan Department of Treasury taxpayer notice issued April 15, 2026
- protect the dated anchor and ordinary pre-credit calculation with focused regression tests

This corrects the underlying PolicyEngine parameter tree; it does not add an oracle-specific override, formula branch, or case-based workaround.

Official source: https://www.michigan.gov/treasury/reference/taxpayer-notices/2026/04/15/425-income-tax-rate-for-individuals-and-fiduciaries-in-2026-tax-year

## Checks

- `UV_PROJECT_ENVIRONMENT=/Users/pavelmakarchuk/policyengine-us/.venv UV_NO_SYNC=1 make format` (ruff format and ruff check passed; two unrelated base formatter changes restored exactly)
- `python -m pytest -c pyproject.toml -q policyengine_us/tests/test_parameter_files.py` (7 passed)
- focused `policyengine-core` YAML file (3 passed)
- full Michigan income-tax YAML suite (280 passed)
- `git diff --check`
- independent review: clean, no actionable findings

No partner contract test or formula was changed.