### PR TITLE
Exclude MFS filers and apply MO investment income limit to WFTC

### DIFF
--- a/changelog.d/fix-mo-wftc-eligibility.fixed.md
+++ b/changelog.d/fix-mo-wftc-eligibility.fixed.md
@@ -1,0 +1,1 @@
+Missouri Working Families Tax Credit: exclude married filing separately filers and apply Missouri's investment income limit ($4,050 in 2023, $4,300 in 2024, $4,400 in 2025).

--- a/changelog.d/fix-mo-wftc-eligibility.fixed.md
+++ b/changelog.d/fix-mo-wftc-eligibility.fixed.md
@@ -1,1 +1,1 @@
-Missouri Working Families Tax Credit: exclude married filing separately filers and apply Missouri's investment income limit ($4,050 in 2023, $4,300 in 2024, $4,400 in 2025).
+Missouri Working Families Tax Credit: require a federal EITC, exclude married filing separately filers and (from 2024) filers claimed as a dependent, and apply Missouri's investment income limit ($4,050 in 2023, $4,300 in 2024, $4,400 in 2025).

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/wftc/dependent_filers_excluded.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/wftc/dependent_filers_excluded.yaml
@@ -1,0 +1,17 @@
+description: Missouri excludes filers claimed as a dependent on another return from the Working Families Tax Credit when this is true.
+# The 2023 Form MO-WFTC checklist stops only married filing separately
+# filers; the claimed-as-a-dependent stop first appears on the 2024 form.
+values:
+  2023-01-01: false
+  2024-01-01: true
+metadata:
+  unit: bool
+  period: year
+  label: Missouri Working Families Tax Credit dependent filer exclusion
+  reference:
+    - title: 2023 Form MO-WFTC, Qualifications, Line 2
+      href: https://dor.mo.gov/forms/MO-WFTC_2023.pdf#page=1
+    - title: 2024 Form MO-WFTC, Qualifications, Line 2
+      href: https://dor.mo.gov/forms/MO-WFTC_2024.pdf#page=1
+    - title: 2025 MO-1040 Book - Individual Income Tax Long Form, Form MO-WFTC
+      href: https://dor.mo.gov/forms/MO-1040%20Instructions_2025.pdf#page=43

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/wftc/investment_income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/wftc/investment_income_limit.yaml
@@ -1,0 +1,29 @@
+description: Missouri disqualifies filers from the Working Families Tax Credit if their investment income exceeds this amount.
+# RSMo 143.177.3(1) computes the credit under the federal EITC "as such credit
+# existed under 26 U.S.C. Section 32 as of January 1, 2021" — pre-ARPA law,
+# whose Section 32(i) disqualified-income limit ($3,650 for 2021 per Rev.
+# Proc. 2020-45) ARPA later replaced with the much higher current-law limit.
+# The IRS no longer publishes the pre-ARPA indexed value, so the Missouri
+# Department of Revenue computes it each year and publishes it only on Form
+# MO-WFTC and its FAQ; the statute contains no dollar amount. There is no
+# federal source to uprate from — each year's value is added when the
+# department releases the new form.
+values:
+  2023-01-01: 4_050
+  2024-01-01: 4_300
+  2025-01-01: 4_400
+metadata:
+  unit: currency-USD
+  period: year
+  label: Missouri Working Families Tax Credit investment income limit
+  reference:
+    - title: 143.177. Missouri working family tax credit act, 3(1)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=143.177&bid=49978&hl=
+    - title: 2023 Form MO-WFTC, Qualifications, Line 3
+      href: https://dor.mo.gov/forms/MO-WFTC_2023.pdf#page=1
+    - title: 2024 Form MO-WFTC, Qualifications, Line 3
+      href: https://dor.mo.gov/forms/MO-WFTC_2024.pdf#page=1
+    - title: 2025 MO-1040 Book - Individual Income Tax Long Form, Form MO-WFTC
+      href: https://dor.mo.gov/forms/MO-1040%20Instructions_2025.pdf#page=43
+    - title: Missouri Department of Revenue, Working Family Tax Credit FAQ
+      href: https://dor.mo.gov/faq/taxation/individual/missouri-working-family-tax-credit.html

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc.yaml
@@ -30,3 +30,21 @@
     mo_income_tax_before_credits: 1000000
   output:
     mo_wftc: 10
+- name: Married filing separately filers receive no credit
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SEPARATE
+    eitc: 100
+    mo_income_tax_before_credits: 1000000
+  output:
+    mo_wftc: 0
+- name: Investment income above the Missouri limit zeroes the credit
+  period: 2025
+  input:
+    state_code: MO
+    eitc: 100
+    eitc_relevant_investment_income: 4_401
+    mo_income_tax_before_credits: 1000000
+  output:
+    mo_wftc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc.yaml
@@ -48,3 +48,12 @@
     mo_income_tax_before_credits: 1000000
   output:
     mo_wftc: 0
+- name: Filers claimed as a dependent receive no credit from 2024
+  period: 2025
+  input:
+    state_code: MO
+    eitc: 100
+    claimed_as_dependent_on_another_return: true
+    mo_income_tax_before_credits: 1000000
+  output:
+    mo_wftc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc_eligible.yaml
@@ -1,0 +1,64 @@
+# Missouri limits the WFTC to filing statuses other than married filing
+# separately (RSMo 143.177.2) and to filers whose investment income does not
+# exceed a Missouri-specific limit reflecting IRC Section 32(i) as of
+# January 1, 2021 (RSMo 143.177.3(1); Form MO-WFTC, Qualifications, Line 3).
+- name: Married filing separately filers are ineligible
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SEPARATE
+  output:
+    mo_wftc_eligible: false
+- name: Single filer with no investment income is eligible
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SINGLE
+  output:
+    mo_wftc_eligible: true
+- name: Investment income exactly at the 2023 limit remains eligible
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc_relevant_investment_income: 4_050
+  output:
+    # The statutorily referenced pre-ARPA IRC Section 32(i) disqualifies only
+    # income exceeding the limit; the 2023 form checklist's "equal to or
+    # greater than" wording conflicts with the statute and the form's own
+    # information page ("cannot exceed"), so the strict reading applies.
+    mo_wftc_eligible: true
+- name: Investment income above the 2023 limit is disqualifying
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc_relevant_investment_income: 4_051
+  output:
+    mo_wftc_eligible: false
+- name: Investment income exactly at the 2024 limit remains eligible
+  period: 2024
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc_relevant_investment_income: 4_300
+  output:
+    mo_wftc_eligible: true
+- name: Investment income above the 2024 limit is disqualifying
+  period: 2024
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc_relevant_investment_income: 4_301
+  output:
+    mo_wftc_eligible: false
+- name: Investment income above the 2025 limit is disqualifying
+  period: 2025
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc_relevant_investment_income: 4_401
+  output:
+    # $4,401 is below the federal EITC investment income limit ($11,950 in
+    # 2025) but above Missouri's $4,400 limit.
+    mo_wftc_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc_eligible.yaml
@@ -13,6 +13,30 @@
     eitc: 0
   output:
     mo_wftc_eligible: false
+- name: Head of household filer with a federal EITC is eligible
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: HEAD_OF_HOUSEHOLD
+    eitc: 100
+  output:
+    mo_wftc_eligible: true
+- name: Married filing combined filer with a federal EITC is eligible
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: JOINT
+    eitc: 100
+  output:
+    mo_wftc_eligible: true
+- name: Widowed filer with a federal EITC is eligible
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SURVIVING_SPOUSE
+    eitc: 100
+  output:
+    mo_wftc_eligible: true
 - name: Married filing separately filers are ineligible
   period: 2023
   input:
@@ -57,9 +81,10 @@
     eitc_relevant_investment_income: 4_050
   output:
     # The statutorily referenced pre-ARPA IRC Section 32(i) disqualifies only
-    # income exceeding the limit; the 2023 form checklist's "equal to or
-    # greater than" wording conflicts with the statute and the form's own
-    # information page ("cannot exceed"), so the strict reading applies.
+    # income exceeding the limit; the 2023 form's checklist and its Line 3
+    # instructions both say "equal to or greater than", conflicting with the
+    # statute and the form's own information page ("cannot exceed"), so the
+    # strict statutory reading applies.
     mo_wftc_eligible: true
 - name: Investment income above the 2023 limit is disqualifying
   period: 2023
@@ -88,6 +113,15 @@
     eitc_relevant_investment_income: 4_301
   output:
     mo_wftc_eligible: false
+- name: Investment income exactly at the 2025 limit remains eligible
+  period: 2025
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc: 100
+    eitc_relevant_investment_income: 4_400
+  output:
+    mo_wftc_eligible: true
 - name: Investment income above the 2025 limit is disqualifying
   period: 2025
   input:

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/wftc/mo_wftc_eligible.yaml
@@ -1,26 +1,59 @@
-# Missouri limits the WFTC to filing statuses other than married filing
-# separately (RSMo 143.177.2) and to filers whose investment income does not
-# exceed a Missouri-specific limit reflecting IRC Section 32(i) as of
-# January 1, 2021 (RSMo 143.177.3(1); Form MO-WFTC, Qualifications, Line 3).
+# Missouri limits the WFTC to filers allowed a federal EITC (RSMo 143.177.2;
+# Form MO-WFTC, Qualifications, Line 1), to filing statuses other than married
+# filing separately (RSMo 143.177.2), from 2024 to filers not claimed as a
+# dependent on another return (Form MO-WFTC, Qualifications, Line 2), and to
+# filers whose investment income does not exceed a Missouri-specific limit
+# reflecting IRC Section 32(i) as of January 1, 2021 (RSMo 143.177.3(1);
+# Form MO-WFTC, Qualifications, Line 3).
+- name: Filer without a federal EITC is ineligible
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc: 0
+  output:
+    mo_wftc_eligible: false
 - name: Married filing separately filers are ineligible
   period: 2023
   input:
     state_code: MO
     filing_status: SEPARATE
+    eitc: 100
   output:
     mo_wftc_eligible: false
-- name: Single filer with no investment income is eligible
+- name: Single filer with a federal EITC and no investment income is eligible
   period: 2023
   input:
     state_code: MO
     filing_status: SINGLE
+    eitc: 100
   output:
     mo_wftc_eligible: true
+- name: Filer claimed as a dependent remains eligible in 2023
+  period: 2023
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc: 100
+    claimed_as_dependent_on_another_return: true
+  output:
+    # The claimed-as-a-dependent stop first appears on the 2024 form.
+    mo_wftc_eligible: true
+- name: Filer claimed as a dependent is ineligible from 2024
+  period: 2024
+  input:
+    state_code: MO
+    filing_status: SINGLE
+    eitc: 100
+    claimed_as_dependent_on_another_return: true
+  output:
+    mo_wftc_eligible: false
 - name: Investment income exactly at the 2023 limit remains eligible
   period: 2023
   input:
     state_code: MO
     filing_status: SINGLE
+    eitc: 100
     eitc_relevant_investment_income: 4_050
   output:
     # The statutorily referenced pre-ARPA IRC Section 32(i) disqualifies only
@@ -33,6 +66,7 @@
   input:
     state_code: MO
     filing_status: SINGLE
+    eitc: 100
     eitc_relevant_investment_income: 4_051
   output:
     mo_wftc_eligible: false
@@ -41,6 +75,7 @@
   input:
     state_code: MO
     filing_status: SINGLE
+    eitc: 100
     eitc_relevant_investment_income: 4_300
   output:
     mo_wftc_eligible: true
@@ -49,6 +84,7 @@
   input:
     state_code: MO
     filing_status: SINGLE
+    eitc: 100
     eitc_relevant_investment_income: 4_301
   output:
     mo_wftc_eligible: false
@@ -57,6 +93,7 @@
   input:
     state_code: MO
     filing_status: SINGLE
+    eitc: 100
     eitc_relevant_investment_income: 4_401
   output:
     # $4,401 is below the federal EITC investment income limit ($11,950 in

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_eligible.py
@@ -1,0 +1,34 @@
+from policyengine_us.model_api import *
+
+
+class mo_wftc_eligible(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Eligible for the Missouri Working Families Tax Credit"
+    definition_period = YEAR
+    reference = (
+        "https://revisor.mo.gov/main/OneSection.aspx?section=143.177&bid=49978&hl=",
+        "https://dor.mo.gov/forms/MO-1040%20Instructions_2025.pdf#page=43",
+    )
+    defined_for = StateCode.MO
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.mo.tax.income.credits.wftc
+        # RSMo 143.177.2 limits the credit to filing statuses of single,
+        # head of household, widowed, or married filing combined, excluding
+        # married filing separately.
+        filing_status = tax_unit("filing_status", period)
+        separate = filing_status == filing_status.possible_values.SEPARATE
+        # Form MO-WFTC applies Missouri's own investment income limit,
+        # reflecting IRC Section 32(i) as of January 1, 2021 per RSMo
+        # 143.177.3(1), which is far below the current-law federal limit.
+        # Missouri defines investment income from Form 1040 lines (taxable
+        # and tax-exempt interest, ordinary dividends, and positive capital
+        # gain net income, with an IRS Publication 596 worksheet fallback);
+        # we approximate it with the federal EITC investment income measure.
+        # The 2023 form checklist disqualifies at "equal to or greater than"
+        # the limit while the 2024 and 2025 checklists use "greater than";
+        # we follow the strict "exceeds" reading of the statutorily
+        # referenced pre-ARPA Section 32(i) in all years.
+        investment_income = tax_unit("eitc_relevant_investment_income", period)
+        return ~separate & (investment_income <= p.investment_income_limit)

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_eligible.py
@@ -35,10 +35,12 @@ class mo_wftc_eligible(Variable):
         # and tax-exempt interest, ordinary dividends, and positive capital
         # gain net income, with an IRS Publication 596 worksheet fallback);
         # we approximate it with the federal EITC investment income measure.
-        # The 2023 form checklist disqualifies at "equal to or greater than"
-        # the limit while the 2024 and 2025 checklists use "greater than";
-        # we follow the strict "exceeds" reading of the statutorily
-        # referenced pre-ARPA Section 32(i) in all years.
+        # The 2023 form disqualifies at "equal to or greater than" the limit
+        # in both its checklist and its Line 3 instructions, though its own
+        # information page says income "cannot exceed" the limit; the 2024
+        # and 2025 forms use "greater than" throughout. We follow the strict
+        # "exceeds" reading of the statutorily referenced pre-ARPA Section
+        # 32(i) in all years.
         investment_income = tax_unit("eitc_relevant_investment_income", period)
         meets_investment_limit = investment_income <= p.investment_income_limit
         return (

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_eligible.py
@@ -14,11 +14,20 @@ class mo_wftc_eligible(Variable):
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.mo.tax.income.credits.wftc
+        # RSMo 143.177.2 defines an eligible taxpayer as one allowed a
+        # federal earned income tax credit; Form MO-WFTC Line 1 stops
+        # filers without one.
+        has_federal_eitc = tax_unit("eitc", period) > 0
         # RSMo 143.177.2 limits the credit to filing statuses of single,
         # head of household, widowed, or married filing combined, excluding
         # married filing separately.
         filing_status = tax_unit("filing_status", period)
         separate = filing_status == filing_status.possible_values.SEPARATE
+        # The 2024 and 2025 Form MO-WFTC checklists also stop filers
+        # claimed as a dependent on another return; the 2023 form does not.
+        excluded_dependent = p.dependent_filers_excluded & tax_unit(
+            "head_is_dependent_elsewhere", period
+        )
         # Form MO-WFTC applies Missouri's own investment income limit,
         # reflecting IRC Section 32(i) as of January 1, 2021 per RSMo
         # 143.177.3(1), which is far below the current-law federal limit.
@@ -31,4 +40,7 @@ class mo_wftc_eligible(Variable):
         # we follow the strict "exceeds" reading of the statutorily
         # referenced pre-ARPA Section 32(i) in all years.
         investment_income = tax_unit("eitc_relevant_investment_income", period)
-        return ~separate & (investment_income <= p.investment_income_limit)
+        meets_investment_limit = investment_income <= p.investment_income_limit
+        return (
+            has_federal_eitc & ~separate & ~excluded_dependent & meets_investment_limit
+        )

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_potential.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/mo_wftc_potential.py
@@ -13,6 +13,7 @@ class mo_wftc_potential(Variable):
     defined_for = StateCode.MO
 
     def formula(tax_unit, period, parameters):
+        eligible = tax_unit("mo_wftc_eligible", period)
         federal_eitc = tax_unit("eitc", period)
         rate = parameters(period).gov.states.mo.tax.income.credits.wftc.match
-        return federal_eitc * rate
+        return eligible * federal_eitc * rate


### PR DESCRIPTION
## Summary

Adds the two missing eligibility conditions to the Missouri Working Families Tax Credit (RSMo 143.177):

1. **Married filing separately exclusion** — RSMo 143.177.2 limits the credit to filing statuses of single, head of household, widowed, or married filing combined. PolicyEngine's federal EITC pays separate filers from 2021 on (ARPA Sec. 9623), so MFS filers were receiving the Missouri match.
2. **Missouri investment income limit** — RSMo 143.177.3(1) computes the credit under IRC Section 32 "as of January 1, 2021" (pre-ARPA), whose Section 32(i) disqualified-income limit is far below current federal law. MO DOR publishes the limit each year on Form MO-WFTC: $4,050 (2023), $4,300 (2024), $4,400 (2025). No Missouri check existed, so only the federal limit ($11,950 in 2025) applied implicitly.

Fixes #9177
Fixes #9178

## Changes

- New parameter `gov/states/mo/tax/income/credits/wftc/investment_income_limit.yaml` — values from Form MO-WFTC with a comment documenting the derivation chain (the statute contains no dollar amount) and why there is no `uprating` (no federal source; each year's value comes from the new form).
- New parameter `gov/states/mo/tax/income/credits/wftc/dependent_filers_excluded.yaml` — the claimed-as-a-dependent stop first appears on the 2024 form checklist (false in 2023, true from 2024).
- New variable `mo_wftc_eligible` — requires a federal EITC (`eitc > 0`, per RSMo 143.177.2 "allowed a federal earned income tax credit" and Form MO-WFTC Line 1), filing status is not SEPARATE, the filer is not claimed as a dependent on another return (from 2024, via `head_is_dependent_elsewhere`), and investment income does not exceed the Missouri limit.
- `mo_wftc_potential` multiplies by the new eligibility. The contrib refundable-WFTC reform builds on `mo_wftc_potential`, so the eligibility conditions flow through to the reform as well.

## Modeling decisions

- **Boundary semantics**: strict "greater than" disqualification in all years. DOR publications disagree: the 2023 form says "equal to or greater than" in both its checklist and its Line 3 instructions (as does the FAQ), while its own information page says "cannot exceed"; the 2024/2025 forms say "greater than" throughout. The statutorily referenced pre-ARPA Section 32(i) says "exceeds" — the only reading with statutory grounding — so the strict reading applies in all years. Documented in the code and test comments and pinned by boundary tests (exactly at the limit remains eligible in 2023, 2024, and 2025). Confirmed as a deliberate maintainer choice in response to the automated program review.
- **Investment income measure**: reuses the federal `eitc_relevant_investment_income`. Missouri's form definition (taxable + tax-exempt interest, ordinary dividends, positive capital gain net income, with a Pub 596 Worksheet 1 fallback) is close but not identical (the federal measure also nets rental/passive income); documented in the variable.
- **Claimed-dependent stop**: modeled from 2024 via the dated parameter and `head_is_dependent_elsewhere` (following the `va_low_income_tax_credit_eligible` precedent). An earlier revision of this PR incorrectly stated this was not representable; `claimed_as_dependent_on_another_return` exists as a person-level input for exactly this case.

## Test plan

- New `mo_wftc_eligible.yaml` unit tests: no federal EITC ineligible; MFS ineligible; eligible baseline plus positive cases for all allowed statuses (single, head of household, married filing combined, widowed); claimed dependent eligible in 2023 but ineligible from 2024; boundary cases at and above the limit for 2023, 2024, and 2025 (including $4,401 in 2025 — below federal, above Missouri).
- Three integration cases in `mo_wftc.yaml`: MFS filer, over-limit investment income, and a claimed dependent (2025) all produce `mo_wftc: 0`.
- Existing tests (baseline WFTC, credit order, MO integration, contrib refundable-WFTC reform) use non-MFS filers with no investment income and are unaffected.
- Not run locally by request — CI validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

