### PR TITLE
Add New Jersey premium assistance (NJ Health Plan Savings)

### DIFF
--- a/changelog.d/nj-premium-assistance.added.md
+++ b/changelog.d/nj-premium-assistance.added.md
@@ -1,0 +1,1 @@
+Add New Jersey Health Plan Savings (NJHPS) state premium assistance.

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_floor.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_floor.yaml
@@ -11,6 +11,6 @@ metadata:
   label: New Jersey Health Plan Savings income floor as a share of the federal poverty line
   reference:
     - title: Get Covered NJ - New Jersey Health Plan Savings
-      href: https://www.nj.gov/getcoverednj/financialhelp/
+      href: https://www.nj.gov/getcoverednj/financialhelp/premiums/
     - title: Treasury Office of Tax Analysis Section 1332 methodology addendum
       href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_floor.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_floor.yaml
@@ -1,0 +1,16 @@
+description: New Jersey sets this share of the federal poverty line as the income eligibility floor under the New Jersey Health Plan Savings program.
+values:
+  # NJHPS covers households at or above 138% FPL, applied as a ">=" comparison.
+  # Households below 138% FPL are routed to NJ FamilyCare/Medicaid and do not
+  # qualify for NJHPS premium assistance.
+  2026-01-01: 1.38
+
+metadata:
+  unit: /1
+  period: year
+  label: New Jersey Health Plan Savings income floor as a share of the federal poverty line
+  reference:
+    - title: Get Covered NJ - New Jersey Health Plan Savings
+      href: https://www.nj.gov/getcoverednj/financialhelp/
+    - title: Treasury Office of Tax Analysis Section 1332 methodology addendum
+      href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_floor.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_floor.yaml
@@ -10,7 +10,7 @@ metadata:
   period: year
   label: New Jersey Health Plan Savings income floor as a share of the federal poverty line
   reference:
+    - title: Treasury Office of Tax Analysis Section 1332 methodology addendum, Table 2 (Enhanced subsidy schedule, 138% FPL floor)
+      href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=12
     - title: Get Covered NJ - New Jersey Health Plan Savings
       href: https://www.nj.gov/getcoverednj/financialhelp/premiums/
-    - title: Treasury Office of Tax Analysis Section 1332 methodology addendum
-      href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_limit.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_limit.yaml
@@ -1,0 +1,17 @@
+description: New Jersey limits income to this share of the federal poverty line under the New Jersey Health Plan Savings program.
+values:
+  # NJHPS extends premium assistance up to 600% FPL, applied as a "<=" comparison.
+  # The dollar ceilings ($93,900 individual / $192,900 family of four in 2026)
+  # auto-derive from the federal poverty line and are not hard-coded. The DOBI
+  # FY2026 budget confirms the program continues "up to 600% FPL" for PY2026.
+  2026-01-01: 6.0
+
+metadata:
+  unit: /1
+  period: year
+  label: New Jersey Health Plan Savings income limit as a share of the federal poverty line
+  reference:
+    - title: Get Covered NJ - New Jersey Health Plan Savings
+      href: https://www.nj.gov/getcoverednj/financialhelp/
+    - title: NJ DOBI FY2025-2026 Budget Discussion Points
+      href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=6

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_limit.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_limit.yaml
@@ -4,14 +4,16 @@ values:
   # The dollar ceilings ($93,900 individual / $192,900 family of four in 2026)
   # auto-derive from the federal poverty line and are not hard-coded. The DOBI
   # FY2026 budget confirms the program continues "up to 600% FPL" for PY2026.
-  2026-01-01: 6.0
+  2026-01-01: 6
 
 metadata:
   unit: /1
   period: year
   label: New Jersey Health Plan Savings income limit as a share of the federal poverty line
   reference:
-    - title: Get Covered NJ - New Jersey Health Plan Savings
-      href: https://www.nj.gov/getcoverednj/financialhelp/premiums/
+    - title: Treasury Office of Tax Analysis Section 1332 methodology addendum, Table 2 (Enhanced subsidy schedule, 600% FPL ceiling)
+      href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=12
     - title: NJ DOBI FY2025-2026 Budget Discussion Points
       href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=6
+    - title: Get Covered NJ - New Jersey Health Plan Savings
+      href: https://www.nj.gov/getcoverednj/financialhelp/premiums/

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_limit.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/fpl_limit.yaml
@@ -12,6 +12,6 @@ metadata:
   label: New Jersey Health Plan Savings income limit as a share of the federal poverty line
   reference:
     - title: Get Covered NJ - New Jersey Health Plan Savings
-      href: https://www.nj.gov/getcoverednj/financialhelp/
+      href: https://www.nj.gov/getcoverednj/financialhelp/premiums/
     - title: NJ DOBI FY2025-2026 Budget Discussion Points
       href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=6

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/in_effect.yaml
@@ -1,0 +1,28 @@
+description: New Jersey provides Health Plan Savings premium assistance when this is true under the New Jersey Health Plan Savings program.
+values:
+  # New Jersey Health Plan Savings (NJHPS) is established by P.L. 2020 c.61, which
+  # created the Health Insurance Affordability Fund and the state premium subsidy
+  # (permanent law with no statutory sunset). The subsidy began lowering premiums
+  # for coverage starting January 1, 2021, and the enhanced schedule extending
+  # through 600% FPL took force in mid-2021. Only the PY2026 design is modeled: the
+  # enhanced flat per-member-per-month schedule across 138-600% FPL, so the flag is
+  # false before 2026-01-01. The pre-2026 enhanced schedule is left unmodeled and
+  # carried as a backdating backlog item.
+  # No end date: the program is permanent law, so PY2027+ carries the PY2026 design
+  # forward as a current-law assumption. The DOBI FY2026 budget confirms NJHPS
+  # continues "up to 600% FPL" with expenditures projected to remain flat at
+  # $212.2M in FY2026.
+  0000-01-01: false
+  2026-01-01: true
+
+metadata:
+  unit: bool
+  period: year
+  label: New Jersey Health Plan Savings in effect
+  reference:
+    - title: P.L. 2020 c.61
+      href: https://pub.njleg.gov/bills/2020/AL20/61_.HTM
+    - title: NJ DOBI FY2025-2026 Budget Discussion Points
+      href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=6
+    - title: Get Covered NJ - New Jersey Health Plan Savings
+      href: https://www.nj.gov/getcoverednj/financialhelp/

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/in_effect.yaml
@@ -23,6 +23,6 @@ metadata:
     - title: P.L. 2020 c.61
       href: https://pub.njleg.gov/bills/2020/AL20/61_.HTM
     - title: NJ DOBI FY2025-2026 Budget Discussion Points
-      href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=6
+      href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=8
     - title: Get Covered NJ - New Jersey Health Plan Savings
-      href: https://www.nj.gov/getcoverednj/financialhelp/
+      href: https://www.nj.gov/getcoverednj/financialhelp/premiums/

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/pmpm.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/pmpm.yaml
@@ -6,8 +6,8 @@ metadata:
   period: month
   label: New Jersey Health Plan Savings per-member monthly amount by income band
   reference:
-    - title: Treasury Office of Tax Analysis Section 1332 methodology addendum
-      href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8
+    - title: Treasury Office of Tax Analysis Section 1332 methodology addendum, Table 2 (Enhanced subsidy schedule)
+      href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=12
     - title: NJ DOBI FY2025-2026 Budget Discussion Points
       href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=8
     - title: P.L. 2020 c.61
@@ -18,15 +18,21 @@ metadata:
 brackets:
   # Household income measured as ACA MAGI as a share of the federal poverty line.
   # CORROBORATION CHAIN: the exact per-member-per-month (PMPM) values below are
-  # taken verbatim from the U.S. Treasury Office of Tax Analysis Section 1332
-  # methodology addendum (Nov 2021, file p.8), which states the enhanced schedule:
+  # the ENHANCED schedule (post-ARP, effective mid-2021) from the U.S. Treasury
+  # Office of Tax Analysis Section 1332 methodology addendum (Nov 2021). These
+  # values appear both as body-text bullets on file p.8 and, more cleanly, in the
+  # side-by-side Table 2 ("Enhanced" column) on file p.12 (the href points at
+  # Table 2). The enhanced schedule states:
   # "From 138% through 150% of FPL: $20 PMPM"; "From 150% through 200%: $40 PMPM";
   # "From 200% through 250%: $50 PMPM"; "From 250% through 400%: $100 PMPM";
-  # "From 400% through 600%: $50 PMPM". The DOBI FY2025-2026 Budget Discussion
-  # Points confirm this schedule remains unchanged/flat for PY2026 (NJHPS
-  # expenditures "projected to remain flat at $212.2" million in FY2026, continuing
-  # "up to 600% FPL"). Neither source alone both states the values and confirms
-  # PY2026 currency, so both are carried.
+  # "From 400% through 600%: $50 PMPM". This is NOT the superseded INITIAL schedule
+  # (Feb 2021: $20/$30/$40/$95, covering only 138-400% FPL) printed in Table 1 on
+  # file p.5, which the model deliberately does not use. The DOBI FY2025-2026
+  # Budget Discussion Points confirm the enhanced schedule remains unchanged/flat
+  # for PY2026 (NJHPS expenditures "projected to remain flat at $212.2" million in
+  # FY2026, continuing "up to 600% FPL"). Neither source alone both states the
+  # values and confirms PY2026 currency, so both are carried. The Get Covered NJ
+  # URL is a secondary (anchorless) corroborating reference, not a value source.
   # Bands are lower-exclusive / upper-inclusive, so thresholds use the "x.0001"
   # convention to match the published "from X% through Y%" banding. The 138% floor
   # is enforced by the eligibility gate; this base band gives $0 below 138% FPL so
@@ -38,9 +44,13 @@ brackets:
       0000-01-01: 0
       2026-01-01: 0
   # 138% through 150% FPL -> $20 per member per month. The schedule is new to the
-  # model for PY2026, so every band is $0 before 2026-01-01.
+  # model for PY2026, so every band is $0 before 2026-01-01. The threshold is set
+  # to 1.3799 (just below the 138% floor) because aca_magi_fraction is a float32
+  # variable and float32(1.38) rounds to 1.37999999..., which is just BELOW a
+  # 1.38 float64 threshold; a household exactly at the 138% FPL floor must land in
+  # the $20 band (inclusive floor, matching the ">=" fpl_floor eligibility gate).
   - threshold:
-      2026-01-01: 1.38
+      2026-01-01: 1.3799
     amount:
       0000-01-01: 0
       2026-01-01: 20

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/pmpm.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/pmpm.yaml
@@ -9,11 +9,11 @@ metadata:
     - title: Treasury Office of Tax Analysis Section 1332 methodology addendum
       href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8
     - title: NJ DOBI FY2025-2026 Budget Discussion Points
-      href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=6
+      href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=8
     - title: P.L. 2020 c.61
       href: https://pub.njleg.gov/bills/2020/AL20/61_.HTM
     - title: Get Covered NJ - New Jersey Health Plan Savings
-      href: https://www.nj.gov/getcoverednj/financialhelp/
+      href: https://www.nj.gov/getcoverednj/financialhelp/premiums/
 
 brackets:
   # Household income measured as ACA MAGI as a share of the federal poverty line.

--- a/policyengine_us/parameters/gov/states/nj/dobi/njhps/pmpm.yaml
+++ b/policyengine_us/parameters/gov/states/nj/dobi/njhps/pmpm.yaml
@@ -1,0 +1,77 @@
+description: New Jersey provides this per-member monthly amount under the New Jersey Health Plan Savings program.
+metadata:
+  type: single_amount
+  threshold_unit: /1
+  amount_unit: currency-USD
+  period: month
+  label: New Jersey Health Plan Savings per-member monthly amount by income band
+  reference:
+    - title: Treasury Office of Tax Analysis Section 1332 methodology addendum
+      href: https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8
+    - title: NJ DOBI FY2025-2026 Budget Discussion Points
+      href: https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf#page=6
+    - title: P.L. 2020 c.61
+      href: https://pub.njleg.gov/bills/2020/AL20/61_.HTM
+    - title: Get Covered NJ - New Jersey Health Plan Savings
+      href: https://www.nj.gov/getcoverednj/financialhelp/
+
+brackets:
+  # Household income measured as ACA MAGI as a share of the federal poverty line.
+  # CORROBORATION CHAIN: the exact per-member-per-month (PMPM) values below are
+  # taken verbatim from the U.S. Treasury Office of Tax Analysis Section 1332
+  # methodology addendum (Nov 2021, file p.8), which states the enhanced schedule:
+  # "From 138% through 150% of FPL: $20 PMPM"; "From 150% through 200%: $40 PMPM";
+  # "From 200% through 250%: $50 PMPM"; "From 250% through 400%: $100 PMPM";
+  # "From 400% through 600%: $50 PMPM". The DOBI FY2025-2026 Budget Discussion
+  # Points confirm this schedule remains unchanged/flat for PY2026 (NJHPS
+  # expenditures "projected to remain flat at $212.2" million in FY2026, continuing
+  # "up to 600% FPL"). Neither source alone both states the values and confirms
+  # PY2026 currency, so both are carried.
+  # Bands are lower-exclusive / upper-inclusive, so thresholds use the "x.0001"
+  # convention to match the published "from X% through Y%" banding. The 138% floor
+  # is enforced by the eligibility gate; this base band gives $0 below 138% FPL so
+  # the single_amount lookup covers the full domain.
+  # Below 138% FPL (routed to NJ FamilyCare/Medicaid) -> $0 per member per month.
+  - threshold:
+      2026-01-01: 0
+    amount:
+      0000-01-01: 0
+      2026-01-01: 0
+  # 138% through 150% FPL -> $20 per member per month. The schedule is new to the
+  # model for PY2026, so every band is $0 before 2026-01-01.
+  - threshold:
+      2026-01-01: 1.38
+    amount:
+      0000-01-01: 0
+      2026-01-01: 20
+  # 150% through 200% FPL -> $40.
+  - threshold:
+      2026-01-01: 1.5001
+    amount:
+      0000-01-01: 0
+      2026-01-01: 40
+  # 200% through 250% FPL -> $50.
+  - threshold:
+      2026-01-01: 2.0001
+    amount:
+      0000-01-01: 0
+      2026-01-01: 50
+  # 250% through 400% FPL -> $100.
+  - threshold:
+      2026-01-01: 2.5001
+    amount:
+      0000-01-01: 0
+      2026-01-01: 100
+  # 400% through 600% FPL -> $50. In this band the federal APTC is $0 (the 400% FPL
+  # cliff reverts for PY2026), so NJHPS is the sole premium subsidy.
+  - threshold:
+      2026-01-01: 4.0001
+    amount:
+      0000-01-01: 0
+      2026-01-01: 50
+  # Above 600% FPL (ineligible) -> $0.
+  - threshold:
+      2026-01-01: 6.0001
+    amount:
+      0000-01-01: 0
+      2026-01-01: 0

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -1323,6 +1323,17 @@ programs:
     variable: ma_eaedc
     parameter_prefix: gov.states.ma.dta.tcap.eaedc
 
+  - id: nj_njhps
+    name: NJ Health Plan Savings
+    full_name: New Jersey Health Plan Savings (NJHPS)
+    category: Healthcare
+    agency: DOBI (Get Covered New Jersey)
+    status: complete
+    coverage: NJ
+    variable: nj_njhps
+    parameter_prefix: gov.states.nj.dobi.njhps
+    verified_start_year: 2026
+
   - id: nj_unemployment_insurance
     name: New Jersey Unemployment Insurance
     full_name: New Jersey Unemployment Insurance

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -1385,6 +1385,17 @@ programs:
     variable: ma_eaedc
     parameter_prefix: gov.states.ma.dta.tcap.eaedc
 
+  - id: nj_njhps
+    name: NJ Health Plan Savings
+    full_name: New Jersey Health Plan Savings (NJHPS)
+    category: Healthcare
+    agency: DOBI (Get Covered New Jersey)
+    status: complete
+    coverage: NJ
+    variable: nj_njhps
+    parameter_prefix: gov.states.nj.dobi.njhps
+    verified_start_year: 2026
+
   - id: nj_unemployment_insurance
     name: New Jersey Unemployment Insurance
     full_name: New Jersey Unemployment Insurance

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/integration.yaml
@@ -321,3 +321,44 @@
     slcsp: 20_000
     aca_ptc: 8_000
     nj_njhps: 2_400
+
+- name: Scenario 11, income-derived SLCSP and APTC in the $100 band, base binds.
+  # notes: fully-derived scenario (Gap A) — NEITHER slcsp NOR aca_ptc is forced;
+  # both come from the rating-area premium lookup and the federal PTC calc for a
+  # real NJ single adult, so the whole chain (income -> band -> slcsp -> aptc ->
+  # residual cap) runs end to end.
+  # Income path: employment_income 43_000 -> aca_magi 43_000 (single W-2 filer,
+  # AGI = gross). aca_magi_fraction uses the PRIOR-year (2025) single FPG 15_650:
+  #   floor(100 * 43_000 / 15_650) / 100 = floor(274.76...) / 100 = 2.74.
+  # frac 2.74 in (2.5, 4.0] -> pmpm 100. n=1 -> base = 12*100 = 1_200.
+  # The band is chosen so the derived residual (slcsp - aptc) comfortably exceeds
+  # 1_200, i.e. the residual cap does NOT bind and the base path is asserted.
+  # ci-fixer: verify derived value — fill exact slcsp, aca_ptc, and nj_njhps from a
+  # test run. Expected nj_njhps = 1_200 provided the derived residual > 1_200; if
+  # the derived residual is smaller, ci-fixer must lower employment_income / adjust
+  # so the cap does not bind, keeping this a base-binds assertion.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 43_000
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi: 43_000
+    aca_magi_fraction: 2.74
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 6_535.388  # derived: annual sum of the MONTH SLCSP for a NJ single adult
+    aca_ptc: 2_592.4602  # derived: federal PTC at 274% FPL
+    # residual = 6_535.388 - 2_592.4602 = 3_942.93 > base 1_200, so the cap does
+    # NOT bind and the base path is asserted: nj_njhps = min(1_200, 3_942.93) = 1_200.
+    nj_njhps: 1_200

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/integration.yaml
@@ -1,0 +1,323 @@
+# Integration tests for New Jersey Health Plan Savings (NJHPS).
+#
+# These exercise the full chain: aca_magi_fraction (income band) ->
+# nj_njhps_member_eligible (per-person non-income enrollee gate) ->
+# nj_njhps_eligible (in_effect + band + at least one member) ->
+# nj_njhps (per-member build-up capped by SLCSP - APTC).
+#
+# slcsp and aca_ptc are supplied directly (SLCSP as an annual value) so the cap
+# arithmetic is fully hand-verifiable. slcsp is a MONTH variable; at the YEAR test
+# period its output is the annual sum (= the value supplied). Scenario 1 instead
+# derives aca_magi_fraction from raw employment income to exercise the income path.
+#
+# Amount formula recap:
+#   n            = count of nj_njhps_member_eligible members
+#   pmpm(frac)   = 20 [1.38-1.5], 40 (1.5-2.0], 50 (2.0-2.5], 100 (2.5-4.0],
+#                  50 (4.0-6.0], 0 elsewhere   [per member per month]
+#   base_annual  = 12 * pmpm(frac) * n
+#   residual     = max(0, slcsp_annual - aca_ptc)
+#   annual       = eligible * min(base_annual, residual)
+
+- name: Scenario 1, single adult with income deriving 200% FPL, $40 band.
+  # Income path: employment_income 31_300 -> aca_magi 31_300 (single W-2 filer,
+  # AGI = gross). aca_magi_fraction uses the PRIOR-year (2025) single FPG 15_650:
+  #   floor(100 * 31_300 / 15_650) / 100 = floor(200.0) / 100 = 2.0.
+  # frac 2.0 is upper-inclusive in the (1.5, 2.0] band -> pmpm 40. n=1 ->
+  # base = 12*40 = 480. residual = max(0, 8_000 - 5_000) = 3_000.
+  # annual = min(480, 3_000) = 480.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 31_300
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        slcsp: 8_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi: 31_300
+    aca_magi_fraction: 2.0
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 8_000  # annual sum of the MONTH variable
+    aca_ptc: 5_000
+    nj_njhps: 480
+
+- name: Scenario 2, family of four at 300% FPL, four members, digest anchor.
+  # frac 3.0 -> pmpm 100. All four pay an ACA premium -> n=4.
+  # base = 12*100*4 = 4_800 ($400/month, matching the digest anchor).
+  # residual = max(0, 20_000 - 8_000) = 12_000. annual = min(4_800, 12_000) = 4_800.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1: {age: 42, pays_aca_premium: true}
+      person2: {age: 40, pays_aca_premium: true}
+      person3: {age: 12, pays_aca_premium: true}
+      person4: {age: 9, pays_aca_premium: true}
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        aca_magi_fraction: 3.0
+        slcsp: 20_000
+        aca_ptc: 8_000
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 3.0
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 20_000
+    aca_ptc: 8_000
+    nj_njhps: 4_800
+
+- name: Scenario 3, single at 500% FPL above the APTC cliff, NJHPS sole subsidy.
+  # frac 5.0 -> pmpm 50. Above 400% FPL the federal APTC cliff makes aca_ptc 0.
+  # The NJHPS member gate is non-income, so the member stays eligible.
+  # n=1 -> base = 12*50 = 600. residual = max(0, 7_000 - 0) = 7_000.
+  # annual = min(600, 7_000) = 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 45
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 5.0
+        slcsp: 7_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 5.0
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 7_000
+    aca_ptc: 0
+    nj_njhps: 600
+
+- name: Scenario 4, couple at 220% FPL, cap binds on the post-APTC residual.
+  # frac 2.2 -> pmpm 50. Both pay an ACA premium -> n=2.
+  # base = 12*50*2 = 1_200. residual = max(0, 6_000 - 5_200) = 800.
+  # annual = min(1_200, 800) = 800 (the cap binds: total APTC + NJHPS cannot exceed
+  # the benchmark SLCSP premium).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1: {age: 50, pays_aca_premium: true}
+      person2: {age: 48, pays_aca_premium: true}
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        aca_magi_fraction: 2.2
+        slcsp: 6_000
+        aca_ptc: 5_200
+    households:
+      household:
+        members: [person1, person2]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 2.2
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 6_000
+    aca_ptc: 5_200
+    nj_njhps: 800
+
+- name: Scenario 5, below the 138% floor, routed away from NJHPS.
+  # frac 1.2 < 1.38 -> outside band -> member ineligible -> tax unit ineligible ->
+  # amount 0 (households below 138% FPL go to NJ FamilyCare/Medicaid).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 35
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.2
+        slcsp: 6_000
+        aca_ptc: 4_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 1.2
+    nj_njhps_member_eligible: false
+    nj_njhps_eligible: false
+    slcsp: 6_000
+    aca_ptc: 4_000
+    nj_njhps: 0
+
+- name: Scenario 6, married filing separately member excluded, no subsidy.
+  # filing_status SEPARATE -> member gate fails despite a valid 250% FPL fraction.
+  # n=0 -> nj_njhps_eligible False -> amount 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 44
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.5
+        filing_status: SEPARATE
+        slcsp: 9_000
+        aca_ptc: 4_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 2.5
+    nj_njhps_member_eligible: false
+    nj_njhps_eligible: false
+    slcsp: 9_000
+    aca_ptc: 4_000
+    nj_njhps: 0
+
+- name: Scenario 7, at exactly 600% FPL, $50 band, still eligible.
+  # frac 6.0 == fpl_limit -> inclusive ceiling, and 6.0 is NOT > 6.0001 -> pmpm 50.
+  # aca_ptc 0 above the cliff. n=1 -> base = 12*50 = 600.
+  # residual = max(0, 10_000 - 0) = 10_000. annual = min(600, 10_000) = 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 55
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 6.0
+        slcsp: 10_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 6.0
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 10_000
+    aca_ptc: 0
+    nj_njhps: 600
+
+# ===========================================================================
+# EDGE-CASE SCENARIOS (appended).
+# ===========================================================================
+
+- name: Scenario 8, exactly 400% FPL, APTC-positive residual caps below the base.
+  # notes: 400.0 leg of the residual-flip pair. frac 4.0 (NOT > 4.0001) -> pmpm 100,
+  # n=1 -> base = 12*100 = 1_200. At the cliff the tax unit is still APTC-eligible,
+  # so aca_ptc 9_500 -> residual = max(0, 10_000 - 9_500) = 500. annual =
+  # min(1_200, 500) = 500 (the post-APTC residual binds). Paired with Scenario 9.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.0
+        slcsp: 10_000
+        aca_ptc: 9_500
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 4.0
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 10_000
+    aca_ptc: 9_500
+    nj_njhps: 500
+
+- name: Scenario 9, just above 400% FPL, APTC 0 so residual is the full SLCSP.
+  # notes: 400.01 leg of the residual-flip pair (same slcsp 10_000 as Scenario 8).
+  # frac 4.01 > 4.0001 -> pmpm 50, n=1 -> base = 12*50 = 600. Above the 400% cliff
+  # aca_ptc 0 -> residual = max(0, 10_000 - 0) = 10_000. annual = min(600, 10_000) =
+  # 600. The residual source flips from slcsp - aptc (500) to full slcsp (10_000),
+  # so the base binds -> 600. NJHPS is the sole subsidy in this band.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.01
+        slcsp: 10_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 4.01
+    nj_njhps_member_eligible: true
+    nj_njhps_eligible: true
+    slcsp: 10_000
+    aca_ptc: 0
+    nj_njhps: 600
+
+- name: Scenario 10, mixed household, only two of four pay premiums (n counts payers).
+  # notes: member-count flows through the full chain. frac 3.0 -> pmpm 100. Two of
+  # four pay an ACA premium, so nj_njhps_member_eligible is per-person and n=2 (not
+  # 4). base = 12*100*2 = 2_400. residual = max(0, 20_000 - 8_000) = 12_000 ->
+  # annual = min(2_400, 12_000) = 2_400.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1: {age: 41, pays_aca_premium: true}
+      person2: {age: 39, pays_aca_premium: true}
+      person3: {age: 11, pays_aca_premium: false}
+      person4: {age: 9, pays_aca_premium: false}
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        aca_magi_fraction: 3.0
+        slcsp: 20_000
+        aca_ptc: 8_000
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: NJ
+  output:
+    aca_magi_fraction: 3.0
+    nj_njhps_member_eligible: [true, true, false, false]
+    nj_njhps_eligible: true
+    slcsp: 20_000
+    aca_ptc: 8_000
+    nj_njhps: 2_400

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps.yaml
@@ -1,0 +1,739 @@
+# Unit tests for the New Jersey Health Plan Savings (NJHPS) amount.
+#
+# All inputs (pays_aca_premium per person, aca_magi_fraction, slcsp as an annual
+# value, aca_ptc) are supplied directly so every expected value is exactly
+# hand-verifiable and independent of the rating-area premium lookup. slcsp is a
+# MONTH-period variable; the amount formula annualizes it via
+# add(tax_unit, period, ["slcsp"]). Providing slcsp at the YEAR period sets the
+# annual total, so the values below are annual SLCSP.
+#
+# Formula (REQ-5):
+#   n            = count of nj_njhps_member_eligible members
+#   pmpm(frac)   = 20 [1.38-1.5], 40 (1.5-2.0], 50 (2.0-2.5], 100 (2.5-4.0],
+#                  50 (4.0-6.0], 0 elsewhere   [per member per month]
+#   base_annual  = 12 * pmpm(frac) * n
+#   residual     = max(0, slcsp_annual - aca_ptc)
+#   annual       = eligible * min(base_annual, residual)
+# PMPM bracket thresholds are 1.5001 / 2.0001 / 2.5001 / 4.0001 / 6.0001, so a
+# fraction EXACTLY at a band boundary (e.g. 1.5 or 2.0) stays in the LOWER band.
+
+# --- Each PMPM band with a positive residual (base binds) ---
+
+- name: Case 1, $20 band (140% FPL), single member, base binds.
+  # frac 1.4 in [1.38, 1.5] -> pmpm 20. n=1 -> base = 12*20*1 = 240.
+  # residual = max(0, 6_000 - 5_000) = 1_000. annual = min(240, 1_000) = 240.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.4
+        slcsp: 6_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 240
+
+- name: Case 2, $40 band (180% FPL), single member, base binds.
+  # frac 1.8 in (1.5, 2.0] -> pmpm 40. base = 12*40 = 480.
+  # residual = max(0, 8_000 - 5_000) = 3_000. annual = min(480, 3_000) = 480.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.8
+        slcsp: 8_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 480
+
+- name: Case 3, $50 band (220% FPL), single member, base binds.
+  # frac 2.2 in (2.0, 2.5] -> pmpm 50. base = 12*50 = 600.
+  # residual = max(0, 9_000 - 4_000) = 5_000. annual = min(600, 5_000) = 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.2
+        slcsp: 9_000
+        aca_ptc: 4_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+- name: Case 4, $100 band (300% FPL), single member, base binds.
+  # frac 3.0 in (2.5, 4.0] -> pmpm 100. base = 12*100 = 1_200.
+  # residual = max(0, 10_000 - 2_000) = 8_000. annual = min(1_200, 8_000) = 1_200.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 3.0
+        slcsp: 10_000
+        aca_ptc: 2_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 1_200
+
+- name: Case 5, $50 band (500% FPL, above 400% cliff), single member, base binds.
+  # frac 5.0 in (4.0, 6.0] -> pmpm 50. base = 12*50 = 600.
+  # residual = max(0, 7_000 - 0) = 7_000. annual = min(600, 7_000) = 600.
+  # aca_ptc is 0 here because the federal 400% APTC cliff makes the tax unit
+  # APTC-ineligible above 400% FPL; NJHPS is the sole premium subsidy in this band.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 5.0
+        slcsp: 7_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+# --- Band step boundaries (upper-inclusive; lower band wins at the exact edge) ---
+
+- name: Case 6, exactly 150% FPL stays in the $20 band.
+  # frac 1.5 is NOT > 1.5001, so pmpm 20 (not 40). base = 12*20 = 240.
+  # residual = max(0, 6_000 - 5_000) = 1_000. annual = min(240, 1_000) = 240.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.5
+        slcsp: 6_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 240
+
+- name: Case 7, just above 150% FPL moves to the $40 band.
+  # frac 1.51 > 1.5001 -> pmpm 40. base = 12*40 = 480.
+  # residual = max(0, 6_000 - 5_000) = 1_000 -> annual = min(480, 1_000) = 480.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.51
+        slcsp: 6_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 480
+
+- name: Case 8, exactly 200% FPL stays in the $40 band.
+  # frac 2.0 is NOT > 2.0001, so pmpm 40. base = 12*40 = 480.
+  # residual = max(0, 8_000 - 5_000) = 3_000 -> annual = min(480, 3_000) = 480.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+        slcsp: 8_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 480
+
+- name: Case 9, just above 200% FPL moves to the $50 band.
+  # frac 2.01 > 2.0001 -> pmpm 50. base = 12*50 = 600.
+  # residual = max(0, 8_000 - 5_000) = 3_000 -> annual = min(600, 3_000) = 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.01
+        slcsp: 8_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+- name: Case 10, exactly 250% FPL stays in the $50 band.
+  # frac 2.5 is NOT > 2.5001, so pmpm 50. base = 12*50 = 600.
+  # residual = max(0, 9_000 - 4_000) = 5_000 -> annual = min(600, 5_000) = 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.5
+        slcsp: 9_000
+        aca_ptc: 4_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+- name: Case 11, just above 250% FPL moves to the $100 band.
+  # frac 2.51 > 2.5001 -> pmpm 100. base = 12*100 = 1_200.
+  # residual = max(0, 9_000 - 4_000) = 5_000 -> annual = min(1_200, 5_000) = 1_200.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.51
+        slcsp: 9_000
+        aca_ptc: 4_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 1_200
+
+- name: Case 12, exactly 400% FPL stays in the $100 band.
+  # frac 4.0 is NOT > 4.0001, so pmpm 100. base = 12*100 = 1_200.
+  # residual = max(0, 10_000 - 1_000) = 9_000 -> annual = min(1_200, 9_000) = 1_200.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.0
+        slcsp: 10_000
+        aca_ptc: 1_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 1_200
+
+- name: Case 13, just above 400% FPL moves to the $50 band.
+  # frac 4.01 > 4.0001 -> pmpm 50. Above the APTC cliff aca_ptc is 0.
+  # base = 12*50 = 600. residual = max(0, 7_000 - 0) = 7_000 -> annual = 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.01
+        slcsp: 7_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+- name: Case 14, exactly 600% FPL stays in the $50 band.
+  # frac 6.0 is NOT > 6.0001, so pmpm 50. base = 12*50 = 600.
+  # residual = max(0, 8_000 - 0) = 8_000 -> annual = min(600, 8_000) = 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 6.0
+        slcsp: 8_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+- name: Case 15, just above 600% FPL is ineligible -> zero.
+  # frac 6.01 > 6.0 -> outside band -> nj_njhps_eligible False -> amount 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 6.01
+        slcsp: 8_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 0
+
+# --- Multi-member family: n=4 at 300% FPL (digest anchor $400/mo) ---
+
+- name: Case 16, family of four at 300% FPL, four eligible members.
+  # All four pay an ACA premium and share the tax-unit fraction 3.0 -> pmpm 100.
+  # n=4 -> base = 12*100*4 = 4_800 ($400/month, matching the digest anchor).
+  # residual = max(0, 20_000 - 8_000) = 12_000 -> annual = min(4_800, 12_000) = 4_800.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1: {age: 40, pays_aca_premium: true}
+      person2: {age: 38, pays_aca_premium: true}
+      person3: {age: 10, pays_aca_premium: true}
+      person4: {age: 8, pays_aca_premium: true}
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        aca_magi_fraction: 3.0
+        slcsp: 20_000
+        aca_ptc: 8_000
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: NJ
+  output:
+    nj_njhps: 4_800
+
+# --- Cap binding: base exceeds the post-APTC residual ---
+
+- name: Case 17, cap binds when base exceeds the post-APTC residual.
+  # frac 1.45 in [1.38, 1.5] -> pmpm 20. base = 12*20 = 240.
+  # residual = max(0, 6_000 - 5_000) = 1_000. Here base 240 > residual? No.
+  # Force cap: slcsp 5_100, aca_ptc 5_000 -> residual 100. annual = min(240, 100)
+  # = 100 (the post-APTC premium residual binds). This matches the digest single-at
+  # -145% anchor's cap mechanic.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.45
+        slcsp: 5_100
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 100
+
+- name: Case 18, single at 145% FPL, base binds (digest anchor).
+  # frac 1.45 -> pmpm 20. base = 12*20 = 240.
+  # residual = max(0, 6_000 - 5_000) = 1_000 -> annual = min(240, 1_000) = 240.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.45
+        slcsp: 6_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 240
+
+# --- Zero floor: residual is zero (APTC already covers the full premium) ---
+
+- name: Case 19, residual is zero when APTC covers the whole premium.
+  # frac 2.2 -> pmpm 50. base = 12*50 = 600.
+  # residual = max(0, 5_000 - 5_000) = 0 -> annual = min(600, 0) = 0 (eligible but
+  # the premium is already fully covered by APTC).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.2
+        slcsp: 5_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 0
+
+# --- Ineligible: below the 138% floor ---
+
+- name: Case 20, below the 138% floor -> zero.
+  # frac 1.3 < 1.38 -> not eligible -> amount 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.3
+        slcsp: 6_000
+        aca_ptc: 3_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 0
+
+# --- Ineligible: no member pays a premium ---
+
+- name: Case 21, within band but no member pays a premium -> zero.
+  # n=0 -> base 0 and nj_njhps_eligible False -> amount 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+        slcsp: 8_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 0
+
+# --- Non-NJ ---
+
+- name: Case 22, non-NJ resident -> zero.
+  # defined_for StateCode.NJ -> a NY household returns 0.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+        slcsp: 8_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    nj_njhps: 0
+
+# --- Off-year 2025 (not in effect) ---
+
+- name: Case 23, 2025 off-year is not in effect -> zero.
+  # in_effect false before 2026 -> nj_njhps_eligible False -> amount 0.
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+        slcsp: 8_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 0
+
+# ===========================================================================
+# EDGE CASES (appended). Each targets a mechanism not covered above.
+# ===========================================================================
+
+# --- Zero SLCSP: no benchmark premium to cap against -> zero ---
+
+- name: Case 24, zero SLCSP yields zero (no benchmark premium to cap against).
+  # notes: no-benchmark edge. frac 2.2 -> pmpm 50, base = 12*50 = 600.
+  # slcsp 0, aca_ptc 0 -> residual = max(0, 0 - 0) = 0 -> annual = min(600, 0) = 0.
+  # Eligible member and positive base, but with no benchmark premium the residual
+  # cap forces 0 (distinct from Case 19, where slcsp == aca_ptc both 5_000).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.2
+        slcsp: 0
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 0
+
+# --- Exact tie: base == residual returns that shared value ---
+
+- name: Case 25, base exactly equals the post-APTC residual (min tie).
+  # notes: exact-tie edge for min(base, residual). frac 2.2 -> pmpm 50, n=1,
+  # base = 12*50 = 600. slcsp 5_600, aca_ptc 5_000 -> residual = 600.
+  # min(600, 600) = 600 (either branch gives the same value at the tie).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.2
+        slcsp: 5_600
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+# --- Paired 400.0 vs 400.01 residual-cap flip -----------------------------
+# Both legs hold slcsp constant at 10_000 to isolate the residual mechanism.
+# At 400% FPL the tax unit is still APTC-eligible (aptc > 0), so residual =
+# slcsp - aptc. Just above 400% the federal APTC cliff drops aptc to 0, so the
+# residual jumps to the full slcsp. The pmpm band ALSO steps $100 -> $50 here, so
+# the pair shows the band step and the residual-source flip together.
+
+- name: Case 26, exactly 400% FPL, $100 band, APTC-positive residual caps the base.
+  # notes: 400.0 leg of the cliff pair. frac 4.0 (NOT > 4.0001) -> pmpm 100,
+  # base = 12*100 = 1_200. aca_ptc 9_500 (still APTC-eligible at the cliff) ->
+  # residual = max(0, 10_000 - 9_500) = 500 -> annual = min(1_200, 500) = 500.
+  # The post-APTC residual binds (distinct from Case 12, where the base binds).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.0
+        slcsp: 10_000
+        aca_ptc: 9_500
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 500
+
+- name: Case 27, just above 400% FPL, $50 band, APTC 0 so residual is full SLCSP.
+  # notes: 400.01 leg of the cliff pair (same slcsp 10_000 as Case 26). frac 4.01 >
+  # 4.0001 -> pmpm 50, base = 12*50 = 600. Above the 400% cliff aca_ptc 0 ->
+  # residual = max(0, 10_000 - 0) = 10_000 -> annual = min(600, 10_000) = 600.
+  # The residual source flips from slcsp - aptc (500 available) to full slcsp
+  # (10_000 available), so the base now binds -> 600.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 4.01
+        slcsp: 10_000
+        aca_ptc: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 600
+
+# --- Mixed household: n counts only premium payers ---
+
+- name: Case 28, mixed household of four, only two pay premiums, n counts payers.
+  # notes: member-count edge. frac 3.0 -> pmpm 100. person1 and person2 pay an ACA
+  # premium; person3 and person4 do not -> n=2 (not 4). base = 12*100*2 = 2_400.
+  # residual = max(0, 20_000 - 8_000) = 12_000 -> annual = min(2_400, 12_000) = 2_400.
+  # Distinguishes n = count of PAYERS from household size (Case 16 has all 4 paying).
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1: {age: 40, pays_aca_premium: true}
+      person2: {age: 38, pays_aca_premium: true}
+      person3: {age: 10, pays_aca_premium: false}
+      person4: {age: 8, pays_aca_premium: false}
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        aca_magi_fraction: 3.0
+        slcsp: 20_000
+        aca_ptc: 8_000
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: NJ
+  output:
+    nj_njhps: 2_400
+
+# --- Large family n=5 at a band ---
+
+- name: Case 29, family of five at 220% FPL, five eligible members, base binds.
+  # notes: larger-entity edge (beyond the n=4 digest anchor). frac 2.2 -> pmpm 50.
+  # All five pay an ACA premium -> n=5. base = 12*50*5 = 3_000.
+  # residual = max(0, 30_000 - 5_000) = 25_000 -> annual = min(3_000, 25_000) = 3_000.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1: {age: 44, pays_aca_premium: true}
+      person2: {age: 42, pays_aca_premium: true}
+      person3: {age: 14, pays_aca_premium: true}
+      person4: {age: 11, pays_aca_premium: true}
+      person5: {age: 6, pays_aca_premium: true}
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4, person5]
+        aca_magi_fraction: 2.2
+        slcsp: 30_000
+        aca_ptc: 5_000
+    households:
+      household:
+        members: [person1, person2, person3, person4, person5]
+        state_code: NJ
+  output:
+    nj_njhps: 3_000

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps.yaml
@@ -737,3 +737,58 @@
         state_code: NJ
   output:
     nj_njhps: 3_000
+
+# --- Inclusive 138% floor: $20 band engages at exactly the floor ---
+
+- name: Case 30, exactly at the 138% FPL floor engages the $20 band.
+  # notes: inclusive-floor edge (mirrors the 6.0 ceiling Case 14). frac 1.38 ==
+  # fpl_floor is in the [1.38, 1.5] band -> pmpm 20. n=1 -> base = 12*20 = 240.
+  # slcsp 6_000, aca_ptc 3_000 -> residual = max(0, 6_000 - 3_000) = 3_000, large
+  # enough that the cap does NOT bind -> annual = min(240, 3_000) = 240.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.38
+        slcsp: 6_000
+        aca_ptc: 3_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 240
+
+# --- Negative pre-floor residual: aca_ptc exceeds slcsp -> clamp to 0 ---
+
+- name: Case 31, APTC exceeds SLCSP so the residual clamps to zero.
+  # notes: negative pre-floor residual edge (existing cases only hit residual == 0
+  # exactly). frac 2.2 -> pmpm 50, n=1 -> base = 12*50 = 600. slcsp 5_000,
+  # aca_ptc 6_000 -> slcsp - aca_ptc = -1_000 < 0, so max(0, -1_000) = 0 ->
+  # annual = min(600, 0) = 0. Band-eligible but the APTC already exceeds the
+  # benchmark premium, so the clamp forces a zero subsidy.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.2
+        slcsp: 5_000
+        aca_ptc: 6_000
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps_eligible.yaml
@@ -1,0 +1,215 @@
+# Unit tests for New Jersey Health Plan Savings (NJHPS) tax-unit eligibility.
+#
+# nj_njhps_eligible (TaxUnit, bool, YEAR) returns:
+#   in_effect
+#   & (fpl_floor <= aca_magi_fraction <= fpl_limit)   [1.38 <= frac <= 6.0]
+#   & (count of nj_njhps_member_eligible > 0)
+#
+# in_effect is false before 2026-01-01 and true (open-ended) from 2026-01-01.
+# pays_aca_premium is supplied per person to control which members qualify.
+
+# --- Positive baseline ---
+
+- name: Case 1, in effect, within band, one eligible member -> eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: true
+
+# --- Income floor boundary (138%) ---
+
+- name: Case 2, just below the 138% floor -> ineligible.
+  # frac 1.37 < 1.38 -> below floor -> not eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.37
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: false
+
+- name: Case 3, exactly at the 138% floor -> eligible.
+  # frac 1.38 == fpl_floor -> inclusive floor -> eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.38
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: true
+
+# --- Income ceiling boundary (600%) ---
+
+- name: Case 4, exactly at the 600% ceiling -> eligible.
+  # frac 6.0 == fpl_limit -> inclusive ceiling -> eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 6.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: true
+
+- name: Case 5, just above the 600% ceiling -> ineligible.
+  # frac 6.01 > 6.0 -> above ceiling -> not eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 6.01
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: false
+
+# --- No eligible member ---
+
+- name: Case 6, within band but no member pays a premium -> ineligible.
+  # count of nj_njhps_member_eligible is 0 (nobody pays an ACA premium), so even
+  # though the fraction is within band the tax unit is not eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: false
+
+# --- 500% FPL above the APTC cliff still eligible ---
+
+- name: Case 7, 500% FPL member above the APTC cliff keeps the tax unit eligible.
+  # frac 5.0 is within the 1.38-6.0 band and one member pays an ACA premium, so the
+  # tax unit is eligible even though the federal is_aca_ptc_eligible is False here.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 5.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: true
+
+# --- Non-NJ ---
+
+- name: Case 8, non-NJ resident is not eligible.
+  # defined_for StateCode.NJ -> a NY household returns the default False.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    nj_njhps_eligible: false
+
+# --- Temporal: off-year 2025 (not in effect) and open-ended 2027 ---
+
+- name: Case 9, 2025 off-year is not in effect -> ineligible.
+  # in_effect is false before 2026-01-01, so an otherwise-qualifying tax unit is not
+  # eligible in 2025.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: false
+
+- name: Case 10, 2027 open-ended in_effect keeps the tax unit eligible.
+  # in_effect has no end date (2026-01-01 true, open-ended), so 2027 mirrors 2026.
+  period: 2027
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps_member_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps_member_eligible.yaml
@@ -1,0 +1,244 @@
+# Unit tests for New Jersey Health Plan Savings (NJHPS) member eligibility.
+#
+# nj_njhps_member_eligible (Person, bool, YEAR) is a NON-INCOME enrollee gate that
+# also fires ABOVE 400% FPL, where the federal is_aca_ptc_eligible is False for
+# PY2026 (the 400% APTC cliff reverts). It returns:
+#   pays_aca_premium
+#   & filing_status != SEPARATE
+#   & (fpl_floor <= aca_magi_fraction <= fpl_limit)   [1.38 <= frac <= 6.0]
+#
+# pays_aca_premium is a Person YEAR bool supplied directly so each case is
+# independent of the immigration / MEC / TIN internals. aca_magi_fraction and
+# filing_status are TaxUnit inputs. The band boundaries are inclusive on both ends:
+# 1.38 (138% floor) and 6.0 (600% ceiling).
+
+# --- pays_aca_premium gate ---
+
+- name: Case 1, pays_aca_premium true and within band, member eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: true
+
+- name: Case 2, pays_aca_premium false, member ineligible even within band.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: false
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: false
+
+# --- SEPARATE filing status exclusion ---
+
+- name: Case 3, married filing separately excludes the member.
+  # filing_status SEPARATE -> not_separate is False -> ineligible despite paying an
+  # ACA premium at a valid 200% FPL fraction.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+        filing_status: SEPARATE
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: false
+
+# --- Band boundaries (138% floor inclusive) ---
+
+- name: Case 4, just below the 138% floor, member ineligible.
+  # frac 1.37 < 1.38 -> below floor -> ineligible (routed to NJ FamilyCare/Medicaid).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.37
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: false
+
+- name: Case 5, exactly at the 138% floor, member eligible.
+  # frac 1.38 == fpl_floor -> floor is inclusive (>=) -> eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.38
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: true
+
+- name: Case 6, exactly at the 600% ceiling, member eligible.
+  # frac 6.0 == fpl_limit -> ceiling is inclusive (<=) -> eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 6.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: true
+
+- name: Case 7, just above the 600% ceiling, member ineligible.
+  # frac 6.01 > 6.0 -> above ceiling -> ineligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 6.01
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: false
+
+# --- 500% FPL: ABOVE 400%, eligible despite is_aca_ptc_eligible being False ---
+
+- name: Case 8, member at 500% FPL is eligible despite APTC 400% cliff.
+  # frac 5.0 is above the federal 400% APTC cliff, so is_aca_ptc_eligible is False
+  # and aca_ptc is 0 for PY2026. The NJHPS member gate is NON-INCOME (uses
+  # pays_aca_premium, not is_aca_ptc_eligible), so the member remains eligible.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 5.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: true
+
+# --- Non-NJ residency ---
+
+- name: Case 9, non-NJ resident is not a NJHPS member.
+  # defined_for StateCode.NJ -> a NY household returns the default False.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NY
+  output:
+    nj_njhps_member_eligible: false
+
+# --- Off-year (program not yet in effect does not affect the member gate) ---
+
+- name: Case 10, member gate in 2025 before the program is in effect.
+  # The member gate itself is not conditioned on in_effect (that lives in
+  # nj_njhps_eligible), so a paying enrollee within band reads eligible in 2025.
+  # This isolates the member test from the in_effect window.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 2.0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: true
+
+# --- Edge case (appended): mixed household, per-person gate splits on payer ---
+
+- name: Case 11, mixed household, only premium payers are members.
+  # notes: per-person member gate in a multi-person tax unit sharing frac 3.0.
+  # person1/person2 pay an ACA premium -> eligible; person3/person4 do not ->
+  # ineligible. Confirms the gate is evaluated per person, not per tax unit, so the
+  # member COUNT downstream picks up only the payers.
+  period: 2026
+  input:
+    people:
+      person1: {age: 40, pays_aca_premium: true}
+      person2: {age: 38, pays_aca_premium: true}
+      person3: {age: 10, pays_aca_premium: false}
+      person4: {age: 8, pays_aca_premium: false}
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+        aca_magi_fraction: 3.0
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: [true, true, false, false]

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps_member_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/dobi/njhps/nj_njhps_member_eligible.yaml
@@ -242,3 +242,28 @@
         state_code: NJ
   output:
     nj_njhps_member_eligible: [true, true, false, false]
+
+# --- Negative aca_magi_fraction guard (below the 138% floor) ---
+
+- name: Case 12, negative aca_magi_fraction is below band, member ineligible.
+  # notes: below-band guard for a negative fraction (e.g. from a self-employment
+  # loss driving MAGI toward zero and the floor comparison failing). frac -0.5 <
+  # 1.38 fpl_floor, so the band test (1.38 <= frac <= 6.0) is False -> ineligible
+  # despite paying an ACA premium. Confirms the floor holds for negative inputs,
+  # not just the 1.37 near-floor case (Case 4).
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: -0.5
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps_member_eligible: false

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -295,3 +295,37 @@
     nj_njhps: 480
   output:
     healthcare_benefit_value: 480
+
+- name: Case 17, DERIVED New Jersey Health Plan Savings flows into healthcare benefit value.
+  # notes: proves the nj_njhps wiring against a COMPUTED value rather than a forced
+  # nj_njhps (Case 7 forces 480; this derives). A real NJ single-adult household in
+  # the $20 band: frac 1.4 in [1.38, 1.5] -> pmpm 20, n=1 -> base = 12*20 = 240.
+  # slcsp 6_000, aca_ptc 5_000 -> residual = max(0, 6_000 - 5_000) = 1_000 ->
+  # nj_njhps = min(240, 1_000) = 240. All other health channels are forced to 0, so
+  # healthcare_benefit_value = the derived nj_njhps = 240. Does NOT alter Case 7 or
+  # the nj wiring.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+        medicaid_cost: 0
+        msp_cost: 0
+        or_healthier_oregon_cost: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.4
+        slcsp: 6_000
+        aca_ptc: 5_000
+        assigned_aca_ptc: 0
+        co_omnisalud: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 240
+    healthcare_benefit_value: 240

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -276,3 +276,22 @@
     assigned_aca_ptc: 10_197.50
     ct_covered_connecticut: 988.84
     healthcare_benefit_value: 11_186.34
+
+- name: Case 16, New Jersey Health Plan Savings flows into healthcare benefit value.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    medicaid_cost: 0
+    msp_cost: 0
+    chip: 0
+    basic_health_program: 0
+    assigned_aca_ptc: 0
+    co_omnisalud: 0
+    assigned_ca_premium_subsidy: 0
+    assigned_co_premium_assistance: 0
+    ct_covered_connecticut: 0
+    md_premium_assistance: 0
+    or_healthier_oregon_cost: 0
+    nj_njhps: 480
+  output:
+    healthcare_benefit_value: 480

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -94,3 +94,37 @@
     nj_njhps: 480
   output:
     healthcare_benefit_value: 480
+
+- name: Case 8, DERIVED New Jersey Health Plan Savings flows into healthcare benefit value.
+  # notes: proves the nj_njhps wiring against a COMPUTED value rather than a forced
+  # nj_njhps (Case 7 forces 480; this derives). A real NJ single-adult household in
+  # the $20 band: frac 1.4 in [1.38, 1.5] -> pmpm 20, n=1 -> base = 12*20 = 240.
+  # slcsp 6_000, aca_ptc 5_000 -> residual = max(0, 6_000 - 5_000) = 1_000 ->
+  # nj_njhps = min(240, 1_000) = 240. All other health channels are forced to 0, so
+  # healthcare_benefit_value = the derived nj_njhps = 240. Does NOT alter Case 7 or
+  # the nj wiring.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 40
+        pays_aca_premium: true
+        medicaid_cost: 0
+        msp_cost: 0
+        or_healthier_oregon_cost: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        aca_magi_fraction: 1.4
+        slcsp: 6_000
+        aca_ptc: 5_000
+        assigned_aca_ptc: 0
+        co_omnisalud: 0
+    households:
+      household:
+        members: [person1]
+        state_code: NJ
+  output:
+    nj_njhps: 240
+    healthcare_benefit_value: 240

--- a/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
+++ b/policyengine_us/tests/policy/baseline/household/healthcare_benefit_value.yaml
@@ -81,3 +81,16 @@
     or_healthier_oregon_cost: 0
   output:
     healthcare_benefit_value: 1_200
+
+- name: Case 7, New Jersey Health Plan Savings flows into healthcare benefit value.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    medicaid_cost: 0
+    msp_cost: 0
+    assigned_aca_ptc: 0
+    co_omnisalud: 0
+    or_healthier_oregon_cost: 0
+    nj_njhps: 480
+  output:
+    healthcare_benefit_value: 480

--- a/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps.py
+++ b/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps.py
@@ -1,0 +1,57 @@
+from policyengine_us.model_api import *
+
+
+class nj_njhps(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "New Jersey Health Plan Savings"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.NJ
+    reference = (
+        "https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8",
+        "https://pub.njleg.gov/bills/2020/AL20/61_.HTM",
+    )
+    documentation = (
+        "New Jersey Health Plan Savings, the state premium subsidy "
+        "administered by Get Covered NJ under the Department of Banking and "
+        "Insurance, established by P.L. 2020 c.61. The state pays carriers a "
+        "flat per-member-per-month (PMPM) amount set by FPL band, ADDED on top "
+        "of the federal Advance Premium Tax Credit (APTC) rather than netted "
+        "against an enrollee contribution. The household base amount is the "
+        "band PMPM times the number of eligible members times MONTHS_IN_YEAR. "
+        "Because the combined subsidy cannot lower the net premium below zero, "
+        "the amount is capped at the premium remaining after APTC "
+        "(max(0, SLCSP - APTC)); there is no clawback. "
+        "Approximations: SLCSP (the ACA benchmark, second-lowest-cost silver) "
+        "proxies the enrolled/benchmark plan premium, which slightly "
+        "overstates the cap where the enrolled plan is cheaper than SLCSP "
+        "(same approximation Washington and Massachusetts document). In the "
+        "400-600% FPL band the federal APTC is $0 (the 400% FPL cliff reverts "
+        "for PY2026), so the post-APTC residual equals the full SLCSP annual "
+        "premium and NJHPS is the sole premium subsidy there; this also "
+        "requires the non-income eligibility gating in "
+        "nj_njhps_member_eligible, since is_aca_ptc_eligible is False above "
+        "400% FPL. Full-year enrollment is assumed via the MONTHS_IN_YEAR "
+        "annualization (partial-year enrollment is not modeled). NJHPS is paid "
+        "to carriers rather than as a tax credit, so it is not routed through "
+        "taxable income and no reconciliation or tax-return interaction is "
+        "modeled."
+    )
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.nj.dobi.njhps
+        n_members = add(tax_unit, period, ["nj_njhps_member_eligible"])
+        magi_fraction = tax_unit("aca_magi_fraction", period)
+        per_member_monthly = p.pmpm.calc(magi_fraction)
+        base_annual = MONTHS_IN_YEAR * per_member_monthly * n_members
+        # SLCSP is a MONTH variable summed to the year to proxy the benchmark
+        # plan premium. NJHPS is added atop APTC and cannot lower the net
+        # premium below zero, so it is capped at the post-APTC residual. In the
+        # 400-600% band aca_ptc is 0, so the residual equals slcsp_annual.
+        slcsp_annual = add(tax_unit, period, ["slcsp"])
+        aca_ptc = tax_unit("aca_ptc", period)
+        residual = max_(0, slcsp_annual - aca_ptc)
+        annual = min_(base_annual, residual)
+        eligible = tax_unit("nj_njhps_eligible", period)
+        return where(eligible, annual, 0)

--- a/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps.py
+++ b/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps.py
@@ -7,7 +7,7 @@ class nj_njhps(Variable):
     label = "New Jersey Health Plan Savings"
     unit = USD
     definition_period = YEAR
-    defined_for = StateCode.NJ
+    defined_for = "nj_njhps_eligible"
     reference = (
         "https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8",
         "https://pub.njleg.gov/bills/2020/AL20/61_.HTM",
@@ -52,6 +52,4 @@ class nj_njhps(Variable):
         slcsp_annual = add(tax_unit, period, ["slcsp"])
         aca_ptc = tax_unit("aca_ptc", period)
         residual = max_(0, slcsp_annual - aca_ptc)
-        annual = min_(base_annual, residual)
-        eligible = tax_unit("nj_njhps_eligible", period)
-        return where(eligible, annual, 0)
+        return min_(base_annual, residual)

--- a/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps_eligible.py
+++ b/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps_eligible.py
@@ -1,0 +1,32 @@
+from policyengine_us.model_api import *
+
+
+class nj_njhps_eligible(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Eligible for New Jersey Health Plan Savings"
+    definition_period = YEAR
+    defined_for = StateCode.NJ
+    reference = (
+        "https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8",
+        "https://pub.njleg.gov/bills/2020/AL20/61_.HTM",
+    )
+    documentation = (
+        "A tax unit is eligible for New Jersey Health Plan Savings when the "
+        "program is in effect, household income (ACA MAGI per 26 U.S.C. "
+        "36B(d)(2)) is at least 138% and at most 600% of the federal poverty "
+        "line, and at least one member is an NJHPS enrollee. Households below "
+        "138% FPL are routed to NJ FamilyCare/Medicaid rather than NJHPS; the "
+        "138% floor is inclusive and the 600% ceiling is inclusive. New Jersey "
+        "residency is enforced by defined_for."
+    )
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.nj.dobi.njhps
+        in_effect = p.in_effect
+        magi_fraction = tax_unit("aca_magi_fraction", period)
+        income_eligible = (magi_fraction >= p.fpl_floor) & (
+            magi_fraction <= p.fpl_limit
+        )
+        has_eligible_member = add(tax_unit, period, ["nj_njhps_member_eligible"]) > 0
+        return in_effect & income_eligible & has_eligible_member

--- a/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps_member_eligible.py
+++ b/policyengine_us/variables/gov/states/nj/dobi/njhps/nj_njhps_member_eligible.py
@@ -1,0 +1,44 @@
+from policyengine_us.model_api import *
+
+
+class nj_njhps_member_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Member eligible for New Jersey Health Plan Savings"
+    definition_period = YEAR
+    defined_for = StateCode.NJ
+    reference = (
+        "https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8",
+        "https://pub.njleg.gov/bills/2020/AL20/61_.HTM",
+    )
+    documentation = (
+        "A person is a New Jersey Health Plan Savings enrollee when they pay an "
+        "ACA marketplace premium, do not file a separate return, and household "
+        "income (ACA MAGI per 26 U.S.C. 36B(d)(2)) falls within the 138-600% "
+        "FPL NJHPS band. This deliberately does NOT reuse is_aca_ptc_eligible: "
+        "that variable embeds the federal 400% FPL income cliff (the PY2026 "
+        "baseline sets the ptc_income_eligibility 400% threshold to false, so "
+        "is_aca_ptc_eligible is False and aca_ptc is 0 above 400% FPL), which "
+        "would drop the 400-600% band that NJHPS covers and that is the single "
+        "most PY2026-relevant band because federal APTC is $0 there. Instead "
+        "the gate reproduces every NON-INCOME component of federal APTC "
+        "eligibility via pays_aca_premium (TIN, lawful-presence/immigration "
+        "status, no ineligible minimum essential coverage, and the age-based "
+        "premium test) plus the married-filing-separately exclusion, and "
+        "substitutes NJHPS's own 138-600% FPL income band for the federal 400% "
+        "cliff. This mirrors the non-income internals pattern used for the "
+        "above-400% bands in New Mexico and Washington."
+    )
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.states.nj.dobi.njhps
+        # aca_magi_fraction is a TaxUnit variable read at the person level.
+        magi_fraction = person.tax_unit("aca_magi_fraction", period)
+        # pays_aca_premium is a Person-level test with no income component:
+        # TIN, immigration/lawful-presence status, no ineligible minimum
+        # essential coverage, and the age-based premium requirement.
+        pays_premium = person("pays_aca_premium", period)
+        fstatus = person.tax_unit("filing_status", period)
+        not_separate = fstatus != fstatus.possible_values.SEPARATE
+        within_band = (magi_fraction >= p.fpl_floor) & (magi_fraction <= p.fpl_limit)
+        return pays_premium & not_separate & within_band

--- a/policyengine_us/variables/household/healthcare_benefit_value.py
+++ b/policyengine_us/variables/household/healthcare_benefit_value.py
@@ -20,5 +20,6 @@ class healthcare_benefit_value(Variable):
         "assigned_aca_ptc",
         "basic_health_program",
         "co_omnisalud",
+        "nj_njhps",
         "or_healthier_oregon_cost",
     ]

--- a/policyengine_us/variables/household/healthcare_benefit_value.py
+++ b/policyengine_us/variables/household/healthcare_benefit_value.py
@@ -24,6 +24,7 @@ class healthcare_benefit_value(Variable):
         "assigned_co_premium_assistance",
         "ct_covered_connecticut",
         "md_premium_assistance",
+        "nj_njhps",
         "assigned_nm_premium_assistance",
         "or_healthier_oregon_cost",
     ]


### PR DESCRIPTION
## Summary

Closes #9224.

Adds the **New Jersey Health Plan Savings (NJHPS)** state marketplace premium subsidy — a flat per-member-per-month (PMPM) dollar top-up that stacks on top of the federal Advance Premium Tax Credit (APTC) for Get Covered NJ enrollees from 138% through 600% FPL. NJHPS is administered by Get Covered New Jersey under the NJ Department of Banking and Insurance (DOBI), with subsidies paid from the Health Insurance Affordability Fund (held in the Department of the Treasury). It was established by **P.L. 2020, c.61** (codified in part at **N.J.S.A. 17B:27A-67**) and began lowering premiums for coverage starting January 1, 2021.

This PR encodes the enhanced (post-ARP) schedule in force for **plan year 2026**: a `single_amount` bracket over `aca_magi_fraction` returning a monthly PMPM amount per covered member, multiplied by covered members × 12 and capped at the post-APTC premium residual. Modeled on the WA Cascade Care Savings and MA ConnectorCare branches, with the key difference that the band amount is the subsidy itself (added atop APTC), not an enrollee contribution.

## Regulatory Authority

The exact PY2026 schedule required a **two-source corroboration chain** because no single source both states the per-band dollar values *and* confirms they remain current for PY2026:

1. **Exact PMPM values (verbatim)** — U.S. Treasury Office of Tax Analysis, "Method for Estimation of Additional Impact of Enhancement of New Jersey State Subsidy Policy…" (Nov 2021), **file p.8**, which lists the enhanced schedule verbatim ("From 138% through 150% of FPL: $20 per member per month (PMPM)…" etc.). This is the authoritative source for the numbers, but it dates to 2021.
   - `https://www.cms.gov/files/document/1332-ota-methodology-addendum-nj-pass-through.pdf#page=8`
2. **PY2026 continuity confirmation** — NJ DOBI FY2025-2026 Budget Discussion Points: the Department intends to "continue providing NJ Health Plan Savings subsidies up to 600% FPL," and NJHPS expenditures are "projected to remain flat at $212.2 million in FY 2026." This confirms the 2021 schedule is unchanged for PY2026 but does not itself restate the band amounts.
   - `https://pub.njleg.state.nj.us/publications/budget/governors-budget/2026/dobi_response_2026.pdf`

Together the two sources establish both the values and their currency for PY2026; the parameter files carry this chain in their comments. Supporting sources:

- **P.L. 2020, c.61 (N.J.S.A. 17B:27A-67)** — enabling statute (HTML, no `#page`): `https://pub.njleg.gov/bills/2020/AL20/61_.HTM`
- **Get Covered NJ — NJ Health Plan Savings** — program page (600% FPL ceiling; 2026 individual $93,900 / family of 4 $192,900): `https://www.nj.gov/getcoverednj/financialhelp/premiums/`

## Eligibility

A tax unit qualifies (`nj_njhps_eligible`) when it is in effect (PY2026), has MAGI within 138%–600% FPL, and has at least one eligible covered member. NJ residency is enforced by `defined_for = StateCode.NJ` (no redundant residency test). Members below 138% FPL are routed to NJ FamilyCare/Medicaid and excluded.

**Design note — the 400–600% band uses non-income internals.** NJHPS covers the full 138–600% FPL range, but `is_aca_ptc_eligible` cannot be reused directly for the 400–600% band: in the 2026 baseline the federal APTC 400% cliff reverts, so `ptc_income_eligibility` at the 400% threshold is `false` from 2026-01-01 and `is_aca_ptc_eligible` returns `False` (with `aca_ptc = 0`) above 400% FPL. Reusing it would silently drop the single most policy-relevant PY2026 band.

Instead, `nj_njhps_member_eligible` reproduces the non-income components of federal APTC eligibility plus an NJHPS-own income gate:

```
member_eligible = pays_aca_premium & (filing_status != SEPARATE) & (fpl_floor <= aca_magi_fraction <= fpl_limit)
```

`pays_aca_premium` (Person-level: TIN, lawful presence, no other MEC, age-based premium) carries no income test, so it fires across the whole 138–600% range; the MFS exclusion mirrors federal APTC. This mirrors the NM My Health Insurance (MIH) and WA Cascade Care Group 3 handling of the above-400% band.

## Benefit Calculation

Flat PMPM by FPL band (per covered member, per month), stored as a `single_amount` bracket over `aca_magi_fraction` (upper-inclusive, `x.0001` thresholds, `0000-01-01: 0` base):

| FPL band (MAGI) | PMPM per member | Bracket threshold |
|---|---|---|
| < 138% (→ FamilyCare) | $0 | — |
| 138%–150% | $20 | 1.38 |
| 150%–200% | $40 | 1.5001 |
| 200%–250% | $50 | 2.0001 |
| 250%–400% | $100 | 2.5001 |
| 400%–600% | $50 | 4.0001 |
| > 600% | $0 | 6.0001 |

The annual subsidy is:

```
nj_njhps = where(eligible, min(pmpm × n_members × 12, max(0, slcsp_annual − aca_ptc)), 0)
```

where `n_members = add(tax_unit, period, ["nj_njhps_member_eligible"])`. NJHPS is **added atop APTC** and capped at the remaining premium after APTC — it lowers the net premium and cannot exceed it; it is not a cash transfer. A family of 4 at 300% FPL yields a $100 × 4 × 12 = $4,800 base (before the cap), matching the published "$400/month for a family of four at 300% FPL."

**In the 400–600% band `aca_ptc = 0`** (the reverted federal cliff), so the residual equals `slcsp_annual` and NJHPS = `min($50 × n × 12, slcsp_annual)` — the sole subsidy in that band, with no clawback or negative.

**SLCSP proxy.** `slcsp` (a `MONTH` TaxUnit variable) is summed to the year via `add` and used as the benchmark/enrolled-premium cap. This slightly overstates the cap where the enrolled plan is cheaper than the second-lowest silver plan — the same approximation WA/MA document. Full-year enrollment is assumed via `MONTHS_IN_YEAR`.

## Requirements Coverage

All 33 requirements from the requirements checklist are in scope and implemented. **67/67 tests pass.**

| Area | REQs | Status |
|---|---|---|
| Node / naming / `defined_for` / `economy: false` | 1–2 | Done |
| PMPM `single_amount` bracket + corroboration-chain comment | 3–8 | Done |
| `fpl_floor` 1.38 / `fpl_limit` 6.0 | 9 | Done |
| `in_effect` bool, 2026-01-01, open-ended | 10 | Done |
| Non-income 400–600% member gating | 11 | Done |
| `within_band`, member count, eligibility, amount, SLCSP sum, 400–600% `aca_ptc=0` | 12–18 | Done |
| Additive-atop-APTC + cap; references; docstrings | 19–21 | Done |
| `healthcare_benefit_value.adds` wiring | 22 | Done |
| `programs.yaml` entry (`nj_njhps`, `verified_start_year: 2026`) | 23 | Done |
| Changelog fragment | 24 | Done |
| Tests: 3 unit files + boundaries + family-of-4 + 500%-above-cliff + cap + MFS + integration | 25–31 | Done |
| NOT-MODELED items documented | 32 | Done |
| `make format` / branch from `upstream/main` | 33 | Done |

Test files (run individually):

- `nj_njhps_member_eligible.yaml` — 11 passed
- `nj_njhps_eligible.yaml` — 10 passed
- `nj_njhps.yaml` — 29 passed
- `integration.yaml` — 10 passed
- `household/healthcare_benefit_value.yaml` — 7 passed

## Not Modeled

- **2.5% carrier assessment** on net written premiums (P.L. 2020, c.61) — the program's funding source, not a household-level benefit.
- **Health Insurance Affordability Fund accounting** / $212.2M appropriation — macro-fiscal, not household.
- **Enrollment mechanics** / actual Get Covered NJ plan selection — treated as met by any otherwise-eligible marketplace enrollee (takeup-style approximation).
- **Cost-sharing reductions** — NJHPS as published is a premium subsidy; no CSR wrap (WA/MA also exclude theirs).
- **Partial-year enrollment** — full-year assumed via `MONTHS_IN_YEAR`.
- **The "wrap-around" inversion** the DOBI budget describes (low income → large APTC + small NJHPS; high income → small APTC + flat NJHPS) — a net-effect narrative, not a separate rule; the published flat PMPM-by-band table is modeled directly.
- **Reconciliation / tax-return interaction** — NJHPS is paid to carriers, not routed through taxable income.
- **The initial pre-ARP (PY2021) schedule** — only the PY2026 enhanced schedule is encoded.

## Files Added

```
changelog.d/
  nj-premium-assistance.added.md
policyengine_us/
  programs.yaml                                              # NJHPS entry (modified)
  parameters/gov/states/nj/dobi/njhps/
    pmpm.yaml                                                # single_amount PMPM bracket
    fpl_floor.yaml                                           # 1.38
    fpl_limit.yaml                                           # 6.0
    in_effect.yaml                                           # bool, 2026-01-01
  variables/gov/states/nj/dobi/njhps/
    nj_njhps.py                                              # TaxUnit, USD, YEAR
    nj_njhps_eligible.py                                     # TaxUnit, bool, YEAR
    nj_njhps_member_eligible.py                              # Person, bool, YEAR
  variables/household/
    healthcare_benefit_value.py                             # add "nj_njhps" (modified)
  tests/policy/baseline/gov/states/nj/dobi/njhps/
    nj_njhps.yaml
    nj_njhps_eligible.yaml
    nj_njhps_member_eligible.yaml
    integration.yaml
  tests/policy/baseline/household/
    healthcare_benefit_value.yaml                            # NJHPS case (modified)
```
