### PR TITLE
Implement Maryland Premium Assistance

### DIFF
--- a/changelog.d/md-premium-assistance.added.md
+++ b/changelog.d/md-premium-assistance.added.md
@@ -1,0 +1,1 @@
+Add Maryland Premium Assistance (State-Based Health Insurance Subsidies Program).

--- a/policyengine_us/parameters/gov/household/household_health_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_health_benefits.yaml
@@ -7,6 +7,7 @@ values:
     - assigned_aca_ptc
     - basic_health_program
     - co_omnisalud
+    - md_premium_assistance
     - or_healthier_oregon_cost
 
 metadata:

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/fpl_limit.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/fpl_limit.yaml
@@ -1,0 +1,13 @@
+description: Maryland limits the income eligibility to this share of the federal poverty line under the State-Based Health Insurance Subsidies Program.
+values:
+  2026-01-01: 4.0
+
+metadata:
+  unit: /1
+  period: year
+  label: Maryland Premium Assistance income limit as fraction of FPL
+  reference:
+    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
+      href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58
+    - title: MIA 2026 ACA Approved Rates State Subsidy Program Impact, Exhibit 2a
+      href: https://insurance.maryland.gov/Documents/newscenter/newsreleases/2026-ACA-Approved-Rates-State-Subsidy-Program-Impact.pdf#page=1

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/fpl_limit.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/fpl_limit.yaml
@@ -1,6 +1,6 @@
 description: Maryland limits the income eligibility to this share of the federal poverty line under the State-Based Health Insurance Subsidies Program.
 values:
-  2026-01-01: 4.0
+  2026-01-01: 4
 
 metadata:
   unit: /1

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
@@ -1,0 +1,15 @@
+description: Maryland provides state premium assistance under the State-Based Health Insurance Subsidies Program when this is true.
+values:
+  0000-01-01: false
+  2026-01-01: true
+  2028-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: Maryland Premium Assistance in effect
+  reference:
+    - title: Md. Insurance Article § 31-125(D)
+      href: https://www.marylandhbe.com/wp-content/uploads/2025/05/State-Based-Subsidy-Parameters-and-Regulations-Board-5.19.25.pdf#page=22
+    - title: COMAR 14.35.21.04E
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
@@ -1,5 +1,9 @@
 description: Maryland provides state premium assistance under the State-Based Health Insurance Subsidies Program when this is true.
 values:
+  # Program authorized only for plan years 2026-2027, so in effect is false
+  # at 2028-01-01. Abrogation trigger: COMAR 14.35.21.01B and Ch.468 of 2025 §2
+  # abrogate the program "with no further action" if the federal enhanced APTC
+  # is extended for plan years 2026-2027.
   0000-01-01: false
   2026-01-01: true
   2028-01-01: false
@@ -10,6 +14,10 @@ metadata:
   label: Maryland Premium Assistance in effect
   reference:
     - title: Md. Insurance Article § 31-125(D)
+      href: https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gin&section=31-125&enactments=false
+    - title: MHBE State-Based Subsidy Parameters and Regulations (Board 5-19-25)
       href: https://www.marylandhbe.com/wp-content/uploads/2025/05/State-Based-Subsidy-Parameters-and-Regulations-Board-5.19.25.pdf#page=22
-    - title: COMAR 14.35.21.04E (State-Based Subsidies effective for plan years 2026 and 2027)
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=6
+    - title: COMAR 14.35.21.04D (State-Based Subsidies; Board parameter-setting deadline)
+      href: https://regs.maryland.gov/us/md/exec/comar/14.35.21
+    - title: Ch.468 of 2025 §2 (program abrogation if federal enhanced APTC is extended)
+      href: https://mgaleg.maryland.gov/2025RS/chapters_noln/Ch_468_hb1082T.pdf#page=7

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
@@ -11,5 +11,5 @@ metadata:
   reference:
     - title: Md. Insurance Article § 31-125(D)
       href: https://www.marylandhbe.com/wp-content/uploads/2025/05/State-Based-Subsidy-Parameters-and-Regulations-Board-5.19.25.pdf#page=22
-    - title: COMAR 14.35.21.04E
+    - title: COMAR 14.35.21.04E (State-Based Subsidies effective for plan years 2026 and 2027)
       href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=6

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/in_effect.yaml
@@ -12,4 +12,4 @@ metadata:
     - title: Md. Insurance Article § 31-125(D)
       href: https://www.marylandhbe.com/wp-content/uploads/2025/05/State-Based-Subsidy-Parameters-and-Regulations-Board-5.19.25.pdf#page=22
     - title: COMAR 14.35.21.04E
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=6

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
@@ -1,16 +1,24 @@
 description: Maryland sets this final target contribution percentage for each bracket under the State-Based Health Insurance Subsidies Program.
 values:
   # Bands: 0-150%, 150-200%, 200-250%, 250-300%, 300-400% FPL.
-  # MD target = 2025 enhanced (ARPA) percentage + replacement share x
-  # (2026 non-enhanced percentage - 2025 enhanced percentage), where the
+  # MD target = 2026 federal percentage - share x (2026 federal - ARPA),
+  # equivalently ARPA + (1 - share) x (2026 federal - ARPA), where the
   # replacement share is 1.0 up to 200% FPL, tapers linearly 1.0 -> 0.5 over
   # 200-250% FPL, and is 0.5 over 250-400% FPL.
+  # Endpoint-linear encoding: bracket start/end rates are the published
+  # endpoints; the pointwise taper is within <=0.02pp of this reading.
   # NOTE: the 150-200% band ends at 2.00% (full replacement of the enhanced
-  # schedule). The HGO 10-16-2025 briefing table (page 58) shows "1.00%" at the
-  # 200% FPL endpoint, but that conflicts with the "full replacement up to 200%
-  # FPL" row label and the MIA Exhibit 2a validation targets (single age 40 at
-  # 200% FPL pays about 2.03%), so 2.00% is used and the table entry is treated
-  # as a typo.
+  # schedule). HGO p.58 prints 1.00% at the 200% FPL boundary twice (a
+  # consistent printed figure, not a one-cell typo); both cells are overridden.
+  # MIA Exhibit 2a arithmetic confirms 2.00%: $53 PMPM at 200% FPL / $31,300 =
+  # 2.03%, whereas 1.00% would give about $26. The Board design is full
+  # replacement of ePTC up to 200% FPL, adopted at the 8-18-2025 special meeting.
+  0000-01-01:
+    - 0       # program not in effect before 2026
+    - 0
+    - 0
+    - 0
+    - 0
   2026-01-01:
     - 0       # 0-150%: flat 0%
     - 0.02    # 150-200%: 0% -> 2%
@@ -23,9 +31,11 @@ metadata:
   period: year
   label: Maryland Premium Assistance target contribution percentage - final rate per bracket
   reference:
-    - title: COMAR 14.35.21.04 (State-Based Subsidies; payment parameters delegated to the MHBE Board)
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
-    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
+    - title: COMAR 14.35.21.04B-C (State-Based Subsidies; basis of calculation)
+      href: https://regs.maryland.gov/us/md/exec/comar/14.35.21
+    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table (prints 1.00% at the 200% FPL boundary; superseded - see MIA Exhibit 2a and Board adoption)
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58
     - title: MIA 2026 ACA Approved Rates State Subsidy Program Impact, Exhibit 2a
       href: https://insurance.maryland.gov/Documents/newscenter/newsreleases/2026-ACA-Approved-Rates-State-Subsidy-Program-Impact.pdf#page=1
+    - title: MHBE Board special meeting minutes (8-18-2025), adoption of state subsidy parameters
+      href: https://www.marylandhbe.com/wp-content/uploads/2025/09/MHBE-Board-Meeting-Minutes-8.18.25.pdf#page=5

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
@@ -24,7 +24,7 @@ metadata:
   label: Maryland Premium Assistance target contribution percentage - final rate per bracket
   reference:
     - title: COMAR 14.35.21.04
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
     - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58
     - title: MIA 2026 ACA Approved Rates State Subsidy Program Impact, Exhibit 2a

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
@@ -23,7 +23,7 @@ metadata:
   period: year
   label: Maryland Premium Assistance target contribution percentage - final rate per bracket
   reference:
-    - title: COMAR 14.35.21.04
+    - title: COMAR 14.35.21.04 (State-Based Subsidies; payment parameters delegated to the MHBE Board)
       href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
     - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/final.yaml
@@ -1,0 +1,31 @@
+description: Maryland sets this final target contribution percentage for each bracket under the State-Based Health Insurance Subsidies Program.
+values:
+  # Bands: 0-150%, 150-200%, 200-250%, 250-300%, 300-400% FPL.
+  # MD target = 2025 enhanced (ARPA) percentage + replacement share x
+  # (2026 non-enhanced percentage - 2025 enhanced percentage), where the
+  # replacement share is 1.0 up to 200% FPL, tapers linearly 1.0 -> 0.5 over
+  # 200-250% FPL, and is 0.5 over 250-400% FPL.
+  # NOTE: the 150-200% band ends at 2.00% (full replacement of the enhanced
+  # schedule). The HGO 10-16-2025 briefing table (page 58) shows "1.00%" at the
+  # 200% FPL endpoint, but that conflicts with the "full replacement up to 200%
+  # FPL" row label and the MIA Exhibit 2a validation targets (single age 40 at
+  # 200% FPL pays about 2.03%), so 2.00% is used and the table entry is treated
+  # as a typo.
+  2026-01-01:
+    - 0       # 0-150%: flat 0%
+    - 0.02    # 150-200%: 0% -> 2%
+    - 0.0622  # 200-250%: 2% -> 6.22%
+    - 0.0798  # 250-300%: 6.22% -> 7.98%
+    - 0.0923  # 300-400%: 7.98% -> 9.23%
+
+metadata:
+  unit: /1
+  period: year
+  label: Maryland Premium Assistance target contribution percentage - final rate per bracket
+  reference:
+    - title: COMAR 14.35.21.04
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
+      href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58
+    - title: MIA 2026 ACA Approved Rates State Subsidy Program Impact, Exhibit 2a
+      href: https://insurance.maryland.gov/Documents/newscenter/newsreleases/2026-ACA-Approved-Rates-State-Subsidy-Program-Impact.pdf#page=1

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
@@ -1,0 +1,31 @@
+description: Maryland sets this initial target contribution percentage for each bracket under the State-Based Health Insurance Subsidies Program.
+values:
+  # Bands: 0-150%, 150-200%, 200-250%, 250-300%, 300-400% FPL.
+  # MD target = 2025 enhanced (ARPA) percentage + replacement share x
+  # (2026 non-enhanced percentage - 2025 enhanced percentage), where the
+  # replacement share is 1.0 up to 200% FPL, tapers linearly 1.0 -> 0.5 over
+  # 200-250% FPL, and is 0.5 over 250-400% FPL.
+  # NOTE: the 150-200% band ends at 2.00% (full replacement of the enhanced
+  # schedule). The HGO 10-16-2025 briefing table (page 58) shows "1.00%" at the
+  # 200% FPL endpoint, but that conflicts with the "full replacement up to 200%
+  # FPL" row label and the MIA Exhibit 2a validation targets (single age 40 at
+  # 200% FPL pays about 2.03%), so 2.00% is used and the table entry is treated
+  # as a typo.
+  2026-01-01:
+    - 0       # 0-150%: flat 0%
+    - 0       # 150-200%: 0% -> 2%
+    - 0.02    # 200-250%: 2% -> 6.22%
+    - 0.0622  # 250-300%: 6.22% -> 7.98%
+    - 0.0798  # 300-400%: 7.98% -> 9.23%
+
+metadata:
+  unit: /1
+  period: year
+  label: Maryland Premium Assistance target contribution percentage - initial rate per bracket
+  reference:
+    - title: COMAR 14.35.21.04
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
+      href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58
+    - title: MIA 2026 ACA Approved Rates State Subsidy Program Impact, Exhibit 2a
+      href: https://insurance.maryland.gov/Documents/newscenter/newsreleases/2026-ACA-Approved-Rates-State-Subsidy-Program-Impact.pdf#page=1

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
@@ -24,7 +24,7 @@ metadata:
   label: Maryland Premium Assistance target contribution percentage - initial rate per bracket
   reference:
     - title: COMAR 14.35.21.04
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
     - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58
     - title: MIA 2026 ACA Approved Rates State Subsidy Program Impact, Exhibit 2a

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
@@ -6,11 +6,15 @@ values:
   # replacement share is 1.0 up to 200% FPL, tapers linearly 1.0 -> 0.5 over
   # 200-250% FPL, and is 0.5 over 250-400% FPL.
   # NOTE: the 150-200% band ends at 2.00% (full replacement of the enhanced
-  # schedule). The HGO 10-16-2025 briefing table (page 58) shows "1.00%" at the
-  # 200% FPL endpoint, but that conflicts with the "full replacement up to 200%
-  # FPL" row label and the MIA Exhibit 2a validation targets (single age 40 at
-  # 200% FPL pays about 2.03%), so 2.00% is used and the table entry is treated
-  # as a typo.
+  # schedule). The HGO 10-16-2025 briefing table (page 58) prints "1.00%" at the
+  # 200% FPL endpoint, but that is treated as a typo, corroborated by four
+  # independent sources: (a) the HGO page 58 row label "Full replacement of
+  # ePTC up to 200% FPL" (a 1.00% target would not be full replacement); (b) the
+  # same HGO row's 2025-enhanced-ePTC column, which itself ends at 2.0% at 200%
+  # FPL, so 1.00% would exceed full replacement; (c) MIA Exhibit 2a, where a
+  # single filer age 40 at 200% FPL pays about 2.03% actual; and (d) the 2025
+  # enhanced ARPA schedule final[1]=0.02 together with the "2024-25 Young Adult"
+  # table, both of which print 2.00% at 200% FPL. So 2.00% is used.
   2026-01-01:
     - 0       # 0-150%: flat 0%
     - 0       # 150-200%: 0% -> 2%
@@ -23,7 +27,7 @@ metadata:
   period: year
   label: Maryland Premium Assistance target contribution percentage - initial rate per bracket
   reference:
-    - title: COMAR 14.35.21.04
+    - title: COMAR 14.35.21.04 (State-Based Subsidies; payment parameters delegated to the MHBE Board)
       href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
     - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/initial.yaml
@@ -1,20 +1,24 @@
 description: Maryland sets this initial target contribution percentage for each bracket under the State-Based Health Insurance Subsidies Program.
 values:
   # Bands: 0-150%, 150-200%, 200-250%, 250-300%, 300-400% FPL.
-  # MD target = 2025 enhanced (ARPA) percentage + replacement share x
-  # (2026 non-enhanced percentage - 2025 enhanced percentage), where the
+  # MD target = 2026 federal percentage - share x (2026 federal - ARPA),
+  # equivalently ARPA + (1 - share) x (2026 federal - ARPA), where the
   # replacement share is 1.0 up to 200% FPL, tapers linearly 1.0 -> 0.5 over
   # 200-250% FPL, and is 0.5 over 250-400% FPL.
+  # Endpoint-linear encoding: bracket start/end rates are the published
+  # endpoints; the pointwise taper is within <=0.02pp of this reading.
   # NOTE: the 150-200% band ends at 2.00% (full replacement of the enhanced
-  # schedule). The HGO 10-16-2025 briefing table (page 58) prints "1.00%" at the
-  # 200% FPL endpoint, but that is treated as a typo, corroborated by four
-  # independent sources: (a) the HGO page 58 row label "Full replacement of
-  # ePTC up to 200% FPL" (a 1.00% target would not be full replacement); (b) the
-  # same HGO row's 2025-enhanced-ePTC column, which itself ends at 2.0% at 200%
-  # FPL, so 1.00% would exceed full replacement; (c) MIA Exhibit 2a, where a
-  # single filer age 40 at 200% FPL pays about 2.03% actual; and (d) the 2025
-  # enhanced ARPA schedule final[1]=0.02 together with the "2024-25 Young Adult"
-  # table, both of which print 2.00% at 200% FPL. So 2.00% is used.
+  # schedule). HGO p.58 prints 1.00% at the 200% FPL boundary twice (a
+  # consistent printed figure, not a one-cell typo); both cells are overridden.
+  # MIA Exhibit 2a arithmetic confirms 2.00%: $53 PMPM at 200% FPL / $31,300 =
+  # 2.03%, whereas 1.00% would give about $26. The Board design is full
+  # replacement of ePTC up to 200% FPL, adopted at the 8-18-2025 special meeting.
+  0000-01-01:
+    - 0       # program not in effect before 2026
+    - 0
+    - 0
+    - 0
+    - 0
   2026-01-01:
     - 0       # 0-150%: flat 0%
     - 0       # 150-200%: 0% -> 2%
@@ -27,9 +31,11 @@ metadata:
   period: year
   label: Maryland Premium Assistance target contribution percentage - initial rate per bracket
   reference:
-    - title: COMAR 14.35.21.04 (State-Based Subsidies; payment parameters delegated to the MHBE Board)
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
-    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
+    - title: COMAR 14.35.21.04B-C (State-Based Subsidies; basis of calculation)
+      href: https://regs.maryland.gov/us/md/exec/comar/14.35.21
+    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table (prints 1.00% at the 200% FPL boundary; superseded - see MIA Exhibit 2a and Board adoption)
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58
     - title: MIA 2026 ACA Approved Rates State Subsidy Program Impact, Exhibit 2a
       href: https://insurance.maryland.gov/Documents/newscenter/newsreleases/2026-ACA-Approved-Rates-State-Subsidy-Program-Impact.pdf#page=1
+    - title: MHBE Board special meeting minutes (8-18-2025), adoption of state subsidy parameters
+      href: https://www.marylandhbe.com/wp-content/uploads/2025/09/MHBE-Board-Meeting-Minutes-8.18.25.pdf#page=5

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
@@ -1,0 +1,19 @@
+description: Maryland sets the federal poverty line thresholds for the target contribution percentage brackets under the State-Based Health Insurance Subsidies Program.
+values:
+  2026-01-01:
+    - 0
+    - 1.50
+    - 2.00
+    - 2.50
+    - 3.00
+    - 4.00
+
+metadata:
+  unit: /1
+  period: year
+  label: Maryland Premium Assistance target contribution percentage bracket thresholds
+  reference:
+    - title: COMAR 14.35.21.04
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+    - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
+      href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
@@ -1,5 +1,12 @@
 description: Maryland sets the federal poverty line thresholds for the target contribution percentage brackets under the State-Based Health Insurance Subsidies Program.
 values:
+  0000-01-01:
+    - 0       # program not in effect before 2026
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
   2026-01-01:
     - 0
     - 1.5
@@ -13,7 +20,7 @@ metadata:
   period: year
   label: Maryland Premium Assistance target contribution percentage bracket thresholds
   reference:
-    - title: COMAR 14.35.21.04 (State-Based Subsidies; payment parameters delegated to the MHBE Board)
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
+    - title: COMAR 14.35.21.04B-C (State-Based Subsidies; basis of calculation)
+      href: https://regs.maryland.gov/us/md/exec/comar/14.35.21
     - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
@@ -14,6 +14,6 @@ metadata:
   label: Maryland Premium Assistance target contribution percentage bracket thresholds
   reference:
     - title: COMAR 14.35.21.04
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
     - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/target_contribution_percentage/threshold.yaml
@@ -2,18 +2,18 @@ description: Maryland sets the federal poverty line thresholds for the target co
 values:
   2026-01-01:
     - 0
-    - 1.50
-    - 2.00
-    - 2.50
-    - 3.00
-    - 4.00
+    - 1.5
+    - 2
+    - 2.5
+    - 3
+    - 4
 
 metadata:
   unit: /1
   period: year
   label: Maryland Premium Assistance target contribution percentage bracket thresholds
   reference:
-    - title: COMAR 14.35.21.04
+    - title: COMAR 14.35.21.04 (State-Based Subsidies; payment parameters delegated to the MHBE Board)
       href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
     - title: HGO Combined MHBE and MIA briefing to HGO and Finance (10-16-2025), state subsidy design table
       href: https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/young_adult/reduction.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/young_adult/reduction.yaml
@@ -8,37 +8,53 @@ metadata:
   reference:
     - title: MHBE Final 2026 State Subsidy and Reinsurance Parameters (Board 7-21-25), young adult expected contribution table
       href: https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14
-    - title: COMAR 14.35.21.04
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
+    - title: MHBE Final 2026 State Subsidy and Reinsurance Parameters (Board 7-21-25), young adult subsidy adoption slide
+      href: https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=24
+    - title: COMAR 14.35.21.04D (State-Based Subsidies; payment parameters delegated to the MHBE Board)
+      href: https://regs.maryland.gov/us/md/exec/comar/14.35.21
 brackets:
   # Reduction (in percentage points, as a share) applied at or above each age.
   # Ages under 18: 0; 18-33: 2.5pp; then taper 0.5pp/year: 34 -> 2.0pp,
   # 35 -> 1.5pp, 36 -> 1.0pp, 37 -> 0.5pp; 38 and older: 0.
   - threshold:
+      0000-01-01: 0
       2026-01-01: 0
     amount:
+      0000-01-01: 0
       2026-01-01: 0
   - threshold:
+      0000-01-01: 18
       2026-01-01: 18
     amount:
+      0000-01-01: 0
       2026-01-01: 0.025
   - threshold:
+      0000-01-01: 34
       2026-01-01: 34
     amount:
+      0000-01-01: 0
       2026-01-01: 0.02
   - threshold:
+      0000-01-01: 35
       2026-01-01: 35
     amount:
+      0000-01-01: 0
       2026-01-01: 0.015
   - threshold:
+      0000-01-01: 36
       2026-01-01: 36
     amount:
+      0000-01-01: 0
       2026-01-01: 0.01
   - threshold:
+      0000-01-01: 37
       2026-01-01: 37
     amount:
+      0000-01-01: 0
       2026-01-01: 0.005
   - threshold:
+      0000-01-01: 38
       2026-01-01: 38
     amount:
+      0000-01-01: 0
       2026-01-01: 0

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/young_adult/reduction.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/young_adult/reduction.yaml
@@ -1,0 +1,44 @@
+description: Maryland reduces the young adult target contribution percentage by this share under the State-Based Health Insurance Subsidies Program.
+metadata:
+  type: single_amount
+  threshold_unit: year
+  amount_unit: /1
+  period: year
+  label: Maryland Premium Assistance young adult contribution percentage reduction by age
+  reference:
+    - title: MHBE Final 2026 State Subsidy and Reinsurance Parameters (Board 7-21-25), young adult expected contribution table
+      href: https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14
+    - title: COMAR 14.35.21.04
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+brackets:
+  # Reduction (in percentage points, as a share) applied at or above each age.
+  # Ages under 18: 0; 18-33: 2.5pp; then taper 0.5pp/year: 34 -> 2.0pp,
+  # 35 -> 1.5pp, 36 -> 1.0pp, 37 -> 0.5pp; 38 and older: 0.
+  - threshold:
+      2026-01-01: 0
+    amount:
+      2026-01-01: 0
+  - threshold:
+      2026-01-01: 18
+    amount:
+      2026-01-01: 0.025
+  - threshold:
+      2026-01-01: 34
+    amount:
+      2026-01-01: 0.02
+  - threshold:
+      2026-01-01: 35
+    amount:
+      2026-01-01: 0.015
+  - threshold:
+      2026-01-01: 36
+    amount:
+      2026-01-01: 0.01
+  - threshold:
+      2026-01-01: 37
+    amount:
+      2026-01-01: 0.005
+  - threshold:
+      2026-01-01: 38
+    amount:
+      2026-01-01: 0

--- a/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/young_adult/reduction.yaml
+++ b/policyengine_us/parameters/gov/states/md/mhbe/premium_assistance/young_adult/reduction.yaml
@@ -9,7 +9,7 @@ metadata:
     - title: MHBE Final 2026 State Subsidy and Reinsurance Parameters (Board 7-21-25), young adult expected contribution table
       href: https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14
     - title: COMAR 14.35.21.04
-      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3
+      href: https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5
 brackets:
   # Reduction (in percentage points, as a share) applied at or above each age.
   # Ages under 18: 0; 18-33: 2.5pp; then taper 0.5pp/year: 34 -> 2.0pp,

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -1133,17 +1133,6 @@ programs:
     variable: co_omnisalud
     parameter_prefix: gov.states.co.hcpf.omnisalud
 
-  - id: md_premium_assistance
-    name: Maryland Premium Assistance
-    full_name: Maryland State-Based Health Insurance Subsidies Program
-    category: Healthcare
-    agency: MHBE
-    status: complete
-    coverage: MD
-    variable: md_premium_assistance
-    parameter_prefix: gov.states.md.mhbe.premium_assistance
-    verified_years: "2026-2027"
-
   - id: dc_power
     name: DC Power
     full_name: DC Program on Work, Employment, and Responsibility
@@ -1163,6 +1152,18 @@ programs:
     coverage: DC
     variable: dc_gac
     parameter_prefix: gov.states.dc.dhc.gac
+
+  - id: md_premium_assistance
+    name: Maryland Premium Assistance
+    full_name: Maryland State-Based Health Insurance Subsidies Program
+    category: Healthcare
+    agency: State
+    status: complete
+    coverage: MD
+    variable: md_premium_assistance
+    parameter_prefix: gov.states.md.mhbe.premium_assistance
+    verified_years: "2026-2027"
+    notes: The permanent Young Adult Subsidy (Insurance Article Section 31-122) is modeled only inside the 2026-2027 window; 2022-2025 and 2028-onward Young Adult Subsidy years are unmodeled. Cost-sharing and non-essential-health-benefit premium components and the enrollment-cap limits are not modeled.
 
   - id: ca_cvrp
     name: California CVRP

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -1133,6 +1133,17 @@ programs:
     variable: co_omnisalud
     parameter_prefix: gov.states.co.hcpf.omnisalud
 
+  - id: md_premium_assistance
+    name: Maryland Premium Assistance
+    full_name: Maryland State-Based Health Insurance Subsidies Program
+    category: Healthcare
+    agency: MHBE
+    status: complete
+    coverage: MD
+    variable: md_premium_assistance
+    parameter_prefix: gov.states.md.mhbe.premium_assistance
+    verified_years: "2026-2027"
+
   - id: dc_power
     name: DC Power
     full_name: DC Program on Work, Employment, and Responsibility

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/integration.yaml
@@ -10,7 +10,9 @@
 # each scenario checks the intermediate values so a reviewer can follow the
 # arithmetic:
 #   md_pct  = target contribution % from the MD schedule (keyed on aca_magi_fraction)
-#   subsidy = min(max(0, aca_magi * (federal_pct - md_pct)), max(0, slcsp - aca_ptc))
+#   subsidy = max(0, max(0, slcsp - aca_ptc) - md_pct * max(aca_magi, 0))  [COMAR .04B]
+# For a filer with a self-consistent APTC (aca_ptc = slcsp - federal_pct * income),
+# this reduces to (federal_pct - md_pct) * income, so the arithmetic below matches.
 #
 # MD target schedule (initial per band): 0-150% 0%, 150-200% 0%->2%,
 # 200-250% 2%->6.22%, 250-300% 6.22%->7.98%, 300-400% 7.98%->9.23%.
@@ -19,7 +21,8 @@
 
 - name: Scenario 1, single age 40 at 138% FPL (full replacement, MIA ~$1/mo net).
   # aca_magi 21_597; md target 0% (below 150%); federal 3.4488%.
-  # gap = 0.034488 * 21_597 = 744.84/yr (~62/mo state subsidy).
+  # COMAR .04B: max(0, (6_000 - 5_255) - 0 * 21_597) = 745/yr (~62/mo state
+  # subsidy); the whole-dollar forced APTC leaves a 745 post-APTC premium balance.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -35,6 +38,7 @@
         aca_required_contribution_percentage: 0.034488
         slcsp: 6_000
         aca_ptc: 5_255  # 6_000 - 0.034488*21_597 (federal contribution)
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
@@ -42,10 +46,11 @@
   output:
     md_premium_assistance_eligible: true
     md_premium_assistance_target_contribution_percentage: 0
-    md_premium_assistance: 744.84
+    md_premium_assistance: 745.00
 
 - name: Scenario 2, single age 40 at 200% FPL (MIA net $53/mo vs $173/mo).
-  # md target 2.00%; federal 6.60%; gap 0.046 * 31_300 = 1_439.80/yr (~120/mo).
+  # md target 2.00%; federal 6.60%. COMAR .04B: max(0, (6_000 - 3_934) - 0.02 *
+  # 31_300) = 2_066 - 626 = 1_440/yr (~120/mo); whole-dollar forced APTC rounding.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -61,6 +66,7 @@
         aca_required_contribution_percentage: 0.066
         slcsp: 6_000
         aca_ptc: 3_934  # 6_000 - 0.066*31_300
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
@@ -68,10 +74,11 @@
   output:
     md_premium_assistance_eligible: true
     md_premium_assistance_target_contribution_percentage: 0.02
-    md_premium_assistance: 1_439.80
+    md_premium_assistance: 1_440.00
 
 - name: Scenario 3, single age 40 at 300% FPL (50% replacement, MIA net $313 vs $390/mo).
-  # md target 7.98%; federal 9.96%; gap 0.0198 * 46_950 = 929.61/yr (~77/mo).
+  # md target 7.98%; federal 9.96%. COMAR .04B: max(0, (9_000 - 4_324) - 0.0798 *
+  # 46_950) = 4_676 - 3_746.61 = 929.39/yr (~77/mo).
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -87,6 +94,7 @@
         aca_required_contribution_percentage: 0.0996
         slcsp: 9_000
         aca_ptc: 4_324  # 9_000 - 0.0996*46_950
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
@@ -94,11 +102,11 @@
   output:
     md_premium_assistance_eligible: true
     md_premium_assistance_target_contribution_percentage: 0.0798
-    md_premium_assistance: 929.61
+    md_premium_assistance: 929.39
 
 - name: Scenario 4, family of four at 200% FPL (MIA net $110/mo vs $356/mo).
-  # ages 45/43/15/13; aca_magi 64_300; md target 2.00%; federal 6.60%.
-  # gap 0.046 * 64_300 = 2_957.80/yr (~246/mo).
+  # ages 45/43/15/13; aca_magi 64_300; md target 2.00%; federal 6.60%. COMAR .04B:
+  # max(0, (18_000 - 13_756) - 0.02 * 64_300) = 4_244 - 1_286 = 2_958/yr (~246/mo).
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -123,6 +131,7 @@
         aca_required_contribution_percentage: 0.066
         slcsp: 18_000
         aca_ptc: 13_756  # 18_000 - 0.066*64_300
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1, person2, person3, person4]
@@ -130,10 +139,11 @@
   output:
     md_premium_assistance_eligible: true
     md_premium_assistance_target_contribution_percentage: 0.02
-    md_premium_assistance: 2_957.80
+    md_premium_assistance: 2_958.00
 
 - name: Scenario 5, family of four at 400% FPL (top of schedule, MIA net $992 vs $1070/mo).
-  # aca_magi 128_600; md target 9.23%; federal 9.96%; gap 0.0073 * 128_600 = 938.78/yr.
+  # aca_magi 128_600; md target 9.23%; federal 9.96%. COMAR .04B:
+  # max(0, (22_000 - 9_191) - 0.0923 * 128_600) = 12_809 - 11_869.78 = 939.22/yr.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -158,6 +168,7 @@
         aca_required_contribution_percentage: 0.0996
         slcsp: 22_000
         aca_ptc: 9_191  # 22_000 - 0.0996*128_600
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1, person2, person3, person4]
@@ -165,10 +176,11 @@
   output:
     md_premium_assistance_eligible: true
     md_premium_assistance_target_contribution_percentage: 0.0923
-    md_premium_assistance: 938.78
+    md_premium_assistance: 939.22
 
 - name: Scenario 6, young adult age 30 at 250% FPL (YAS overlay, HGO p.59 example).
-  # md target 6.22% - 2.5pp = 3.72%; federal 8.44%; gap 4.72% * 39_125 = 1_846.70/yr.
+  # md target 6.22% - 2.5pp = 3.72%; federal 8.44%. COMAR .04B:
+  # max(0, (6_000 - 2_698) - 0.0372 * 39_125) = 3_302 - 1_455.45 = 1_846.55/yr.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -184,6 +196,7 @@
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_000
         aca_ptc: 2_698  # 6_000 - 0.0844*39_125
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
@@ -192,9 +205,9 @@
     md_premium_assistance_eligible: true
     md_premium_assistance_young_adult_reduction: 0.025
     md_premium_assistance_target_contribution_percentage: 0.0372
-    md_premium_assistance: 1_846.70
+    md_premium_assistance: 1_846.55
 
-- name: Scenario 7, single age 40 at 401% FPL (over the limit, no subsidy, REQ-014).
+- name: Scenario 7, single age 40 at 401% FPL (over the limit, no subsidy).
   # aca_magi 62_757; above 400% FPL -> ineligible -> subsidy 0.
   period: 2026
   absolute_error_margin: 0.01
@@ -218,11 +231,16 @@
     md_premium_assistance_eligible: false
     md_premium_assistance: 0
 
-- name: Scenario 8a, young adult age 30 at 200% FPL -> full floor (target 0%).
-  # md target = 2.00% - 2.5pp = 0 (floored, REQ-018); federal 6.60%.
-  # gap = (0.066 - 0) * 31_300 = 2_065.80; cap = 6_000 - 0.066*31_300 = 4_066 -> not binding.
+- name: Scenario 8, young adult age 30 at 200% FPL -> full floor (target 0%).
+  # md target = 2.00% - 2.5pp = 0 (floored); federal 6.60%. Forced APTC 1_934.
+  # New COMAR .04B form: with md_pct 0 the subsidy is the full post-APTC premium
+  # balance max(0, (6_000 - 1_934) - 0) = 4_066. This is the intended behaviour of
+  # the new form: a 0% MD target means the state covers the entire premium balance
+  # left after the federal APTC (it is NOT the old (federal - 0) * income reading).
+  # Margin tightened to 0.0001 so the target-% floor assertion is functional (the
+  # blanket 0.01 tolerated a full 1pp).
   period: 2026
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.0001
   input:
     people:
       person1:
@@ -235,7 +253,8 @@
         aca_magi_fraction: 2.00
         aca_required_contribution_percentage: 0.066
         slcsp: 6_000
-        aca_ptc: 1_934  # 6_000 - 0.066*31_300 leaves a 4_066 cap headroom
+        aca_ptc: 1_934  # 6_000 - 0.066*31_300 (self-consistent federal contribution)
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
@@ -244,12 +263,13 @@
     md_premium_assistance_eligible: true
     md_premium_assistance_young_adult_reduction: 0.025
     md_premium_assistance_target_contribution_percentage: 0
-    md_premium_assistance: 2_065.80
+    md_premium_assistance: 4_066.00  # 0% MD target -> full post-APTC premium balance
 
 - name: Scenario 9, single age 40 at 250% FPL, APTC already covers full premium.
-  # aca_ptc 6_000 == slcsp 6_000 -> cap 0 -> subsidy 0 despite a positive gap (REQ-016).
+  # aca_ptc 6_000 == slcsp 6_000 -> post-APTC premium 0 -> subsidy 0 despite a
+  # positive gap. Margin 0.0001 so the target-% assertion is functional.
   period: 2026
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.0001
   input:
     people:
       person1:
@@ -270,30 +290,6 @@
   output:
     md_premium_assistance_eligible: true
     md_premium_assistance_target_contribution_percentage: 0.0622
-    md_premium_assistance: 0
-
-- name: Scenario 8, single age 40 at 250% FPL living in Virginia (non-MD -> 0).
-  period: 2026
-  absolute_error_margin: 0.01
-  input:
-    people:
-      person1:
-        age: 40
-        is_aca_ptc_eligible: true
-    tax_units:
-      tax_unit:
-        members: [person1]
-        aca_magi: 39_125
-        aca_magi_fraction: 2.50
-        aca_required_contribution_percentage: 0.0844
-        slcsp: 6_000
-        aca_ptc: 2_698
-    households:
-      household:
-        members: [person1]
-        state_code: VA
-  output:
-    md_premium_assistance_eligible: false
     md_premium_assistance: 0
 
 - name: Scenario 10, fully income-derived young-adult subsidy (no forced intermediates).
@@ -323,14 +319,17 @@
   output:
     md_premium_assistance_eligible: true
     md_premium_assistance_young_adult_reduction: 0.025
-    md_premium_assistance: 2_101.82  # derived, verified
+    md_premium_assistance: 2_101.82  # fully income-derived through the federal chain
 
 - name: Scenario 11a, age-36 young adult at 250% FPL flowing through the target-% subtraction.
   # base target 6.22% - age-36 reduction 1.0pp = 5.22% md_pct; federal 8.44%.
-  # gap = (0.0844 - 0.0522) * 39_125 = 0.0322 * 39_125 = 1_259.825; cap
-  # (6_000 - 2_698 = 3_302) not binding.
+  # Self-consistent APTC 2_698 = 6_000 - 0.0844*39_125. New COMAR .04B form:
+  # max(0, (6_000 - 2_698) - 0.0522 * 39_125) = 3_302 - 2_042.325 = 1_259.675
+  # (matches the old (0.0844 - 0.0522) * 39_125 = 1_259.825 up to the APTC rounding).
+  # Margin 0.0001 so the target-% subtraction assertion (0.0522) is functional;
+  # the dollar reconciles to the forced-APTC .04B value (filer gate satisfied).
   period: 2026
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.0001
   input:
     people:
       person1:
@@ -344,6 +343,7 @@
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_000
         aca_ptc: 2_698
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
@@ -352,13 +352,17 @@
     md_premium_assistance_eligible: true
     md_premium_assistance_young_adult_reduction: 0.01
     md_premium_assistance_target_contribution_percentage: 0.0522
-    md_premium_assistance: 1_259.83
+    md_premium_assistance: 1_259.6749  # max(0, (6_000 - 2_698) - 0.0522 * 39_125)
 
 - name: Scenario 11b, age-37 young adult at 250% FPL flowing through the target-% subtraction.
   # base target 6.22% - age-37 reduction 0.5pp = 5.72% md_pct; federal 8.44%.
-  # gap = (0.0844 - 0.0572) * 39_125 = 0.0272 * 39_125 = 1_064.20; cap not binding.
+  # Self-consistent APTC 2_698 = 6_000 - 0.0844*39_125. New COMAR .04B form:
+  # max(0, (6_000 - 2_698) - 0.0572 * 39_125) = 3_302 - 2_237.95 = 1_064.05
+  # (matches the old (0.0844 - 0.0572) * 39_125 = 1_064.20 up to the APTC rounding).
+  # Margin 0.0001 so the reduction assertion (0.005) is functional (the blanket
+  # 0.01 was 2x this value); dollar reconciled to the forced-APTC .04B value.
   period: 2026
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.0001
   input:
     people:
       person1:
@@ -372,6 +376,7 @@
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_000
         aca_ptc: 2_698
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
@@ -380,4 +385,30 @@
     md_premium_assistance_eligible: true
     md_premium_assistance_young_adult_reduction: 0.005
     md_premium_assistance_target_contribution_percentage: 0.0572
-    md_premium_assistance: 1_064.20
+    md_premium_assistance: 1_064.05  # max(0, (6_000 - 2_698) - 0.0572 * 39_125)
+
+- name: Scenario 12, single age 40 at 250% FPL living in Virginia (non-MD -> 0).
+  # Non-MD households are masked to ineligible by defined_for StateCode.MD.
+  # (Placed last so the MD scenarios read sequentially.)
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 2_698
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+  output:
+    md_premium_assistance_eligible: false
+    md_premium_assistance: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/integration.yaml
@@ -1,0 +1,297 @@
+# End-to-end integration tests for Maryland Premium Assistance
+# (State-Based Health Insurance Subsidies Program), PY2026.
+# Scenarios follow the MIA Exhibit 2a illustrative net-premium targets
+# (single age 40 and family of four across FPL tiers), plus a young-adult case,
+# an over-400% ineligible case, and a non-MD case.
+#
+# To keep expected values exactly hand-verifiable and independent of the
+# rating-area premium lookup, aca_magi, aca_magi_fraction, the federal required
+# contribution percentage, slcsp (annual) and aca_ptc are supplied directly, and
+# each scenario checks the intermediate values so a reviewer can follow the
+# arithmetic:
+#   md_pct  = target contribution % from the MD schedule (keyed on aca_magi_fraction)
+#   subsidy = min(max(0, aca_magi * (federal_pct - md_pct)), max(0, slcsp - aca_ptc))
+#
+# MD target schedule (initial per band): 0-150% 0%, 150-200% 0%->2%,
+# 200-250% 2%->6.22%, 250-300% 6.22%->7.98%, 300-400% 7.98%->9.23%.
+# 2026 federal non-enhanced percentages at each tier: 138% 3.4488%, 150% 4.19%,
+# 200% 6.60%, 250% 8.44%, 300% 9.96%, 400% 9.96%.
+
+- name: Scenario 1, single age 40 at 138% FPL (full replacement, MIA ~$1/mo net).
+  # aca_magi 21_597; md target 0% (below 150%); federal 3.4488%.
+  # gap = 0.034488 * 21_597 = 744.84/yr (~62/mo state subsidy).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 21_597
+        aca_magi_fraction: 1.38
+        aca_required_contribution_percentage: 0.034488
+        slcsp: 6_000
+        aca_ptc: 5_255  # 6_000 - 0.034488*21_597 (federal contribution)
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_target_contribution_percentage: 0
+    md_premium_assistance: 744.84
+
+- name: Scenario 2, single age 40 at 200% FPL (MIA net $53/mo vs $173/mo).
+  # md target 2.00%; federal 6.60%; gap 0.046 * 31_300 = 1_439.80/yr (~120/mo).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 31_300
+        aca_magi_fraction: 2.00
+        aca_required_contribution_percentage: 0.066
+        slcsp: 6_000
+        aca_ptc: 3_934  # 6_000 - 0.066*31_300
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_target_contribution_percentage: 0.02
+    md_premium_assistance: 1_439.80
+
+- name: Scenario 3, single age 40 at 300% FPL (50% replacement, MIA net $313 vs $390/mo).
+  # md target 7.98%; federal 9.96%; gap 0.0198 * 46_950 = 929.61/yr (~77/mo).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 46_950
+        aca_magi_fraction: 3.00
+        aca_required_contribution_percentage: 0.0996
+        slcsp: 9_000
+        aca_ptc: 4_324  # 9_000 - 0.0996*46_950
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_target_contribution_percentage: 0.0798
+    md_premium_assistance: 929.61
+
+- name: Scenario 4, family of four at 200% FPL (MIA net $110/mo vs $356/mo).
+  # ages 45/43/15/13; aca_magi 64_300; md target 2.00%; federal 6.60%.
+  # gap 0.046 * 64_300 = 2_957.80/yr (~246/mo).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 45
+        is_aca_ptc_eligible: true
+      person2:
+        age: 43
+        is_aca_ptc_eligible: true
+      person3:
+        age: 15
+        is_aca_ptc_eligible: true
+      person4:
+        age: 13
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        aca_magi: 64_300
+        aca_magi_fraction: 2.00
+        aca_required_contribution_percentage: 0.066
+        slcsp: 18_000
+        aca_ptc: 13_756  # 18_000 - 0.066*64_300
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_target_contribution_percentage: 0.02
+    md_premium_assistance: 2_957.80
+
+- name: Scenario 5, family of four at 400% FPL (top of schedule, MIA net $992 vs $1070/mo).
+  # aca_magi 128_600; md target 9.23%; federal 9.96%; gap 0.0073 * 128_600 = 938.78/yr.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 45
+        is_aca_ptc_eligible: true
+      person2:
+        age: 43
+        is_aca_ptc_eligible: true
+      person3:
+        age: 15
+        is_aca_ptc_eligible: true
+      person4:
+        age: 13
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        aca_magi: 128_600
+        aca_magi_fraction: 4.00
+        aca_required_contribution_percentage: 0.0996
+        slcsp: 22_000
+        aca_ptc: 9_191  # 22_000 - 0.0996*128_600
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_target_contribution_percentage: 0.0923
+    md_premium_assistance: 938.78
+
+- name: Scenario 6, young adult age 30 at 250% FPL (YAS overlay, HGO p.59 example).
+  # md target 6.22% - 2.5pp = 3.72%; federal 8.44%; gap 4.72% * 39_125 = 1_846.70/yr.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 2_698  # 6_000 - 0.0844*39_125
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_young_adult_reduction: 0.025
+    md_premium_assistance_target_contribution_percentage: 0.0372
+    md_premium_assistance: 1_846.70
+
+- name: Scenario 7, single age 40 at 401% FPL (over the limit, no subsidy, REQ-014).
+  # aca_magi 62_757; above 400% FPL -> ineligible -> subsidy 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 62_757
+        aca_magi_fraction: 4.01
+        slcsp: 6_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: false
+    md_premium_assistance: 0
+
+- name: Scenario 8a, young adult age 30 at 200% FPL -> full floor (target 0%).
+  # md target = 2.00% - 2.5pp = 0 (floored, REQ-018); federal 6.60%.
+  # gap = (0.066 - 0) * 31_300 = 2_065.80; cap = 6_000 - 0.066*31_300 = 4_066 -> not binding.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 31_300
+        aca_magi_fraction: 2.00
+        aca_required_contribution_percentage: 0.066
+        slcsp: 6_000
+        aca_ptc: 1_934  # 6_000 - 0.066*31_300 leaves a 4_066 cap headroom
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_young_adult_reduction: 0.025
+    md_premium_assistance_target_contribution_percentage: 0
+    md_premium_assistance: 2_065.80
+
+- name: Scenario 9, single age 40 at 250% FPL, APTC already covers full premium.
+  # aca_ptc 6_000 == slcsp 6_000 -> cap 0 -> subsidy 0 despite a positive gap (REQ-016).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 6_000
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_target_contribution_percentage: 0.0622
+    md_premium_assistance: 0
+
+- name: Scenario 8, single age 40 at 250% FPL living in Virginia (non-MD -> 0).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 2_698
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+  output:
+    md_premium_assistance_eligible: false
+    md_premium_assistance: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/integration.yaml
@@ -295,3 +295,89 @@
   output:
     md_premium_assistance_eligible: false
     md_premium_assistance: 0
+
+- name: Scenario 10, fully income-derived young-adult subsidy (no forced intermediates).
+  # A single age-30 enrollee in MD with only employment_income set. aca_magi,
+  # aca_magi_fraction, the federal applicable %, slcsp and aca_ptc are ALL derived
+  # from the rating-area premium lookup and the federal PTC engine; the young-adult
+  # 2.5pp reduction flows through the MD target %. Asserts a derived non-round
+  # subsidy rather than a forced arithmetic identity. Derived intermediates:
+  # aca_magi 35_000, aca_magi_fraction 2.23, federal 7.4464%, md target
+  # (2.23 FPL base minus the 2.5pp young-adult floor) 1.4412%; cap not binding.
+  # gap = (0.074464 - 0.014412) * 35_000 = 2_101.82.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 35_000
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_young_adult_reduction: 0.025
+    md_premium_assistance: 2_101.82  # derived, verified
+
+- name: Scenario 11a, age-36 young adult at 250% FPL flowing through the target-% subtraction.
+  # base target 6.22% - age-36 reduction 1.0pp = 5.22% md_pct; federal 8.44%.
+  # gap = (0.0844 - 0.0522) * 39_125 = 0.0322 * 39_125 = 1_259.825; cap
+  # (6_000 - 2_698 = 3_302) not binding.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 36
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 2_698
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_young_adult_reduction: 0.01
+    md_premium_assistance_target_contribution_percentage: 0.0522
+    md_premium_assistance: 1_259.83
+
+- name: Scenario 11b, age-37 young adult at 250% FPL flowing through the target-% subtraction.
+  # base target 6.22% - age-37 reduction 0.5pp = 5.72% md_pct; federal 8.44%.
+  # gap = (0.0844 - 0.0572) * 39_125 = 0.0272 * 39_125 = 1_064.20; cap not binding.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 37
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 2_698
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance_young_adult_reduction: 0.005
+    md_premium_assistance_target_contribution_percentage: 0.0572
+    md_premium_assistance: 1_064.20

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance.yaml
@@ -1,0 +1,430 @@
+# Unit tests for the Maryland Premium Assistance subsidy amount
+# (REQ-010/014/016/018).
+# Formula: min_(max_(0, aca_magi * (federal_pct - md_pct)),
+#               max_(0, slcsp - aca_ptc))
+# gated on md_premium_assistance_eligible (in effect, MD, APTC-eligible, <=400% FPL).
+#
+# Inputs are provided directly so expected values are hand-verifiable and
+# independent of the rating-area premium lookup. aca_required_contribution_percentage
+# (federal_pct) is supplied directly using the true 2026 non-enhanced values for each
+# FPL point (like the federal aca_ptc unit tests). md_pct interpolates from the MD
+# target schedule keyed on aca_magi_fraction. slcsp is supplied as an annual amount;
+# the cap slcsp - aca_ptc is set generously so it binds only in the dedicated cap case.
+#
+# 2026 federal required contribution percentages used below:
+#   150% -> 0.0419, 200% -> 0.066, 250% -> 0.0844, 300% -> 0.0996, 400% -> 0.0996
+# MD target percentages:
+#   150% -> 0, 200% -> 0.02, 250% -> 0.0622, 300% -> 0.0798, 400% -> 0.0923
+
+- name: Case 1, single age 40 at 150% FPL -> 983.60 (full replacement band).
+  # gap = (0.0419 - 0) * 23_475 = 983.6025
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 23_475
+        aca_magi_fraction: 1.50
+        aca_required_contribution_percentage: 0.0419
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 983.60
+
+- name: Case 2, single age 40 at 200% FPL -> 1439.80.
+  # gap = (0.066 - 0.02) * 31_300 = 0.046 * 31_300 = 1_439.80
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 31_300
+        aca_magi_fraction: 2.00
+        aca_required_contribution_percentage: 0.066
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 1_439.80
+
+- name: Case 3, single age 40 at 250% FPL -> 868.58 (50% replacement band).
+  # gap = (0.0844 - 0.0622) * 39_125 = 0.0222 * 39_125 = 868.575
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 868.58
+
+- name: Case 4, single age 40 at 400% FPL -> 456.98 (top of schedule).
+  # gap = (0.0996 - 0.0923) * 62_600 = 0.0073 * 62_600 = 456.98
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 62_600
+        aca_magi_fraction: 4.00
+        aca_required_contribution_percentage: 0.0996
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 456.98
+
+- name: Case 5, above 400% FPL -> 0 (ineligible, no subsidy, REQ-014).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 62_757
+        aca_magi_fraction: 4.01
+        slcsp: 6_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 6, premium cap binds -> subsidy limited to slcsp - aca_ptc (REQ-016).
+  # Uncapped gap at 250% = 868.575, but slcsp - aca_ptc = 6_300 - 6_000 = 300.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_300
+        aca_ptc: 6_000
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 300
+
+- name: Case 7, subsidy never negative when APTC already exceeds the premium.
+  # slcsp - aca_ptc = 6_000 - 6_500 = -500 -> cap floored at 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 6_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 8, non-MD state -> 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+  output:
+    md_premium_assistance: 0
+
+- name: Case 9, program not in effect in 2025 -> 0.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 10, program sunset in 2028 -> 0.
+  period: 2028
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 11, young adult age 30 at 250% FPL -> 1846.70 (YAS raises the subsidy).
+  # md target 6.22% - 2.5pp = 3.72%; gap = 8.44% - 3.72% = 4.72%;
+  # 0.0472 * 39_125 = 1_846.70
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 1_846.70
+
+# ---- Edge cases ----
+
+- name: Case 12, zero MAGI -> 0 subsidy (gap = 0 * pct).
+  # Eligible (0 <= 400% FPL) but aca_magi 0 zeroes the contribution gap.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 0
+        aca_magi_fraction: 1.50
+        aca_required_contribution_percentage: 0.0419
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 13, federal applicable % below MD target % -> negative gap floored to 0.
+  # At 250% FPL md target = 6.22%; federal supplied at 5.00% < md target ->
+  # gap = max(0, 39_125 * (0.05 - 0.0622)) = max(0, negative) = 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.05
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 14, aca_ptc exactly equals slcsp -> premium cap 0 -> subsidy 0 (REQ-016).
+  # Uncapped gap positive, but slcsp - aca_ptc = 6_000 - 6_000 = 0 caps to 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 6_000
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 15, zero SLCSP -> no benchmark premium -> subsidy 0 (REQ-015/016).
+  # slcsp 0 and aca_ptc 0 -> cap = max(0, 0 - 0) = 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 0
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 16, single age 40 at 225% FPL -> 1193.50 (interpolated 200-250% band).
+  # md target 2.25 FPL = 0.02 + 0.5*(0.0622-0.02) = 0.0411; federal 0.0752 supplied.
+  # gap = (0.0752 - 0.0411) * 35_000 = 0.0341 * 35_000 = 1_193.50.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 35_000
+        aca_magi_fraction: 2.25
+        aca_required_contribution_percentage: 0.0752
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 1_193.50
+
+- name: Case 17, multi-member mixed APTC eligibility -> 929.61 (non-enrollee YA excluded).
+  # age-40 enrollee + age-30 NON-enrollee at 300% FPL. Unit is eligible (one enrollee),
+  # and the age-30 non-enrollee does not trigger the young adult reduction, so
+  # md target = 7.98%; gap = (0.0996 - 0.0798) * 46_950 = 0.0198 * 46_950 = 929.61.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+      person2:
+        age: 30
+        is_aca_ptc_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        aca_magi: 46_950
+        aca_magi_fraction: 3.00
+        aca_required_contribution_percentage: 0.0996
+        slcsp: 9_000
+        aca_ptc: 4_324
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    md_premium_assistance: 929.61

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance.yaml
@@ -1,23 +1,32 @@
-# Unit tests for the Maryland Premium Assistance subsidy amount
-# (REQ-010/014/016/018).
-# Formula: min_(max_(0, aca_magi * (federal_pct - md_pct)),
-#               max_(0, slcsp - aca_ptc))
+# Unit tests for the Maryland Premium Assistance subsidy amount.
+# Formula (COMAR 14.35.21.04B): the benchmark SLCSP premium remaining after the
+# federal APTC, less the Maryland target contribution (md_pct * income), floored
+# at 0, and 0 for non-filers:
+#   where(tax_unit_is_filer,
+#         max_(0, max_(0, slcsp - aca_ptc) - md_pct * max_(aca_magi, 0)),
+#         0)
 # gated on md_premium_assistance_eligible (in effect, MD, APTC-eligible, <=400% FPL).
 #
 # Inputs are provided directly so expected values are hand-verifiable and
 # independent of the rating-area premium lookup. aca_required_contribution_percentage
 # (federal_pct) is supplied directly using the true 2026 non-enhanced values for each
-# FPL point (like the federal aca_ptc unit tests). md_pct interpolates from the MD
-# target schedule keyed on aca_magi_fraction. slcsp is supplied as an annual amount;
-# the cap slcsp - aca_ptc is set generously so it binds only in the dedicated cap case.
+# FPL point (like the federal aca_ptc unit tests), EXCEPT Cases 13 and 21, which use
+# synthetic federal percentages chosen to exercise a specific edge (federal below the
+# MD target, and the young-adult floor) rather than the true schedule. md_pct
+# interpolates from the MD target schedule keyed on aca_magi_fraction. slcsp is
+# supplied as an annual amount, and aca_ptc is chosen self-consistently with the
+# federal contribution so the post-APTC premium balance drives the subsidy.
 #
-# 2026 federal required contribution percentages used below:
+# 2026 federal required contribution percentages used below (true schedule):
 #   150% -> 0.0419, 200% -> 0.066, 250% -> 0.0844, 300% -> 0.0996, 400% -> 0.0996
 # MD target percentages:
 #   150% -> 0, 200% -> 0.02, 250% -> 0.0622, 300% -> 0.0798, 400% -> 0.0923
 
-- name: Case 1, single age 40 at 150% FPL -> 983.60 (full replacement band).
-  # gap = (0.0419 - 0) * 23_475 = 983.6025
+- name: Case 1, single age 40 at 150% FPL -> 2500 (full replacement band).
+  # COMAR .04B: max(0, (slcsp - aca_ptc) - md_pct * income). md_pct = 0 in the
+  # 0-150% band, so subsidy = max(0, 6_000 - 3_500) - 0 = 2_500. The forced APTC
+  # 3_500 is not self-consistent with the federal %, so this exceeds the old
+  # (federal - md) * income reading.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -33,15 +42,16 @@
         aca_required_contribution_percentage: 0.0419
         slcsp: 6_000
         aca_ptc: 3_500
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 983.60
+    md_premium_assistance: 2_500
 
-- name: Case 2, single age 40 at 200% FPL -> 1439.80.
-  # gap = (0.066 - 0.02) * 31_300 = 0.046 * 31_300 = 1_439.80
+- name: Case 2, single age 40 at 200% FPL -> 1874.
+  # COMAR .04B: max(0, (6_000 - 3_500) - 0.02 * 31_300) = 2_500 - 626 = 1_874.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -57,15 +67,18 @@
         aca_required_contribution_percentage: 0.066
         slcsp: 6_000
         aca_ptc: 3_500
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 1_439.80
+    md_premium_assistance: 1_874
 
-- name: Case 3, single age 40 at 250% FPL -> 868.58 (50% replacement band).
-  # gap = (0.0844 - 0.0622) * 39_125 = 0.0222 * 39_125 = 868.575
+- name: Case 3, single age 40 at 250% FPL -> 66.43 (50% replacement band).
+  # COMAR .04B: max(0, (6_000 - 3_500) - 0.0622 * 39_125) = 2_500 - 2_433.575
+  # = 66.425. The forced APTC 3_500 is below the self-consistent value, so the
+  # post-APTC premium balance drives a smaller subsidy than the old reading.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -81,15 +94,21 @@
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_000
         aca_ptc: 3_500
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 868.58
+    md_premium_assistance: 66.425
 
-- name: Case 4, single age 40 at 400% FPL -> 456.98 (top of schedule).
-  # gap = (0.0996 - 0.0923) * 62_600 = 0.0073 * 62_600 = 456.98
+- name: Case 4, single age 40 at 400% FPL, self-consistent APTC (top of schedule).
+  # New formula (COMAR .04B): subsidy = max(0, (slcsp - aca_ptc) - md_pct * income).
+  # At 400% FPL the federal required contribution 0.0996 * 62_600 = 6_234.96 exceeds
+  # the slcsp 6_000, so the self-consistent federal APTC is 0. The MD required
+  # contribution 0.0923 * 62_600 = 5_777.98, leaving the state to cover the residual
+  # premium: max(0, (6_000 - 0) - 5_777.98) = 222.02. Filer inputs supplied so the
+  # subsidy is not zeroed by the non-filer gate.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -97,6 +116,7 @@
       person1:
         age: 40
         is_aca_ptc_eligible: true
+        employment_income: 62_600
     tax_units:
       tax_unit:
         members: [person1]
@@ -104,15 +124,15 @@
         aca_magi_fraction: 4.00
         aca_required_contribution_percentage: 0.0996
         slcsp: 6_000
-        aca_ptc: 3_500
+        aca_ptc: 0
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 456.98
+    md_premium_assistance: 222.02  # max(0, (6_000 - 0) - 0.0923 * 62_600) residual
 
-- name: Case 5, above 400% FPL -> 0 (ineligible, no subsidy, REQ-014).
+- name: Case 5, above 400% FPL -> 0 (ineligible, no subsidy).
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -134,8 +154,10 @@
   output:
     md_premium_assistance: 0
 
-- name: Case 6, premium cap binds -> subsidy limited to slcsp - aca_ptc (REQ-016).
-  # Uncapped gap at 250% = 868.575, but slcsp - aca_ptc = 6_300 - 6_000 = 300.
+- name: Case 6, small post-APTC premium fully offset by MD contribution -> 0.
+  # COMAR .04B: post-APTC premium balance = 6_300 - 6_000 = 300, but the MD
+  # required contribution 0.0622 * 39_125 = 2_433.58 exceeds it, so
+  # max(0, 300 - 2_433.58) = 0.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -151,12 +173,13 @@
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_300
         aca_ptc: 6_000
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 300
+    md_premium_assistance: 0
 
 - name: Case 7, subsidy never negative when APTC already exceeds the premium.
   # slcsp - aca_ptc = 6_000 - 6_500 = -500 -> cap floored at 0.
@@ -251,9 +274,9 @@
   output:
     md_premium_assistance: 0
 
-- name: Case 11, young adult age 30 at 250% FPL -> 1846.70 (YAS raises the subsidy).
-  # md target 6.22% - 2.5pp = 3.72%; gap = 8.44% - 3.72% = 4.72%;
-  # 0.0472 * 39_125 = 1_846.70
+- name: Case 11, young adult age 30 at 250% FPL -> 1044.55 (YAS raises the subsidy).
+  # md target 6.22% - 2.5pp = 3.72%. COMAR .04B:
+  # max(0, (6_000 - 3_500) - 0.0372 * 39_125) = 2_500 - 1_455.45 = 1_044.55.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -269,12 +292,13 @@
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_000
         aca_ptc: 3_500
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 1_846.70
+    md_premium_assistance: 1_044.55
 
 # ---- Edge cases ----
 
@@ -327,7 +351,7 @@
   output:
     md_premium_assistance: 0
 
-- name: Case 14, aca_ptc exactly equals slcsp -> premium cap 0 -> subsidy 0 (REQ-016).
+- name: Case 14, aca_ptc exactly equals slcsp -> premium cap 0 -> subsidy 0.
   # Uncapped gap positive, but slcsp - aca_ptc = 6_000 - 6_000 = 0 caps to 0.
   period: 2026
   absolute_error_margin: 0.01
@@ -351,7 +375,7 @@
   output:
     md_premium_assistance: 0
 
-- name: Case 15, zero SLCSP -> no benchmark premium -> subsidy 0 (REQ-015/016).
+- name: Case 15, zero SLCSP -> no benchmark premium -> subsidy 0.
   # slcsp 0 and aca_ptc 0 -> cap = max(0, 0 - 0) = 0.
   period: 2026
   absolute_error_margin: 0.01
@@ -375,9 +399,9 @@
   output:
     md_premium_assistance: 0
 
-- name: Case 16, single age 40 at 225% FPL -> 1193.50 (interpolated 200-250% band).
-  # md target 2.25 FPL = 0.02 + 0.5*(0.0622-0.02) = 0.0411; federal 0.0752 supplied.
-  # gap = (0.0752 - 0.0411) * 35_000 = 0.0341 * 35_000 = 1_193.50.
+- name: Case 16, single age 40 at 225% FPL -> 1061.50 (interpolated 200-250% band).
+  # md target 2.25 FPL = 0.02 + 0.5*(0.0622-0.02) = 0.0411. COMAR .04B:
+  # max(0, (6_000 - 3_500) - 0.0411 * 35_000) = 2_500 - 1_438.50 = 1_061.50.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -393,17 +417,19 @@
         aca_required_contribution_percentage: 0.0752
         slcsp: 6_000
         aca_ptc: 3_500
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 1_193.50
+    md_premium_assistance: 1_061.50
 
-- name: Case 17, multi-member mixed APTC eligibility -> 929.61 (non-enrollee YA excluded).
+- name: Case 17, multi-member mixed APTC eligibility -> 929.39 (non-enrollee YA excluded).
   # age-40 enrollee + age-30 NON-enrollee at 300% FPL. Unit is eligible (one enrollee),
   # and the age-30 non-enrollee does not trigger the young adult reduction, so
-  # md target = 7.98%; gap = (0.0996 - 0.0798) * 46_950 = 0.0198 * 46_950 = 929.61.
+  # md target = 7.98%. COMAR .04B:
+  # max(0, (9_000 - 4_324) - 0.0798 * 46_950) = 4_676 - 3_746.61 = 929.39.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -422,19 +448,23 @@
         aca_required_contribution_percentage: 0.0996
         slcsp: 9_000
         aca_ptc: 4_324
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1, person2]
         state_code: MD
   output:
-    md_premium_assistance: 929.61
+    md_premium_assistance: 929.39
 
 - name: Case 18, interior interpolation in the 300-400% band with a DERIVED target %.
   # aca_magi_fraction 3.50 -> md_pct interpolates initial[4]=0.0798 (at 3.0) to
   # final[4]=0.0923 (at 4.0): position 0.5 -> 0.08605 (target % is NOT forced, so a
   # target-% interpolation bug would surface here). federal 0.0996 supplied.
-  # gap = (0.0996 - 0.08605) * 54_775 = 0.01355 * 54_775 = 742.20125; cap
-  # (slcsp 8_000 - aca_ptc 3_000 = 5_000) not binding.
+  # Self-consistent APTC: slcsp 8_000 - 0.0996 * 54_775 = 8_000 - 5_455.59 =
+  # 2_544.41. New formula (COMAR .04B):
+  # max(0, (8_000 - 2_544.41) - 0.08605 * 54_775) = max(0, 5_455.59 - 4_713.39)
+  # = 742.20. When APTC is self-consistent this equals the old
+  # (federal - md) * income reading. Filer inputs supplied.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -442,6 +472,7 @@
       person1:
         age: 40
         is_aca_ptc_eligible: true
+        employment_income: 54_775
     tax_units:
       tax_unit:
         members: [person1]
@@ -449,18 +480,18 @@
         aca_magi_fraction: 3.50
         aca_required_contribution_percentage: 0.0996
         slcsp: 8_000
-        aca_ptc: 3_000
+        aca_ptc: 2_544.41
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 742.20  # 0.01355 * 54_775 = 742.20125 (derived, verified)
+    md_premium_assistance: 742.20  # self-consistent APTC: equals the old reading
 
-- name: Case 19, second in-effect year (2027) mirrors the 2026 250% FPL case -> 868.58.
+- name: Case 19, second in-effect year (2027) mirrors the 2026 250% FPL case -> 66.43.
   # Same forced-input shape as Case 3 but at period 2027, proving the program is
   # still in effect in its second plan year (distinct from the 2028 sunset).
-  # gap = (0.0844 - 0.0622) * 39_125 = 0.0222 * 39_125 = 868.575.
+  # COMAR .04B: max(0, (6_000 - 3_500) - 0.0622 * 39_125) = 2_500 - 2_433.575 = 66.425.
   period: 2027
   absolute_error_margin: 0.01
   input:
@@ -476,16 +507,21 @@
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_000
         aca_ptc: 3_500
+        tax_unit_is_filer: true
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 868.58
+    md_premium_assistance: 66.425
 
-- name: Case 20, negative aca_magi -> subsidy floored at 0 (no sign-flip).
-  # Eligible (aca_magi_fraction 1.50 <= 400% FPL) but negative income yields a
-  # negative contribution gap: max(0, -8_000 * (0.0419 - 0)) = max(0, negative) = 0.
+- name: Case 20, negative aca_magi -> income floored before multiplying (no sign-flip).
+  # The formula floors income at 0 (max_(aca_magi, 0)), so a negative aca_magi
+  # contributes a 0 Maryland required contribution, NOT a negative one; there is no
+  # sign-flip that could inflate the subsidy. A real negative-MAGI unit sits at
+  # aca_magi_fraction 0 (still eligible). Here the APTC already covers the full
+  # benchmark (aca_ptc 6_000 == slcsp 6_000), so the post-APTC premium balance is 0
+  # and the subsidy is 0: max(0, (6_000 - 6_000) - 0 * 0) = 0.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -497,10 +533,10 @@
       tax_unit:
         members: [person1]
         aca_magi: -8_000
-        aca_magi_fraction: 1.50
+        aca_magi_fraction: 0
         aca_required_contribution_percentage: 0.0419
         slcsp: 6_000
-        aca_ptc: 3_500
+        aca_ptc: 6_000
     households:
       household:
         members: [person1]
@@ -508,10 +544,13 @@
   output:
     md_premium_assistance: 0
 
-- name: Case 21, young-adult floor drives target % to 0 -> subsidy uses full federal gap.
+- name: Case 21, young-adult floor drives target % to 0 -> subsidy is the full post-APTC premium.
   # Age 25 (2.5pp reduction) at 175% FPL where base target = 0.01 (interpolated
   # 0%@1.5 -> 2%@2.0, position 0.5). 0.01 - 0.025 < 0 -> md_pct floors at 0.
-  # gap = (0.05 - 0) * 27_000 = 1_350; cap (6_000 - 3_000 = 3_000) not binding.
+  # SYNTHETIC federal % 0.05 (not the true schedule); self-consistent APTC =
+  # slcsp 6_000 - 0.05 * 27_000 = 6_000 - 1_350 = 4_650. With md_pct 0 the MD
+  # contribution is 0, so the subsidy is the full post-APTC premium balance:
+  # max(0, (6_000 - 4_650) - 0 * 27_000) = 1_350. Filer inputs supplied.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -519,6 +558,7 @@
       person1:
         age: 25
         is_aca_ptc_eligible: true
+        employment_income: 27_000
     tax_units:
       tax_unit:
         members: [person1]
@@ -526,10 +566,160 @@
         aca_magi_fraction: 1.75
         aca_required_contribution_percentage: 0.05
         slcsp: 6_000
-        aca_ptc: 3_000
+        aca_ptc: 4_650
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 1_350  # 0.05 * 27_000 = 1_350 (derived, verified)
+    md_premium_assistance: 1_350  # md_pct floored to 0 -> full post-APTC premium
+
+# ---- C1 formula-correction boundary cases (post-COMAR .04B re-derivation) ----
+
+- name: Case 22, exactly 400% FPL with a low benchmark -> corrected subsidy 0.
+  # Under the OLD min_(income*(federal - md), slcsp - aca_ptc) form this unit was
+  # paid 456.98 even though the benchmark premium is fully covered by the MD
+  # required contribution. New COMAR .04B form: at 400% FPL the federal required
+  # contribution 0.0996 * 62_600 = 6_234.96 exceeds the slcsp 5_000, so APTC 0;
+  # the MD contribution 0.0923 * 62_600 = 5_777.98 exceeds the post-APTC premium
+  # 5_000, so the residual is 0: max(0, (5_000 - 0) - 5_777.98) = 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+        employment_income: 62_600
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 62_600
+        aca_magi_fraction: 4.00
+        aca_required_contribution_percentage: 0.0996
+        slcsp: 5_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0  # MD contribution exceeds the low benchmark -> 0
+
+- name: Case 23, APTC=0 region (~350% FPL) matches MIA Exhibit 2a, not the old over-grant.
+  # MIA Exhibit 2a age-40 single, gross benchmark ~$414 PMPM = 4_968/yr. At 350% FPL
+  # the federal required contribution 0.0996 * 54_775 = 5_455.59 exceeds the benchmark,
+  # so APTC 0. New COMAR .04B form: subsidy = max(0, (4_968 - 0) - 0.08605 * 54_775)
+  # = max(0, 4_968 - 4_713.39) = 254.61, leaving the enrollee at the MD target
+  # contribution (~$393/mo net) rather than the OLD 742.20 over-grant.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+        employment_income: 54_775
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 54_775
+        aca_magi_fraction: 3.50
+        aca_required_contribution_percentage: 0.0996
+        slcsp: 4_968
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 254.61  # MIA Exhibit 2a APTC=0 region, not the old 742.20
+
+# ---- A12(a) full-pipeline derived cases (no forced ACA intermediates) ----
+
+- name: Case 24, non-YAS filer derives the subsidy from raw income through the federal chain.
+  # A single age-45 (>= 38, no young-adult reduction) MD enrollee with only
+  # employment_income set. aca_magi, aca_magi_fraction, the federal applicable %,
+  # slcsp and aca_ptc are ALL derived by the model. Asserts a derived non-round
+  # subsidy rather than a forced arithmetic identity.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 45
+        employment_income: 40_000
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance: 878.40  # derived through full federal ACA chain
+
+- name: Case 25, non-YAS family derives the subsidy from raw income through the federal chain.
+  # Married couple (ages 45/43) with two children (15/13), only employment_income
+  # set. Full pipeline: aca_magi, FPL fraction, federal %, slcsp and aca_ptc all
+  # derived; no young-adult reduction (all adults >= 38).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 45
+        employment_income: 60_000
+        is_aca_ptc_eligible: true
+      parent2:
+        age: 43
+        is_aca_ptc_eligible: true
+      child1:
+        age: 15
+        is_aca_ptc_eligible: true
+      child2:
+        age: 13
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child1, child2]
+    households:
+      household:
+        members: [parent1, parent2, child1, child2]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+    md_premium_assistance: 2_691.12  # derived through full federal ACA chain
+
+- name: Case 26, mixed MD + non-MD two-household case proves defined_for masking vectorizes.
+  # Two independent tax units in one simulation: an MD enrollee (should receive a
+  # subsidy) and an identical VA enrollee (masked to 0 by defined_for StateCode.MD).
+  # Confirms the state mask vectorizes without leaking across units.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      md_person:
+        age: 40
+        employment_income: 39_125
+        is_aca_ptc_eligible: true
+      va_person:
+        age: 40
+        employment_income: 39_125
+        is_aca_ptc_eligible: true
+    tax_units:
+      md_unit:
+        members: [md_person]
+      va_unit:
+        members: [va_person]
+    households:
+      md_household:
+        members: [md_person]
+        state_code: MD
+      va_household:
+        members: [va_person]
+        state_code: VA
+  output:
+    md_premium_assistance: [868.57, 0]  # MD unit derived > 0, VA unit masked to 0 by defined_for

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance.yaml
@@ -428,3 +428,108 @@
         state_code: MD
   output:
     md_premium_assistance: 929.61
+
+- name: Case 18, interior interpolation in the 300-400% band with a DERIVED target %.
+  # aca_magi_fraction 3.50 -> md_pct interpolates initial[4]=0.0798 (at 3.0) to
+  # final[4]=0.0923 (at 4.0): position 0.5 -> 0.08605 (target % is NOT forced, so a
+  # target-% interpolation bug would surface here). federal 0.0996 supplied.
+  # gap = (0.0996 - 0.08605) * 54_775 = 0.01355 * 54_775 = 742.20125; cap
+  # (slcsp 8_000 - aca_ptc 3_000 = 5_000) not binding.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 54_775
+        aca_magi_fraction: 3.50
+        aca_required_contribution_percentage: 0.0996
+        slcsp: 8_000
+        aca_ptc: 3_000
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 742.20  # 0.01355 * 54_775 = 742.20125 (derived, verified)
+
+- name: Case 19, second in-effect year (2027) mirrors the 2026 250% FPL case -> 868.58.
+  # Same forced-input shape as Case 3 but at period 2027, proving the program is
+  # still in effect in its second plan year (distinct from the 2028 sunset).
+  # gap = (0.0844 - 0.0622) * 39_125 = 0.0222 * 39_125 = 868.575.
+  period: 2027
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 868.58
+
+- name: Case 20, negative aca_magi -> subsidy floored at 0 (no sign-flip).
+  # Eligible (aca_magi_fraction 1.50 <= 400% FPL) but negative income yields a
+  # negative contribution gap: max(0, -8_000 * (0.0419 - 0)) = max(0, negative) = 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: -8_000
+        aca_magi_fraction: 1.50
+        aca_required_contribution_percentage: 0.0419
+        slcsp: 6_000
+        aca_ptc: 3_500
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 0
+
+- name: Case 21, young-adult floor drives target % to 0 -> subsidy uses full federal gap.
+  # Age 25 (2.5pp reduction) at 175% FPL where base target = 0.01 (interpolated
+  # 0%@1.5 -> 2%@2.0, position 0.5). 0.01 - 0.025 < 0 -> md_pct floors at 0.
+  # gap = (0.05 - 0) * 27_000 = 1_350; cap (6_000 - 3_000 = 3_000) not binding.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 25
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 27_000
+        aca_magi_fraction: 1.75
+        aca_required_contribution_percentage: 0.05
+        slcsp: 6_000
+        aca_ptc: 3_000
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 1_350  # 0.05 * 27_000 = 1_350 (derived, verified)

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.yaml
@@ -1,4 +1,4 @@
-# Unit tests for Maryland Premium Assistance eligibility (REQ-001/003/004/019).
+# Unit tests for Maryland Premium Assistance eligibility.
 # Eligible when: program in effect (PY2026-2027), household in MD, at least one
 # tax-unit member is federal-APTC-eligible, and ACA MAGI <= 400% FPL.
 # is_aca_ptc_eligible and aca_magi_fraction are provided directly so the gate
@@ -22,7 +22,7 @@
   output:
     md_premium_assistance_eligible: true
 
-- name: Case 2, MD unit above 400% FPL is ineligible (income cap, REQ-004).
+- name: Case 2, MD unit above 400% FPL is ineligible (income cap).
   period: 2026
   input:
     people:
@@ -58,7 +58,7 @@
   output:
     md_premium_assistance_eligible: true
 
-- name: Case 4, no federal-APTC-eligible member makes the unit ineligible (REQ-001).
+- name: Case 4, no federal-APTC-eligible member makes the unit ineligible.
   period: 2026
   input:
     people:
@@ -94,7 +94,7 @@
   output:
     md_premium_assistance_eligible: false
 
-- name: Case 6, program not in effect in 2025 (before PY2026 start, REQ-019).
+- name: Case 6, program not in effect in 2025 (before PY2026 start).
   period: 2025
   input:
     people:
@@ -112,7 +112,7 @@
   output:
     md_premium_assistance_eligible: false
 
-- name: Case 7, program sunset in 2028 (after PY2027 end, REQ-019).
+- name: Case 7, program sunset in 2028 (after PY2027 end).
   period: 2028
   input:
     people:
@@ -189,3 +189,70 @@
         state_code: MD
   output:
     md_premium_assistance_eligible: true
+
+- name: Case 11, direct 2027 case (second plan year) is eligible.
+  # The program is authorized for plan years 2026-2027; this confirms eligibility
+  # holds in 2027 directly (distinct from the 2028 sunset), not only via 2026.
+  period: 2027
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+
+# ---- A12(c): raw-income 400%-FPL boundary eligibility pair ----
+# These derive aca_magi_fraction from employment_income through the federal FPL
+# chain instead of forcing it. EXPECTED TO CHANGE when the upstream federal
+# 400%/truncation fix lands (aca ptc_income_eligibility 4.00 threshold is
+# lower-bound-inclusive and zeroes [400%,401%) FPL); the masked boundary here
+# pairs with that upstream issue.
+
+- name: Case 12, raw income just below the 400% FPL cap is eligible.
+  # employment_income set so aca_magi_fraction is DERIVED; a single filer near but
+  # under 4x the 2026 FPL should be eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 60_000
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true  # derived aca_magi_fraction < 4.00 cap
+
+- name: Case 13, raw income just above the 400% FPL cap is ineligible.
+  # employment_income set above 4x the 2026 FPL so the DERIVED aca_magi_fraction
+  # exceeds the cap; the unit should be ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 70_000
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: false  # derived aca_magi_fraction > 4.00 cap

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.yaml
@@ -1,0 +1,191 @@
+# Unit tests for Maryland Premium Assistance eligibility (REQ-001/003/004/019).
+# Eligible when: program in effect (PY2026-2027), household in MD, at least one
+# tax-unit member is federal-APTC-eligible, and ACA MAGI <= 400% FPL.
+# is_aca_ptc_eligible and aca_magi_fraction are provided directly so the gate
+# logic is tested in isolation from the premium-data lookup.
+
+- name: Case 1, MD APTC-eligible unit at 250% FPL in 2026 is eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+
+- name: Case 2, MD unit above 400% FPL is ineligible (income cap, REQ-004).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.01
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: false
+
+- name: Case 3, exactly 400% FPL is eligible (boundary, at limit not above).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+
+- name: Case 4, no federal-APTC-eligible member makes the unit ineligible (REQ-001).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: false
+
+- name: Case 5, non-Maryland state is ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: VA
+  output:
+    md_premium_assistance_eligible: false
+
+- name: Case 6, program not in effect in 2025 (before PY2026 start, REQ-019).
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: false
+
+- name: Case 7, program sunset in 2028 (after PY2027 end, REQ-019).
+  period: 2028
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: false
+
+- name: Case 8, one eligible member in a multi-person unit qualifies the unit.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 45
+        is_aca_ptc_eligible: false
+      person2:
+        age: 43
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        aca_magi_fraction: 3.00
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+
+# ---- Edge cases ----
+
+- name: Case 9, zero income (0% FPL) APTC-eligible MD unit is eligible.
+  # Lower bound of the income test: 0 <= 4.00 FPL limit holds.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true
+
+- name: Case 10, just below 400% FPL (3.99) is eligible (below the income cap).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 3.99
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.yaml
@@ -1,12 +1,11 @@
-# Unit tests for the Maryland target contribution percentage
-# (REQ-011/012/013/014/018).
+# Unit tests for the Maryland target contribution percentage.
 # Bracket-interpolated from gov.states.md.mhbe.premium_assistance.
 # target_contribution_percentage:
 #   threshold: [0, 1.50, 2.00, 2.50, 3.00, 4.00]
 #   initial:   [0, 0,    0.02, 0.0622, 0.0798]
 #   final:     [0, 0.02, 0.0622, 0.0798, 0.0923]
-# Young adults have their target reduced by the YAS amount, floored at 0
-# (REQ-018). age 40 -> no reduction.
+# Young adults have their target reduced by the YAS amount, floored at 0.
+# age 40 -> no reduction.
 
 # ---- Base schedule (age 40, no YAS) ----
 
@@ -48,7 +47,7 @@
   output:
     md_premium_assistance_target_contribution_percentage: 0
 
-- name: Case 3, exactly 200% FPL -> 2.00% (start of 200-250% band, REQ-011 endpoint).
+- name: Case 3, exactly 200% FPL -> 2.00% (start of 200-250% band, endpoint).
   period: 2026
   absolute_error_margin: 0.0001
   input:
@@ -67,7 +66,7 @@
   output:
     md_premium_assistance_target_contribution_percentage: 0.02
 
-- name: Case 4, exactly 250% FPL -> 6.22% (start of 250-300% band, REQ-013).
+- name: Case 4, exactly 250% FPL -> 6.22% (start of 250-300% band).
   period: 2026
   absolute_error_margin: 0.0001
   input:
@@ -125,7 +124,7 @@
   output:
     md_premium_assistance_target_contribution_percentage: 0.08605
 
-- name: Case 7, exactly 400% FPL -> 9.23% (top of schedule, REQ-013).
+- name: Case 7, exactly 400% FPL -> 9.23% (top of schedule).
   period: 2026
   absolute_error_margin: 0.0001
   input:
@@ -264,7 +263,7 @@
   output:
     md_premium_assistance_target_contribution_percentage: 0.0004
 
-- name: Case 14, mid 200-250% band (2.25) -> 4.11% (linear phase, REQ-012).
+- name: Case 14, mid 200-250% band (2.25) -> 4.11% (linear phase).
   # bracket [2.00, 2.50]: 0.02 + (2.25-2.00)/0.50 * (0.0622-0.02) = 0.02 + 0.5*0.0422.
   period: 2026
   absolute_error_margin: 0.0001
@@ -485,3 +484,47 @@
         state_code: MD
   output:
     md_premium_assistance_target_contribution_percentage: 0.0572
+
+# ---- S8 additions ----
+
+- name: Case 25, just inside the 200-250% band (2.01) -> 2.0844% (no YAS).
+  # bracket [2.00, 2.50]: 0.02 + (2.01-2.00)/0.50 * (0.0622-0.02)
+  # = 0.02 + 0.02 * 0.0422 = 0.020844. Pins the just-inside-band interpolation.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.01
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.020844
+
+- name: Case 26, young adult below 150% FPL -> 0.00% (base 0 - 2.5pp floors at 0).
+  # In the 0-150% band the base target is a flat 0%; subtracting the age-30 young
+  # adult reduction 0.025 floors at 0 rather than going negative.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.yaml
@@ -404,3 +404,84 @@
         state_code: MD
   output:
     md_premium_assistance_target_contribution_percentage: 0.0598
+
+- name: Case 21, mid 150-200% band (1.75) -> 1.00% (interpolation midpoint, no YAS).
+  # bracket [1.50, 2.00]: 0 + (1.75-1.50)/0.50 * (0.02-0) = 0.5 * 0.02 = 0.01.
+  # Pins the typo-reconciled final=2.00% at 200% FPL via the midpoint.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.75
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.01
+
+- name: Case 22, just below 200% FPL (1.99) -> 1.96% (top of 150-200% ramp).
+  # bracket [1.50, 2.00]: 0 + (1.99-1.50)/0.50 * 0.02 = 0.98 * 0.02 = 0.0196.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.99
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0196
+
+- name: Case 23, age 36 young adult at 250% FPL -> 5.22% (6.22% - 1.0pp through the subtraction).
+  # base target 0.0622 (start of 250-300% band) minus the age-36 reduction 0.01.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 36
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0522
+
+- name: Case 24, age 37 young adult at 250% FPL -> 5.72% (6.22% - 0.5pp through the subtraction).
+  # base target 0.0622 (start of 250-300% band) minus the age-37 reduction 0.005.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 37
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0572

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.yaml
@@ -1,0 +1,406 @@
+# Unit tests for the Maryland target contribution percentage
+# (REQ-011/012/013/014/018).
+# Bracket-interpolated from gov.states.md.mhbe.premium_assistance.
+# target_contribution_percentage:
+#   threshold: [0, 1.50, 2.00, 2.50, 3.00, 4.00]
+#   initial:   [0, 0,    0.02, 0.0622, 0.0798]
+#   final:     [0, 0.02, 0.0622, 0.0798, 0.0923]
+# Young adults have their target reduced by the YAS amount, floored at 0
+# (REQ-018). age 40 -> no reduction.
+
+# ---- Base schedule (age 40, no YAS) ----
+
+- name: Case 1, 138% FPL -> 0.00% (0-150% band, full replacement).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.38
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0
+
+- name: Case 2, exactly 150% FPL -> 0.00% (start of 150-200% band).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0
+
+- name: Case 3, exactly 200% FPL -> 2.00% (start of 200-250% band, REQ-011 endpoint).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.02
+
+- name: Case 4, exactly 250% FPL -> 6.22% (start of 250-300% band, REQ-013).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0622
+
+- name: Case 5, exactly 300% FPL -> 7.98% (start of 300-400% band).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 3.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0798
+
+- name: Case 6, 350% FPL -> 8.605% (interpolated in 300-400% band).
+  # 0.0798 + (3.50-3.00)/(4.00-3.00) * (0.0923-0.0798) = 0.0798 + 0.5*0.0125
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 3.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.08605
+
+- name: Case 7, exactly 400% FPL -> 9.23% (top of schedule, REQ-013).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0923
+
+# ---- Young Adult Subsidy overlay (single-person unit; person reduction = unit reduction) ----
+
+- name: Case 8, young adult age 30 at 250% FPL -> 3.72% (6.22% - 2.5pp).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0372
+
+- name: Case 9, young adult age 30 at 200% FPL -> 0.00% (2.00% - 2.5pp floored at 0).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0
+
+- name: Case 10, age 35 at 300% FPL -> 6.48% (7.98% - 1.5pp taper).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 35
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 3.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0648
+
+# ---- Edge cases: bracket-boundary semantics (searchsorted side="right") ----
+
+- name: Case 11, 0% FPL clamps to the first bracket -> 0.00%.
+  # searchsorted right of 0 -> idx 1, minus 1 -> bracket 0 (0-150%), rate 0.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0
+
+- name: Case 12, just below 150% FPL (1.49) -> 0.00% (still in 0-150% band).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.49
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0
+
+- name: Case 13, just above 150% FPL (1.51) -> 0.04% (start of 150-200% ramp).
+  # bracket [1.50, 2.00]: 0 + (1.51-1.50)/0.50 * (0.02-0) = 0.02*0.02 = 0.0004.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.51
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0004
+
+- name: Case 14, mid 200-250% band (2.25) -> 4.11% (linear phase, REQ-012).
+  # bracket [2.00, 2.50]: 0.02 + (2.25-2.00)/0.50 * (0.0622-0.02) = 0.02 + 0.5*0.0422.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.25
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0411
+
+- name: Case 15, just below 250% FPL (2.49) -> 6.1356% (top of 200-250% band).
+  # bracket [2.00, 2.50]: 0.02 + (2.49-2.00)/0.50 * 0.0422 = 0.02 + 0.98*0.0422.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.49
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.061356
+
+- name: Case 16, just above 250% FPL (2.51) -> 6.2552% (start of 250-300% band).
+  # bracket [2.50, 3.00]: 0.0622 + (2.51-2.50)/0.50 * (0.0798-0.0622) = 0.0622 + 0.02*0.0176.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.51
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.062552
+
+- name: Case 17, just below 300% FPL (2.99) -> 7.9448% (top of 250-300% band).
+  # bracket [2.50, 3.00]: 0.0622 + (2.99-2.50)/0.50 * 0.0176 = 0.0622 + 0.98*0.0176.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.99
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.079448
+
+- name: Case 18, just above 300% FPL (3.01) -> 7.9925% (start of 300-400% band).
+  # bracket [3.00, 4.00]: 0.0798 + (3.01-3.00)/1.00 * (0.0923-0.0798) = 0.0798 + 0.01*0.0125.
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 3.01
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.079925
+
+- name: Case 19, above 400% FPL (4.50) clamps to the top bracket rate -> 9.23%.
+  # bracket_idx clips to the last band [3.00, 4.00]; position clips to 1 -> final 0.0923.
+  # (Subsidy is still 0 for these units via the eligibility gate; this checks the
+  #  target-% variable does not extrapolate past the schedule.)
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.50
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0923
+
+- name: Case 20, young adult age 34 at 300% FPL -> 5.98% (7.98% - 2.0pp taper).
+  period: 2026
+  absolute_error_margin: 0.0001
+  input:
+    people:
+      person1:
+        age: 34
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 3.00
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_target_contribution_percentage: 0.0598

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.yaml
@@ -1,5 +1,5 @@
 # Unit tests for the Maryland Premium Assistance Young Adult Subsidy (YAS)
-# percentage-point reduction by age (REQ-018).
+# percentage-point reduction by age.
 # Reduction (as a share) at or above each age: 18-33 -> 0.025; 34 -> 0.02;
 # 35 -> 0.015; 36 -> 0.01; 37 -> 0.005; 38+ -> 0; under 18 -> 0.
 # Values map directly to gov.states.md.mhbe.premium_assistance.young_adult.reduction.

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.yaml
@@ -259,3 +259,47 @@
         state_code: MD
   output:
     md_premium_assistance_young_adult_reduction: 0
+
+- name: Case 15, two enrollees aged 33 and 34 -> unit takes the max (younger 2.5pp).
+  # Age-33 enrollee (full band 2.5pp) and age-34 enrollee (taper 2.0pp), both
+  # APTC-eligible -> tax-unit reduction = max(0.025, 0.02) = 0.025.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 33
+        is_aca_ptc_eligible: true
+      person2:
+        age: 34
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.025
+
+- name: Case 16, non-enrollee younger member excluded -> older enrollee drives the reduction.
+  # Age-33 member is NOT APTC-eligible (its 2.5pp is masked out); the age-34
+  # enrollee applies -> tax-unit reduction = 0.02.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 33
+        is_aca_ptc_eligible: false
+      person2:
+        age: 34
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.02

--- a/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.yaml
@@ -1,0 +1,261 @@
+# Unit tests for the Maryland Premium Assistance Young Adult Subsidy (YAS)
+# percentage-point reduction by age (REQ-018).
+# Reduction (as a share) at or above each age: 18-33 -> 0.025; 34 -> 0.02;
+# 35 -> 0.015; 36 -> 0.01; 37 -> 0.005; 38+ -> 0; under 18 -> 0.
+# Values map directly to gov.states.md.mhbe.premium_assistance.young_adult.reduction.
+# The variable takes the largest reduction among the tax unit's federally
+# APTC-eligible enrollees, so each person is marked is_aca_ptc_eligible: true.
+# All periods use 2026 (program starts PY2026; YAS modeled 2026+ only).
+
+- name: Case 1, age 17 (under 18) receives no reduction.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 17
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0
+
+- name: Case 2, age 18 (start of full band) reduced by 2.5 points.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 18
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.025
+
+- name: Case 3, age 30 (mid full band) reduced by 2.5 points.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.025
+
+- name: Case 4, age 33 (end of full band) reduced by 2.5 points.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 33
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.025
+
+- name: Case 5, age 34 reduced by 2.0 points (taper begins).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 34
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.02
+
+- name: Case 6, age 35 reduced by 1.5 points.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 35
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.015
+
+- name: Case 7, age 36 reduced by 1.0 point.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 36
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.01
+
+- name: Case 8, age 37 reduced by 0.5 points (taper ends).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 37
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.005
+
+- name: Case 9, age 38 receives no reduction (above the young adult band).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 38
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0
+
+- name: Case 10, age 40 receives no reduction.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0
+
+- name: Case 11, unit takes the largest reduction among APTC-eligible enrollees.
+  # Age-30 enrollee (2.5pp) and age-50 enrollee (0pp) -> unit reduction 2.5pp.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: true
+      person2:
+        age: 50
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.025
+
+- name: Case 12, ineligible young adult does not drive the reduction.
+  # Age-30 member is NOT APTC-eligible; only the age-40 enrollee counts -> 0.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_aca_ptc_eligible: false
+      person2:
+        age: 40
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0
+
+# ---- Edge cases ----
+
+- name: Case 13, two taper-age enrollees take the larger (younger) reduction.
+  # Age-34 enrollee (2.0pp) and age-37 enrollee (0.5pp) -> unit reduction 2.0pp.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 34
+        is_aca_ptc_eligible: true
+      person2:
+        age: 37
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0.02
+
+- name: Case 14, age 0 (newborn enrollee) receives no reduction.
+  # Below the age-18 young adult band start.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 0
+        is_aca_ptc_eligible: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance_young_adult_reduction: 0

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -94,3 +94,36 @@
     or_healthier_oregon_cost: 0
   output:
     healthcare_benefit_value: 850
+
+- name: Case 8, DERIVED Maryland Premium Assistance aggregates into the household total.
+  # A real MD tax unit (single age 40 at 250% FPL) with the ACA intermediates
+  # supplied so md_premium_assistance is DERIVED by the model rather than forced:
+  # gap = (0.0844 - 0.0622) * 39_125 = 868.575 -> 868.58. Other health components
+  # zeroed so the household total equals the derived MD subsidy.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+        medicaid_cost: 0
+        msp_cost: 0
+        or_healthier_oregon_cost: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 3_500
+        assigned_aca_ptc: 0
+        co_omnisalud: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 868.58
+    healthcare_benefit_value: 868.58  # 0.0222 * 39_125 = 868.575 (derived, verified)

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -81,3 +81,16 @@
     or_healthier_oregon_cost: 0
   output:
     healthcare_benefit_value: 1_200
+
+- name: Case 7, Maryland Premium Assistance flows into healthcare benefit value.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    medicaid_cost: 0
+    msp_cost: 0
+    assigned_aca_ptc: 0
+    co_omnisalud: 0
+    md_premium_assistance: 850
+    or_healthier_oregon_cost: 0
+  output:
+    healthcare_benefit_value: 850

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -88,6 +88,8 @@
   input:
     medicaid_cost: 0
     msp_cost: 0
+    chip: 0
+    basic_health_program: 0
     assigned_aca_ptc: 0
     co_omnisalud: 0
     md_premium_assistance: 850
@@ -97,9 +99,10 @@
 
 - name: Case 8, DERIVED Maryland Premium Assistance aggregates into the household total.
   # A real MD tax unit (single age 40 at 250% FPL) with the ACA intermediates
-  # supplied so md_premium_assistance is DERIVED by the model rather than forced:
-  # gap = (0.0844 - 0.0622) * 39_125 = 868.575 -> 868.58. Other health components
-  # zeroed so the household total equals the derived MD subsidy.
+  # supplied so md_premium_assistance is DERIVED by the model rather than forced.
+  # COMAR .04B: max(0, (6_000 - 2_698) - 0.0622 * 39_125) = 3_302 - 2_433.575
+  # = 868.425. Other health components zeroed so the household total equals the
+  # derived MD subsidy.
   period: 2026
   absolute_error_margin: 0.01
   input:
@@ -107,8 +110,10 @@
       person1:
         age: 40
         is_aca_ptc_eligible: true
+        employment_income: 39_125
         medicaid_cost: 0
         msp_cost: 0
+        chip: 0
         or_healthier_oregon_cost: 0
     tax_units:
       tax_unit:
@@ -117,13 +122,14 @@
         aca_magi_fraction: 2.50
         aca_required_contribution_percentage: 0.0844
         slcsp: 6_000
-        aca_ptc: 3_500
+        aca_ptc: 2_698  # self-consistent: 6_000 - 0.0844*39_125
         assigned_aca_ptc: 0
+        basic_health_program: 0
         co_omnisalud: 0
     households:
       household:
         members: [person1]
         state_code: MD
   output:
-    md_premium_assistance: 868.58
-    healthcare_benefit_value: 868.58  # 0.0222 * 39_125 = 868.575 (derived, verified)
+    md_premium_assistance: 868.425
+    healthcare_benefit_value: 868.425  # derived MD subsidy aggregates to the household

--- a/policyengine_us/tests/policy/baseline/household/household_health_benefits.yaml
+++ b/policyengine_us/tests/policy/baseline/household/household_health_benefits.yaml
@@ -54,3 +54,60 @@
   output:
     household_health_benefits: 4_234.8
     household_benefits: 4_234.8
+
+- name: Case 5, flag on includes forced Maryland Premium Assistance value.
+  # md_premium_assistance is registered in the household_health_benefits list
+  # (the second registration that feeds net income when the flag is on), so a
+  # forced $850 subsidy flows through to the household total. Other health
+  # components are zeroed so the total equals the MD subsidy.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    gov.simulation.include_health_benefits_in_net_income: true
+    medicaid_cost: 0
+    msp_cost: 0
+    chip: 0
+    assigned_aca_ptc: 0
+    md_premium_assistance: 850
+    snap: 0
+  output:
+    household_health_benefits: 850
+    household_benefits: 850
+
+- name: Case 6, DERIVED Maryland Premium Assistance flows into net income with the flag on.
+  # A real MD tax unit (single age 40 at 250% FPL, self-consistent APTC) derives
+  # md_premium_assistance through the model; with the flag on it aggregates into
+  # household_health_benefits and thus household_benefits / net income, proving the
+  # second registration list carries the state subsidy through the pipeline.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    gov.simulation.include_health_benefits_in_net_income: true
+    people:
+      person1:
+        age: 40
+        is_aca_ptc_eligible: true
+        employment_income: 39_125
+        medicaid_cost: 0
+        msp_cost: 0
+        chip: 0
+        or_healthier_oregon_cost: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi: 39_125
+        aca_magi_fraction: 2.50
+        aca_required_contribution_percentage: 0.0844
+        slcsp: 6_000
+        aca_ptc: 2_698  # self-consistent: 6_000 - 0.0844*39_125
+        assigned_aca_ptc: 0
+        basic_health_program: 0
+        co_omnisalud: 0
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_premium_assistance: 868.425  # COMAR .04B: max(0, (6_000 - 2_698) - 0.0622 * 39_125)
+    household_health_benefits: 868.425  # derived MD subsidy flows through the pipeline
+    household_benefits: 868.425  # carried into household_benefits / net income

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
@@ -9,7 +9,7 @@ class md_premium_assistance(Variable):
     definition_period = YEAR
     defined_for = "md_premium_assistance_eligible"
     reference = (
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
         "https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58",
     )
     documentation = (

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
@@ -25,7 +25,7 @@ class md_premium_assistance(Variable):
     )
 
     def formula(tax_unit, period, parameters):
-        income = tax_unit("aca_magi", period)
+        income = max_(tax_unit("aca_magi", period), 0)
         federal_percentage = tax_unit("aca_required_contribution_percentage", period)
         md_percentage = tax_unit(
             "md_premium_assistance_target_contribution_percentage", period

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
@@ -1,0 +1,42 @@
+from policyengine_us.model_api import *
+
+
+class md_premium_assistance(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maryland Premium Assistance"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "md_premium_assistance_eligible"
+    reference = (
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
+        "https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58",
+    )
+    documentation = (
+        "Maryland state top-up to the federal ACA premium tax credit. The "
+        "subsidy reduces the enrollee's required contribution toward the "
+        "benchmark SLCSP from the federal applicable percentage down to the "
+        "lower Maryland target percentage, capped at the premium remaining "
+        "after the federal APTC so it never duplicates the federal credit. "
+        "For enrollees with a 0% target contribution the program also covers "
+        "the non-essential-health-benefit premium components so their net "
+        "premium is $0, but this non-EHB split is not modeled here "
+        "(COMAR 14.35.21.04)."
+    )
+
+    def formula(tax_unit, period, parameters):
+        income = tax_unit("aca_magi", period)
+        federal_percentage = tax_unit("aca_required_contribution_percentage", period)
+        md_percentage = tax_unit(
+            "md_premium_assistance_target_contribution_percentage", period
+        )
+        # Contribution gap between the federal applicable percentage and the
+        # lower Maryland target percentage.
+        contribution_gap = max_(0, income * (federal_percentage - md_percentage))
+        # slcsp is a MONTH-period variable; core sums the 12 months when
+        # called from this YEAR formula.
+        slcsp = add(tax_unit, period, ["slcsp"])
+        aca_ptc = tax_unit("aca_ptc", period)
+        # Cap at the premium balance remaining after the federal APTC.
+        premium_after_aptc = max_(0, slcsp - aca_ptc)
+        return min_(contribution_gap, premium_after_aptc)

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance.py
@@ -8,35 +8,51 @@ class md_premium_assistance(Variable):
     unit = USD
     definition_period = YEAR
     defined_for = "md_premium_assistance_eligible"
+    # COMAR 14.35.21 (codified chapter, permanent effective 2025-10-13). The
+    # basis-of-calculation rule .04B-C and the Board delegation .04D are on
+    # page 6 of the codified chapter. The emergency PDF (25-134E) expired
+    # 2026-01-06.
     reference = (
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
+        "https://regs.maryland.gov/us/md/exec/comar/14.35.21#page=6",
         "https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58",
     )
-    documentation = (
-        "Maryland state top-up to the federal ACA premium tax credit. The "
-        "subsidy reduces the enrollee's required contribution toward the "
-        "benchmark SLCSP from the federal applicable percentage down to the "
-        "lower Maryland target percentage, capped at the premium remaining "
-        "after the federal APTC so it never duplicates the federal credit. "
-        "For enrollees with a 0% target contribution the program also covers "
-        "the non-essential-health-benefit premium components so their net "
-        "premium is $0, but this non-EHB split is not modeled here "
-        "(COMAR 14.35.21.04)."
-    )
+    # Maryland state top-up to the federal ACA premium tax credit. Per COMAR
+    # 14.35.21.04B, the subsidy equals the benchmark SLCSP premium remaining
+    # after the federal APTC, less the enrollee's Maryland target
+    # contribution (the target percentage applied to income). This "premium
+    # balance after APTC" form never duplicates the federal credit.
+    #
+    # For enrollees with a 0% target contribution the program also covers the
+    # non-essential-health-benefit premium components so their net premium is
+    # $0, but this non-EHB split is not modeled here.
+    #
+    # A non-filer has aca_ptc = 0, which would inflate the post-APTC premium
+    # balance and over-grant the state subsidy. COMAR 14.35.21.03A(1)
+    # conditions the subsidy on APTC eligibility, which requires filing, so
+    # the subsidy is gated on tax_unit_is_filer below.
+    #
+    # The display name "Premium Assistance" follows the MHBE consumer-facing
+    # site ("Maryland Premium Assistance"); the statute and COMAR title the
+    # program the "State-Based Health Insurance Subsidies Program".
+    #
+    # Not modeled: the April 1, 2026 enrollment cutoff and .03C budget-cap
+    # authority, the mid-2026 special-enrollment-period closure, the Board's
+    # budget-limit authority, the requirement to enroll in a QHP through the
+    # Exchange (.02B(1)), and the monthly eligibility timing in .03E (this
+    # variable uses a year period).
 
     def formula(tax_unit, period, parameters):
         income = max_(tax_unit("aca_magi", period), 0)
-        federal_percentage = tax_unit("aca_required_contribution_percentage", period)
         md_percentage = tax_unit(
             "md_premium_assistance_target_contribution_percentage", period
         )
-        # Contribution gap between the federal applicable percentage and the
-        # lower Maryland target percentage.
-        contribution_gap = max_(0, income * (federal_percentage - md_percentage))
         # slcsp is a MONTH-period variable; core sums the 12 months when
         # called from this YEAR formula.
         slcsp = add(tax_unit, period, ["slcsp"])
         aca_ptc = tax_unit("aca_ptc", period)
-        # Cap at the premium balance remaining after the federal APTC.
+        # Premium balance remaining after the federal APTC (COMAR .04B).
         premium_after_aptc = max_(0, slcsp - aca_ptc)
-        return min_(contribution_gap, premium_after_aptc)
+        subsidy = max_(0, premium_after_aptc - md_percentage * income)
+        # Gate on filing: non-filers are not APTC-eligible (COMAR .03A(1)).
+        is_filer = tax_unit("tax_unit_is_filer", period)
+        return where(is_filer, subsidy, 0)

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
@@ -7,16 +7,17 @@ class md_premium_assistance_eligible(Variable):
     label = "Eligible for Maryland Premium Assistance"
     definition_period = YEAR
     defined_for = StateCode.MD
+    # COMAR 14.35.21.03 (eligibility) is on page 5 of the codified chapter,
+    # permanent effective 2025-10-13. The emergency PDF (25-134E) expired
+    # 2026-01-06. HGO briefing p.58 documents the all-ages eligibility design.
     reference = (
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
-        "https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14",
+        "https://regs.maryland.gov/us/md/exec/comar/14.35.21#page=5",
+        "https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58",
     )
-    documentation = (
-        "A tax unit is eligible for Maryland Premium Assistance when the "
-        "program is in effect, at least one member is eligible for the "
-        "federal ACA premium tax credit, and household income is at or below "
-        "the federal poverty line limit."
-    )
+    # A tax unit is eligible for Maryland Premium Assistance when the program
+    # is in effect, at least one member is eligible for the federal ACA
+    # premium tax credit, and household income is at or below the federal
+    # poverty line limit.
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.md.mhbe.premium_assistance

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
@@ -22,7 +22,7 @@ class md_premium_assistance_eligible(Variable):
         p = parameters(period).gov.states.md.mhbe.premium_assistance
         in_effect = p.in_effect
         # At least one member must be eligible for the federal ACA PTC.
-        aptc_eligible = tax_unit.any(tax_unit.members("is_aca_ptc_eligible", period))
+        aptc_eligible = add(tax_unit, period, ["is_aca_ptc_eligible"]) > 0
         magi_frac = tax_unit("aca_magi_fraction", period)
         income_eligible = magi_frac <= p.fpl_limit
         return in_effect & aptc_eligible & income_eligible

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
@@ -1,0 +1,28 @@
+from policyengine_us.model_api import *
+
+
+class md_premium_assistance_eligible(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Eligible for Maryland Premium Assistance"
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = (
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
+        "https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=25",
+    )
+    documentation = (
+        "A tax unit is eligible for Maryland Premium Assistance when the "
+        "program is in effect, at least one member is eligible for the "
+        "federal ACA premium tax credit, and household income is at or below "
+        "the federal poverty line limit."
+    )
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.md.mhbe.premium_assistance
+        in_effect = p.in_effect
+        # At least one member must be eligible for the federal ACA PTC.
+        aptc_eligible = tax_unit.any(tax_unit.members("is_aca_ptc_eligible", period))
+        magi_frac = tax_unit("aca_magi_fraction", period)
+        income_eligible = magi_frac <= p.fpl_limit
+        return in_effect & aptc_eligible & income_eligible

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_eligible.py
@@ -8,8 +8,8 @@ class md_premium_assistance_eligible(Variable):
     definition_period = YEAR
     defined_for = StateCode.MD
     reference = (
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
-        "https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=25",
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
+        "https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14",
     )
     documentation = (
         "A tax unit is eligible for Maryland Premium Assistance when the "

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
@@ -1,0 +1,64 @@
+from policyengine_us.model_api import *
+
+
+class md_premium_assistance_target_contribution_percentage(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maryland Premium Assistance target contribution percentage"
+    unit = "/1"
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = (
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
+        "https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58",
+    )
+    documentation = (
+        "Maryland target contribution percentage toward the benchmark SLCSP, "
+        "bracket-interpolated across FPL bands, then reduced by the Young "
+        "Adult Subsidy overlay and floored at zero."
+    )
+
+    def formula(tax_unit, period, parameters):
+        magi_frac = tax_unit("aca_magi_fraction", period)
+        p = parameters(
+            period
+        ).gov.states.md.mhbe.premium_assistance.target_contribution_percentage
+
+        thresholds = np.array(p.threshold)
+        initial_rates = np.array(p.initial)
+        final_rates = np.array(p.final)
+
+        # Find which bracket each tax unit falls into. searchsorted returns
+        # the index where magi_frac would be inserted; subtract 1 to get the
+        # bracket index, clamped to the valid range.
+        bracket_idx = clip(
+            np.searchsorted(thresholds, magi_frac, side="right") - 1,
+            0,
+            len(initial_rates) - 1,
+        )
+
+        bracket_start = thresholds[bracket_idx]
+        next_idx = min_(bracket_idx + 1, len(thresholds) - 1)
+        bracket_end = where(
+            bracket_idx < len(thresholds) - 1,
+            thresholds[next_idx],
+            bracket_start + 1,
+        )
+
+        bracket_width = bracket_end - bracket_start
+        position = where(
+            bracket_width > 0,
+            (magi_frac - bracket_start) / bracket_width,
+            0,
+        )
+        position = clip(position, 0, 1)
+
+        initial = initial_rates[bracket_idx]
+        final = final_rates[bracket_idx]
+        base_percentage = initial + position * (final - initial)
+
+        # Subtract the Young Adult Subsidy reduction, floored at zero.
+        young_adult_reduction = tax_unit(
+            "md_premium_assistance_young_adult_reduction", period
+        )
+        return max_(0, base_percentage - young_adult_reduction)

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
@@ -8,15 +8,16 @@ class md_premium_assistance_target_contribution_percentage(Variable):
     unit = "/1"
     definition_period = YEAR
     defined_for = StateCode.MD
+    # COMAR 14.35.21.04D (Board delegation to set the target contribution
+    # schedule) is on page 6 of the codified chapter, permanent effective
+    # 2025-10-13. The emergency PDF (25-134E) expired 2026-01-06.
     reference = (
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
+        "https://regs.maryland.gov/us/md/exec/comar/14.35.21#page=6",
         "https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58",
     )
-    documentation = (
-        "Maryland target contribution percentage toward the benchmark SLCSP, "
-        "bracket-interpolated across FPL bands, then reduced by the Young "
-        "Adult Subsidy overlay and floored at zero."
-    )
+    # Maryland target contribution percentage toward the benchmark SLCSP,
+    # bracket-interpolated across FPL bands, then reduced by the Young Adult
+    # Subsidy overlay and floored at zero.
 
     def formula(tax_unit, period, parameters):
         magi_frac = tax_unit("aca_magi_fraction", period)

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
@@ -37,13 +37,12 @@ class md_premium_assistance_target_contribution_percentage(Variable):
             len(initial_rates) - 1,
         )
 
+        # Interpolate within the bracket, mirroring the canonical
+        # aca_required_contribution_percentage.py idiom. bracket_idx is clipped
+        # to [0, len(initial_rates) - 1] = [0, 4], and len(thresholds) - 1 = 5,
+        # so bracket_idx + 1 is always a valid threshold index (<= 5).
         bracket_start = thresholds[bracket_idx]
-        next_idx = min_(bracket_idx + 1, len(thresholds) - 1)
-        bracket_end = where(
-            bracket_idx < len(thresholds) - 1,
-            thresholds[next_idx],
-            bracket_start + 1,
-        )
+        bracket_end = thresholds[bracket_idx + 1]
 
         bracket_width = bracket_end - bracket_start
         position = where(

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_target_contribution_percentage.py
@@ -9,7 +9,7 @@ class md_premium_assistance_target_contribution_percentage(Variable):
     definition_period = YEAR
     defined_for = StateCode.MD
     reference = (
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
         "https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58",
     )
     documentation = (

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.py
@@ -1,0 +1,29 @@
+from policyengine_us.model_api import *
+
+
+class md_premium_assistance_young_adult_reduction(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Maryland Premium Assistance young adult contribution percentage reduction"
+    unit = "/1"
+    definition_period = YEAR
+    defined_for = StateCode.MD
+    reference = (
+        "https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14",
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
+    )
+    documentation = (
+        "Young Adult Subsidy overlay reduces the tax unit's target "
+        "contribution percentage. The reduction is age-based per enrollee; "
+        "the most generous reduction among the tax unit's federally "
+        "APTC-eligible members applies at the tax unit level."
+    )
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.md.mhbe.premium_assistance
+        age = tax_unit.members("age", period)
+        person_reduction = p.young_adult.reduction.calc(age)
+        # Only enrollees eligible for the federal APTC receive the subsidy,
+        # so only their ages can drive the tax unit's reduction.
+        is_enrollee = tax_unit.members("is_aca_ptc_eligible", period)
+        return tax_unit.max(where(is_enrollee, person_reduction, 0))

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.py
@@ -8,16 +8,25 @@ class md_premium_assistance_young_adult_reduction(Variable):
     unit = "/1"
     definition_period = YEAR
     defined_for = StateCode.MD
+    # COMAR 14.35.19.04B (Young Adult Subsidy) defines the age-based
+    # reduction per enrollee; codified COMAR chapter 14.35.21 governs the
+    # State-Based Health Insurance Subsidies Program.
     reference = (
         "https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14",
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
+        "https://regs.maryland.gov/us/md/exec/comar/14.35.21#page=6",
     )
-    documentation = (
-        "Young Adult Subsidy overlay reduces the tax unit's target "
-        "contribution percentage. The reduction is age-based per enrollee; "
-        "the most generous reduction among the tax unit's federally "
-        "APTC-eligible members applies at the tax unit level."
-    )
+    # Young Adult Subsidy overlay reduces the tax unit's target contribution
+    # percentage. COMAR 14.35.19.04B defines the reduction per enrollee, and
+    # no source states how to combine enrollees of different ages within one
+    # tax unit. This variable applies the most generous reduction among the
+    # unit's federally APTC-eligible members at the tax-unit level, which is a
+    # unit-wide APPROXIMATION: it is exact for single-enrollee units but
+    # over-grants for mixed-age multi-enrollee units. It is not restructured
+    # to a per-enrollee calculation here.
+    #
+    # The YAS Medicaid-ineligibility floor is satisfied via
+    # is_aca_ptc_eligible below, since APTC eligibility excludes those
+    # eligible for Medicaid.
 
     def formula(tax_unit, period, parameters):
         p = parameters(period).gov.states.md.mhbe.premium_assistance

--- a/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.py
+++ b/policyengine_us/variables/gov/states/md/mhbe/premium_assistance/md_premium_assistance_young_adult_reduction.py
@@ -10,7 +10,7 @@ class md_premium_assistance_young_adult_reduction(Variable):
     defined_for = StateCode.MD
     reference = (
         "https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=14",
-        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3",
+        "https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=5",
     )
     documentation = (
         "Young Adult Subsidy overlay reduces the tax unit's target "

--- a/policyengine_us/variables/household/healthcare_benefit_value.py
+++ b/policyengine_us/variables/household/healthcare_benefit_value.py
@@ -20,5 +20,6 @@ class healthcare_benefit_value(Variable):
         "assigned_aca_ptc",
         "basic_health_program",
         "co_omnisalud",
+        "md_premium_assistance",
         "or_healthier_oregon_cost",
     ]


### PR DESCRIPTION
# Maryland Premium Assistance (State-Based Health Insurance Subsidies Program)

## Summary

Implements the Maryland State-Based Health Insurance Subsidies Program ("Maryland Premium Assistance") in PolicyEngine — a PY2026–2027 state top-up to the federal ACA premium tax credit. Maryland fills part of the gap created by the expiration of the enhanced federal premium tax credits (ARPA/IRA eAPTC): full replacement of the lost federal help up to 200% FPL, a linear phase-down from 100% to 50% replacement over 200–250% FPL, 50% replacement over 250–400% FPL, and no subsidy above 400% FPL. The pre-existing Young Adult Subsidy (ages 18–37) is maintained as an overlay that further reduces the target contribution percentage. The subsidy is administered by the Maryland Health Benefit Exchange (MHBE) and applied automatically on top of the federal APTC.

Closes #9217

## Regulatory Authority

| Source | Citation | URL |
|---|---|---|
| Enabling statute | Md. Insurance Article §31-125 (HB 1082, 2025 Session, enacted May 13, 2025) | https://mgaleg.maryland.gov/mgawebsite/Legislation/Details/HB1082?ys=2025rs |
| Statutory text (§31-125, incl. sunset §31-125(D)) | MHBE Board 5-19-25 deck appendix | https://www.marylandhbe.com/wp-content/uploads/2025/05/State-Based-Subsidy-Parameters-and-Regulations-Board-5.19.25.pdf#page=22 |
| Regulation | COMAR 14.35.21.01–.07 (emergency chapter; authority Ins. Art. §31-106(c)(1)(iv)) | https://mgaleg.maryland.gov/pubs/committee/AELR/25-134E-Regulation.pdf#page=3 |
| Adopted 2026 parameters | MHBE Board — Final 2026 State Subsidy and Reinsurance Parameters (July 21, 2025); YAS table p.14, FPL table p.7 | https://www.marylandhbe.com/wp-content/uploads/2025/07/Final-2026-State-Subsidy-and-Reinsurance-Parameters-Board-7-21-25-1.pdf#page=25 |
| Definitive subsidy design table | Combined MHBE/MIA briefing to HGO & Finance committees (Oct 16, 2025), p.58 | https://mgaleg.maryland.gov/meeting_material/2025/hgo%20-%20134051066649659653%20-%20Combined%20MHBE.MIA%20slides_10.16.2025%20briefing%20to%20HGO&Finance.pdf#page=58 |
| Validation targets (net premiums) | MIA 2026 ACA Approved Rates — State Subsidy Program Impact, Exhibit 2a | https://insurance.maryland.gov/Documents/newscenter/newsreleases/2026-ACA-Approved-Rates-State-Subsidy-Program-Impact.pdf#page=1 |

Note: the primary consumer page (marylandhealthconnection.gov/maryland-premium-assistance) is bot-blocked (HTTP 403); its content was corroborated via a govdelivery bulletin and secondary sources.

## Eligibility

A tax unit is eligible (`md_premium_assistance_eligible`) when all of the following hold:

1. **Federal APTC eligibility / QHP enrollment** — the enrollee must be in a tax filer's household where the filer meets APTC eligibility requirements and is enrolled in a QHP through the Individual Exchange. Modeled as any member having `is_aca_ptc_eligible` (COMAR 14.35.21.03A(1), cross-referencing COMAR 14.35.07.08). Because eligibility is gated on the federal APTC, OBBBA immigration-related APTC losses (2026 and 2027) flow through automatically with no MD-specific code.
2. **Maryland residence** — household `state_code` is MD.
3. **Income at or below 400% FPL** — `aca_magi_fraction <= 4.0` (`fpl_limit.yaml`); no state subsidy above 400% FPL (HGO briefing p.58; MIA Exhibit 2a 401% rows). The FPL year follows the "FPL as of the first day of open enrollment" convention (COMAR 14.35.21.02B(3)) — PY2026 uses 2025 FPL guidelines, which matches the prior-year FPG convention already encoded in `aca_magi_fraction`.
4. **Program in effect** — Plan Years 2026–2027 only (`in_effect.yaml`; Ins. Art. §31-125(D); COMAR 14.35.21.04E).
5. **All ages** — no age restriction (expansion from the young-adults-only pilot; COMAR 14.35.21.03; MHBE Final 2026 Parameters).

The COMAR 14.35.21.03A(2) requirement that the enrollee "experience an increase in the applicable percentages" versus CY2025 falls out of the benefit formula (the `max_(0, ...)` floor) rather than a separate flag.

## Benefit Calculation

### Target contribution percentage schedule (MD target vs federal 2026 applicable %)

The Maryland target is derived as: 2025 enhanced (ARPA) % + replacement share × (2026 non-enhanced % − 2025 enhanced %), where the replacement share is 1.0 up to 200% FPL, tapers linearly 1.0 → 0.5 over 200–250% FPL, and is 0.5 over 250–400% FPL (HGO briefing p.58; interpolation validated against MIA Exhibit 2a).

| % FPL band | 2025 enhanced (ARPA) % | Federal 2026 applicable % | MD target % | Replacement rule |
|---|---|---|---|---|
| 0–150% | 0.00% | 2.10% → 4.19% | **0.00%** | Full replacement |
| 150–200% | 0.00% → 2.00% | 4.19% → 6.60% | **0.00% → 2.00%** | Full replacement (see Historical Notes re the HGO "1.00%" entry) |
| 200–250% | 2.00% → 4.00% | 6.60% → 8.44% | **2.00% → 6.22%** | Phase down: 100% at 200% → 50% at 250% |
| 250–300% | 4.00% → 6.00% | 8.44% → 9.96% | **6.22% → 7.98%** | 50% replacement |
| 300–400% | 6.00% → 8.50% | 9.96% | **7.98% → 9.23%** | 50% replacement |
| > 400% | — | — | — | No state subsidy |

Encoded as a threshold/initial/final bracket triple with linear interpolation within bands (`target_contribution_percentage/{threshold,initial,final}.yaml`), cloning the mechanism of the federal `aca_required_contribution_percentage`. The schedule ends at 4.0, so the 400% FPL limit is encoded explicitly in the MD parameters rather than relying on the federal `ptc_income_eligibility` cutoff (REQ-014).

### Core formula (COMAR 14.35.21.04; HGO p.58)

```
md_premium_assistance = min_(
    max_(0, aca_magi × (federal_2026_pct − md_target_pct)),   # contribution gap
    max_(0, slcsp − aca_ptc)                                  # premium cap
)
```

- **Benchmark** = SLCSP, the same benchmark as the federal APTC (COMAR 14.35.21.04; MIA Exhibit 2a "Benchmark Second Lowest Cost Silver"). Reuses the existing `slcsp` variable (MONTH-period, summed to annual).
- **Premium cap** — the subsidy may not exceed the enrollee's premium and applies to the premium balance remaining after the federal APTC, so it never duplicates or stacks beyond the premium (COMAR 14.35.21.04). This cap binds at the top of the range, e.g. the MIA single-age-40 400% FPL row (MD target contribution $481/mo exceeds the $414/mo benchmark → subsidy $0).
- The `max_(0, ...)` floor implements the COMAR 14.35.21.03A(2) "experiences an increase" condition.

### Young Adult Subsidy overlay (Final 2026 Parameters p.14)

Maryland's pre-existing Young Adult Subsidy is maintained on top of the all-ages subsidy for PY2026. It reduces the target contribution percentage, floored at 0:

- Ages 18–33: −2.5 percentage points
- Ages 34–37: taper of −0.5pp per year (34: −2.0pp, 35: −1.5pp, 36: −1.0pp, 37: −0.5pp)
- Ages 38+ (and under 18): no reduction
- Applies only under 400% FPL (inherited from the program's FPL gate)

Encoded as an age-bracket parameter (`young_adult/reduction.yaml`) with a person-level variable (`md_premium_assistance_young_adult_reduction`) aggregated to the tax unit and subtracted from the MD target percentage (floored at 0) in `md_premium_assistance_target_contribution_percentage`. Validated against the Final 2026 Parameters p.14 expected-contribution table (e.g., at 200% FPL: 2.00% → 0.00% for ages 18–33; at 400% FPL: 8.50% → 6.00%) and the HGO p.59 age-30 example.

### Validation

Integration tests target the MIA Exhibit 2a illustrative net premiums (single age 40 and family of four at 138–401% FPL, annualized) and the HGO p.59 savings examples. The ~$1/mo residual MIA shows at ≤150% FPL is a non-EHB artifact (see Not Modeled).

## Requirements Coverage

| REQ | Description | Param | Variable | Test |
|---|---|---|---|---|
| REQ-001 | Gated on federal APTC eligibility + QHP enrollment | — | `md_premium_assistance_eligible` (any-member `is_aca_ptc_eligible`) | `md_premium_assistance_eligible.yaml` cases 1/4/8 |
| REQ-002 | Applicable-% increase vs CY2025 enhanced | — | falls out of `max_(0, gap)` in `md_premium_assistance` | `md_premium_assistance.yaml` case 13 (negative gap floored) |
| REQ-003 | All ages eligible | — | no age gate in eligibility (by design) | ages 0–50 across eligible/YAS tests |
| REQ-004 | MAGI ≤ 400% FPL | `fpl_limit.yaml` (4.0) | `md_premium_assistance_eligible` | eligible cases 2/3/9/10 (boundary 4.00/4.01) |
| REQ-005 | Prior-year FPL convention | — | reuses `aca_magi_fraction` | supplied as input (convention tested upstream) |
| REQ-010 | Core contribution-gap formula | — | `md_premium_assistance` | `md_premium_assistance.yaml` cases 1–4, 16 |
| REQ-011 | ≤200% FPL: full replacement (ARPA schedule) | `target_contribution_percentage/{threshold,initial,final}.yaml` | `..._target_contribution_percentage` | target % cases 1–3, 13 |
| REQ-012 | 200–250% FPL: linear phase 100%→50% (2.00%→6.22%) | same | same | target % cases 14/15; amount case 16 |
| REQ-013 | 250–400% FPL: 50% replacement (6.22/7.98/9.23%) | same | same | target % cases 4–7, 16–18 |
| REQ-014 | >400% FPL: no subsidy, 4.0 limit explicit in MD params | `fpl_limit.yaml` | `md_premium_assistance_eligible` | amount case 5; eligible case 2; integration scenario 7; target % case 19 (no extrapolation) |
| REQ-015 | Benchmark = SLCSP | — | `md_premium_assistance` reuses `slcsp` | cases 6/14/15 |
| REQ-016 | Cap at post-APTC premium; never duplicates APTC | — | `min_` with `max_(0, slcsp − aca_ptc)` | cases 6/7/14; integration scenario 9 |
| REQ-017 | 0%-contribution non-EHB coverage (partial) | — | documented in `md_premium_assistance` documentation string | — (not modeled; see Not Modeled) |
| REQ-018 | Young Adult Subsidy overlay with age taper | `young_adult/reduction.yaml` | `..._young_adult_reduction` + target-% floor | `..._young_adult_reduction.yaml` (14 cases); target % cases 8–10/20; integration scenarios 6/8a |
| REQ-019 | In effect PY2026–2027 | `in_effect.yaml` | eligibility gate | amount cases 9/10; eligible cases 6/7 |
| REQ-021 | OBBBA APTC immigration losses flow through | — | no MD-specific code (inherits `is_aca_ptc_eligible` gate) | eligible case 4 |
| REQ-022 | Aggregate wiring into `healthcare_benefit_value` | — | `healthcare_benefit_value` adds list | `household/healthcare_benefit_value.yaml` |
| REQ-023 | Program registry entry | — | `programs.yaml` (id `md_premium_assistance`, agency MHBE, verified_years "2026-2027") | — |

All 78 test cases across 6 files pass locally.

## Not Modeled

| REQ | Rule | Reason |
|---|---|---|
| REQ-006 | Newly Medicaid/MCHP-eligible enrollees lose the subsidy the first of the following month (COMAR 14.35.21.03) | Sub-annual transition timing; the ACA stack already excludes Medicaid-eligible people from `pays_aca_premium` |
| REQ-007 | Subsidy applied automatically, no separate application | Operational; MD assistance inherits the existing ACA takeup treatment |
| REQ-008 | MHBE Board enrollment-cap / cost-control levers (COMAR 14.35.21.03C) | Discretionary/operational, not a computable rule |
| REQ-009 | PY2026 enrollment cutoff (no assistance for enrollments after April 1, 2026) | Sub-annual enrollment timing not simulatable in the annual model |
| REQ-020 | Abrogation if Congress extends the enhanced APTC (COMAR 14.35.21.01B) | Handled via the documented `in_effect` switch, not structural coupling (see Historical Notes) |
| REQ-017 (partial) | For 0%-contribution enrollees the subsidy also covers the non-EHB premium so net premium = $0 (COMAR 14.35.21.04) | PolicyEngine models only the benchmark/EHB premium via `slcsp`; the non-EHB increment is not separately observed. Documented in the `md_premium_assistance` documentation string. This is why MIA Exhibit 2a shows a ~$1/mo residual at ≤150% FPL |

## Historical Notes

- **Brand-new program for PY2026.** Maryland previously ran a Young Adult Subsidy pilot (ages 18–37) since PY2022, made permanent by 2025 legislation. For PY2026 Maryland expanded the state subsidy to all ages up to 400% FPL in response to the eAPTC expiration, keeping the YAS as an overlay (adopted Option A1 retained the 2025 YAS parameters). Per the approved scope, the PY2022–2025 young-adult-only pilot is **not** backdated; the YAS is modeled from 2026 only, inside the program window.
- **200%-FPL endpoint discrepancy (reviewers, please note).** The HGO briefing p.58 design table's column (c) reads "0.00% → **1.00%**" for the 150–200% FPL band. This implementation uses **2.00%** at 200% FPL instead, because (a) the same table row is labeled "Full replacement up to 200% FPL," and full replacement of the 2025 enhanced (ARPA) schedule implies 2.00% at 200%; and (b) the MIA Exhibit 2a validation targets imply ~2.0% at exactly 200% FPL (single age 40 at $31,300: $53/mo ≈ 2.03% of income; family of four at $64,300: $110/mo ≈ 2.05%). The "1.00%" table entry is treated as a typo; the discrepancy is documented in `target_contribution_percentage/initial.yaml` and `final.yaml` comments.
- **2027 parameters.** The MHBE Board sets each plan year's payment parameters before December 31 of the preceding year; 2027 parameters have not yet been adopted. The 2026 MD target values carry forward through PY2027 (parameter value dating), with `in_effect` ending 2028-01-01. Update the target schedule when the Board adopts 2027 parameters (expected by December 31, 2026); note the federal 2027 applicable percentages will also shift via Rev. Proc. indexing.
- **Abrogation clause.** COMAR 14.35.21.01B abrogates the program if Congress extends the enhanced APTC for CY2026–2027. Under baseline law the eAPTC expired, so the baseline has the program in effect. No structural coupling to federal parameters is encoded; any contributed reform restoring the enhanced APTC should also set `gov.states.md.mhbe.premium_assistance.in_effect` to false.

## Files Added

```
policyengine_us/
├── parameters/gov/states/md/mhbe/premium_assistance/
│   ├── in_effect.yaml
│   ├── fpl_limit.yaml
│   ├── target_contribution_percentage/
│   │   ├── threshold.yaml
│   │   ├── initial.yaml
│   │   └── final.yaml
│   └── young_adult/
│       └── reduction.yaml
├── variables/gov/states/md/mhbe/premium_assistance/
│   ├── md_premium_assistance.py
│   ├── md_premium_assistance_eligible.py
│   ├── md_premium_assistance_target_contribution_percentage.py
│   └── md_premium_assistance_young_adult_reduction.py
└── tests/policy/baseline/gov/states/md/mhbe/premium_assistance/
    ├── md_premium_assistance.yaml                          (17 cases)
    ├── md_premium_assistance_eligible.yaml                 (10 cases)
    ├── md_premium_assistance_target_contribution_percentage.yaml  (20 cases)
    ├── md_premium_assistance_young_adult_reduction.yaml    (14 cases)
    └── integration.yaml                                    (10 cases)

Modified:
├── policyengine_us/variables/household/healthcare_benefit_value.py   (adds md_premium_assistance)
├── policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml  (7 cases incl. MD)
├── policyengine_us/programs.yaml                                     (registry entry)
└── changelog.d/md-premium-assistance.added.md
```
