### PR TITLE
Clarify -inf sentinel in CHIP income limit parameter descriptions

### DIFF
--- a/changelog.d/chip-income-limit-inf-docs.changed.md
+++ b/changelog.d/chip-income-limit-inf-docs.changed.md
@@ -1,0 +1,1 @@
+Clarify in CHIP income limit parameter descriptions that -inf denotes states without a separate CHIP program for that category.

--- a/policyengine_us/parameters/gov/hhs/chip/child/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/chip/child/income_limit.yaml
@@ -1,4 +1,4 @@
-description: The US limits the Children's Health Insurance Program for children to families with income below this fraction of the poverty line.
+description: The US limits the Children's Health Insurance Program for children to families with income below this fraction of the poverty line. A value of -inf indicates the state does not operate a separate CHIP program for children; these states instead cover children through CHIP-funded Medicaid expansion (M-CHIP), reflected in the Medicaid child income limit parameters.
 metadata:
   unit: /1
   period: year

--- a/policyengine_us/parameters/gov/hhs/chip/fcep/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/chip/fcep/income_limit.yaml
@@ -1,4 +1,4 @@
-description: State governments limit Children's Health Insurance Program from-conception-to-end-of-pregnancy eligibility to these incomes, as a share of the federal poverty line.
+description: State governments limit Children's Health Insurance Program from-conception-to-end-of-pregnancy eligibility to these incomes, as a share of the federal poverty line. A value of -inf indicates the state has not adopted the from-conception-to-end-of-pregnancy option.
 metadata:
   unit: /1
   period: year

--- a/policyengine_us/parameters/gov/hhs/chip/pregnant/income_limit.yaml
+++ b/policyengine_us/parameters/gov/hhs/chip/pregnant/income_limit.yaml
@@ -1,4 +1,4 @@
-description: State governments limit standard Children's Health Insurance Program pregnancy eligibility to these incomes, as a share of the federal poverty line.  
+description: State governments limit standard Children's Health Insurance Program pregnancy eligibility to these incomes, as a share of the federal poverty line. A value of -inf indicates the state does not operate a standard separate CHIP program for pregnant people; these states cover pregnancy through Medicaid or through the from-conception-to-end-of-pregnancy option, reflected in the Medicaid pregnant and CHIP FCEP income limit parameters.
 metadata:
   unit: /1
   label: CHIP pregnant income limit


### PR DESCRIPTION
## Summary

The CHIP income limit parameters (`chip/child`, `chip/pregnant`, `chip/fcep`) use `-.inf` as a sentinel meaning the state does not operate a separate CHIP program for that category — the eligibility formulas gate on `income_limit > 0`. Nothing in the parameter files documented this, so the values read as missing data (an API partner recently flagged California's `-.inf` as an unfilled placeholder).

California, for example, covers children through CHIP-funded Medicaid expansion (M-CHIP) up to 266% FPL — captured in the Medicaid child income limit parameters — and CHIP-funded pregnancy coverage through the FCEP option at 322% FPL, so `-.inf` in the separate-CHIP files is correct per the CMS eligibility-levels table.

This PR adds one sentence to each of the three parameter descriptions explaining the sentinel and pointing to where the coverage for those states actually lives. No values or logic change.

## Changes
- `parameters/gov/hhs/chip/child/income_limit.yaml`: document that -inf = no separate children's CHIP (M-CHIP states)
- `parameters/gov/hhs/chip/pregnant/income_limit.yaml`: document that -inf = no standard separate pregnant CHIP (coverage via Medicaid or FCEP)
- `parameters/gov/hhs/chip/fcep/income_limit.yaml`: document that -inf = state has not adopted the FCEP option
- Changelog fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)