### PR TITLE
Include NC SCCA, DC CCSP, NY additional CTC, and RI CTC in their aggregates

### DIFF
--- a/changelog.d/aggregator-audit-guards.fixed.md
+++ b/changelog.d/aggregator-audit-guards.fixed.md
@@ -1,0 +1,1 @@
+NY supplemental EITC in the state EITC aggregate (from 2019) and the Ohio CDCC in the state CDCC aggregate (from 2021), with structural tests guarding aggregate lists against undefined members, missing state gates, and silent year-block drops.

--- a/changelog.d/fix-state-aggregator-omissions.added.md
+++ b/changelog.d/fix-state-aggregator-omissions.added.md
@@ -1,0 +1,1 @@
+NC SCCA and DC CCSP in the child care subsidies and household state benefits aggregates (via new `nc_child_care_subsidies` and `dc_child_care_subsidies` wrappers), and the NY additional CTC (2021 and 2023) and RI CTC (2027 onwards) in the state CTC aggregate.

--- a/changelog.d/fix-state-aggregator-omissions.added.md
+++ b/changelog.d/fix-state-aggregator-omissions.added.md
@@ -1,1 +1,1 @@
-NC SCCA and DC CCSP in the child care subsidies and household state benefits aggregates (via new `nc_child_care_subsidies` and `dc_child_care_subsidies` wrappers), and the NY additional CTC (2021 and 2023) and RI CTC (2027 onwards) in the state CTC aggregate.
+NC SCCA (from 2024) and DC CCSP (from 2025) in the child care subsidies and household state benefits aggregates (via new `nc_child_care_subsidies` and `dc_child_care_subsidies` wrappers), and the NY additional CTC (2021 and 2023) and RI CTC (2027 onwards) in the state CTC aggregate.

--- a/policyengine_us/parameters/gov/hhs/ccdf/child_care_subsidy_programs.yaml
+++ b/policyengine_us/parameters/gov/hhs/ccdf/child_care_subsidy_programs.yaml
@@ -85,7 +85,7 @@ values:
     - ok_child_care_subsidies  # Oklahoma Child Care Subsidy Program
     - sd_child_care_subsidies  # South Dakota Child Care Assistance (CCA)
     - nc_child_care_subsidies  # North Carolina Subsidized Child Care Assistance
-  2026-01-01:
+  2025-01-01:
     - ak_child_care_subsidies  # Alaska Child Care Assistance Program (PASS)
     - ar_child_care_subsidies  # Arkansas School Readiness Assistance
     - al_child_care_subsidies  # Alabama Child Care Subsidy Program

--- a/policyengine_us/parameters/gov/hhs/ccdf/child_care_subsidy_programs.yaml
+++ b/policyengine_us/parameters/gov/hhs/ccdf/child_care_subsidy_programs.yaml
@@ -42,7 +42,93 @@ values:
     - nd_child_care_subsidies  # North Dakota Child Care Assistance Program
     - ok_child_care_subsidies  # Oklahoma Child Care Subsidy Program
     - sd_child_care_subsidies  # South Dakota Child Care Assistance (CCA)
-
+  2024-01-01:
+    - ak_child_care_subsidies  # Alaska Child Care Assistance Program (PASS)
+    - ar_child_care_subsidies  # Arkansas School Readiness Assistance
+    - al_child_care_subsidies  # Alabama Child Care Subsidy Program
+    - az_child_care_subsidies  # Arizona Child Care Assistance Program
+    - ca_child_care_subsidies  # California Child Care
+    - co_child_care_subsidies  # Colorado Child Care Assistance Program
+    - ct_child_care_subsidies  # Connecticut Care 4 Kids
+    - de_child_care_subsidies  # Delaware Purchase of Care
+    - fl_child_care_subsidies  # Florida School Readiness Program (SR)
+    - ga_child_care_subsidies  # Georgia Childcare and Parent Services
+    - hi_child_care_subsidies  # Hawaii Child Care Subsidy
+    - ia_child_care_subsidies  # Iowa Child Care Assistance
+    - id_child_care_subsidies  # Idaho Child Care Program
+    - in_child_care_subsidies  # Indiana Child Care and Development Fund Voucher Program
+    - ks_child_care_subsidies  # Kansas Child Care Assistance Program
+    - ky_child_care_subsidies  # Kentucky Child Care Assistance Program
+    - la_child_care_subsidies  # Louisiana Child Care Assistance Program
+    - ma_child_care_subsidies  # Massachusetts Child Care Financial Assistance
+    - md_child_care_subsidies  # Maryland Child Care Scholarship
+    - me_child_care_subsidies  # Maine Child Care Affordability Program
+    - mi_child_care_subsidies  # Michigan Child Development and Care program
+    - mn_child_care_subsidies  # Minnesota Child Care Assistance Program
+    - mo_child_care_subsidies  # Missouri Child Care Subsidy
+    - ms_child_care_subsidies  # Mississippi Child Care Payment Program (CCPP)
+    - mt_child_care_subsidies  # Montana Best Beginnings Child Care Scholarship
+    - ne_child_care_subsidies  # Nebraska Child Care Subsidy
+    - nm_child_care_subsidies  # New Mexico Child Care Assistance Program
+    - vt_child_care_subsidies  # Vermont Child Care Financial Assistance Program
+    - nh_child_care_subsidies  # New Hampshire Child Care Scholarship Program
+    - pa_child_care_subsidies  # Pennsylvania Child Care Works
+    - nj_child_care_subsidies  # New Jersey Child Care Assistance Program
+    - oh_child_care_subsidies  # Ohio Publicly Funded Child Care
+    - nv_child_care_subsidies  # Nevada Child Care and Development Program (CCDP)
+    - ri_child_care_subsidies  # Rhode Island Child Care Assistance Program
+    - sc_child_care_subsidies  # South Carolina Child Care Scholarship Program
+    - va_child_care_subsidies  # Virginia Child Care Subsidy Program
+    - wa_child_care_subsidies  # Washington Working Connections Child Care
+    - wv_child_care_subsidies  # West Virginia Child Care Assistance Program
+    - nd_child_care_subsidies  # North Dakota Child Care Assistance Program
+    - ok_child_care_subsidies  # Oklahoma Child Care Subsidy Program
+    - sd_child_care_subsidies  # South Dakota Child Care Assistance (CCA)
+    - nc_child_care_subsidies  # North Carolina Subsidized Child Care Assistance
+  2026-01-01:
+    - ak_child_care_subsidies  # Alaska Child Care Assistance Program (PASS)
+    - ar_child_care_subsidies  # Arkansas School Readiness Assistance
+    - al_child_care_subsidies  # Alabama Child Care Subsidy Program
+    - az_child_care_subsidies  # Arizona Child Care Assistance Program
+    - ca_child_care_subsidies  # California Child Care
+    - co_child_care_subsidies  # Colorado Child Care Assistance Program
+    - ct_child_care_subsidies  # Connecticut Care 4 Kids
+    - de_child_care_subsidies  # Delaware Purchase of Care
+    - fl_child_care_subsidies  # Florida School Readiness Program (SR)
+    - ga_child_care_subsidies  # Georgia Childcare and Parent Services
+    - hi_child_care_subsidies  # Hawaii Child Care Subsidy
+    - ia_child_care_subsidies  # Iowa Child Care Assistance
+    - id_child_care_subsidies  # Idaho Child Care Program
+    - in_child_care_subsidies  # Indiana Child Care and Development Fund Voucher Program
+    - ks_child_care_subsidies  # Kansas Child Care Assistance Program
+    - ky_child_care_subsidies  # Kentucky Child Care Assistance Program
+    - la_child_care_subsidies  # Louisiana Child Care Assistance Program
+    - ma_child_care_subsidies  # Massachusetts Child Care Financial Assistance
+    - md_child_care_subsidies  # Maryland Child Care Scholarship
+    - me_child_care_subsidies  # Maine Child Care Affordability Program
+    - mi_child_care_subsidies  # Michigan Child Development and Care program
+    - mn_child_care_subsidies  # Minnesota Child Care Assistance Program
+    - mo_child_care_subsidies  # Missouri Child Care Subsidy
+    - ms_child_care_subsidies  # Mississippi Child Care Payment Program (CCPP)
+    - mt_child_care_subsidies  # Montana Best Beginnings Child Care Scholarship
+    - ne_child_care_subsidies  # Nebraska Child Care Subsidy
+    - nm_child_care_subsidies  # New Mexico Child Care Assistance Program
+    - vt_child_care_subsidies  # Vermont Child Care Financial Assistance Program
+    - nh_child_care_subsidies  # New Hampshire Child Care Scholarship Program
+    - pa_child_care_subsidies  # Pennsylvania Child Care Works
+    - nj_child_care_subsidies  # New Jersey Child Care Assistance Program
+    - oh_child_care_subsidies  # Ohio Publicly Funded Child Care
+    - nv_child_care_subsidies  # Nevada Child Care and Development Program (CCDP)
+    - ri_child_care_subsidies  # Rhode Island Child Care Assistance Program
+    - sc_child_care_subsidies  # South Carolina Child Care Scholarship Program
+    - va_child_care_subsidies  # Virginia Child Care Subsidy Program
+    - wa_child_care_subsidies  # Washington Working Connections Child Care
+    - wv_child_care_subsidies  # West Virginia Child Care Assistance Program
+    - nd_child_care_subsidies  # North Dakota Child Care Assistance Program
+    - ok_child_care_subsidies  # Oklahoma Child Care Subsidy Program
+    - sd_child_care_subsidies  # South Dakota Child Care Assistance (CCA)
+    - nc_child_care_subsidies  # North Carolina Subsidized Child Care Assistance
+    - dc_child_care_subsidies  # DC Child Care Subsidy Program
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -165,7 +165,7 @@ values:
     # West Virginia benefits
     - wv_child_care_subsidies
     # North Carolina benefits
-    - nc_scca
+    - nc_child_care_subsidies
     # South Carolina benefits
     - sc_child_care_subsidies
     # Massachusetts benefits
@@ -265,7 +265,7 @@ values:
     # West Virginia benefits
     - wv_child_care_subsidies
     # North Carolina benefits
-    - nc_scca
+    - nc_child_care_subsidies
     # South Carolina benefits
     - sc_child_care_subsidies
     # Massachusetts benefits
@@ -273,6 +273,7 @@ values:
     - ma_tafdc
     # DC benefits
     - dc_ossp
+    - dc_child_care_subsidies
     # Kansas benefits
     - ks_sspp
     # Hawaii benefits

--- a/policyengine_us/parameters/gov/household/household_state_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_state_benefits.yaml
@@ -189,6 +189,107 @@ values:
     - oh_child_care_subsidies
     # Washington child care subsidies
     - wa_child_care_subsidies
+  2025-01-01:
+    # Delaware benefits
+    - de_ssp
+    - de_child_care_subsidies
+    # Indiana benefits
+    - in_ssp
+    - in_child_care_subsidies
+    # Connecticut benefits
+    - ct_ssp
+    # Georgia benefits
+    - ga_ssp
+    # Maine benefits
+    - me_ssp
+    # Missouri benefits
+    - mo_ssp
+    - mo_child_care_subsidies
+    # Montana benefits
+    - mt_child_care_subsidies
+    # Massachusetts benefits
+    - ma_state_supplement
+    # Maryland benefits
+    - md_paa
+    # Michigan benefits
+    - mi_ssp
+    # Minnesota benefits
+    - mn_msa
+    # Colorado benefits
+    - co_state_supplement
+    - co_oap
+    - co_child_care_subsidies
+    # California benefits
+    - ca_child_care_subsidies
+    - ca_cvrp
+    - ca_care
+    - ca_fera
+    - ca_la_ez_save
+    - ca_la_infant_supplement
+    - ca_la_expectant_parent_payment
+    - ca_capi
+    - ca_state_supplement
+    # Alabama benefits
+    - al_ssp
+    - al_child_care_subsidies
+    # Alaska benefits
+    - ak_ssp
+    # Arizona benefits
+    - az_child_care_subsidies
+    # Florida benefits
+    - fl_oss
+    # Idaho benefits
+    - id_aabd
+    - id_child_care_subsidies
+    # Kentucky benefits
+    - ky_ssp
+    # Georgia benefits
+    - ga_child_care_subsidies
+    # Maryland benefits
+    - md_child_care_subsidies
+    # Nebraska benefits
+    - ne_aabd
+    - ne_child_care_subsidies
+    # Nevada benefits
+    - nv_child_care_subsidies
+    # Oklahoma benefits
+    - ok_child_care_subsidies
+    # New Mexico benefits
+    - nm_ssi_state_supplement
+    # South Carolina benefits
+    - sc_ssi_state_supplement
+    # Texas benefits
+    - tx_ssi_state_supplement
+    # Virginia benefits
+    - va_child_care_subsidies
+    # West Virginia benefits
+    - wv_child_care_subsidies
+    # North Carolina benefits
+    - nc_child_care_subsidies
+    # South Carolina benefits
+    - sc_child_care_subsidies
+    # Massachusetts benefits
+    - ma_eaedc
+    - ma_tafdc
+    # DC benefits
+    - dc_ossp
+    - dc_child_care_subsidies
+    # Kansas benefits
+    - ks_sspp
+    # Hawaii benefits
+    - hi_oss
+    # Washington benefits
+    - wa_ssp
+    - wa_sfa
+    - wa_rca
+    # Louisiana benefits
+    - la_oss
+    # Arkansas benefits
+    - ar_child_care_subsidies
+    # Ohio benefits
+    - oh_child_care_subsidies
+    # Washington child care subsidies
+    - wa_child_care_subsidies
   2026-01-01:
     # Delaware benefits
     - de_ssp

--- a/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
@@ -130,6 +130,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - ri_cdcc
@@ -160,6 +161,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - pa_cdcc
@@ -193,6 +195,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - pa_cdcc
@@ -226,6 +229,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - pa_cdcc

--- a/policyengine_us/parameters/gov/states/household/state_ctcs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_ctcs.yaml
@@ -24,6 +24,7 @@ values:
     - me_dependent_exemption_credit
     - nc_ctc
     - ny_ctc
+    - ny_additional_ctc
     - taxsim_ok_child_tax_credit_component
   2022-01-01:
     - az_dependent_tax_credit
@@ -51,6 +52,7 @@ values:
     - nj_ctc
     - nm_ctc
     - ny_ctc
+    - ny_additional_ctc
     - taxsim_ok_child_tax_credit_component
     - or_ctc
     - vt_ctc
@@ -97,6 +99,29 @@ values:
     - ut_ctc
     - vt_ctc
 
+  2027-01-01:
+    - az_dependent_tax_credit
+    - ca_yctc
+    - co_ctc
+    - co_family_affordability_credit
+    - dc_ctc
+    - ga_ctc
+    - id_ctc
+    - il_ctc
+    - ma_child_and_family_credit_or_dependent_care_credit
+    - md_ctc
+    - me_dependent_exemption_credit
+    - taxsim_mn_child_tax_credit_component
+    - nc_ctc
+    - ne_refundable_ctc
+    - nj_ctc
+    - nm_ctc
+    - ny_ctc
+    - taxsim_ok_child_tax_credit_component
+    - or_ctc
+    - ri_ctc
+    - ut_ctc
+    - vt_ctc
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/household/state_eitcs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_eitcs.yaml
@@ -111,6 +111,7 @@ values:
     - ne_eitc
     - nj_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - or_eitc
     - ri_eitc
     - sc_eitc
@@ -132,6 +133,7 @@ values:
     - ne_eitc
     - nj_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - or_eitc
     - ri_eitc
@@ -160,6 +162,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc
@@ -192,6 +195,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc
@@ -227,6 +231,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc
@@ -262,6 +267,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc

--- a/policyengine_us/tests/policy/baseline/gov/hhs/ccdf/child_care_subsidies.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/ccdf/child_care_subsidies.yaml
@@ -1,0 +1,55 @@
+- name: NC SCCA flows into the child care subsidies aggregate from 2024
+  period: 2024
+  input:
+    people:
+      parent:
+        age: 30
+    spm_units:
+      spm_unit:
+        members: [parent]
+        nc_scca:
+          2024-01: 450
+    households:
+      household:
+        members: [parent]
+        county_str: ALAMANCE_COUNTY_NC
+        state_code: NC
+  output:
+    child_care_subsidies: 450
+
+- name: NC SCCA is not counted before 2024
+  period: 2023
+  input:
+    people:
+      parent:
+        age: 30
+    spm_units:
+      spm_unit:
+        members: [parent]
+        nc_scca:
+          2023-01: 450
+    households:
+      household:
+        members: [parent]
+        county_str: ALAMANCE_COUNTY_NC
+        state_code: NC
+  output:
+    child_care_subsidies: 0
+
+- name: DC CCSP flows into the child care subsidies aggregate from 2026
+  period: 2026
+  input:
+    people:
+      parent:
+        age: 30
+    spm_units:
+      spm_unit:
+        members: [parent]
+        dc_ccsp:
+          2026-01: 500
+    households:
+      household:
+        members: [parent]
+        state_code: DC
+  output:
+    child_care_subsidies: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_cdcc.yaml
@@ -1,0 +1,33 @@
+- name: OH CDCC is included in the state CDCC aggregate from 2021
+  period: 2021
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        oh_cdcc: 200
+    households:
+      household:
+        members: [parent]
+        state_code: OH
+  output:
+    taxsim_state_cdcc: 200
+
+- name: OH CDCC is not counted before 2021
+  period: 2020
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        oh_cdcc: 200
+    households:
+      household:
+        members: [parent]
+        state_code: OH
+  output:
+    taxsim_state_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_ctc.yaml
@@ -1,0 +1,69 @@
+- name: NY additional CTC is included in the state CTC aggregate in 2023
+  period: 2023
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_ctc: 330
+        ny_additional_ctc: 82.5
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_ctc: 412.5
+
+- name: NY additional CTC is excluded in 2024, a year without supplemental payments
+  period: 2024
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_ctc: 330
+        ny_additional_ctc: 100
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_ctc: 330
+
+- name: RI CTC is included in the state CTC aggregate from 2027
+  period: 2027
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ri_ctc: 330
+    households:
+      household:
+        members: [parent]
+        state_code: RI
+  output:
+    taxsim_state_ctc: 330
+
+- name: RI CTC is not counted before 2027
+  period: 2026
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ri_ctc: 330
+    households:
+      household:
+        members: [parent]
+        state_code: RI
+  output:
+    taxsim_state_ctc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_ctc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_ctc.yaml
@@ -1,3 +1,39 @@
+- name: NY additional CTC is included in the state CTC aggregate in 2021
+  period: 2021
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_ctc: 330
+        ny_additional_ctc: 82.5
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_ctc: 412.5
+
+- name: NY additional CTC is excluded in 2022, a year without supplemental payments
+  period: 2022
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_ctc: 330
+        ny_additional_ctc: 100
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_ctc: 330
+
 - name: NY additional CTC is included in the state CTC aggregate in 2023
   period: 2023
   input:
@@ -18,6 +54,24 @@
 
 - name: NY additional CTC is excluded in 2024, a year without supplemental payments
   period: 2024
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_ctc: 330
+        ny_additional_ctc: 100
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_ctc: 330
+
+- name: NY additional CTC remains excluded in 2027
+  period: 2027
   input:
     people:
       parent:

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_eitc.yaml
@@ -1,0 +1,35 @@
+- name: NY supplemental EITC is included in the state EITC aggregate from 2019
+  period: 2021
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_eitc: 300
+        ny_supplemental_eitc: 75
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_eitc: 375
+
+- name: NY supplemental EITC is not counted before 2019
+  period: 2018
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_eitc: 300
+        ny_supplemental_eitc: 75
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_eitc: 300

--- a/policyengine_us/tests/policy/baseline/household/income/household/household_state_benefits.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/household/household_state_benefits.yaml
@@ -1,4 +1,4 @@
-- name: NC SCCA flows into the child care subsidies aggregate from 2024, summing across months
+- name: NC SCCA flows into household state benefits from 2024
   period: 2024
   input:
     people:
@@ -9,17 +9,15 @@
         members: [parent]
         nc_scca:
           2024-01: 450
-          2024-02: 250
     households:
       household:
         members: [parent]
         county_str: ALAMANCE_COUNTY_NC
         state_code: NC
   output:
-    nc_child_care_subsidies: 700
-    child_care_subsidies: 700
+    household_state_benefits: 450
 
-- name: NC SCCA is not counted before 2024
+- name: NC SCCA is not counted in household state benefits before 2024
   period: 2023
   input:
     people:
@@ -36,9 +34,9 @@
         county_str: ALAMANCE_COUNTY_NC
         state_code: NC
   output:
-    child_care_subsidies: 0
+    household_state_benefits: 0
 
-- name: DC CCSP flows into the child care subsidies aggregate from 2025
+- name: DC CCSP flows into household state benefits from 2025
   period: 2025
   input:
     people:
@@ -54,5 +52,4 @@
         members: [parent]
         state_code: DC
   output:
-    dc_child_care_subsidies: 500
-    child_care_subsidies: 500
+    household_state_benefits: 500

--- a/policyengine_us/tests/test_aggregate_list_integrity.py
+++ b/policyengine_us/tests/test_aggregate_list_integrity.py
@@ -1,0 +1,111 @@
+"""Structural guards for state-summing aggregate list parameters.
+
+These lists sum implemented per-state variables into national aggregates.
+Three failure modes have shipped before (see issues #9234 and #9080):
+1. A list member that is not a defined variable (silent typo or rename).
+2. A member without a state gate, leaking one state's program into every
+   state (the dc_ctc bug).
+3. A new year block silently dropping members of the previous block, since
+   these lists are full-replacement rather than incremental.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+PARAMETERS = Path(__file__).parent.parent / "parameters"
+
+AGGREGATE_LISTS = [
+    "gov/states/household/state_ctcs.yaml",
+    "gov/states/household/state_eitcs.yaml",
+    "gov/states/household/state_cdccs.yaml",
+    "gov/hhs/ccdf/child_care_subsidy_programs.yaml",
+    "gov/household/household_state_benefits.yaml",
+]
+
+# Gates that restrict a variable geographically without a StateCode
+# defined_for (locality booleans).
+GEOGRAPHIC_GATES = {"in_la", "in_nyc"}
+
+# Members intentionally removed in a year block, keyed by (list, block date).
+# Add an entry here when a credit genuinely ends; do not silently drop
+# members when copying a block forward.
+ALLOWED_REMOVALS = {
+    # NY additional Empire State Child Credit was a supplemental payment
+    # in 2021 and 2023 only.
+    ("gov/states/household/state_ctcs.yaml", "2022-01-01"): {"ny_additional_ctc"},
+    ("gov/states/household/state_ctcs.yaml", "2024-01-01"): {"ny_additional_ctc"},
+    # VT restructured its CDCC into a single vt_cdcc in 2022.
+    ("gov/states/household/state_cdccs.yaml", "2022-01-01"): {
+        "vt_low_income_cdcc",
+        "vt_nonrefundable_cdcc",
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def variables():
+    from policyengine_us.system import system
+
+    return system.variables
+
+
+def blocks_of(list_path):
+    raw = yaml.load((PARAMETERS / list_path).read_text(), Loader=yaml.BaseLoader)
+    return sorted(
+        (date, members)
+        for date, members in raw["values"].items()
+        if isinstance(members, list)
+    )
+
+
+def members_of(list_path):
+    return {m for _, members in blocks_of(list_path) for m in members}
+
+
+@pytest.mark.parametrize("list_path", AGGREGATE_LISTS)
+def test_members_are_defined_variables(list_path, variables):
+    undefined = sorted(members_of(list_path) - set(variables))
+    assert not undefined, (
+        f"{list_path} references variables that do not exist: {undefined}"
+    )
+
+
+@pytest.mark.parametrize("list_path", AGGREGATE_LISTS)
+def test_members_are_state_gated(list_path, variables):
+    ungated = []
+    for member in sorted(members_of(list_path)):
+        gate = variables[member].defined_for
+        for _ in range(10):
+            if gate is None:
+                break
+            if re.fullmatch(r"[A-Z]{2}", str(gate)):
+                break  # StateCode gate found
+            if gate in GEOGRAPHIC_GATES:
+                break
+            gate = variables[gate].defined_for if gate in variables else None
+        else:
+            gate = None
+        if gate is None:
+            ungated.append(member)
+    assert not ungated, (
+        f"{list_path} members without a StateCode gate in their "
+        f"defined_for chain (dc_ctc-style leak risk): {ungated}"
+    )
+
+
+@pytest.mark.parametrize("list_path", AGGREGATE_LISTS)
+def test_no_silent_removals_between_year_blocks(list_path):
+    blocks = blocks_of(list_path)
+    for (_, prev), (date, curr) in zip(blocks, blocks[1:]):
+        removed = set(prev) - set(curr)
+        allowed = ALLOWED_REMOVALS.get((list_path, date), set())
+        unexpected = sorted(removed - allowed)
+        assert not unexpected, (
+            f"{list_path} block {date} drops {unexpected} from the "
+            "previous block. These lists are full replacements: copy all "
+            "prior members forward, or record an intentional removal in "
+            "ALLOWED_REMOVALS in this test."
+        )

--- a/policyengine_us/variables/gov/states/dc/dhs/ccsp/dc_child_care_subsidies.py
+++ b/policyengine_us/variables/gov/states/dc/dhs/ccsp/dc_child_care_subsidies.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class dc_child_care_subsidies(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "DC child care subsidies"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.DC
+    adds = ["dc_ccsp"]

--- a/policyengine_us/variables/gov/states/nc/ncdhhs/scca/nc_child_care_subsidies.py
+++ b/policyengine_us/variables/gov/states/nc/ncdhhs/scca/nc_child_care_subsidies.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class nc_child_care_subsidies(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "North Carolina child care subsidies"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.NC
+    adds = ["nc_scca"]


### PR DESCRIPTION
Fixes #9234
Fixes #9241

External feedback (verified against 1.771.2 and re-verified on current main) flagged implemented per-state variables that their national aggregators never sum.

## Changes

**Child care subsidies** (`gov/hhs/ccdf/child_care_subsidy_programs.yaml` and `gov/household/household_state_benefits.yaml`):
- New `nc_child_care_subsidies` and `dc_child_care_subsidies` YEAR wrappers over `nc_scca` and `dc_ccsp`, matching the existing `xx_child_care_subsidies` convention used by every other member of the CCDF list.
- The CCDF list gains NC from 2024 (aligned with `nc_scca`'s existing entry in household state benefits) and DC from 2026 (first full calendar year after DC's FY25 reimbursement rates take effect in Oct 2024).
- `household_state_benefits` swaps its raw `nc_scca` entry for the wrapper (numerically identical, prevents future double-counting) and gains `dc_child_care_subsidies` in the 2026 block.

**State CTC aggregate** (`gov/states/household/state_ctcs.yaml`):
- `ny_additional_ctc` added for 2021 and 2023 only, mirroring `gov/states/ny/tax/income/credits/refundable.yaml` — the additional Empire State Child Credit was a supplemental payment in those years, so the reviewer's expectation of ~$500 extra in 2026 does not apply under the model's design.
- `ri_ctc` added from 2027, when Rhode Island's $330/child credit takes effect, mirroring RI's refundable credits list.

## Not in this PR
- `tx_ccs` stays unwired pending the entity broadcast bug in #7767.
- The `dc_ctc` state leak from the same feedback was already fixed in #9080.
- Whether `md_local_eitc` belongs in the state EITC aggregate is tracked in #9235.

## Tests
- New `child_care_subsidies.yaml` tests: NC SCCA counted from 2024 (not 2023), DC CCSP counted from 2026.
- New `taxsim_state_ctc.yaml` tests: NY additional CTC counted in 2023 but not 2024; RI CTC counted in 2027 but not 2026.
- Existing NC SCCA, DC DHS, RI credits, NY credits, CCDF, and NC partner analytics suites all pass locally (529 tests).
- Vectorized (axes) smoke test of `child_care_subsidies` and `household_state_benefits` for a DC household runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)