### PR TITLE
Refactor MO property tax credit to the statutory table method with 2026 H.B. 594 parameters

### DIFF
--- a/changelog.d/mo-ptc-refactor.fixed.md
+++ b/changelog.d/mo-ptc-refactor.fixed.md
@@ -1,0 +1,1 @@
+Refactor the Missouri Property Tax Credit to the statutory table method with the 2026 H.B. 594 parameters, upper income limits, and corrected eligibility pathways.

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_owner.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_owner.yaml
@@ -1,11 +1,14 @@
 description: Gross income offset for a married couple filing jointly who own.
 values:
   2021-01-01: 4_000
+  2026-01-01: 5_800
 metadata:
   unit: currency-USD
   period: year
   label: Missouri income offset for married joint unit that owns house (and paid no rent)
   reference:
+    - title: MO Rev Stat § 135.010 (5), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.010
     - title: 2025 MO-PTC Property Tax Credit Claim
       href: https://dor.mo.gov/forms/MO-PTC%20Instructions_2025.pdf#page=2
     - title: MO-PTS 2024 Property Tax Credit Schedule, Line 9

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_owner.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_owner.yaml
@@ -7,8 +7,8 @@ metadata:
   period: year
   label: Missouri income offset for married joint unit that owns house (and paid no rent)
   reference:
-    - title: MO Rev Stat § 135.010 (5), effective 2026-01-01
-      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.010
+    - title: MO Rev Stat § 135.010(5), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.010&bid=57540
     - title: 2025 MO-PTC Property Tax Credit Claim
       href: https://dor.mo.gov/forms/MO-PTC%20Instructions_2025.pdf#page=2
     - title: MO-PTS 2024 Property Tax Credit Schedule, Line 9

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_renter.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_renter.yaml
@@ -7,8 +7,8 @@ metadata:
   period: year
   label: Missouri income offset for married joint unit that paid some rent
   reference:
-    - title: MO Rev Stat § 135.010 (5), effective 2026-01-01
-      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.010
+    - title: MO Rev Stat § 135.010(5), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.010&bid=57540
     - title: 2025 MO-PTC Property Tax Credit Claim
       href: https://dor.mo.gov/forms/MO-PTC%20Instructions_2025.pdf#page=2
     - title: MO-PTS 2024 Property Tax Credit Schedule, Line 9

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_renter.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/income_offset/joint_renter.yaml
@@ -1,11 +1,14 @@
 description: Gross income offset for a married couple filing jointly who rent.
 values:
   2021-01-01: 2_000
+  2026-01-01: 2_800
 metadata:
   unit: currency-USD
   period: year
   label: Missouri income offset for married joint unit that paid some rent
   reference:
+    - title: MO Rev Stat § 135.010 (5), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.010
     - title: 2025 MO-PTC Property Tax Credit Claim
       href: https://dor.mo.gov/forms/MO-PTC%20Instructions_2025.pdf#page=2
     - title: MO-PTS 2024 Property Tax Credit Schedule, Line 9

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/max_rate.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/max_rate.yaml
@@ -1,5 +1,7 @@
 description: Missouri caps the accumulated property tax credit phaseout percent at this rate.
 values:
+  # The 4% cap is unreachable within the pre-2026 income limits: the
+  # accumulation peaks at 53 increments (3.3125%) at the 30,000 owner limit.
   2008-08-28: 0.04
   2026-01-01: 0.02
 metadata:
@@ -7,7 +9,7 @@ metadata:
   period: year
   label: Missouri property tax credit maximum phaseout rate
   reference:
-    - title: MO Rev Stat § 135.030 (2)
+    - title: MO Rev Stat § 135.030.2(1)
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
-    - title: MO Rev Stat § 135.030 (3)(1), effective 2026-01-01
+    - title: MO Rev Stat § 135.030.3(1), effective 2026-01-01
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/max_rate.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/max_rate.yaml
@@ -1,0 +1,13 @@
+description: Missouri caps the accumulated property tax credit phaseout percent at this rate.
+values:
+  2008-08-28: 0.04
+  2026-01-01: 0.02
+metadata:
+  unit: /1
+  period: year
+  label: Missouri property tax credit maximum phaseout rate
+  reference:
+    - title: MO Rev Stat § 135.030 (2)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
+    - title: MO Rev Stat § 135.030 (3)(1), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/payment_increment.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/payment_increment.yaml
@@ -1,0 +1,14 @@
+description: Missouri computes the property tax credit from a table with qualifying property tax and rent amounts in increments of this width.
+values:
+  2008-08-28: 25
+metadata:
+  unit: currency-USD
+  period: year
+  label: Missouri property tax credit table payment increment
+  reference:
+    - title: MO Rev Stat § 135.030 (2)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
+    - title: MO Rev Stat § 135.030 (3)(2), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542
+    - title: 2025 Property Tax Credit Chart
+      href: https://dor.mo.gov/forms/Property%20Tax%20Claim%20Chart_2025.pdf#page=1

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/payment_increment.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/payment_increment.yaml
@@ -6,9 +6,9 @@ metadata:
   period: year
   label: Missouri property tax credit table payment increment
   reference:
-    - title: MO Rev Stat § 135.030 (2)
+    - title: MO Rev Stat § 135.030.2(2)
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
-    - title: MO Rev Stat § 135.030 (3)(2), effective 2026-01-01
+    - title: MO Rev Stat § 135.030.3(2), effective 2026-01-01
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542
     - title: 2025 Property Tax Credit Chart
       href: https://dor.mo.gov/forms/Property%20Tax%20Claim%20Chart_2025.pdf#page=1

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/rate.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/rate.yaml
@@ -2,7 +2,7 @@ description: Rate at which maximum MO property tax credit is phased out.
 values:
   2021-01-01: 0.000625  # = 1 / 16 / 100
 metadata:
-  unit: currency-USD
+  unit: /1
   period: year
   label: Missouri property tax credit phaseout rate
   reference:

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/step.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/step.yaml
@@ -1,12 +1,15 @@
 description: Step size by which maximum MO property tax credit is phased out.
 values:
   2021-01-01: 300
+  2026-01-01: 495
 metadata:
   unit: currency-USD
   period: year
   label: Missouri property tax credit phaseout step size
   reference:
     - title: 2025 Property Tax Credit Chart
-      href: https://dor.mo.gov/forms/Property%20Tax%20Claim%20Chart_2025.pdf
+      href: https://dor.mo.gov/forms/Property%20Tax%20Claim%20Chart_2025.pdf#page=1
     - title: MO Rev Stat § 135.030
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
+    - title: MO Rev Stat § 135.030 (3)(1), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/step.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/phase_out/step.yaml
@@ -1,6 +1,8 @@
 description: Step size by which maximum MO property tax credit is phased out.
 values:
   2021-01-01: 300
+  # Indexed annually for inflation (national CPI-U) from 2027-01-01;
+  # update when DOR publishes adjusted amounts.
   2026-01-01: 495
 metadata:
   unit: currency-USD
@@ -9,7 +11,9 @@ metadata:
   reference:
     - title: 2025 Property Tax Credit Chart
       href: https://dor.mo.gov/forms/Property%20Tax%20Claim%20Chart_2025.pdf#page=1
-    - title: MO Rev Stat § 135.030
+    - title: MO Rev Stat § 135.030.2(1)
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
-    - title: MO Rev Stat § 135.030 (3)(1), effective 2026-01-01
+    - title: MO Rev Stat § 135.030.3(1), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542
+    - title: MO Rev Stat § 135.030.3(2) (table income increments), effective 2026-01-01
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/property_tax_limit.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/property_tax_limit.yaml
@@ -1,6 +1,8 @@
 description: Maximum claimable property tax associated with an owned property.
 values:
   2008-08-28: 1_100
+  # Indexed annually for inflation (Midwest-region CPI-U) from 2027-01-01
+  # per RSMo 135.025; update when DOR publishes adjusted amounts.
   2026-01-01: 1_550
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/rent_property_tax_limit.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/rent_property_tax_limit.yaml
@@ -1,6 +1,8 @@
 description: Maximum claimable property tax associated with a rented property.
 values:
   2008-08-28: 750
+  # Indexed annually for inflation (Midwest-region CPI-U) from 2027-01-01
+  # per RSMo 135.025; update when DOR publishes adjusted amounts.
   2026-01-01: 1_055
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married.yaml
@@ -1,0 +1,13 @@
+description: Missouri property tax credit upper income limit for married filing combined.
+values:
+  2008-08-28: 27_500
+  2026-01-01: 41_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Missouri property tax credit upper income limit for married filing combined
+  reference:
+    - title: MO Rev Stat § 135.030 (1)(2)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
+    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married.yaml
@@ -1,13 +1,15 @@
 description: Missouri property tax credit upper income limit for married filing combined.
 values:
   2008-08-28: 27_500
+  # Indexed annually for inflation (national CPI-U) from 2027-01-01;
+  # update when DOR publishes adjusted amounts.
   2026-01-01: 41_000
 metadata:
   unit: currency-USD
   period: year
   label: Missouri property tax credit upper income limit for married filing combined
   reference:
-    - title: MO Rev Stat § 135.030 (1)(2)
+    - title: MO Rev Stat § 135.030.1(1)
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
-    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+    - title: MO Rev Stat § 135.030.1(1)(c), effective 2026-01-01
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married_homestead.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married_homestead.yaml
@@ -1,13 +1,15 @@
 description: Missouri property tax credit upper income limit for married homestead owners.
 values:
   2008-08-28: 30_000
+  # Indexed annually for inflation (national CPI-U) from 2027-01-01;
+  # update when DOR publishes adjusted amounts.
   2026-01-01: 48_000
 metadata:
   unit: currency-USD
   period: year
   label: Missouri property tax credit upper income limit for married homestead owners
   reference:
-    - title: MO Rev Stat § 135.030 (1)(2)
+    - title: MO Rev Stat § 135.030.1(1)
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
-    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+    - title: MO Rev Stat § 135.030.1(1)(d), effective 2026-01-01
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married_homestead.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/married_homestead.yaml
@@ -1,0 +1,13 @@
+description: Missouri property tax credit upper income limit for married homestead owners.
+values:
+  2008-08-28: 30_000
+  2026-01-01: 48_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Missouri property tax credit upper income limit for married homestead owners
+  reference:
+    - title: MO Rev Stat § 135.030 (1)(2)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
+    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single.yaml
@@ -1,0 +1,13 @@
+description: Missouri property tax credit upper income limit for single filers.
+values:
+  2008-08-28: 27_500
+  2026-01-01: 38_200
+metadata:
+  unit: currency-USD
+  period: year
+  label: Missouri property tax credit upper income limit for single filers
+  reference:
+    - title: MO Rev Stat § 135.030 (1)(2)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
+    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single.yaml
@@ -1,13 +1,15 @@
 description: Missouri property tax credit upper income limit for single filers.
 values:
   2008-08-28: 27_500
+  # Indexed annually for inflation (national CPI-U) from 2027-01-01;
+  # update when DOR publishes adjusted amounts.
   2026-01-01: 38_200
 metadata:
   unit: currency-USD
   period: year
   label: Missouri property tax credit upper income limit for single filers
   reference:
-    - title: MO Rev Stat § 135.030 (1)(2)
+    - title: MO Rev Stat § 135.030.1(1)
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
-    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+    - title: MO Rev Stat § 135.030.1(1)(a), effective 2026-01-01
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single_homestead.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single_homestead.yaml
@@ -1,13 +1,15 @@
 description: Missouri property tax credit upper income limit for single homestead owners.
 values:
   2008-08-28: 30_000
+  # Indexed annually for inflation (national CPI-U) from 2027-01-01;
+  # update when DOR publishes adjusted amounts.
   2026-01-01: 42_200
 metadata:
   unit: currency-USD
   period: year
   label: Missouri property tax credit upper income limit for single homestead owners
   reference:
-    - title: MO Rev Stat § 135.030 (1)(2)
+    - title: MO Rev Stat § 135.030.1(1)
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
-    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+    - title: MO Rev Stat § 135.030.1(1)(b), effective 2026-01-01
       href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single_homestead.yaml
+++ b/policyengine_us/parameters/gov/states/mo/tax/income/credits/property_tax/upper_income_limit/single_homestead.yaml
@@ -1,0 +1,13 @@
+description: Missouri property tax credit upper income limit for single homestead owners.
+values:
+  2008-08-28: 30_000
+  2026-01-01: 42_200
+metadata:
+  unit: currency-USD
+  period: year
+  label: Missouri property tax credit upper income limit for single homestead owners
+  reference:
+    - title: MO Rev Stat § 135.030 (1)(2)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439
+    - title: MO Rev Stat § 135.030 (1)(1), effective 2026-01-01
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.yaml
@@ -82,8 +82,11 @@
     household:
       members: [person1]
       state_code: MO
-  output:  # expected results from TAXSIM35 12/24/22 version
-    mo_property_tax_credit: 721.87
+  output:
+    # 2025 DOR credit chart, row 14,901-15,200, column 726-750: payment
+    # midpoint 738 less ceil(3 x 0.0625% x 15,050) = 29 gives 709. TAXSIM35
+    # approximates the table with a continuous formula (721.87).
+    mo_property_tax_credit: 709
 
 - name: TAXSIM35 test S3
   period: 2021
@@ -110,8 +113,11 @@
     household:
       members: [person1]
       state_code: MO
-  output:  # expected results from TAXSIM35 12/24/22 version
-    mo_property_tax_credit: 187.50
+  output:
+    # 2025 DOR credit chart, row 24,801-25,100, column 726-750: payment
+    # midpoint 738 less ceil(36 x 0.0625% x 24,950) = 562 gives 176. TAXSIM35
+    # approximates the table with a continuous formula (187.50).
+    mo_property_tax_credit: 176
 
 - name: TAXSIM35 integration test, 16k income, 12k real estate taxes
   period: 2021
@@ -146,3 +152,184 @@
       state_code: MO
   output:  # expected results from TAXSIM35 12/08/22 version
     mo_property_tax_credit: 1_100
+
+- name: 2021 chart final clipped row, homestead owner near the 30,000 limit
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 68
+        real_estate_taxes: 1_200
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 29_950
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # DOR credit chart row 29,901-30,000 (clipped at the limit), column
+    # 1,076-1,100: 1,088 less ceil(53 x 0.0625% x 29,950) = 993 gives 95.
+    mo_property_tax_credit: 95
+
+- name: 2021 homestead owner above the 30,000 income limit gets nothing
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 68
+        real_estate_taxes: 1_200
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 30_300
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_property_tax_credit: 0
+
+- name: 2026 single owner on the 2% plateau, RSMo 135.030(3)(1)
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_800
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 42_100
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # 57 increments of 495 above 14,300 accumulate past the 2% cap; final
+    # bracket 42,021-42,515 is clipped at the 42,200 limit, midpoint 42,110;
+    # 1,538 payment midpoint less ceil(2% x 42,110) = 843 gives 695.
+    mo_property_tax_credit: 695
+
+- name: 2026 married full-year owners below the minimum base get the full credit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 2_200
+      person2:
+        is_tax_unit_spouse: true
+        age: 64
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        # 19,200 gross less the 5,800 owner offset is 13,400 net income,
+        # below the 14,300 minimum base
+        mo_ptc_gross_income: 19_200
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_property_tax_credit: 1_550
+
+- name: 2026 single renter just above the minimum base uses table midpoints
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_400
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Rent equivalent 1,200 capped at 1,055, increment 1,031-1,055 midpoint
+    # 1,043; one 495 increment, bracket 14,301-14,795 midpoint 14,547.5;
+    # 1,043 less ceil(0.0625% x 14,547.5) = 10 gives 1,033.
+    mo_property_tax_credit: 1_033
+
+- name: 2026 single renter at the 38,200 income limit keeps a plateau credit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 38_200
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # 49 increments cap the rate at 2%; final bracket 38,061-38,555 is
+    # clipped at the 38,200 limit, midpoint 38,130; 1,043 payment midpoint
+    # less ceil(2% x 38,130) = 763 gives 280.
+    mo_property_tax_credit: 280
+
+- name: 2026 single renter above the 38,200 income limit gets nothing
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 38_300
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_property_tax_credit: 0
+
+- name: 2026 mixed rent and property tax combine under the owner cap
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 3_000
+        real_estate_taxes: 500
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 20_000
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Payment 600 rent equivalent plus 500 property tax is 1,100; increment
+    # 1,076-1,100 midpoint 1,088; 12 increments give a 0.75% rate on bracket
+    # 19,746-20,240 midpoint 19,992.5; 1,088 less ceil(149.95) = 150 is 938.
+    mo_property_tax_credit: 938

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.yaml
@@ -481,3 +481,133 @@
   output:
     mo_ptc_taxunit_eligible: false
     mo_property_tax_credit: 0
+
+- name: 2026 eligible owner fully phased out through the formula floor
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 30
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 42_200
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Eligible (income at the 42,200 homestead limit), but the 38 payment
+    # midpoint is below the 843 phase-out, so the formula floors at zero.
+    mo_ptc_taxunit_eligible: true
+    mo_property_tax_credit: 0
+
+- name: 2026 renter at the minimum base receives the actual capped payment
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_300
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # At the base there is no table lookup: 20% of 6,000 capped at 1,055.
+    mo_property_tax_credit: 1_055
+
+- name: 2026 renter one dollar over the minimum base switches to the table
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_301
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # First increment: payment midpoint 1,043 less ceil(0.0625% x 14,547.5)
+    # = 10 gives 1,033.
+    mo_property_tax_credit: 1_033
+
+- name: 2025 DOR chart cell, row 14,901-15,200, column 726-750
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 15_000
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Payment midpoint 738 less ceil(3 x 0.0625% x 15,050) = 29 gives 709.
+    mo_property_tax_credit: 709
+
+- name: 2025 DOR chart cell, row 24,801-25,100, column 726-750
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 25_000
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Payment midpoint 738 less ceil(36 x 0.0625% x 24,950) = 562 gives 176.
+    mo_property_tax_credit: 176
+
+- name: Negative gross income floors net income at zero and pays in full
+  period: 2021
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_200
+    tax_units:
+      tax_unit:
+        members: [person1]
+        # Nonbusiness losses can push PTC gross income negative; net income
+        # floors at zero, below the base, so the capped payment is paid.
+        mo_ptc_gross_income: -5_000
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_property_tax_credit: 1_100

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.yaml
@@ -333,3 +333,151 @@
     # 1,076-1,100 midpoint 1,088; 12 increments give a 0.75% rate on bracket
     # 19,746-20,240 midpoint 19,992.5; 1,088 less ceil(149.95) = 150 is 938.
     mo_property_tax_credit: 938
+
+- name: 2025 payment rounds down before selecting a table column
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_075.49
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_400
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Line 11 rounds to 1,075, selecting the 1,051-1,075 column. Its 1,063
+    # midpoint less the first-row phaseout of 10 produces a 1,053 credit.
+    mo_property_tax_credit: 1_053
+
+- name: 2025 payment rounds up before selecting a table column
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_075.50
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_400
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Line 11 rounds to 1,076, selecting the 1,076-1,100 column. Its 1,088
+    # midpoint less the first-row phaseout of 10 produces a 1,078 credit.
+    mo_property_tax_credit: 1_078
+
+- name: 2025 income rounds down before selecting a table row
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_100
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_600.49
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Line 8 rounds to 14,600, selecting the 14,301-14,600 row.
+    mo_property_tax_credit: 1_078
+
+- name: 2025 income rounds up before selecting a table row
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_100
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_600.50
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # Line 8 rounds to 14,601, selecting the 14,601-14,900 row.
+    mo_property_tax_credit: 1_069
+
+- name: 2025 below-base payment rounds to the nearest whole dollar
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 500.50
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 14_000
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_property_tax_credit: 501
+
+- name: 2026 income rounds down to the upper eligibility limit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 38_200.49
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+    mo_property_tax_credit: 280
+
+- name: 2026 income rounds above the upper eligibility limit
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 38_200.50
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+    mo_property_tax_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_ptc_income_offset.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_ptc_income_offset.yaml
@@ -49,6 +49,50 @@
   output:
     mo_ptc_income_offset: 2_000
 
+- name: Joint renter offset rises to 2,800 in 2026 per RSMo 135.010(5)
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 30
+      person2:
+        is_tax_unit_spouse: true
+        age: 29
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        rents: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_income_offset: 2_800
+
+- name: Joint owner offset rises to 5,800 in 2026 per RSMo 135.010(5)
+  absolute_error_margin: 0.01
+  period: 2026
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 30
+      person2:
+        is_tax_unit_spouse: true
+        age: 29
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        rents: false
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_income_offset: 5_800
+
 - name: Unit test 3 for MO property tax credit income offset (joint owner)
   absolute_error_margin: 0.01
   period: 2021

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.yaml
@@ -1,74 +1,257 @@
-- name: Head of household disability qualification
+# Categorical pathways per RSMo 135.010(1), payment requirement per RSMo
+# 135.025 and the DOR eligibility diagram, income limits per RSMo 135.030(1).
+- name: Disabled head qualifies through the general disability definition
   period: 2022
   absolute_error_margin: 0
   input:
-    age_head: 50
-    age_spouse: 50
-    disabled_head: true
-    disabled_spouse: false
-    military_disabled_head: false
-    military_disabled_spouse: false
-    social_security_survivors: false
-    state_code: MO
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 50
+        is_disabled: true
+        rent: 3_600
+    households:
+      household:
+        members: [person1]
+        state_code: MO
   output:
     mo_ptc_taxunit_eligible: true
 
-- name: Head of household age qualification
+- name: Head aged 65 or older qualifies
   period: 2022
   absolute_error_margin: 0
   input:
-    age_head: 66
-    age_spouse: 64
-    disabled_head: false 
-    disabled_spouse: false
-    military_disabled_head: false
-    military_disabled_spouse: false
-    social_security_survivors: false
-    state_code: MO
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 500
+    households:
+      household:
+        members: [person1]
+        state_code: MO
   output:
     mo_ptc_taxunit_eligible: true
 
-- name: Military disabled spouse qualfication
+- name: Military disabled spouse qualifies
   period: 2022
   absolute_error_margin: 0
   input:
-    age_head: 29
-    age_spouse: 35
-    disabled_head: false 
-    disabled_spouse: false
-    military_disabled_head: false
-    military_disabled_spouse: true
-    social_security_survivors: false
-    state_code: MO
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 29
+        rent: 3_600
+      person2:
+        is_tax_unit_spouse: true
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        military_disabled_spouse: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
   output:
     mo_ptc_taxunit_eligible: true
 
-- name: Both qualifying, all counts
+- name: No categorical pathway is not eligible
   period: 2022
   absolute_error_margin: 0
   input:
-    age_head: 66
-    age_spouse: 66
-    disabled_head: true 
-    disabled_spouse: true
-    military_disabled_head: true
-    military_disabled_spouse: true
-    social_security_survivors: false
-    state_code: MO
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 29
+        rent: 3_600
+      person2:
+        is_tax_unit_spouse: true
+        age: 35
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Claimant aged 60 receiving surviving spouse Social Security qualifies
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 62
+        social_security_survivors: 6_000
+        rent: 3_600
+    households:
+      household:
+        members: [person1]
+        state_code: MO
   output:
     mo_ptc_taxunit_eligible: true
 
-- name: Both not qualifying
+- name: Survivor pathway is claimant-only, a qualifying spouse does not count
   period: 2022
   absolute_error_margin: 0
   input:
-    age_head: 29
-    age_spouse: 35
-    disabled_head: false 
-    disabled_spouse: false
-    military_disabled_head: false
-    military_disabled_spouse: false
-    social_security_survivors: false
-    state_code: MO
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 58
+        rent: 3_600
+      person2:
+        is_tax_unit_spouse: true
+        age: 62
+        social_security_survivors: 6_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: A child's survivor benefits do not qualify an aged head
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 62
+        rent: 3_600
+      person2:
+        age: 10
+        social_security_survivors: 6_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: No rent or property tax paid is not eligible
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 70
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Single renter at the 2026 income limit is eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 38_200
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+
+- name: Single renter above the 2026 income limit is not eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 38_300
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Married homestead owners at the 2026 net income limit are eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 2_000
+      person2:
+        is_tax_unit_spouse: true
+        age: 64
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        # 53,800 gross less the 5,800 owner offset is 48,000 net income
+        mo_ptc_gross_income: 53_800
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+
+- name: Married homestead owners above the 2026 net income limit are not eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 2_000
+      person2:
+        is_tax_unit_spouse: true
+        age: 64
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        # 53,900 gross less the 5,800 owner offset is 48,100 net income
+        mo_ptc_gross_income: 53_900
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Homestead owner above the pre-2026 30,000 limit is not eligible
+  period: 2021
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_200
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 30_300
+    households:
+      household:
+        members: [person1]
+        state_code: MO
   output:
     mo_ptc_taxunit_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.yaml
@@ -255,3 +255,211 @@
         state_code: MO
   output:
     mo_ptc_taxunit_eligible: false
+
+- name: Claimant at exactly 60 with own survivor benefits qualifies
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 60
+        social_security_survivors: 6_000
+        rent: 3_600
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+
+- name: Claimant at 59 with own survivor benefits does not qualify
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 59
+        social_security_survivors: 6_000
+        rent: 3_600
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Paying both rent and property tax takes the renter income limit
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 100
+        real_estate_taxes: 1_800
+    tax_units:
+      tax_unit:
+        members: [person1]
+        # Any rent paid means the part-year 38,200 limit applies, not the
+        # 42,200 full-year homestead limit.
+        mo_ptc_gross_income: 40_000
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Paying both rent and property tax is eligible under the renter limit
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 100
+        real_estate_taxes: 1_800
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 38_100
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+
+- name: Single homestead owner at the 2026 income limit is eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_200
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 42_200
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+
+- name: Single homestead owner above the 2026 income limit is not eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        real_estate_taxes: 1_200
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 42_300
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Married renters at the 2026 net income limit are eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+      person2:
+        is_tax_unit_spouse: true
+        age: 64
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        # 43,800 gross less the 2,800 renter offset is 41,000 net income
+        mo_ptc_gross_income: 43_800
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+
+- name: Married renters above the 2026 net income limit are not eligible
+  period: 2026
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+      person2:
+        is_tax_unit_spouse: true
+        age: 64
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: JOINT
+        # 43,900 gross less the 2,800 renter offset is 41,100 net income
+        mo_ptc_gross_income: 43_900
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false
+
+- name: Renter at the pre-2026 27,500 limit is eligible
+  period: 2021
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 27_500
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: true
+
+- name: Renter above the pre-2026 27,500 limit is not eligible
+  period: 2021
+  absolute_error_margin: 0
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 66
+        rent: 6_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        mo_ptc_gross_income: 27_600
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    mo_ptc_taxunit_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/income_tax/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/tax/income/income_tax/integration.yaml
@@ -177,7 +177,7 @@
     people:
       person1:
         age: 45
-        is_ssi_disabled: true
+        is_disabled: true
         employment_income: 18_000
         rent: 9_600
     tax_units:
@@ -193,12 +193,15 @@
         state_code: MO
   output:
     # Form MO-WFTC 2025: Line 6 = 20% x $84.43 EITC = $16.89; Line 7 =
-    # $17.17 tax before credits; Line 8 includes the $446.49 property tax
-    # credit; Line 9 = max(17.17 - 446.49, 0) = 0; Line 10 = min(16.89, 0).
+    # $17.17 tax before credits; Line 8 includes the $591 property tax
+    # credit from the 2025 DOR chart: rent 20% x 9,600 = 1,920 capped at
+    # 750 (payment midpoint 738), net income 18,000 in the 17,901-18,200
+    # row, phase-out = ceil(13 x 0.0625% x 18,050) = 147, 738 - 147 = 591;
+    # Line 9 = max(17.17 - 591, 0) = 0; Line 10 = min(16.89, 0).
     eitc: 84.43
     mo_wftc_potential: 16.89
     mo_income_tax_before_credits: 17.17
-    mo_property_tax_credit: 446.49
+    mo_property_tax_credit: 591
     mo_wftc_liability_cap: 0
     mo_wftc: 0
-    mo_income_tax: -429.32
+    mo_income_tax: -573.84

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.py
@@ -8,31 +8,49 @@ class mo_property_tax_credit(Variable):
     unit = USD
     definition_period = YEAR
     reference = (
-        "https://dor.mo.gov/forms/MO-PTS_2021.pdf",
-        "https://revisor.mo.gov/main/OneSection.aspx?section=135.010&bid=6435",
         "https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439",
+        "https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542",
+        "https://dor.mo.gov/forms/Property%20Tax%20Claim%20Chart_2025.pdf#page=1",
     )
     defined_for = "mo_ptc_taxunit_eligible"
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.mo.tax.income.credits.property_tax
-        # compute maximum (that is, pre-phaseout) credit amount for rent
+        # Qualifying payment: 20% of gross rent (capped) plus property taxes,
+        # subject to the combined property tax limit, per RSMo 135.010(7) and
+        # 135.030.
         rent = add(tax_unit, period, ["rent"])
-        ratio = p.property_tax_rent_ratio
-        rent_limit = p.rent_property_tax_limit
-        rent_amount = min_(rent * ratio, rent_limit)
-        # compute maximum (that is, pre-phaseout) credit amount for taxes
-        ptax = add(tax_unit, period, ["real_estate_taxes"])
-        ptax_limit = p.property_tax_limit
-        ptax_amount = min_(ptax, ptax_limit)
-        # combine the rent_amount and ptax_amount subject to ptax_limit
-        max_credit = min_(rent_amount + ptax_amount, ptax_limit)
-        # phase out credit amount using legislative formula (not form table)
-        po_start = p.phase_out.threshold
-        po_step = p.phase_out.step
-        po_rate = p.phase_out.rate
+        rent_equivalent = min_(
+            rent * p.property_tax_rent_ratio, p.rent_property_tax_limit
+        )
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+        payment = min_(
+            rent_equivalent + min_(property_tax, p.property_tax_limit),
+            p.property_tax_limit,
+        )
         net_income = tax_unit("mo_ptc_net_income", period)
-        excess_income = max_(0, net_income - po_start)
-        po_steps = np.ceil(excess_income / po_step)
-        phaseout_amount = po_rate * po_steps * net_income
-        return max_(0, max_credit - phaseout_amount)
+        base = p.phase_out.threshold
+        step = p.phase_out.step
+        # RSMo 135.030(2)-(3): income at or below the minimum base receives
+        # the actual capped payment; above it, the credit comes from the
+        # director's table, which accumulates 1/16% per income increment (up
+        # to the maximum rate) and computes at increment midpoints. The
+        # statute says the result is rounded to the nearest whole dollar,
+        # but the published DOR charts round the credit down (the phaseout
+        # up); this formula reproduces every cell of the published charts.
+        increments = np.ceil(max_(net_income - base, 0) / step)
+        rate = min_(increments * p.phase_out.rate, p.phase_out.max_rate)
+        # The final income increment is clipped at the upper income limit.
+        income_limit = tax_unit("mo_ptc_income_limit", period)
+        bracket_bottom = base + (increments - 1) * step
+        bracket_top = min_(base + increments * step, income_limit)
+        income_midpoint = (bracket_bottom + bracket_top) / 2
+        phase_out = np.ceil(rate * income_midpoint)
+        # Payment increments are anchored at the applicable cap; renter-only
+        # units use the rent-equivalent cap.
+        cap = where(property_tax > 0, p.property_tax_limit, p.rent_property_tax_limit)
+        width = p.phase_out.payment_increment
+        payment_steps = (cap - payment) // width
+        payment_midpoint = cap - payment_steps * width - (width - 1) / 2
+        table_credit = max_(payment_midpoint - phase_out, 0)
+        return where(increments == 0, payment, table_credit)

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_property_tax_credit.py
@@ -28,7 +28,9 @@ class mo_property_tax_credit(Variable):
             rent_equivalent + min_(property_tax, p.property_tax_limit),
             p.property_tax_limit,
         )
-        net_income = tax_unit("mo_ptc_net_income", period)
+        # DOR forms round entries half-up to whole dollars before table lookup.
+        payment = np.floor(payment + 0.5)
+        net_income = np.floor(tax_unit("mo_ptc_net_income", period) + 0.5)
         base = p.phase_out.threshold
         step = p.phase_out.step
         # RSMo 135.030(2)-(3): income at or below the minimum base receives

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_income_limit.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_income_limit.py
@@ -1,0 +1,37 @@
+from policyengine_us.model_api import *
+
+
+class mo_ptc_income_limit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Missouri property tax credit upper income limit"
+    unit = USD
+    definition_period = YEAR
+    reference = (
+        "https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=6439",
+        "https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542",
+    )
+    defined_for = StateCode.MO
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.mo.tax.income.credits.property_tax
+        filing_status = tax_unit("filing_status", period)
+        joint = filing_status == filing_status.possible_values.JOINT
+        # The higher homestead limit requires a homestead owned and occupied
+        # by the claimant for the entire year; units that paid any rent take
+        # the renter/part-year-owner limit.
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+        homestead = (property_tax > 0) & ~tax_unit("rents", period)
+        return where(
+            joint,
+            where(
+                homestead,
+                p.upper_income_limit.married_homestead,
+                p.upper_income_limit.married,
+            ),
+            where(
+                homestead,
+                p.upper_income_limit.single_homestead,
+                p.upper_income_limit.single,
+            ),
+        )

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.py
@@ -2,45 +2,51 @@ from policyengine_us.model_api import *
 
 
 class mo_ptc_taxunit_eligible(Variable):
-    value_type = float
+    value_type = bool
     entity = TaxUnit
     label = "Missouri property tax credit taxunit eligible"
-    unit = USD
     definition_period = YEAR
     reference = (
-        "https://dor.mo.gov/forms/MO-PTS_2021.pdf",
         "https://revisor.mo.gov/main/OneSection.aspx?section=135.010&bid=6435",
+        "https://revisor.mo.gov/main/OneSection.aspx?section=135.030&bid=57542",
+        "https://dor.mo.gov/forms/MO-PTC%20Instructions_2025.pdf#page=2",
     )
     defined_for = StateCode.MO
 
     def formula(tax_unit, period, parameters):
-        # check age
+        p = parameters(period).gov.states.mo.tax.income.credits.property_tax
+        # RSMo 135.010(1) claimant pathways; the first three are satisfied by
+        # the claimant or spouse.
         age_head = tax_unit("age_head", period)
         age_spouse = tax_unit("age_spouse", period)
-        p = parameters(period).gov.states.mo.tax.income.credits.property_tax
-        elderly_head = age_head >= p.age_threshold
-        elderly_spouse = age_spouse >= p.age_threshold
-        elderly_head_or_spouse = elderly_head | elderly_spouse
-        # check disability
-        disabled_head = tax_unit("disabled_head", period)
-        disabled_spouse = tax_unit("disabled_spouse", period)
-        disabled_head_or_spouse = disabled_head | disabled_spouse
-        # check for military disability
-        military_disabled_head = tax_unit("military_disabled_head", period)
-        military_disabled_spouse = tax_unit("military_disabled_spouse", period)
-        military_disabled_head_or_spouse = (
-            military_disabled_head | military_disabled_spouse
+        elderly = (age_head >= p.age_threshold) | (age_spouse >= p.age_threshold)
+        # 135.010(2) defines "disabled" by inability to engage in substantial
+        # gainful activity, without requiring SSI participation.
+        disabled = tax_unit("head_is_disabled", period) | tax_unit(
+            "spouse_is_disabled", period
         )
-        # check aged social security survivor benefits eligibility
-        survivor_ben = add(tax_unit, period, ["social_security_survivors"]) > 0
-        aged_survivor_min_age = p.aged_survivor_min_age
-        aged_head = age_head >= aged_survivor_min_age
-        aged_spouse = age_spouse >= aged_survivor_min_age
-        aged_head_or_spouse = aged_head | aged_spouse
-        survivor_benefits_eligible = survivor_ben & aged_head_or_spouse
-        return (
-            elderly_head_or_spouse
-            | disabled_head_or_spouse
-            | military_disabled_head_or_spouse
-            | survivor_benefits_eligible
+        military_disabled = tax_unit("military_disabled_head", period) | tax_unit(
+            "military_disabled_spouse", period
         )
+        # The surviving-spouse pathway applies to the claimant only: the
+        # claimant must be 60 or older and have received surviving spouse
+        # Social Security benefits themselves.
+        person = tax_unit.members
+        head_survivor_benefits = tax_unit.sum(
+            person("social_security_survivors", period)
+            * person("is_tax_unit_head", period)
+        )
+        aged_survivor = (age_head >= p.aged_survivor_min_age) & (
+            head_survivor_benefits > 0
+        )
+        categorical = elderly | disabled | military_disabled | aged_survivor
+        # RSMo 135.025 bases the credit on property taxes accrued and rent
+        # constituting property taxes accrued; DOR routes claimants who paid
+        # neither to not eligible.
+        rent = add(tax_unit, period, ["rent"])
+        property_tax = add(tax_unit, period, ["real_estate_taxes"])
+        paid_rent_or_property_tax = (rent + property_tax) > 0
+        # RSMo 135.030(1) caps net income at the maximum upper limit.
+        net_income = tax_unit("mo_ptc_net_income", period)
+        income_eligible = net_income <= tax_unit("mo_ptc_income_limit", period)
+        return categorical & paid_rent_or_property_tax & income_eligible

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.py
@@ -30,7 +30,9 @@ class mo_ptc_taxunit_eligible(Variable):
         )
         # The surviving-spouse pathway applies to the claimant only: the
         # claimant must be 60 or older and have received surviving spouse
-        # Social Security benefits themselves.
+        # Social Security benefits themselves. The model treats the tax
+        # unit head as the filer/claimant, so the same-person test runs on
+        # the head; the other three pathways are claimant-or-spouse.
         person = tax_unit.members
         head_survivor_benefits = tax_unit.sum(
             person("social_security_survivors", period)

--- a/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/tax/income/credits/property_tax/mo_ptc_taxunit_eligible.py
@@ -47,6 +47,7 @@ class mo_ptc_taxunit_eligible(Variable):
         property_tax = add(tax_unit, period, ["real_estate_taxes"])
         paid_rent_or_property_tax = (rent + property_tax) > 0
         # RSMo 135.030(1) caps net income at the maximum upper limit.
-        net_income = tax_unit("mo_ptc_net_income", period)
+        # DOR forms round entries half-up to whole dollars.
+        net_income = np.floor(tax_unit("mo_ptc_net_income", period) + 0.5)
         income_eligible = net_income <= tax_unit("mo_ptc_income_limit", period)
         return categorical & paid_rent_or_property_tax & income_eligible


### PR DESCRIPTION
## Summary

Full refactor of the Missouri Property Tax Credit ("circuit breaker"): replaces the continuous phaseout approximation with the statutory/DOR credit-table method, implements the remaining 2026 H.B. 594 & 508 changes, and corrects the eligibility pathways.

Fixes #9208
Fixes #9209
Fixes #9210
Fixes #1285

## Regulatory authority

- [RSMo §135.010](https://revisor.mo.gov/main/OneSection.aspx?section=135.010) (definitions: claimant, disabled, income, gross rent, property taxes accrued)
- [RSMo §135.025](https://revisor.mo.gov/main/OneSection.aspx?section=135.025) (qualifying payment caps)
- [RSMo §135.030](https://revisor.mo.gov/main/OneSection.aspx?section=135.030) (minimum base, maximum upper limits, phaseout table)
- [2025 Property Tax Credit Chart](https://dor.mo.gov/forms/Property%20Tax%20Claim%20Chart_2025.pdf#page=1) (DOR-published table, used to validate the algorithm)
- [2025 MO-PTC instructions](https://dor.mo.gov/forms/MO-PTC%20Instructions_2025.pdf#page=2) (eligibility diagram)

All statutory values below were verified against the current revisor.mo.gov text (effective 2025-08-28, A.L. 2025 H.B. 594 & 508, which embeds both the pre-2026 and 2026+ eras as date-conditioned text).

## The table method (#1285)

RSMo §135.030 directs the DOR to compute the credit from a table with $25 payment increments and $300 (2026: $495) income increments, "computed on the basis of the property tax and income at the midpoints of each increment". The exact convention was reverse-engineered and validated against **all 2,332 cells of the 2025 DOR chart (1,445 credit values + 887 blank "no credit" cells) with zero mismatches**, including both printed DOR examples and the final clipped row:

- Net income ≤ $14,300 minimum base → credit = the actual capped payment (per the chart's own instruction).
- Otherwise: `credit = payment_midpoint − ceil(rate × income_midpoint)`, floored at 0, where
  - `rate = min(increments × 1/16%, max_rate)` with `increments = ceil((net_income − base)/step)`;
  - the income bracket midpoint uses the `((lo−1)+hi)/2` convention, with the final bracket clipped at the upper income limit (matches the chart's 29,901–30,000 row);
  - payment midpoints are $25-increment midpoints anchored descending from the applicable cap.

Two documented judgment calls:
- **Rounding**: the statute says "rounded to the nearest whole dollar", but the published charts consistently round the credit *down* (the phaseout up). This PR matches the charts.
- **Payment-increment anchor**: anchoring descending from the applicable cap only diverges from a zero-anchored grid for renter-only units from 2026 (the $1,055 rent cap is not divisible by 25 — every published chart cap is). DOR has not yet published a 2026 chart; this convention matches the partner's (MyFriendBen) validated implementation.

## Parameter changes ([RSMo §135.030.3](https://revisor.mo.gov/main/OneSection.aspx?section=135.030) unless noted)

| Parameter | Pre-2026 | 2026 | Note |
|---|---|---|---|
| `phase_out/step` | $300 | $495 | |
| `phase_out/max_rate` (new) | 4% | 2% | pre-2026 cap never binds; the 2% cap creates a plateau |
| `phase_out/payment_increment` (new) | $25 | $25 | table payment increment |
| `income_offset/joint_renter` | $2,000 | $2,800 | §135.010(5) spouse exemption |
| `income_offset/joint_owner` | $4,000 | $5,800 | §135.010(5), full-year owner-occupied |
| `upper_income_limit/single` (restored) | $27,500 | $38,200 | §135.030.1(1) |
| `upper_income_limit/single_homestead` (restored) | $30,000 | $42,200 | |
| `upper_income_limit/married` (restored) | $27,500 | $41,000 | |
| `upper_income_limit/married_homestead` (restored) | $30,000 | $48,000 | |

The four upper-income-limit files restore the parameters removed in 4c0855990964 ("can be re-added in a follow-up PR when the formula is also updated") — this is that follow-up. Drive-by: `phase_out/rate` metadata unit corrected from `currency-USD` to `/1`.

## Eligibility changes (`mo_ptc_taxunit_eligible`, now `bool`)

| Change | Authority |
|---|---|
| Survivor pathway is claimant-only: the head must be 60+ **and** have received the surviving-spouse Social Security benefits themselves (a spouse's or child's benefits no longer qualify) | §135.010(1): "the claimant has reached the age of sixty… and such claimant received surviving spouse Social Security benefits" |
| Disability pathway switched from SSI-specific `disabled_head`/`disabled_spouse` to `head_is_disabled`/`spouse_is_disabled` (general SGA standard; no benefit receipt required) | §135.010(2); matches RI/WI/KS/OK convention |
| New gate: rent or property tax must actually have been paid | §135.010(3)/(6), §135.025 ("actually paid"), DOR eligibility diagram |
| New gate: net income ≤ maximum upper limit (new `mo_ptc_income_limit` variable: filing status × full-year-homestead) | §135.030.1(1); also fixes the pre-2026 leak where owners with net income $30,001–≈$31,500 received a small credit |

"Full-year homestead owner" is proxied as paying property tax and no rent; units paying any rent take the renter/part-year limits and the smaller spouse exemption, mirroring the MO-PTS instructions.

## Not modeled (by design)

| What | Source | Why |
|---|---|---|
| Part-year ownership proration | §135.010(6) | ownership duration not collected; units with both rent and property tax fall to the part-year limits |
| Rent to a facility that pays no property tax does not qualify | 2025 chart note | no landlord tax-status concept |
| Full-year MO residency on the age-65 pathway | §135.010(1) | residency duration not modeled; `StateCode.MO` is the proxy |
| §137.106 interaction (repealed 2018) | §135.010(1) footnote | repealed |

## Tests

- 33/33 property-tax directory tests pass; 580/580 full MO shard; 5/5 MO refundable EITC reform tests.
- Every expected value is hand-computed in a YAML comment from the statutory parameters, anchored to published chart cells where they exist (rows 14,901–15,200 → 709, 24,801–25,100 → 176, clipped final row → 95).
- Partner-reported examples reproduce exactly: single owner $42,100/$1,800 → **$695**; married full-year owners $19,200/$2,200 → **$1,550**; renter $14,400/$1,200-equivalent → **$1,033**; plateau/cliff at the $38,200 limit → $280 then $0.
- Old TAXSIM35-derived expectations (721.87, 187.50) intentionally change to the chart values (709, 176): TAXSIM35 approximates the table with a continuous formula; the DOR chart is authoritative.
- One integration test updated from `is_ssi_disabled` to `is_disabled` input to match the corrected disability gate (#9210), with chart-method expectations.

## Verification TODO

- [ ] Verify the payment-increment anchor and rounding against the 2026 DOR chart when published
- [ ] 2027 CPI uprating: §135.025 caps index to **Midwest-region** CPI-U while §135.030 income limits and the $495 increment index to **national** CPI-U — refresh when DOR publishes 2027 values
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
