### PR TITLE
Compare KS zero-tax threshold against taxable income per K.S.A. 79-32,110

### DIFF
--- a/changelog.d/fix-ks-zero-tax-taxable-income.fixed.md
+++ b/changelog.d/fix-ks-zero-tax-taxable-income.fixed.md
@@ -1,0 +1,1 @@
+Compare the Kansas zero-tax threshold against taxable income per K.S.A. 79-32,110 and the K-40 tax tables (2016-2023), keeping the 2024+ minimum-filing-requirement values on an AGI basis in a separate parameter; this lets the refundable Kansas EITC pay out for filers in the zero-tax band.

--- a/policyengine_us/parameters/gov/states/ks/tax/income/rates/agi_zero_tax_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ks/tax/income/rates/agi_zero_tax_threshold.yaml
@@ -1,0 +1,31 @@
+description: Kansas zeroes the income tax of filers with adjusted gross income at or below this amount, reflecting the minimum filing requirement.
+metadata:
+  label: KS zero-tax AGI threshold (minimum filing requirement)
+  period: year
+  unit: currency-USD
+  breakdown:
+  - filing_status
+  reference:
+  # The minimum filing requirement only appears in the tax forms, not in the legal code
+  - title: 2024 Form K-40 instructions
+    href: https://www.ksrevenue.gov/pdf/ip24.pdf#page=3
+  - title: 2025 Form K-40 instructions
+    href: https://www.ksrevenue.gov/pdf/ip25.pdf#page=3
+
+# Before 2024, the taxable-income zero-tax band in zero_tax_threshold.yaml
+# applies instead.
+JOINT:
+  0000-01-01: 0
+  2024-01-01: 26_560 # 8,240 + 18,320
+HEAD_OF_HOUSEHOLD:
+  0000-01-01: 0
+  2024-01-01: 17_660 # 6,180 + 9,160 + 2,320
+SURVIVING_SPOUSE:
+  0000-01-01: 0
+  2024-01-01: 12_765 # 3,605 + 9,160
+SINGLE:
+  0000-01-01: 0
+  2024-01-01: 12_765 # 3,605 + 9,160
+SEPARATE:
+  0000-01-01: 0
+  2024-01-01: 13_280 # 4,120 + 9,160

--- a/policyengine_us/parameters/gov/states/ks/tax/income/rates/zero_tax_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ks/tax/income/rates/zero_tax_threshold.yaml
@@ -1,43 +1,43 @@
-description: Kansas only levies taxes on filers with at least this much taxable income.
+description: Kansas zeroes the income tax of filers with taxable income at or below this amount.
 metadata:
-  label: KS zero-tax taxable-income threshold 
+  label: KS zero-tax taxable-income threshold
   period: year
   unit: currency-USD
   breakdown:
   - filing_status
   reference:
-  - title: 2021 Form K-40 instructions
-    href: https://www.ksrevenue.gov/pdf/ip21.pdf
+  - title: Kansas 2022 Statute Article 32 79-32,110 (a)(2)(F)
+    href: http://www.kslegislature.org/li/b2023_24/statute/079_000_0000_chapter/079_032_0000_article/079_032_0110_section/079_032_0110_k/
+  # The 2021 tax table applies the threshold to line 7 taxable income: the
+  # married filing joint column is 0 through $5,000 while the other-status
+  # column is nonzero (e.g., 137 at 4,401-4,450).
+  - title: 2021 Form K-40 instructions, tax table
+    href: https://www.ksrevenue.gov/pdf/ip21.pdf#page=22
   - title: 2022 Form K-40 instructions
     href: https://www.ksrevenue.gov/pdf/ip22.pdf
   - title: 2023 Form K-40 instructions
     href: https://www.ksrevenue.gov/pdf/ip23.pdf#page=32
-  - title: 2024 Form K-40 instructions
-    href: https://www.ksrevenue.gov/pdf/ip24.pdf#page=3
-  - title: 2025 Form K-40 instructions
-    href: https://www.ksrevenue.gov/pdf/ip25.pdf#page=3
-  # The minimum filing requirement only appears in the tax forms, not in the legal code
-  - title: Kansas 2022 Statute Article 32 79-32,110_(e)
-    href: http://www.kslegislature.org/li/b2023_24/statute/079_000_0000_chapter/079_032_0000_article/079_032_0110_section/079_032_0110_k/
 
-  
+# From 2024, the taxable-income zero-tax band no longer appears in the
+# restructured rate schedule; the AGI-based minimum filing requirement in
+# agi_zero_tax_threshold.yaml takes over.
 JOINT:
   2016-01-01: 12_500
   2018-01-01: 5_000
-  2024-01-01: 26_560 # 8,240 + 18,320
+  2024-01-01: 0
 HEAD_OF_HOUSEHOLD:
   2016-01-01: 5_000
   2018-01-01: 2_500
-  2024-01-01: 17_660 # 6,180 + 9,160 + 2,320
+  2024-01-01: 0
 SURVIVING_SPOUSE:
   2016-01-01: 5_000
   2018-01-01: 2_500
-  2024-01-01: 12_765 # 3,605 + 9,160
+  2024-01-01: 0
 SINGLE:
   2016-01-01: 5_000
   2018-01-01: 2_500
-  2024-01-01: 12_765 # 3,605 + 9,160
+  2024-01-01: 0
 SEPARATE:
   2016-01-01: 5_000
   2018-01-01: 2_500
-  2024-01-01: 13_280 # 4,120 + 9,160
+  2024-01-01: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_income_tax_before_credits.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_income_tax_before_credits.yaml
@@ -63,3 +63,45 @@
         state_fips: 20
   output:
     ks_income_tax: 1_223
+
+- name: Zero-tax threshold applies to taxable income, not AGI (issue 9172, taxsim issue 1115)
+  period: 2021
+  input:
+    filing_status: JOINT
+    ks_taxable_income: 4_440
+    ks_agi: 18_340
+    state_code: KS
+  output:
+    # 2021 tax table, married filing joint column: 0 through $5,000 of
+    # line 7 taxable income.
+    ks_income_tax_before_credits: 0
+
+- name: Tax resumes above the joint taxable-income threshold
+  period: 2021
+  input:
+    filing_status: JOINT
+    ks_taxable_income: 5_100
+    ks_agi: 18_340
+    state_code: KS
+  output:
+    ks_income_tax_before_credits: 0.031 * 5_100
+
+- name: Single filer threshold is 2,500 of taxable income
+  period: 2021
+  input:
+    filing_status: SINGLE
+    ks_taxable_income: 2_500
+    ks_agi: 20_000
+    state_code: KS
+  output:
+    ks_income_tax_before_credits: 0
+
+- name: 2024 AGI-based minimum filing requirement still zeroes the tax
+  period: 2024
+  input:
+    filing_status: JOINT
+    ks_taxable_income: 3_000
+    ks_agi: 25_000
+    state_code: KS
+  output:
+    ks_income_tax_before_credits: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_refundable_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/tax/income/ks_refundable_eitc.yaml
@@ -17,3 +17,19 @@
     state_code: KS
   output:
     ks_refundable_eitc: 0  # because ks_nonrefundable_eitc = 600
+
+- name: EITC fully refundable when the zero-tax band eliminates the tax (taxsim issue 1115)
+  period: 2021
+  absolute_error_margin: 0.05
+  input:
+    filing_status: JOINT
+    ks_taxable_income: 4_440
+    ks_agi: 18_340
+    eitc: 709.95
+    state_code: KS
+  output:
+    # Line 8 tax is 0, so the page 8 worksheet routes the entire 17%
+    # Kansas EITC to line 25 as refundable.
+    ks_total_eitc: 120.69
+    ks_nonrefundable_eitc: 0
+    ks_refundable_eitc: 120.69

--- a/policyengine_us/variables/gov/states/ks/tax/income/ks_income_tax_before_credits.py
+++ b/policyengine_us/variables/gov/states/ks/tax/income/ks_income_tax_before_credits.py
@@ -21,6 +21,14 @@ class ks_income_tax_before_credits(Variable):
             p.joint.calc(taxable_income),
             p.other.calc(taxable_income),
         )
-        zero_tax_agi_threshold = p.zero_tax_threshold[filing_status]
+        # K.S.A. 79-32,110 zeroes the tax below a taxable-income threshold
+        # through 2023 (the K-40 tax table's married-joint column is 0 up to
+        # $5,000 of line 7 taxable income); from 2024 the AGI-based minimum
+        # filing requirement applies instead.
+        zero_tax_taxable_income_threshold = p.zero_tax_threshold[filing_status]
+        zero_tax_agi_threshold = p.agi_zero_tax_threshold[filing_status]
         agi = tax_unit("ks_agi", period)
-        return where(agi <= zero_tax_agi_threshold, 0, tax)
+        no_tax = (taxable_income <= zero_tax_taxable_income_threshold) | (
+            agi <= zero_tax_agi_threshold
+        )
+        return where(no_tax, 0, tax)


### PR DESCRIPTION
Fixes #9172

Surfaced by PolicyEngine/policyengine-taxsim#1115 (KS 2021 joint, ages 72/80, $17,809.52 wages, $44,865.84 Social Security).

## Changes

K.S.A. 79-32,110 zeroes Kansas tax below a **taxable-income** threshold ($5,000 joint / $2,500 other, 2018–2023). The 2021 K-40 tax table shows it directly: at taxable income 4,401–4,450 the single/HoH/separate column is 137 while the married-joint column is **0**, with the joint zero band running through $5,000. `ks_income_tax_before_credits` compared the (correctly labeled and valued) threshold against **Kansas AGI**, so the rule almost never fired — any filer with AGI that low has near-zero taxable income anyway.

- Formula now compares taxable income against `zero_tax_threshold` (2016–2023 values; zeroed from 2024 when the band left the restructured rate schedule).
- The 2024+ values (26,560 joint etc.), which are derived **minimum-filing-requirement gross-income** amounts, move to a new `agi_zero_tax_threshold` parameter that keeps the AGI comparison — 2024+ behavior is unchanged (the existing 2024 integration test still passes).

The knock-on is the real impact: with line 8 = 0, the K-40 page 8 EITC worksheet routes the entire 17% Kansas EITC to line 25 as **refundable**. The existing `ks_nonrefundable_eitc`/`ks_refundable_eitc` split already implements that worksheet, so no EITC change is needed.

## Validation

Against the #1115 record (K-40: taxable 4,441, tax 0, refundable EITC 121, refund 121):

| | Before | After | K-40 (TaxAct) |
|---|---|---|---|
| Tax before credits | 137.65 | 0 | 0 |
| KS refundable EITC | 0 | 120.69 | 121 |
| ks_income_tax / siitax | 0 | −120.69 | −121 |

New tests: the #1115 record (taxable 4,440 / AGI 18,340 → 0), the boundary above the joint band (5,100 → 158.10), the single 2,500 threshold, the 2024 AGI-gate case, and the fully-refundable EITC case. All 13 tests in the touched files pass locally, including the pre-existing ones and the 2024 integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
