### PR TITLE
Convert GA, MO, and NY CHIP premiums to monthly variables

### DIFF
--- a/changelog.d/hua7450-issue9256.fixed.md
+++ b/changelog.d/hua7450-issue9256.fixed.md
@@ -1,1 +1,1 @@
-Convert Georgia, Missouri, and New York CHIP premiums to monthly variables so mid-year schedule changes take effect.
+Convert Georgia, Missouri, and New York CHIP premiums to monthly variables so mid-year schedule changes take effect, align Missouri's tier boundaries with the operative July-to-June Appendix E chart, re-date New York's premium restructuring to October 2022 per SPA NY-22-0033 and remove erroneous 2026 threshold entries, and exempt children under six and in foster care from Georgia's premium.

--- a/changelog.d/hua7450-issue9256.fixed.md
+++ b/changelog.d/hua7450-issue9256.fixed.md
@@ -1,0 +1,1 @@
+Convert Georgia, Missouri, and New York CHIP premiums to monthly variables so mid-year schedule changes take effect.

--- a/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/family_cap.yaml
+++ b/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/family_cap.yaml
@@ -8,32 +8,43 @@ metadata:
   reference:
     - title: Georgia DFCS Medicaid Manual 2194, Premiums
       href: https://pamms.dhs.ga.gov/dfcs/medicaid/2194/
+# Premiums were suspended during the COVID public health emergency and
+# resumed on 2024-10-01. The explicit zero amounts before that date keep the
+# resumption values from being backdated over the suspension period; the
+# pre-suspension premium schedule is not yet modeled, so years before the
+# suspension also show a zero premium.
 brackets:
   - threshold:
       2024-10-01: -.inf
     amount:
-      2024-10-01: 0
+      2015-01-01: 0
   - threshold:
       2024-10-01: 1.34
     amount:
+      2015-01-01: 0
       2024-10-01: 16
   - threshold:
       2024-10-01: 1.59
     amount:
+      2015-01-01: 0
       2024-10-01: 44
   - threshold:
       2024-10-01: 1.71
     amount:
+      2015-01-01: 0
       2024-10-01: 49
   - threshold:
       2024-10-01: 1.91
     amount:
+      2015-01-01: 0
       2024-10-01: 58
   - threshold:
       2024-10-01: 2.11
     amount:
+      2015-01-01: 0
       2024-10-01: 64
   - threshold:
       2024-10-01: 2.32
     amount:
+      2015-01-01: 0
       2024-10-01: 72

--- a/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/family_cap.yaml
+++ b/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/family_cap.yaml
@@ -8,11 +8,15 @@ metadata:
   reference:
     - title: Georgia DFCS Medicaid Manual 2194, Premiums
       href: https://pamms.dhs.ga.gov/dfcs/medicaid/2194/
-# Premiums were suspended during the COVID public health emergency and
-# resumed on 2024-10-01. The explicit zero amounts before that date keep the
-# resumption values from being backdated over the suspension period; the
-# pre-suspension premium schedule is not yet modeled, so years before the
-# suspension also show a zero premium.
+    - title: Georgia DCH PeachCare for Kids premiums and copays resume October 1, 2024
+      href: https://dch.georgia.gov/announcement/2024-08-13/peachcare-kidsr-co-payments-and-premiums-resume-oct-1-2024
+    - title: Georgia DCH COVID-19 operations update (Spring 2021 Medicaid Fair), waiving all PeachCare for Kids premiums for the duration of the federal emergency
+      href: https://www.mmis.georgia.gov/portal/Portals/0/StaticContent/Public/ALL/NOTICES/Covid-19-%20Spring%20Medicaid%20Fair%202021%2020210325165058.pdf#page=12
+# DCH waived all PeachCare premiums during the COVID federal emergency and
+# resumed collecting them on 2024-10-01. The explicit zero amounts before
+# that date keep the resumption values from being backdated over the
+# suspension period; the pre-suspension premium schedule is not yet
+# modeled, so years before the suspension also show a zero premium.
 brackets:
   - threshold:
       2024-10-01: -.inf

--- a/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/min_age.yaml
+++ b/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/min_age.yaml
@@ -1,0 +1,10 @@
+description: Georgia exempts children below this age from the PeachCare for Kids monthly premium.
+values:
+  2015-01-01: 6
+metadata:
+  unit: year
+  period: year
+  label: Georgia PeachCare for Kids premium minimum child age
+  reference:
+    - title: Georgia DFCS Medicaid Manual 2194, Premiums
+      href: https://pamms.dhs.ga.gov/dfcs/medicaid/2194/

--- a/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/per_child.yaml
+++ b/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/per_child.yaml
@@ -10,11 +10,13 @@ metadata:
       href: https://pamms.dhs.ga.gov/dfcs/medicaid/2194/
     - title: Georgia DCH PeachCare for Kids premiums and copays resume October 1, 2024
       href: https://dch.georgia.gov/announcement/2024-08-13/peachcare-kidsr-co-payments-and-premiums-resume-oct-1-2024
-# Premiums were suspended during the COVID public health emergency and
-# resumed on 2024-10-01. The explicit zero amounts before that date keep the
-# resumption values from being backdated over the suspension period; the
-# pre-suspension premium schedule is not yet modeled, so years before the
-# suspension also show a zero premium.
+    - title: Georgia DCH COVID-19 operations update (Spring 2021 Medicaid Fair), waiving all PeachCare for Kids premiums for the duration of the federal emergency
+      href: https://www.mmis.georgia.gov/portal/Portals/0/StaticContent/Public/ALL/NOTICES/Covid-19-%20Spring%20Medicaid%20Fair%202021%2020210325165058.pdf#page=12
+# DCH waived all PeachCare premiums during the COVID federal emergency and
+# resumed collecting them on 2024-10-01. The explicit zero amounts before
+# that date keep the resumption values from being backdated over the
+# suspension period; the pre-suspension premium schedule is not yet
+# modeled, so years before the suspension also show a zero premium.
 brackets:
   - threshold:
       2024-10-01: -.inf

--- a/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/per_child.yaml
+++ b/policyengine_us/parameters/gov/states/ga/hhs/chip/premium/per_child.yaml
@@ -10,32 +10,43 @@ metadata:
       href: https://pamms.dhs.ga.gov/dfcs/medicaid/2194/
     - title: Georgia DCH PeachCare for Kids premiums and copays resume October 1, 2024
       href: https://dch.georgia.gov/announcement/2024-08-13/peachcare-kidsr-co-payments-and-premiums-resume-oct-1-2024
+# Premiums were suspended during the COVID public health emergency and
+# resumed on 2024-10-01. The explicit zero amounts before that date keep the
+# resumption values from being backdated over the suspension period; the
+# pre-suspension premium schedule is not yet modeled, so years before the
+# suspension also show a zero premium.
 brackets:
   - threshold:
       2024-10-01: -.inf
     amount:
-      2024-10-01: 0
+      2015-01-01: 0
   - threshold:
       2024-10-01: 1.34
     amount:
+      2015-01-01: 0
       2024-10-01: 11
   - threshold:
       2024-10-01: 1.59
     amount:
+      2015-01-01: 0
       2024-10-01: 22
   - threshold:
       2024-10-01: 1.71
     amount:
+      2015-01-01: 0
       2024-10-01: 24
   - threshold:
       2024-10-01: 1.91
     amount:
+      2015-01-01: 0
       2024-10-01: 29
   - threshold:
       2024-10-01: 2.11
     amount:
+      2015-01-01: 0
       2024-10-01: 32
   - threshold:
       2024-10-01: 2.32
     amount:
+      2015-01-01: 0
       2024-10-01: 36

--- a/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
+++ b/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/family_cap.yaml
@@ -8,14 +8,23 @@ metadata:
   reference:
     - title: New York State Department of Health - Child Health Plus Eligibility and Cost (current)
       href: https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
-    - title: Child Health Plus page captured January 2020 (pre-2023 schedule with $27 cap at 160-222 percent FPL)
+    - title: CHIP State Plan Amendment NY-22-0033, eliminating the 9 dollar tier and extending free coverage to 222 percent FPL, effective October 1, 2022
+      href: https://www.medicaid.gov/CHIP/Downloads/NY-22-0033-CHIP.pdf#page=1
+    - title: Child Health Plus page captured January 2020 (pre-restructuring schedule with $27 cap at 160-222 percent FPL)
       href: https://web.archive.org/web/20200118155511/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
-    - title: Child Health Plus page captured February 2023 (restructured schedule)
+    - title: Child Health Plus page captured February 2023 (documents the restructured schedule)
       href: https://web.archive.org/web/20230207084107/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: 2026 Income Levels for Medicaid, Child Health Plus and Essential Plan (CHPlus bands unchanged; the 223 percent column is the Medicaid pregnant women and under-1 limit)
+      href: https://info.nystateofhealth.ny.gov/sites/default/files/2026%20Income%20Levels_for%20Medicaid,%20CHPlus%20&%20EP.pdf
     - title: New York Child Health Plus CY 2025 Rate Development, CY 2025 Rate Summary
       href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY25/NY%20CY25%20CHPlus%20Rate%20Presentation%20-%202024.11.08.pdf#page=14
     - title: New York Child Health Plus CY 2026 Rate Development, CY 2026 Rate Summary
       href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY26/NY%20CY26%20CHPlus%20Rate%20Presentation%20-%202025.11.10_FINAL.pdf#page=16
+# SPA NY-22-0033 (effective 2022-10-01) eliminated the 9 dollar tier and
+# extended free coverage to 222 percent FPL. The band thresholds have not
+# changed since: the 2026 income-levels chart keeps them at 222/250/300/350
+# percent FPL, and its 223 percent column is the Medicaid pregnant women
+# and children under age 1 limit, not a CHPlus band.
 brackets:
   - threshold:
       2020-01-01: -.inf
@@ -23,36 +32,32 @@ brackets:
       2020-01-01: 0
   - threshold:
       2020-01-01: 1.60
-      2023-02-01: 2.22
-      2026-02-17: 2.23
+      2022-10-01: 2.22
     amount:
       2020-01-01: 27
-      2023-02-01: 45
+      2022-10-01: 45
   - threshold:
       2020-01-01: 2.22
-      2023-02-01: 2.50
-      2026-02-17: 2.51
+      2022-10-01: 2.50
     amount:
       2020-01-01: 45
-      2023-02-01: 90
+      2022-10-01: 90
   - threshold:
       2020-01-01: 2.50
-      2023-02-01: 3.00
-      2026-02-17: 3.01
+      2022-10-01: 3.00
     amount:
       2020-01-01: 90
-      2023-02-01: 135
+      2022-10-01: 135
   - threshold:
       2020-01-01: 3.00
-      2023-02-01: 3.50
-      2026-02-17: 3.51
+      2022-10-01: 3.50
     amount:
       2020-01-01: 135
-      2023-02-01: 180
+      2022-10-01: 180
   - threshold:
       2020-01-01: 3.50
-      2023-02-01: 4.00
+      2022-10-01: 4.00
     amount:
       2020-01-01: 180
-      2023-02-01: 0
+      2022-10-01: 0
       2024-01-01: .inf

--- a/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/per_child.yaml
+++ b/policyengine_us/parameters/gov/states/ny/hhs/chip/premium/per_child.yaml
@@ -8,16 +8,23 @@ metadata:
   reference:
     - title: New York State Department of Health - Child Health Plus Eligibility and Cost (current)
       href: https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
-    - title: Child Health Plus page captured January 2020 (pre-2023 schedule with $9 tier at 160-222 percent FPL)
+    - title: CHIP State Plan Amendment NY-22-0033, eliminating the 9 dollar tier and extending free coverage to 222 percent FPL, effective October 1, 2022
+      href: https://www.medicaid.gov/CHIP/Downloads/NY-22-0033-CHIP.pdf#page=1
+    - title: Child Health Plus page captured January 2020 (pre-restructuring schedule with $9 tier at 160-222 percent FPL)
       href: https://web.archive.org/web/20200118155511/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
-    - title: Child Health Plus page captured February 2023 (restructured schedule, $9 tier eliminated, free threshold raised to 222 percent FPL)
+    - title: Child Health Plus page captured February 2023 (documents the restructured schedule)
       href: https://web.archive.org/web/20230207084107/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
-    - title: Child Health Plus page captured February 2024 (first page using "Effective for applications received on or after" caption)
-      href: https://web.archive.org/web/20240229061759/https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm
+    - title: 2026 Income Levels for Medicaid, Child Health Plus and Essential Plan (CHPlus bands unchanged; the 223 percent column is the Medicaid pregnant women and under-1 limit)
+      href: https://info.nystateofhealth.ny.gov/sites/default/files/2026%20Income%20Levels_for%20Medicaid,%20CHPlus%20&%20EP.pdf
     - title: New York Child Health Plus CY 2025 Rate Development, CY 2025 Rate Summary
       href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY25/NY%20CY25%20CHPlus%20Rate%20Presentation%20-%202024.11.08.pdf#page=14
     - title: New York Child Health Plus CY 2026 Rate Development, CY 2026 Rate Summary
       href: https://mmcor.phpcoalition.org/docs/Rate%20Setting%20Documents/CY26/NY%20CY26%20CHPlus%20Rate%20Presentation%20-%202025.11.10_FINAL.pdf#page=16
+# SPA NY-22-0033 (effective 2022-10-01) eliminated the 9 dollar tier and
+# extended free coverage to 222 percent FPL. The band thresholds have not
+# changed since: the 2026 income-levels chart keeps them at 222/250/300/350
+# percent FPL, and its 223 percent column is the Medicaid pregnant women
+# and children under age 1 limit, not a CHPlus band.
 brackets:
   - threshold:
       2020-01-01: -.inf
@@ -25,38 +32,34 @@ brackets:
       2020-01-01: 0
   - threshold:
       2020-01-01: 1.60
-      2023-02-01: 2.22
-      2026-02-17: 2.23
+      2022-10-01: 2.22
     amount:
       2020-01-01: 9
-      2023-02-01: 15
+      2022-10-01: 15
   - threshold:
       2020-01-01: 2.22
-      2023-02-01: 2.50
-      2026-02-17: 2.51
+      2022-10-01: 2.50
     amount:
       2020-01-01: 15
-      2023-02-01: 30
+      2022-10-01: 30
   - threshold:
       2020-01-01: 2.50
-      2023-02-01: 3.00
-      2026-02-17: 3.01
+      2022-10-01: 3.00
     amount:
       2020-01-01: 30
-      2023-02-01: 45
+      2022-10-01: 45
   - threshold:
       2020-01-01: 3.00
-      2023-02-01: 3.50
-      2026-02-17: 3.51
+      2022-10-01: 3.50
     amount:
       2020-01-01: 45
-      2023-02-01: 60
+      2022-10-01: 60
   - threshold:
       2020-01-01: 3.50
-      2023-02-01: 4.00
+      2022-10-01: 4.00
     amount:
       2020-01-01: 60
-      2023-02-01: 0
+      2022-10-01: 0
       2024-01-01: 267.06
       2025-01-01: 272.35
       2026-01-01: 270.14

--- a/policyengine_us/tests/policy/baseline/gov/hhs/chip/chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/chip/chip_premium.yaml
@@ -54,7 +54,7 @@
   output:
     chip_premium: 180
 
-- name: Federal chip_premium aggregates Missouri family-size premium.
+- name: Federal chip_premium sums Missouri's monthly premium across the two schedules a calendar year spans.
   period: 2024
   input:
     people:
@@ -76,7 +76,9 @@
         members: [p, c1, c2]
         state_code: MO
   output:
-    chip_premium: 300
+    # Size-3 tier 1: 6 x 25 through June 2024, then 6 x 30 from July 1.
+    # Well under the 5 percent cap on 100,000 dollars of income.
+    chip_premium: 330
 
 - name: Federal chip_premium caps Missouri tier 3 premium at 5 percent of income.
   period: 2024

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/hhs/chip/ga_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/hhs/chip/ga_chip_premium.yaml
@@ -1,4 +1,7 @@
-- name: Georgia PeachCare tier 1 tax unit with one child pays 11 dollars monthly.
+# 2025 sits entirely within the schedule that took effect on 2024-10-01, so
+# every month carries the same premium and the calendar year is twelve times
+# the monthly amount.
+- name: Georgia PeachCare tier 1 tax unit with one child pays 11 dollars in every month of 2025.
   period: 2025
   input:
     people:
@@ -14,7 +17,11 @@
         members: [child]
         state_code: GA
   output:
-    ga_chip_premium: 132
+    ga_chip_premium:
+      2025-01: 11
+      2025-07: 11
+      2025-12: 11
+      2025: 132 # 12 x 11
 
 - name: Georgia PeachCare tier 1 tax unit with three children is capped at 16 dollars monthly.
   period: 2025

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/hhs/chip/ga_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/hhs/chip/ga_chip_premium.yaml
@@ -74,6 +74,32 @@
   output:
     ga_chip_premium: 192
 
+# Manual 2194 charges no premium for children under age six, so only the
+# eight-year-old is counted.
+- name: Georgia PeachCare charges only the child aged six or older.
+  period: 2025
+  input:
+    people:
+      young_child:
+        age: 5
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+      older_child:
+        age: 8
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [young_child, older_child]
+        tax_unit_medicaid_income_level: 1.40
+    households:
+      household:
+        members: [young_child, older_child]
+        state_code: GA
+  output:
+    ga_chip_premium:
+      2025-01: 11
+
 - name: Georgia PeachCare below 134 percent FPL owes no premium.
   period: 2025
   input:

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/hhs/chip/ga_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/hhs/chip/ga_chip_premium.yaml
@@ -1,3 +1,30 @@
+# Premiums were suspended during the COVID public health emergency and
+# resumed on 2024-10-01, so 2024 spans the boundary: September carries no
+# premium, October carries the tier 1 amount, and the calendar year is three
+# times the monthly amount.
+- name: Georgia PeachCare tier 1 tax unit pays nothing in September 2024 and 11 dollars from October 2024.
+  period: 2024
+  input:
+    people:
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [child]
+        tax_unit_medicaid_income_level: 1.40
+    households:
+      household:
+        members: [child]
+        state_code: GA
+  output:
+    ga_chip_premium:
+      2024-01: 0
+      2024-09: 0
+      2024-10: 11
+      2024-12: 11
+      2024: 33 # 3 x 11
+
 # 2025 sits entirely within the schedule that took effect on 2024-10-01, so
 # every month carries the same premium and the calendar year is twelve times
 # the monthly amount.

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/hhs/chip/mo_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/hhs/chip/mo_chip_premium.yaml
@@ -207,11 +207,13 @@
 
 # The unborn child counts only in the pregnant member's own MAGI household;
 # the CHIP child's household counts the pregnant member as one person (DSS
-# manual 1885.010.00 example), so the chart keeps the size-2 boundaries
-# (2,705 / 3,337 / 4,058 dollars in 2026) and size-2 amounts. The pregnancy
-# still enlarges the FPG underlying tax_unit_medicaid_income_level, which
-# the formula must undo when recovering dollar income.
-- name: Missouri pregnant parent with one child at 4,058 dollars monthly in 2026 pays the size-2 tier 2 premiums.
+# manual 1885.010.00 example), so the chart keeps the size-2 boundaries and
+# size-2 amounts. The pregnancy still enlarges the FPG underlying
+# tax_unit_medicaid_income_level, which the formula must undo when
+# recovering dollar income. At 4,058 dollars monthly the family sits above
+# the July 2025 chart's tier 3 floor (3,966 dollars) through June and at
+# the July 2026 chart's tier 2 ceiling from July.
+- name: Missouri pregnant parent with one child at 4,058 dollars monthly in 2026 moves from tier 3 to tier 2 at the July chart change.
   period: 2026
   input:
     people:
@@ -231,9 +233,9 @@
         state_code: MO
   output:
     mo_chip_premium:
-      2026-06: 81
+      2026-06: 198
       2026-07: 83
-      2026: 984 # 6 x 81 + 6 x 83
+      2026: 1_686 # 6 x 198 + 6 x 83
 
 - name: Missouri pregnant parent with one child at 4,212 dollars monthly in 2026 pays the size-2 tier 3 premiums.
   period: 2026
@@ -260,12 +262,37 @@
       2026: 2_406 # 6 x 198 + 6 x 203
 
 # Boundary tests for the Appendix E chart's rounded monthly-dollar tier
-# boundaries. Family of 2 in 2026: FPG is 21,640 dollars (1,803.33 monthly),
-# so the ceiled boundaries are 2,705 / 3,337 / 4,058 dollars. The FPG only
-# changes each January, so the boundaries hold for the whole calendar year,
-# while the premium amounts change on July 1: 25 / 81 / 198 dollars under the
-# July 2025 schedule and 25 / 83 / 203 dollars under the July 2026 schedule.
-- name: Missouri family of 2 just below the tier 1 floor (2,704 dollars monthly) in 2026 owes no premium.
+# boundaries. Each July edition derives its boundaries from that January's
+# FPG and stays in force through the following June, so 2026 spans two
+# charts for a family of 2: January-June uses the July 2025 chart built on
+# the 2025 FPG of 21,150 dollars (floors 2,644 / 3,261 / 3,966, premiums
+# 25 / 81 / 198), and July-December uses the July 2026 chart built on the
+# 2026 FPG of 21,640 dollars (floors 2,705 / 3,337 / 4,058, premiums
+# 25 / 83 / 203).
+- name: Missouri family of 2 at the July 2025 chart's tier 1 floor (2,644 dollars monthly) pays through June 2026 and falls below the July 2026 floor.
+  period: 2026
+  input:
+    people:
+      parent:
+        is_chip_eligible: false
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+        medicaid_magi: 31_728
+    households:
+      household:
+        members: [parent, child]
+        state_code: MO
+  output:
+    mo_chip_premium:
+      2026-06: 25
+      2026-07: 0
+      2026: 150 # 6 x 25
+
+- name: Missouri family of 2 at 2,704 dollars monthly in 2026 pays tier 1 through June and nothing from July.
   period: 2026
   input:
     people:
@@ -283,9 +310,12 @@
         members: [parent, child]
         state_code: MO
   output:
-    mo_chip_premium: 0
+    mo_chip_premium:
+      2026-06: 25
+      2026-07: 0
+      2026: 150 # 6 x 25
 
-- name: Missouri family of 2 at the tier 1 floor (2,705 dollars monthly) in 2026 pays the tier 1 premium.
+- name: Missouri family of 2 at 2,705 dollars monthly in 2026 pays the tier 1 premium under both charts.
   period: 2026
   input:
     people:
@@ -305,7 +335,7 @@
   output:
     mo_chip_premium: 300
 
-- name: Missouri family of 2 at the published tier 1 upper boundary (3,337 dollars monthly) in 2026 stays in tier 1.
+- name: Missouri family of 2 at 3,337 dollars monthly in 2026 is in tier 2 through June and at the tier 1 ceiling from July.
   period: 2026
   input:
     people:
@@ -323,9 +353,12 @@
         members: [parent, child]
         state_code: MO
   output:
-    mo_chip_premium: 300
+    mo_chip_premium:
+      2026-06: 81
+      2026-07: 25
+      2026: 636 # 6 x 81 + 6 x 25
 
-- name: Missouri family of 2 one dollar above the tier 1 upper boundary (3,338 dollars monthly) in 2026 pays the tier 2 premium.
+- name: Missouri family of 2 at 3,338 dollars monthly in 2026 pays the tier 2 premium under both charts.
   period: 2026
   input:
     people:
@@ -349,7 +382,7 @@
       2026-08: 83
       2026: 984 # 6 x 81 + 6 x 83
 
-- name: Missouri family of 2 at the published tier 2 upper boundary (4,058 dollars monthly) in 2026 stays in tier 2.
+- name: Missouri family of 2 at 4,058 dollars monthly in 2026 is in tier 3 through June and at the tier 2 ceiling from July.
   period: 2026
   input:
     people:
@@ -368,11 +401,11 @@
         state_code: MO
   output:
     mo_chip_premium:
-      2026-06: 81
+      2026-06: 198
       2026-07: 83
-      2026: 984 # 6 x 81 + 6 x 83
+      2026: 1_686 # 6 x 198 + 6 x 83
 
-- name: Missouri family of 2 one dollar above the tier 2 upper boundary (4,059 dollars monthly) in 2026 pays the tier 3 premium.
+- name: Missouri family of 2 at 4,059 dollars monthly in 2026 pays the tier 3 premium under both charts.
   period: 2026
   input:
     people:

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/hhs/chip/mo_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/hhs/chip/mo_chip_premium.yaml
@@ -1,4 +1,4 @@
-- name: Missouri tier 1 family of 3 in 2024 uses the pre-July 2024 schedule (25 dollars monthly).
+- name: Missouri tier 1 family of 3 in 2024 pays six months at 25 dollars then six at 30.
   period: 2024
   input:
     people:
@@ -19,9 +19,12 @@
         members: [parent, child1, child2]
         state_code: MO
   output:
-    mo_chip_premium: 300
+    mo_chip_premium:
+      2024-06: 25
+      2024-07: 30
+      2024: 330 # 6 x 25 + 6 x 30
 
-- name: Missouri tier 2 family of 4 in 2024 uses the pre-July 2024 schedule (99 dollars monthly).
+- name: Missouri tier 2 family of 4 in 2024 pays six months at 99 dollars then six at 119.
   period: 2024
   input:
     people:
@@ -44,9 +47,12 @@
         members: [p1, p2, c1, c2]
         state_code: MO
   output:
-    mo_chip_premium: 1188
+    mo_chip_premium:
+      2024-06: 99
+      2024-07: 119
+      2024: 1308 # 6 x 99 + 6 x 119
 
-- name: Missouri tier 1 family of 3 in 2026 uses the post-July 2025 schedule (31 dollars monthly).
+- name: Missouri tier 1 family of 3 in 2026 pays six months at 31 dollars then six at 32.
   period: 2026
   input:
     people:
@@ -67,9 +73,12 @@
         members: [parent, child1, child2]
         state_code: MO
   output:
-    mo_chip_premium: 372
+    mo_chip_premium:
+      2026-06: 31
+      2026-07: 32
+      2026: 378 # 6 x 31 + 6 x 32
 
-- name: Missouri tier 1 family of 3 in 2027 uses the post-July 2026 schedule (32 dollars monthly).
+- name: Missouri tier 1 family of 3 in 2027 uses the post-July 2026 schedule (32 dollars monthly) all year.
   period: 2027
   input:
     people:
@@ -202,7 +211,7 @@
 # (2,705 / 3,337 / 4,058 dollars in 2026) and size-2 amounts. The pregnancy
 # still enlarges the FPG underlying tax_unit_medicaid_income_level, which
 # the formula must undo when recovering dollar income.
-- name: Missouri pregnant parent with one child at 4,058 dollars monthly in 2026 pays the size-2 tier 2 premium.
+- name: Missouri pregnant parent with one child at 4,058 dollars monthly in 2026 pays the size-2 tier 2 premiums.
   period: 2026
   input:
     people:
@@ -221,9 +230,12 @@
         members: [parent, child]
         state_code: MO
   output:
-    mo_chip_premium: 972
+    mo_chip_premium:
+      2026-06: 81
+      2026-07: 83
+      2026: 984 # 6 x 81 + 6 x 83
 
-- name: Missouri pregnant parent with one child at 4,212 dollars monthly in 2026 pays the size-2 tier 3 premium.
+- name: Missouri pregnant parent with one child at 4,212 dollars monthly in 2026 pays the size-2 tier 3 premiums.
   period: 2026
   input:
     people:
@@ -242,12 +254,17 @@
         members: [parent, child]
         state_code: MO
   output:
-    mo_chip_premium: 2_376
+    mo_chip_premium:
+      2026-06: 198
+      2026-07: 203
+      2026: 2_406 # 6 x 198 + 6 x 203
 
 # Boundary tests for the Appendix E chart's rounded monthly-dollar tier
 # boundaries. Family of 2 in 2026: FPG is 21,640 dollars (1,803.33 monthly),
-# so the ceiled boundaries are 2,705 / 3,337 / 4,058 dollars, and January
-# 2026 resolves to the July 2025 premium schedule (25 / 81 / 198 dollars).
+# so the ceiled boundaries are 2,705 / 3,337 / 4,058 dollars. The FPG only
+# changes each January, so the boundaries hold for the whole calendar year,
+# while the premium amounts change on July 1: 25 / 81 / 198 dollars under the
+# July 2025 schedule and 25 / 83 / 203 dollars under the July 2026 schedule.
 - name: Missouri family of 2 just below the tier 1 floor (2,704 dollars monthly) in 2026 owes no premium.
   period: 2026
   input:
@@ -326,7 +343,11 @@
         members: [parent, child]
         state_code: MO
   output:
-    mo_chip_premium: 972
+    mo_chip_premium:
+      2026-06: 81
+      2026-07: 83
+      2026-08: 83
+      2026: 984 # 6 x 81 + 6 x 83
 
 - name: Missouri family of 2 at the published tier 2 upper boundary (4,058 dollars monthly) in 2026 stays in tier 2.
   period: 2026
@@ -346,7 +367,10 @@
         members: [parent, child]
         state_code: MO
   output:
-    mo_chip_premium: 972
+    mo_chip_premium:
+      2026-06: 81
+      2026-07: 83
+      2026: 984 # 6 x 81 + 6 x 83
 
 - name: Missouri family of 2 one dollar above the tier 2 upper boundary (4,059 dollars monthly) in 2026 pays the tier 3 premium.
   period: 2026
@@ -366,4 +390,7 @@
         members: [parent, child]
         state_code: MO
   output:
-    mo_chip_premium: 2_376
+    mo_chip_premium:
+      2026-06: 198
+      2026-07: 203
+      2026: 2_406 # 6 x 198 + 6 x 203

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
@@ -1,9 +1,8 @@
-# New York's schedule changes take effect in February, so a calendar year
-# spans two schedules. The 2023 restructuring eliminated the 9 dollar tier and
-# raised the free threshold from 160 to 222 percent FPL, so a child at 180
-# percent FPL pays only for January 2023.
-- name: New York Child Health Plus charges 9 dollars for January 2023 only, before the February 2023 restructuring.
-  period: 2023
+# SPA NY-22-0033 (effective 2022-10-01) eliminated the 9 dollar tier and
+# raised the free threshold from 160 to 222 percent FPL mid-year, so a
+# child at 180 percent FPL pays only through September 2022.
+- name: New York Child Health Plus charges 9 dollars through September 2022 and nothing from October 2022.
+  period: 2022
   input:
     people:
       child:
@@ -19,14 +18,32 @@
         state_code: NY
   output:
     ny_chip_premium:
-      2023-01: 9
-      2023-02: 0
-      2023: 9
+      2022-09: 9
+      2022-10: 0
+      2022: 81 # 9 x 9
 
-# The 2026 schedule takes effect on 2026-02-17. Monthly resolution reads
-# parameters at the start of each month, so February 2026 still charges the
-# prior schedule and the new thresholds first bind in March 2026.
-- name: New York Child Health Plus at 222.5 percent FPL loses its 15 dollar premium when the 2026 thresholds bind in March.
+- name: New York Child Health Plus at 180 percent FPL owes nothing throughout 2023.
+  period: 2023
+  input:
+    people:
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [child]
+        tax_unit_medicaid_income_level: 1.80
+    households:
+      household:
+        members: [child]
+        state_code: NY
+  output:
+    ny_chip_premium: 0
+
+# The 2026 income-levels chart keeps the CHPlus bands at 222/250/300/350
+# percent FPL, so a family just above 222 percent FPL pays 15 dollars in
+# every month of 2026.
+- name: New York Child Health Plus at 222.5 percent FPL pays 15 dollars per month throughout 2026.
   period: 2026
   input:
     people:
@@ -45,28 +62,10 @@
     ny_chip_premium:
       2026-01: 15
       2026-02: 15
-      2026-03: 0
-      2026: 30 # 2 x 15
+      2026-03: 15
+      2026: 180 # 12 x 15
 
-- name: New York Child Health Plus in 2022 charges 9 dollars per child between 160 and 222 percent FPL.
-  period: 2022
-  input:
-    people:
-      child:
-        is_chip_eligible: true
-        is_chip_eligible_child: true
-    tax_units:
-      tax_unit:
-        members: [child]
-        tax_unit_medicaid_income_level: 1.80
-    households:
-      household:
-        members: [child]
-        state_code: NY
-  output:
-    ny_chip_premium: 108
-
-- name: New York Child Health Plus below 223 percent FPL owes no premium in 2024 after 9 dollar tier elimination.
+- name: New York Child Health Plus below 222 percent FPL owes no premium in 2024 after 9 dollar tier elimination.
   period: 2024
   input:
     people:

--- a/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ny/hhs/chip/ny_chip_premium.yaml
@@ -1,3 +1,53 @@
+# New York's schedule changes take effect in February, so a calendar year
+# spans two schedules. The 2023 restructuring eliminated the 9 dollar tier and
+# raised the free threshold from 160 to 222 percent FPL, so a child at 180
+# percent FPL pays only for January 2023.
+- name: New York Child Health Plus charges 9 dollars for January 2023 only, before the February 2023 restructuring.
+  period: 2023
+  input:
+    people:
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [child]
+        tax_unit_medicaid_income_level: 1.80
+    households:
+      household:
+        members: [child]
+        state_code: NY
+  output:
+    ny_chip_premium:
+      2023-01: 9
+      2023-02: 0
+      2023: 9
+
+# The 2026 schedule takes effect on 2026-02-17. Monthly resolution reads
+# parameters at the start of each month, so February 2026 still charges the
+# prior schedule and the new thresholds first bind in March 2026.
+- name: New York Child Health Plus at 222.5 percent FPL loses its 15 dollar premium when the 2026 thresholds bind in March.
+  period: 2026
+  input:
+    people:
+      child:
+        is_chip_eligible: true
+        is_chip_eligible_child: true
+    tax_units:
+      tax_unit:
+        members: [child]
+        tax_unit_medicaid_income_level: 2.225
+    households:
+      household:
+        members: [child]
+        state_code: NY
+  output:
+    ny_chip_premium:
+      2026-01: 15
+      2026-02: 15
+      2026-03: 0
+      2026: 30 # 2 x 15
+
 - name: New York Child Health Plus in 2022 charges 9 dollars per child between 160 and 222 percent FPL.
   period: 2022
   input:
@@ -104,7 +154,9 @@
         members: [person1, person2, person3, person4]
         state_code: NY
   output:
-    ny_chip_premium: 12_966.72
+    ny_chip_premium: 12_966.72 # 12 x 4 x 270.14
+  # Summing twelve monthly premiums accumulates float32 rounding.
+  absolute_error_margin: 0.01
 
 - name: Case 6, New York Child Health Plus above 400 percent FPL with one child pays the per-child full premium.
   period: 2026
@@ -122,4 +174,6 @@
         members: [person1]
         state_code: NY
   output:
-    ny_chip_premium: 3_241.68
+    ny_chip_premium: 3_241.68 # 12 x 270.14
+  # Summing twelve monthly premiums accumulates float32 rounding.
+  absolute_error_margin: 0.01

--- a/policyengine_us/variables/gov/hhs/chip/chip_premium.py
+++ b/policyengine_us/variables/gov/hhs/chip/chip_premium.py
@@ -41,6 +41,9 @@ class chip_premium(Variable):
     reference = "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-D/part-457/subpart-E/section-457.560"
 
     def formula(tax_unit, period, parameters):
+        # State premiums defined monthly (GA, MO, NY, whose schedules change
+        # mid-year) are summed over the twelve months of this year; annually
+        # defined state premiums are read directly.
         uncapped_premium = add(tax_unit, period, STATE_CHIP_PREMIUM_VARIABLES)
         p = parameters(period).gov.hhs.chip.cost_sharing.cap
         annual_family_income = max_(0, tax_unit("medicaid_magi", period))

--- a/policyengine_us/variables/gov/states/ga/hhs/chip/ga_chip_premium.py
+++ b/policyengine_us/variables/gov/states/ga/hhs/chip/ga_chip_premium.py
@@ -11,7 +11,13 @@ class ga_chip_premium(Variable):
         "the tax unit. Per-child monthly premium capped at a family maximum, "
         "tiered by the tax unit's income as a fraction of the federal "
         "poverty line. Defined monthly because premiums resumed mid-year, on "
-        "2024-10-01."
+        "2024-10-01. Manual 2194 charges no premium for children under age "
+        "six, children in foster care, or American Indians and Alaska "
+        "Natives; the AI/AN exemption is not modeled. The state phased the "
+        "2024 resumption in by renewal date - cases renewed before "
+        "2024-10-01 owed no premium until their next renewal - which is "
+        "not modeled, so premiums between October 2024 and September 2025 "
+        "are overstated for continuing enrollees."
     )
     definition_period = MONTH
     defined_for = StateCode.GA
@@ -21,9 +27,17 @@ class ga_chip_premium(Variable):
         # The child count is a count and the income level a ratio, so both are
         # read at the enclosing year rather than divided into monthly values.
         year = period.this_year
-        n_chip_children = add(tax_unit, year, ["is_chip_eligible_child"])
-        income_level = tax_unit("tax_unit_medicaid_income_level", year)
+        person = tax_unit.members
         p = parameters(period).gov.states.ga.hhs.chip.premium
+        # Manual 2194: no premium is charged for children under age six or
+        # children in foster care (the AI/AN exemption is not modeled).
+        charged_child = (
+            person("is_chip_eligible_child", year)
+            & (person("age", year) >= p.min_age)
+            & ~person("is_in_foster_care", period)
+        )
+        n_chip_children = tax_unit.sum(charged_child)
+        income_level = tax_unit("tax_unit_medicaid_income_level", year)
         per_child = p.per_child.calc(income_level)
         family_cap = p.family_cap.calc(income_level)
         return min_(n_chip_children * per_child, family_cap)

--- a/policyengine_us/variables/gov/states/ga/hhs/chip/ga_chip_premium.py
+++ b/policyengine_us/variables/gov/states/ga/hhs/chip/ga_chip_premium.py
@@ -4,23 +4,26 @@ from policyengine_us.model_api import *
 class ga_chip_premium(Variable):
     value_type = float
     entity = TaxUnit
-    label = "Georgia PeachCare for Kids annual premium"
+    label = "Georgia PeachCare for Kids monthly premium"
     unit = USD
     documentation = (
-        "Annual Georgia PeachCare for Kids (separate CHIP) premium paid by "
+        "Monthly Georgia PeachCare for Kids (separate CHIP) premium paid by "
         "the tax unit. Per-child monthly premium capped at a family maximum, "
         "tiered by the tax unit's income as a fraction of the federal "
-        "poverty line. Premiums resumed on 2024-10-01."
+        "poverty line. Defined monthly because premiums resumed mid-year, on "
+        "2024-10-01."
     )
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.GA
     reference = "https://dch.georgia.gov/announcement/2024-08-13/peachcare-kidsr-co-payments-and-premiums-resume-oct-1-2024"
 
     def formula(tax_unit, period, parameters):
-        n_chip_children = add(tax_unit, period, ["is_chip_eligible_child"])
-        income_level = tax_unit("tax_unit_medicaid_income_level", period)
+        # The child count is a count and the income level a ratio, so both are
+        # read at the enclosing year rather than divided into monthly values.
+        year = period.this_year
+        n_chip_children = add(tax_unit, year, ["is_chip_eligible_child"])
+        income_level = tax_unit("tax_unit_medicaid_income_level", year)
         p = parameters(period).gov.states.ga.hhs.chip.premium
         per_child = p.per_child.calc(income_level)
         family_cap = p.family_cap.calc(income_level)
-        monthly = min_(n_chip_children * per_child, family_cap)
-        return monthly * MONTHS_IN_YEAR
+        return min_(n_chip_children * per_child, family_cap)

--- a/policyengine_us/variables/gov/states/mo/hhs/chip/mo_chip_premium.py
+++ b/policyengine_us/variables/gov/states/mo/hhs/chip/mo_chip_premium.py
@@ -39,8 +39,10 @@ class mo_chip_premium(Variable):
         # dollars explicitly.
         # tax_unit_medicaid_income_level divides income by an FPG that
         # counts children a pregnant member is expected to deliver;
-        # multiply by that same FPG to recover monthly dollar income.
-        income_fpg = fpg(family_size + pregnant_count, state_group, period, parameters)
+        # multiply by that same FPG to recover monthly dollar income. Read it
+        # at the year so it resolves at the same instant as the annual income
+        # level's divisor and the round-trip cancels exactly.
+        income_fpg = fpg(family_size + pregnant_count, state_group, year, parameters)
         # Missouri keys the Appendix E chart on the CHIP child's MAGI
         # household size, which counts a pregnant member as one person -
         # the unborn child counts only in the pregnant member's own

--- a/policyengine_us/variables/gov/states/mo/hhs/chip/mo_chip_premium.py
+++ b/policyengine_us/variables/gov/states/mo/hhs/chip/mo_chip_premium.py
@@ -5,17 +5,19 @@ from policyengine_us.variables.gov.hhs.tax_unit_fpg import fpg
 class mo_chip_premium(Variable):
     value_type = float
     entity = TaxUnit
-    label = "Missouri MO HealthNet for Kids annual CHIP premium"
+    label = "Missouri MO HealthNet for Kids monthly CHIP premium"
     unit = USD
     documentation = (
-        "Annual Missouri MO HealthNet for Kids (separate CHIP) premium "
+        "Monthly Missouri MO HealthNet for Kids (separate CHIP) premium "
         "paid by the tax unit. The state sets one household-level monthly "
         "premium that varies by both family size and three FPL tiers, "
         "assigned by comparing monthly income to the Appendix E chart's "
         "dollar boundaries: each FPL percentage converted to monthly "
-        "dollars and rounded up to the next whole dollar."
+        "dollars and rounded up to the next whole dollar. Defined monthly "
+        "because Missouri revises the Appendix E schedule every July 1, so "
+        "a calendar year spans two schedules."
     )
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.MO
     reference = (
         "https://mydss.mo.gov/childrens-health-insurance-program-chip-premium-chart",
@@ -23,11 +25,18 @@ class mo_chip_premium(Variable):
     )
 
     def formula(tax_unit, period, parameters):
-        has_chip_member = add(tax_unit, period, ["is_chip_eligible"]) > 0
-        income_level = tax_unit("tax_unit_medicaid_income_level", period)
-        family_size = tax_unit("tax_unit_size", period)
-        pregnant_count = add(tax_unit, period, ["current_pregnancies"])
-        state_group = tax_unit.household("state_group_str", period)
+        # Every input below is annually defined: eligibility and the pregnancy
+        # count are counts, and the income level is a ratio, so none of them
+        # should be divided into a monthly value.
+        year = period.this_year
+        has_chip_member = add(tax_unit, year, ["is_chip_eligible"]) > 0
+        income_level = tax_unit("tax_unit_medicaid_income_level", year)
+        family_size = tax_unit("tax_unit_size", year)
+        pregnant_count = add(tax_unit, year, ["current_pregnancies"])
+        state_group = tax_unit.household("state_group_str", year)
+        # The FPG parameters are annual dollars, and parameters are never
+        # auto-divided, so both FPG figures below are converted to monthly
+        # dollars explicitly.
         # tax_unit_medicaid_income_level divides income by an FPG that
         # counts children a pregnant member is expected to deliver;
         # multiply by that same FPG to recover monthly dollar income.
@@ -61,4 +70,4 @@ class mo_chip_premium(Variable):
             ],
             default=0,
         )
-        return has_chip_member * monthly_premium * MONTHS_IN_YEAR
+        return has_chip_member * monthly_premium

--- a/policyengine_us/variables/gov/states/mo/hhs/chip/mo_chip_premium.py
+++ b/policyengine_us/variables/gov/states/mo/hhs/chip/mo_chip_premium.py
@@ -47,7 +47,18 @@ class mo_chip_premium(Variable):
         # household size, which counts a pregnant member as one person -
         # the unborn child counts only in the pregnant member's own
         # household (DSS manual 1885.010.00 household example).
-        monthly_fpg = fpg(family_size, state_group, period, parameters) / MONTHS_IN_YEAR
+        # Each July edition of the chart derives its dollar boundaries from
+        # its issue year's January FPG and stays in force through the
+        # following June (the 07-25 chart's size-2 tier 1 floor is 1.5 x the
+        # 2025 FPG, and the 07-26 chart's is 1.5 x the 2026 FPG), so
+        # January-June months read the prior January's FPG.
+        if period.start.month >= 7:
+            chart_instant = f"{period.start.year}-01-01"
+        else:
+            chart_instant = f"{period.start.year - 1}-01-01"
+        monthly_fpg = (
+            fpg(family_size, state_group, chart_instant, parameters) / MONTHS_IN_YEAR
+        )
         p = parameters(period).gov.states.mo.hhs.chip.premium
         # The Appendix E chart sets each tier boundary at the FPL percentage
         # converted to monthly dollars and rounded up to the next whole

--- a/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
+++ b/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
@@ -13,7 +13,8 @@ class ny_chip_premium(Variable):
         "as a fraction of the federal poverty line. Families above 400 "
         "percent FPL pay an uncapped statewide average full plan premium, "
         "because the actual premium varies by health plan. Defined monthly "
-        "because New York's schedule changes take effect in February."
+        "because schedule changes take effect mid-year, most recently the "
+        "October 2022 restructuring under SPA NY-22-0033."
     )
     definition_period = MONTH
     defined_for = StateCode.NY

--- a/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
+++ b/policyengine_us/variables/gov/states/ny/hhs/chip/ny_chip_premium.py
@@ -4,25 +4,28 @@ from policyengine_us.model_api import *
 class ny_chip_premium(Variable):
     value_type = float
     entity = TaxUnit
-    label = "New York Child Health Plus annual premium"
+    label = "New York Child Health Plus monthly premium"
     unit = USD
     documentation = (
-        "Annual New York Child Health Plus (separate CHIP) premium paid by "
+        "Monthly New York Child Health Plus (separate CHIP) premium paid by "
         "the tax unit. Subsidized per-child monthly premiums are capped at "
         "a three-child family maximum and tiered by the tax unit's income "
         "as a fraction of the federal poverty line. Families above 400 "
         "percent FPL pay an uncapped statewide average full plan premium, "
-        "because the actual premium varies by health plan."
+        "because the actual premium varies by health plan. Defined monthly "
+        "because New York's schedule changes take effect in February."
     )
-    definition_period = YEAR
+    definition_period = MONTH
     defined_for = StateCode.NY
     reference = "https://www.health.ny.gov/health_care/child_health_plus/eligibility_and_cost.htm"
 
     def formula(tax_unit, period, parameters):
-        n_chip_children = add(tax_unit, period, ["is_chip_eligible_child"])
-        income_level = tax_unit("tax_unit_medicaid_income_level", period)
+        # The child count is a count and the income level a ratio, so both are
+        # read at the enclosing year rather than divided into monthly values.
+        year = period.this_year
+        n_chip_children = add(tax_unit, year, ["is_chip_eligible_child"])
+        income_level = tax_unit("tax_unit_medicaid_income_level", year)
         p = parameters(period).gov.states.ny.hhs.chip.premium
         per_child = p.per_child.calc(income_level)
         family_cap = p.family_cap.calc(income_level)
-        monthly = min_(n_chip_children * per_child, family_cap)
-        return monthly * MONTHS_IN_YEAR
+        return min_(n_chip_children * per_child, family_cap)


### PR DESCRIPTION
## Summary

State CHIP premium variables were `definition_period = YEAR`, so `parameters(period)` resolved at January 1 and any mid-year schedule change stayed invisible for the rest of the calendar year. Missouri revises its Appendix E schedule **every July 1**, so MO was permanently understated rather than wrong only in a transition year. Georgia's premiums resumed **October 1, 2024** after the COVID-era suspension, and New York's restructuring took effect **October 1, 2022** mid-year.

Converts `mo_chip_premium`, `ga_chip_premium`, and `ny_chip_premium` to `MONTH`, and corrects the schedule data each conversion activates:

- **MO**: tier boundaries follow the operative Appendix E chart's July-to-June cycle instead of re-basing every January.
- **NY**: the restructuring is dated 2022-10-01 per SPA NY-22-0033, and erroneous 2026 threshold entries are removed.
- **GA**: the suspension period is encoded with explicit zeros, and children under six and in foster care are exempt per Manual 2194.

Fixes #9256
Fixes #8098

## What changed

| File | Change |
|---|---|
| `variables/gov/states/mo/hhs/chip/mo_chip_premium.py` | `YEAR` → `MONTH`; tier boundaries read the FPG of the operative chart's issue year (July–June cycle, `snap_fpg`-style instant selection); income-recovery FPG read at the year so it cancels exactly against `tax_unit_medicaid_income_level`'s divisor |
| `variables/gov/states/ga/hhs/chip/ga_chip_premium.py` | `YEAR` → `MONTH`; children under six and in foster care excluded from the premium count (Manual 2194); renewal-phased resumption documented |
| `variables/gov/states/ny/hhs/chip/ny_chip_premium.py` | `YEAR` → `MONTH` |
| `parameters/gov/states/ga/hhs/chip/premium/{per_child,family_cap}.yaml` | Explicit `2015-01-01: 0` amounts before the `2024-10-01` resumption values so `backdate_parameters` does not clone the resumption schedule over the suspension; DCH COVID-19 deck and resumption announcement cited |
| `parameters/gov/states/ga/hhs/chip/premium/min_age.yaml` | New: premium charged only from age 6 (Manual 2194) |
| `parameters/gov/states/ny/hhs/chip/premium/{per_child,family_cap}.yaml` | Restructuring re-dated `2023-02-01` → `2022-10-01` (SPA NY-22-0033); four `2026-02-17` threshold entries deleted — the 2026 income-levels chart keeps the bands at 222/250/300/350 percent FPL, and the 223 percent figure is the Medicaid pregnant-women/under-1 limit, not a CHPlus band |
| `variables/gov/hhs/chip/chip_premium.py` | Comment only — stays `YEAR`, sums the months via `add()` |

Every annually defined input (`is_chip_eligible`, `is_chip_eligible_child`, `current_pregnancies`, `tax_unit_medicaid_income_level`, `tax_unit_size`, `state_group_str`, `age`) is read at `period.this_year`, so Core does not divide counts and ratios by twelve.

The federal aggregator stays `YEAR`. Core sums a `MONTH` FLOW child over the twelve contained months, and the 42 CFR 457.560 five-percent cost-sharing cap continues to apply annually against annual income.

## Missouri: the Appendix E chart cycle

Each July edition of the chart derives its dollar tier boundaries from its issue year's January FPG and stays in force through the following June, verified against both charts:

- [IM-4(PRM) 07-26](https://dssmanuals.mo.gov/wp-content/uploads/2019/05/appendix-e.pdf) ("Effective July 1, 2026"): size-2 floors $2,705 / $3,337.01 / $4,058.01 = the 2026 FPG ($21,640/12) × 150/185/225%, premiums $25/$83/$203.
- [Live DSS chart (07-25)](https://mydss.mo.gov/childrens-health-insurance-program-chip-premium-chart) ("As of 07/01/2025"): size-2 floors $2,644 / $3,261.01 / $3,966.01 = the 2025 FPG ($21,150/12), premiums $25/$81/$198.

The formula selects the operative chart's FPG instant the same way `snap_fpg` selects the October fiscal-year instant: months from July read this year's January FPG, months through June read last year's. January–June 2026 therefore matches the 07-25 chart and July 2026 onward matches the 07-26 chart.

`tax_unit_medicaid_income_level` divides income by an FPG resolved at January 1 (it is a `YEAR` variable); the formula multiplies by an FPG read at the same instant so the round-trip recovers dollar income exactly by construction.

## New York: schedule data corrections

[SPA NY-22-0033](https://www.medicaid.gov/CHIP/Downloads/NY-22-0033-CHIP.pdf) (submitted 2022-09-15, effective and implemented **2022-10-01**) eliminated the $9 tier and extended free coverage to 222 percent FPL. The restructuring entries were previously keyed 2023-02-01 — the date of the earliest Wayback capture documenting the new schedule, not the legal effective date.

The former `2026-02-17` threshold entries (2.23/2.51/3.01/3.51) contradicted the official [2026 income-levels chart](https://info.nystateofhealth.ny.gov/sites/default/files/2026%20Income%20Levels_for%20Medicaid,%20CHPlus%20&%20EP.pdf), which keeps the CHPlus bands at "Free ≤222%, $15 >222–250%, $30 >250–300%, $45 >300–350%, $60 >350–400%". The 223 percent column on that chart is the Medicaid pregnant-women/children-under-1 limit (size-1 monthly $2,966 = 2.23 × $1,330) — a wrong-row transcription, now removed and documented in the parameter files.

## Georgia: suspension, resumption, and exemptions

Premiums were waived during the COVID federal emergency ([DCH COVID-19 operations deck, p.12](https://www.mmis.georgia.gov/portal/Portals/0/StaticContent/Public/ALL/NOTICES/Covid-19-%20Spring%20Medicaid%20Fair%202021%2020210325165058.pdf#page=12): "Waive all PeachCare for Kids® Premiums") and resumed 2024-10-01 ([DCH announcement](https://dch.georgia.gov/announcement/2024-08-13/peachcare-kidsr-co-payments-and-premiums-resume-oct-1-2024)). Without explicit pre-resumption values, `backdate_parameters` clones the 2024-10-01 amounts back to 2015, charging post-resumption premiums through the suspension. The parameter files carry `2015-01-01: 0` amounts with both citations.

Manual 2194 charges no premium for "children under age six (6), children in Foster Care or American Indians and Alaskan Natives (AI/AN)". The formula excludes under-six children (new `min_age` parameter) and children in foster care from the premium count; the AI/AN exemption has no suitable variable and is documented as unmodeled.

**Not modeled (by design)**:
- The pre-suspension premium schedule — years before the suspension show a zero premium; neither [PAMMS 2194](https://pamms.dhs.ga.gov/dfcs/medicaid/2194/) nor the DCH announcement documents the pre-2020 schedule, and medicaid.gov's SPA GA-24-0039/0041 returns 403. Left for follow-up rather than encoding inferred values.
- Renewal-phased resumption — the state charged premiums "for all new applicants and renewals that occur on or after Oct. 1, 2024", so continuing enrollees renewed earlier paid from their next renewal. Renewal timing is not modelable; premiums between October 2024 and September 2025 are overstated for those enrollees (documented in the variable).

## Correction to the issue's proposed fix

The issue proposed also dropping `monthly_fpg = fpg(...) / MONTHS_IN_YEAR` and the `/ MONTHS_IN_YEAR` in `monthly_income`. Those divisions **must stay**: `fpg()` reads the FPG *parameters*, and parameters are never auto-divided, so they are annual dollars even inside a `MONTH` formula. Only the trailing `* MONTHS_IN_YEAR` came out.

## Verification

Missouri family of 2 in tier 2, CY2026:

| Period | Before | After | Published rate |
|---|---|---|---|
| 2026-06 | 81 | 81 | 81 (07-25 chart) |
| 2026-07 | 81 | **83** | 83 (07-26 chart) |
| CY2026 | 972 | **984** | 6 × 81 + 6 × 83 |

Boundary incomes that sit between the two charts' floors now switch tiers at the July chart change, matching both published charts: $2,704/month pays $25 through June (above the 07-25 floor of $2,644) and $0 from July (below the 07-26 floor of $2,705); $3,337 is tier 2 ($81) through June and tier 1 ($25) from July; $4,058 is tier 3 ($198) through June and tier 2 ($83) from July.

Georgia tier 1 single-child unit, CY2024: $0 through September, $11 from October, CY2024 = **$33** (was $0 for the whole year under `YEAR` resolution, per #8098).

New York child at 180 percent FPL, CY2022: $9 through September, $0 from October, CY2022 = **$81**.

## Boundary tests

- **MO July 2026 chart change**: month-keyed assertions across June/July 2026 for tier-stable incomes ($2,705, $3,338, $4,059), tier-switching incomes ($2,704, $3,337, $4,058), and the exact 07-25 floor ($2,644).
- **GA October 2024 resumption**: `2024-01: 0`, `2024-09: 0`, `2024-10: 11`, `2024: 33`; under-six exemption test (age-5 child exempt, age-8 child charged).
- **NY October 2022 restructuring**: `2022-09: 9`, `2022-10: 0`, `2022: 81`; 2023 free at 180 percent FPL; 222.5 percent FPL pays $15 in every month of 2026.

The two NY above-400%-FPL cases needed `absolute_error_margin: 0.01`: summing twelve float32 monthly premiums lands at 12,966.723 rather than the single-multiply 12,966.72.

## Scope checklist

- [x] Convert `mo_chip_premium` to MONTH with chart-vintage tier boundaries
- [x] Convert `ga_chip_premium` to MONTH; encode the suspension so the 2024 Q4 resumption is modeled (#8098); exempt under-six and foster children
- [x] Convert `ny_chip_premium` to MONTH; correct the restructuring date and 2026 thresholds
- [x] Verify `chip_premium` still aggregates correctly and the 5% cap is unchanged
- [x] Add YAML tests asserting each state's mid-year boundary

## Test plan

- [x] MO (17), GA (5), NY (8), and federal `chip_premium` (100) suites pass locally
- [x] No partner contract test covers a GA/MO/NY CHIP household — none touched
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
