### PR TITLE
Fix West Virginia low-income exclusion double count

### DIFF
--- a/changelog.d/fix-wv-low-income-exclusion-once.fixed.md
+++ b/changelog.d/fix-wv-low-income-exclusion-once.fixed.md
@@ -1,0 +1,1 @@
+Fix West Virginia adjusted gross and taxable income to apply the low-income earned-income exclusion exactly once.

--- a/policyengine_us/parameters/gov/states/wv/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/wv/tax/income/subtractions/subtractions.yaml
@@ -9,7 +9,6 @@ values:
     - salt_refund_income # Line 36
     - wv_529_plan_deduction
     - wv_senior_citizen_disability_deduction # Line 47
-    - wv_low_income_earned_income_exclusion
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/wv_taxable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/tax/income/wv_taxable_income.yaml
@@ -17,3 +17,19 @@
     state_code: WV
   output:
     wv_taxable_income: 500
+
+- name: Low-income earned-income exclusion is applied once after West Virginia AGI
+  period: 2026
+  input:
+    adjusted_gross_income: 10_000
+    tax_unit_earned_income: 7_000
+    filing_status: SINGLE
+    tax_unit_size: 1
+    state_code: WV
+  output:
+    wv_low_income_earned_income_exclusion: 7_000
+    wv_subtractions: 0
+    wv_agi: 10_000
+    wv_personal_exemption: 2_000
+    wv_taxable_income: 1_000
+    wv_income_tax_before_non_refundable_credits: 21.10

--- a/policyengine_us/variables/gov/states/wv/tax/income/wv_taxable_income.py
+++ b/policyengine_us/variables/gov/states/wv/tax/income/wv_taxable_income.py
@@ -7,7 +7,7 @@ class wv_taxable_income(Variable):
     label = "West Virginia taxable income"
     unit = USD
     definition_period = YEAR
-    reference = "https://code.wvlegislature.gov/11-21-4E/"
+    reference = "https://code.wvlegislature.gov/11-21-11/"
     defined_for = StateCode.WV
 
     def formula(tax_unit, period, parameters):


### PR DESCRIPTION
## Summary

- remove the low-income earned-income exclusion from West Virginia Schedule M subtractions
- preserve its single application between West Virginia adjusted gross income and taxable income
- add an integrated 2026 regression covering the intermediate values and pre-credit tax

## Statutory and form basis

West Virginia IT-140 lines 1-7 compute West Virginia adjusted gross income from federal AGI plus Schedule M additions minus Schedule M subtractions, then subtract the low-income earned-income exclusion and personal exemptions to reach taxable income. This matches West Virginia Code sections 11-21-10 through 11-21-12 and prevents the exclusion from being applied twice.

## Checks

- focused wv_taxable_income YAML: 3 passed
- full baseline WV income-tax YAML directory: 109 passed
- WV contrib/reform YAML: 16 passed (test assertions completed; Python 3.14 process was interrupted during teardown)
- household marginal-tax-rate YAML: 5 passed
- make format (including Ruff): passed
- git diff --check: passed
- independent review-fix-review cycle: CLEAN at ad56b658abc317349f92cfc5e948ba0bb7e1d5f3

No partner contract files are changed.