### PR TITLE
Add Montana unemployment compensation subtraction for pre-2024 years

### DIFF
--- a/changelog.d/fix-mt-unemployment-subtraction.added.md
+++ b/changelog.d/fix-mt-unemployment-subtraction.added.md
@@ -1,0 +1,1 @@
+Added Montana's unemployment compensation subtraction for tax years before 2024, when SB 399 repealed the exemption; previously unemployment income was incorrectly taxed by Montana and inflated Montana-taxable Social Security.

--- a/policyengine_us/parameters/gov/states/mt/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/mt/tax/income/subtractions/subtractions.yaml
@@ -2,11 +2,15 @@ description: Montana counts these sources as subtractions.
 values:
   2010-01-01:
     - mt_disability_income_exclusion_person
+    - mt_unemployment_compensation_subtraction
   2021-01-01:
     - mt_interest_exemption_person
     - us_govt_interest_person
     - mt_tuition_subtraction_person
     - mt_disability_income_exclusion_person
+    # Former 15-30-2110, MCA exempted unemployment compensation;
+    # SB 399 (2021) repealed the exemption effective tax year 2024.
+    - mt_unemployment_compensation_subtraction
   2024-01-01:
     - mt_interest_exemption_person
     - mt_tuition_subtraction_person

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_unemployment_compensation_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_unemployment_compensation_subtraction.yaml
@@ -1,0 +1,61 @@
+- name: Unemployment compensation is fully subtracted in 2021
+  period: 2021
+  input:
+    taxable_unemployment_compensation: 23_120
+    state_code: MT
+  output:
+    mt_unemployment_compensation_subtraction: 23_120
+
+- name: No unemployment compensation, no subtraction
+  period: 2021
+  input:
+    taxable_unemployment_compensation: 0
+    state_code: MT
+  output:
+    mt_unemployment_compensation_subtraction: 0
+
+- name: Subtraction repealed by SB 399 effective tax year 2024
+  period: 2024
+  input:
+    people:
+      person1:
+        taxable_unemployment_compensation: 10_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MT
+  output:
+    mt_subtractions: 0
+
+- name: Taxsim issue 1120 record - unemployment exemption flows through the
+    taxable Social Security worksheet
+  absolute_error_margin: 0.05
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 74
+        taxable_interest_income: 956.886_6
+        taxable_pension_income: 17_539.746
+        social_security_retirement: 48_053.035
+        unemployment_compensation: 23_120
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MT
+  output:
+    # Subtractions Schedule: line 3 interest exemption 800, line 7
+    # unemployment 23,120.
+    mt_subtractions: 23_920
+    # Worksheet VIII: provisional income 41,723.16 -> 85% x (41,723.16
+    # - 34,000) + 4,500 = 11,064.69 (federal taxable amount is 31,396.68,
+    # matching TaxAct's line 37 subtraction of 20,332).
+    mt_taxable_social_security: 11_064.69
+    # 73,013.31 - 800 - 23,120 - (31,396.68 - 11,064.69) = 28,761.32
+    mt_agi_indiv: 28_761.32

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_unemployment_compensation_subtraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/subtractions/mt_unemployment_compensation_subtraction.yaml
@@ -59,3 +59,28 @@
     mt_taxable_social_security: 11_064.69
     # 73,013.31 - 800 - 23,120 - (31,396.68 - 11,064.69) = 28,761.32
     mt_agi_indiv: 28_761.32
+
+- name: Taxsim issue 1121 record - unemployment-only income zeroes out
+    Montana taxable income
+  absolute_error_margin: 0.05
+  period: 2021
+  input:
+    people:
+      person1:
+        age: 53
+        taxable_interest_income: 309.730_99
+        unemployment_compensation: 50_823.199
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MT
+  output:
+    mt_subtractions: 50_823.20
+    # Only the interest remains in Montana AGI; the standard deduction
+    # floors at the single minimum (2,140), so taxable income is zero.
+    mt_agi_indiv: 309.73
+    mt_taxable_income_indiv: 0
+    mt_income_tax: 0

--- a/policyengine_us/variables/gov/states/mt/tax/income/subtractions/unemployment/mt_unemployment_compensation_subtraction.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/subtractions/unemployment/mt_unemployment_compensation_subtraction.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class mt_unemployment_compensation_subtraction(Variable):
+    value_type = float
+    entity = Person
+    label = "Montana unemployment compensation subtraction"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        # 2021 Form 2 instructions, Montana Subtractions Schedule, line 7:
+        # unemployment benefits from Montana or another state are exempt;
+        # enter the amount reported on federal Schedule 1, line 7.
+        "https://taxsim.nber.org/historical_state_tax_forms/MT/2021/form%202%202021%20instructions.pdf#page=25",
+        # Former 15-30-2110, MCA; repealed by SB 399 (Ch. 503, L. 2021)
+        # effective tax year 2024, after which unemployment compensation
+        # is taxable in Montana.
+        "https://mca.legmt.gov/bills/mca/title_0150/chapter_0300/part_0210/section_0100/0150-0300-0210-0100.html",
+    )
+    defined_for = StateCode.MT
+
+    adds = ["taxable_unemployment_compensation"]


### PR DESCRIPTION
Fixes #9211.

Montana exempted unemployment compensation from state income tax until SB 399 (Ch. 503, L. 2021) repealed the exemption effective tax year 2024, but the model had no unemployment subtraction in any year — UI flowed into Montana AGI and, as a knock-on, inflated Montana-taxable Social Security (the Taxable Social Security Benefits worksheet subtracts the Subtractions Schedule subtotal from provisional income).

Found via PolicyEngine/policyengine-taxsim#1120 (2021 MT single filer, age 74, with $23,120 of unemployment compensation; filed by @feenberg with a TaxAct return).

## Changes

- New `mt_unemployment_compensation_subtraction` (Person): `adds = ["taxable_unemployment_compensation"]`, matching the Subtractions Schedule line 7 instruction to enter "the same amount" of unemployment benefits reported on federal Schedule 1, line 7 ([2021 Form 2 instructions, p. 25](https://taxsim.nber.org/historical_state_tax_forms/MT/2021/form%202%202021%20instructions.pdf#page=25)).
- Added it to the pre-2024 `subtractions.yaml` lists (2010 and 2021 brackets). The 2024+ lists are unchanged — UI is taxable in Montana from 2024.
- No change needed in `mt_taxable_social_security`; it already subtracts `mt_subtractions`, so the exemption propagates into the worksheet automatically.

## Validation against the TaxAct return (taxsim #1120)

| Quantity | TaxAct | PE before | PE after |
|---|---|---|---|
| Federal AGI | 73,013 | 73,013.31 | 73,013.31 |
| Subtractions line 3 (interest exemption 65+) | 800 | 800 | 800 |
| Subtractions line 7 (unemployment) | 23,120 | 0 | 23,120 |
| Subtractions line 37 (SS adjustment) | 20,332 | 680 | 20,332 |
| Montana AGI | 28,761 | 71,533.32 | **28,761.32** |
| Montana taxable income | n/a* | 61,373.32 | 18,601.32 |

\* Only the Subtractions Schedule page of the TaxAct return was uploaded; the remaining difference between PE's itemized federal-tax deduction ($5,000) and the capped standard deduction ($4,830) is a separate, known convention question (taxsim #1112).

Emulator end-to-end on the exact TAXSIM input row reproduces the table above (tax before the HB 192 rebate: 686.08; the 2023 one-time rebate then nets 2021 liability to 0 under the taxsim #1068 booking convention).

All tests in the new file pass, plus the full `gov/states/mt` baseline suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
