### PR TITLE
Add NY supplemental EITC and OH CDCC to state aggregates, with structural guards

### DIFF
--- a/changelog.d/aggregator-audit-guards.fixed.md
+++ b/changelog.d/aggregator-audit-guards.fixed.md
@@ -1,0 +1,1 @@
+NY supplemental EITC in the state EITC aggregate (from 2019) and the Ohio CDCC in the state CDCC aggregate (from 2021), with structural tests guarding aggregate lists against undefined members, missing state gates, and silent year-block drops.

--- a/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_cdccs.yaml
@@ -130,6 +130,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - ri_cdcc
@@ -160,6 +161,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - pa_cdcc
@@ -193,6 +195,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - pa_cdcc
@@ -226,6 +229,7 @@ values:
     - nj_cdcc
     - nm_cdcc
     - ny_cdcc
+    - oh_cdcc
     - taxsim_ok_child_care_credit_component
     - or_working_family_household_and_dependent_care_credit
     - pa_cdcc

--- a/policyengine_us/parameters/gov/states/household/state_eitcs.yaml
+++ b/policyengine_us/parameters/gov/states/household/state_eitcs.yaml
@@ -111,6 +111,7 @@ values:
     - ne_eitc
     - nj_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - or_eitc
     - ri_eitc
     - sc_eitc
@@ -132,6 +133,7 @@ values:
     - ne_eitc
     - nj_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - or_eitc
     - ri_eitc
@@ -160,6 +162,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc
@@ -192,6 +195,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc
@@ -227,6 +231,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc
@@ -262,6 +267,7 @@ values:
     - nj_eitc
     - nm_eitc
     - ny_eitc
+    - ny_supplemental_eitc
     - oh_eitc
     - ok_eitc
     - or_eitc

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_cdcc.yaml
@@ -1,0 +1,33 @@
+- name: OH CDCC is included in the state CDCC aggregate from 2021
+  period: 2021
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        oh_cdcc: 200
+    households:
+      household:
+        members: [parent]
+        state_code: OH
+  output:
+    taxsim_state_cdcc: 200
+
+- name: OH CDCC is not counted before 2021
+  period: 2020
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        oh_cdcc: 200
+    households:
+      household:
+        members: [parent]
+        state_code: OH
+  output:
+    taxsim_state_cdcc: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_eitc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tax/income/taxsim_state_eitc.yaml
@@ -1,0 +1,35 @@
+- name: NY supplemental EITC is included in the state EITC aggregate from 2019
+  period: 2021
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_eitc: 300
+        ny_supplemental_eitc: 75
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_eitc: 375
+
+- name: NY supplemental EITC is not counted before 2019
+  period: 2018
+  input:
+    people:
+      parent:
+        age: 35
+    tax_units:
+      tax_unit:
+        members: [parent]
+        ny_eitc: 300
+        ny_supplemental_eitc: 75
+    households:
+      household:
+        members: [parent]
+        state_code: NY
+  output:
+    taxsim_state_eitc: 300

--- a/policyengine_us/tests/test_aggregate_list_integrity.py
+++ b/policyengine_us/tests/test_aggregate_list_integrity.py
@@ -1,0 +1,111 @@
+"""Structural guards for state-summing aggregate list parameters.
+
+These lists sum implemented per-state variables into national aggregates.
+Three failure modes have shipped before (see issues #9234 and #9080):
+1. A list member that is not a defined variable (silent typo or rename).
+2. A member without a state gate, leaking one state's program into every
+   state (the dc_ctc bug).
+3. A new year block silently dropping members of the previous block, since
+   these lists are full-replacement rather than incremental.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+PARAMETERS = Path(__file__).parent.parent / "parameters"
+
+AGGREGATE_LISTS = [
+    "gov/states/household/state_ctcs.yaml",
+    "gov/states/household/state_eitcs.yaml",
+    "gov/states/household/state_cdccs.yaml",
+    "gov/hhs/ccdf/child_care_subsidy_programs.yaml",
+    "gov/household/household_state_benefits.yaml",
+]
+
+# Gates that restrict a variable geographically without a StateCode
+# defined_for (locality booleans).
+GEOGRAPHIC_GATES = {"in_la", "in_nyc"}
+
+# Members intentionally removed in a year block, keyed by (list, block date).
+# Add an entry here when a credit genuinely ends; do not silently drop
+# members when copying a block forward.
+ALLOWED_REMOVALS = {
+    # NY additional Empire State Child Credit was a supplemental payment
+    # in 2021 and 2023 only.
+    ("gov/states/household/state_ctcs.yaml", "2022-01-01"): {"ny_additional_ctc"},
+    ("gov/states/household/state_ctcs.yaml", "2024-01-01"): {"ny_additional_ctc"},
+    # VT restructured its CDCC into a single vt_cdcc in 2022.
+    ("gov/states/household/state_cdccs.yaml", "2022-01-01"): {
+        "vt_low_income_cdcc",
+        "vt_nonrefundable_cdcc",
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def variables():
+    from policyengine_us.system import system
+
+    return system.variables
+
+
+def blocks_of(list_path):
+    raw = yaml.load((PARAMETERS / list_path).read_text(), Loader=yaml.BaseLoader)
+    return sorted(
+        (date, members)
+        for date, members in raw["values"].items()
+        if isinstance(members, list)
+    )
+
+
+def members_of(list_path):
+    return {m for _, members in blocks_of(list_path) for m in members}
+
+
+@pytest.mark.parametrize("list_path", AGGREGATE_LISTS)
+def test_members_are_defined_variables(list_path, variables):
+    undefined = sorted(members_of(list_path) - set(variables))
+    assert not undefined, (
+        f"{list_path} references variables that do not exist: {undefined}"
+    )
+
+
+@pytest.mark.parametrize("list_path", AGGREGATE_LISTS)
+def test_members_are_state_gated(list_path, variables):
+    ungated = []
+    for member in sorted(members_of(list_path)):
+        gate = variables[member].defined_for
+        for _ in range(10):
+            if gate is None:
+                break
+            if re.fullmatch(r"[A-Z]{2}", str(gate)):
+                break  # StateCode gate found
+            if gate in GEOGRAPHIC_GATES:
+                break
+            gate = variables[gate].defined_for if gate in variables else None
+        else:
+            gate = None
+        if gate is None:
+            ungated.append(member)
+    assert not ungated, (
+        f"{list_path} members without a StateCode gate in their "
+        f"defined_for chain (dc_ctc-style leak risk): {ungated}"
+    )
+
+
+@pytest.mark.parametrize("list_path", AGGREGATE_LISTS)
+def test_no_silent_removals_between_year_blocks(list_path):
+    blocks = blocks_of(list_path)
+    for (_, prev), (date, curr) in zip(blocks, blocks[1:]):
+        removed = set(prev) - set(curr)
+        allowed = ALLOWED_REMOVALS.get((list_path, date), set())
+        unexpected = sorted(removed - allowed)
+        assert not unexpected, (
+            f"{list_path} block {date} drops {unexpected} from the "
+            "previous block. These lists are full replacements: copy all "
+            "prior members forward, or record an intentional removal in "
+            "ALLOWED_REMOVALS in this test."
+        )


### PR DESCRIPTION
Fixes the two omissions found by the systematic audit in #9241, and adds a structural test so this class of mistake fails CI in the future.

## Changes
- `state_eitcs.yaml`: `ny_supplemental_eitc` added from 2019, mirroring NY's refundable credits list (the credit is non-zero only in 2021, when its match was 25%).
- `state_cdccs.yaml`: `oh_cdcc` added from 2021, when its parameters begin.
- New `tests/test_aggregate_list_integrity.py` guarding the five state-summing aggregate lists (`state_ctcs`, `state_eitcs`, `state_cdccs`, `child_care_subsidy_programs`, `household_state_benefits`) against the three failure modes that have shipped before:
  1. members that are not defined variables,
  2. members without a StateCode gate in their `defined_for` chain (the #9080 `dc_ctc` leak class),
  3. year blocks silently dropping prior members (full-replacement hazard) — intentional removals must be declared in `ALLOWED_REMOVALS`.
- YAML wiring tests for both additions, including pre-wiring exclusion years.

## Notes
- Forward-compatible with #9236: the `ALLOWED_REMOVALS` entries for `ny_additional_ctc` (2022, 2024) and the guard over the CCDF list activate once that PR merges; the two branches touch disjoint files.
- Partner contract tests are unaffected (their `state_cdcc`/`state_eitc` assertions are CA households; these additions are NY- and OH-gated) — full partners suite passes locally.
- 963 partner + OH + NY tests, 15 structural checks, and 4 new wiring tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)