### PR TITLE
Default weekly_hours_worked_before_lsr to 0 to harden SNAP work requirements (#9254)

### DIFF
--- a/changelog.d/harden-snap-wr-hours-default.fixed.md
+++ b/changelog.d/harden-snap-wr-hours-default.fixed.md
@@ -1,0 +1,1 @@
+Default weekly_hours_worked_before_lsr to 0 rather than 40 so that missing hours data fails the SNAP work-requirement hours tests loudly instead of silently satisfying them.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/tanf/non_cash/meets_tanf_non_cash_gross_income_test.yaml
@@ -20,6 +20,7 @@
   absolute_error_margin: 0.05
   input:
     employment_income: 30_600 # 2550 monthly
+    weekly_hours_worked_before_lsr: 40
     state_code: NC
   output:
     snap_gross_income: 2_550

--- a/policyengine_us/tests/policy/baseline/gov/states/ak/dpa/ccap/benefit/ak_ccap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ak/dpa/ccap/benefit/ak_ccap.yaml
@@ -169,6 +169,7 @@
     people:
       parent:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
         # A small AK fishing operation has a bad season — net loss of $30K.
         self_employment_income: -30_000

--- a/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/az_ccap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/az_ccap.yaml
@@ -5,6 +5,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 0
         childcare_attending_days_per_month: 20
@@ -28,6 +29,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 0
         childcare_attending_days_per_month: 20
@@ -52,6 +54,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
         childcare_attending_days_per_month: 20

--- a/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/copay/az_ccap_copay_exempt.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/copay/az_ccap_copay_exempt.yaml
@@ -42,6 +42,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
     spm_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/eligibility/az_ccap_categorically_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/eligibility/az_ccap_categorically_eligible.yaml
@@ -42,6 +42,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
     spm_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/az/hhs/ccap/integration.yaml
@@ -5,6 +5,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 0
         childcare_attending_days_per_month: 20
@@ -58,6 +59,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 44_000
       person2:
         age: 4
@@ -88,6 +90,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
         childcare_attending_days_per_month: 20
@@ -112,6 +115,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
         childcare_attending_days_per_month: 20

--- a/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_snap_temporary_local_benefit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/dc/tax/income/dc_snap_temporary_local_benefit.yaml
@@ -4,6 +4,7 @@
     spm_unit_size: 1
     state_code: DC
     snap_region_str: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     # 291 * 0.1 = 29.1
     dc_snap_temporary_local_benefit: 29.1
@@ -14,6 +15,7 @@
     spm_unit_size: 4
     state_code: DC
     snap_region_str: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     # 973 * 0.1 = 97.3
     dc_snap_temporary_local_benefit: 97.3
@@ -24,6 +26,7 @@
     spm_unit_size: 4
     state_code: DC
     snap_region_str: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     # 973 * 0.1 = 97.3 * 9 = 875.7
     dc_snap_temporary_local_benefit: 875.7
@@ -34,6 +37,7 @@
     spm_unit_size: 10
     state_code: DC
     snap_region_str: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     # (1751 + 219 * 2) * 0.1 * 9 = 1_970.1
     dc_snap_temporary_local_benefit: 1_970.1
@@ -43,6 +47,7 @@
   input:
     snap_max_allotment: 1_000
     state_code: DC
+    weekly_hours_worked_before_lsr: 40
   output:
     # (1000 * 0.1) / 12 * 9 = 75
     dc_snap_temporary_local_benefit: 75

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/decal/caps/eligibility/ga_caps_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/decal/caps/eligibility/ga_caps_eligible.yaml
@@ -11,6 +11,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/decal/caps/ga_caps.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/decal/caps/ga_caps.yaml
@@ -16,6 +16,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 35_000
         immigration_status: CITIZEN
       person2:
@@ -58,6 +59,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -104,6 +106,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -144,6 +147,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -180,6 +184,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 5_000
         immigration_status: CITIZEN
       person2:
@@ -265,6 +270,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 15_000
         immigration_status: CITIZEN
       person2:
@@ -320,6 +326,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
         immigration_status: CITIZEN
       person2:
@@ -359,6 +366,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 10_000
         immigration_status: CITIZEN
       person2:
@@ -403,6 +411,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -438,6 +447,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 10_000
         immigration_status: CITIZEN
       person2:
@@ -484,6 +494,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 35_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ga/decal/caps/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ga/decal/caps/integration.yaml
@@ -24,6 +24,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -87,6 +88,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 2_000
         immigration_status: CITIZEN
       person2:
@@ -140,6 +142,7 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
         immigration_status: CITIZEN
       person2:
@@ -235,6 +238,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -304,6 +308,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 35_000
         immigration_status: CITIZEN
       person2:
@@ -398,10 +403,12 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 73_085
         immigration_status: CITIZEN
       person2:
         age: 38
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 10
@@ -486,6 +493,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 50_000
         immigration_status: CITIZEN
       person2:
@@ -581,6 +589,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -635,6 +644,7 @@
     people:
       person1:
         age: 50
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/ccap/ks_ccap_family_share.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ks/dcf/ccap/ks_ccap_family_share.yaml
@@ -438,6 +438,7 @@
         weekly_hours_worked_before_lsr: 40
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 10
         is_tax_unit_dependent: true
@@ -482,6 +483,7 @@
         weekly_hours_worked_before_lsr: 40
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 8
         is_tax_unit_dependent: true
@@ -519,6 +521,7 @@
         weekly_hours_worked_before_lsr: 40
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 9
         is_tax_unit_dependent: true

--- a/policyengine_us/tests/policy/baseline/gov/states/la/ldoe/ccap/la_ccap_daily_copay.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/la/ldoe/ccap/la_ccap_daily_copay.yaml
@@ -28,6 +28,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 42_000  # $3,500/month.
       person2:
         age: 2
@@ -48,6 +49,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 46_800  # $3,900/month.
       person2:
         age: 2
@@ -68,6 +70,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 49_200  # $4,100/month.
       person2:
         age: 2
@@ -88,6 +91,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 52_800  # $4,400/month.
       person2:
         age: 2
@@ -150,6 +154,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 40_800  # $3,400/month, 2024-scale $3 band starts at $3,400.
       person2:
         age: 2
@@ -191,6 +196,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 52_800  # Top band income, as in Case 5.
       person2:
         age: 2

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/dta/tcap/eaedc/ma_eaedc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/dta/tcap/eaedc/ma_eaedc.yaml
@@ -64,6 +64,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         is_disabled: false
         is_tax_unit_head_or_spouse: true
         weekly_hours_worked: 40

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/eec/ccfa/ma_ccfa.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/eec/ccfa/ma_ccfa.yaml
@@ -33,6 +33,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income_before_lsr: 1_800 * 12
         weekly_hours_worked: 40
       person2:
@@ -113,10 +114,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income_before_lsr: 2_000 * 12
         weekly_hours_worked: 40
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income_before_lsr: 1_500 * 12
         weekly_hours_worked: 30
       person3:
@@ -159,6 +162,7 @@
     people:
       person1:
         age: 29
+        weekly_hours_worked_before_lsr: 40
         employment_income_before_lsr: 1_800 * 12
         weekly_hours_worked: 35
       person2:
@@ -228,6 +232,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income_before_lsr: 5_000 * 12
         weekly_hours_worked: 35
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ccap/eligibility/me_ccap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ccap/eligibility/me_ccap_eligible.yaml
@@ -4,6 +4,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 5
         is_tax_unit_dependent: true

--- a/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/me/dhhs/ccap/integration.yaml
@@ -5,6 +5,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
       person2:
         age: 4
@@ -79,9 +80,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 45_000
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 10_000
       person3:
         age: 2
@@ -241,11 +244,13 @@
     people:
       person1:
         age: 42
+        weekly_hours_worked_before_lsr: 40
         # SMI for ME size 3 (2025-10-01): 118,065 * 0.84 = $99,174.60.
         # Target ~115% SMI => 99,175 * 1.15 = $114,051.
         employment_income: 115_000
       person2:
         age: 40
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 1
         is_tax_unit_dependent: true
@@ -312,6 +317,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 50_000
       person2:
         age: 15
@@ -410,6 +416,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
       person2:
         age: 4
@@ -462,9 +469,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 35_000
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 0
         is_tax_unit_dependent: true
@@ -548,10 +557,12 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         # Target ~110% SMI for size 4 => $118,065 * 1.10 = $129,871.50.
         employment_income: 129_872
       person2:
         age: 38
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 0
         is_tax_unit_dependent: true

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/eligibility/mn_ccap_activity_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/eligibility/mn_ccap_activity_eligible.yaml
@@ -11,6 +11,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 4
@@ -94,6 +95,7 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 30
@@ -143,9 +145,11 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
       person3:
         age: 4
@@ -278,6 +282,7 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 30

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/eligibility/mn_ccap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/eligibility/mn_ccap_eligible.yaml
@@ -8,6 +8,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 4

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/integration.yaml
@@ -12,6 +12,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # 2,500/month
       person2:
         age: 0
@@ -50,6 +51,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # size-2 copay band (>= 15,863) -> $2 biweekly
       person2:
         age: 0
@@ -81,6 +83,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -6_000_000  # large business loss
       person2:
         age: 0
@@ -112,6 +115,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # size-2 copay band (>= 15,863) -> $2 biweekly
       person2:
         age: 0
@@ -177,9 +181,11 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # $0 copay band
       person2:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 0
         childcare_hours_per_week: 45
@@ -241,6 +247,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -6_000_000  # large business loss, no deductions
       person2:
         age: 0
@@ -272,6 +279,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 62_000  # high income -> large copay
       person2:
         age: 0
@@ -303,6 +311,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
       person2:
         age: 0
@@ -336,6 +345,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
       person2:
         age: 0
@@ -367,6 +377,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
       person2:
         age: 0
@@ -397,9 +408,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 0  # infant
         childcare_hours_per_week: 45
@@ -443,6 +456,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
       person2:
         age: 0
@@ -474,6 +488,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
       person2:
         age: 0
@@ -506,6 +521,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
       person2:
         age: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/mn_child_care_subsidies.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/ccap/mn_child_care_subsidies.yaml
@@ -8,6 +8,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # size-2 copay band (>= 15,863) -> $2 biweekly
       person2:
         age: 0
@@ -64,6 +65,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # size-2 copay band -> $2 biweekly
       person2:
         age: 13

--- a/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/ccpp/ms_ccpp.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ms/dhs/ccpp/ms_ccpp.yaml
@@ -82,6 +82,7 @@
         weekly_hours_worked_before_lsr: 40
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 4
         is_tax_unit_dependent: true

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/dphhs/ccap/mt_ccap_copay.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/dphhs/ccap/mt_ccap_copay.yaml
@@ -10,6 +10,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_490  # 75% FPG; 0.5% of 1,707.50 = 8.54 < 10
       person2:
         age: 4
@@ -32,6 +33,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 27_320  # 100% FPG, ratio 1.0 -> 0.5%
       person2:
         age: 4
@@ -55,6 +57,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 41_520  # 3,460/mo, 152% of size-3 FPG
       person2:
         age: 4
@@ -79,6 +82,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 49_716  # 4,143/mo, 182% of size-3 FPG
       person2:
         age: 4
@@ -103,6 +107,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 46_992  # 3,916/mo, 172% of size-3 FPG
       person2:
         age: 4
@@ -126,6 +131,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 40_980  # would be 119.53 on the scale
       person2:
         age: 4
@@ -153,6 +159,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
       person2:
         age: 4
@@ -176,6 +183,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/mo; 0.5% of 2,000 = 10 exactly
       person2:
         age: 4
@@ -200,6 +208,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 28_140  # 103% of size-3 FPG (2,345/mo)
       person2:
         age: 4
@@ -223,6 +232,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 29_520  # 108% of size-3 FPG (2,460/mo)
       person2:
         age: 4
@@ -247,6 +257,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_600  # 112% of size-3 FPG (2,550/mo)
       person2:
         age: 4
@@ -270,6 +281,7 @@
   input:
     people:
       person1:
+        weekly_hours_worked_before_lsr: 40
         employment_income: 32_280  # 118% of size-3 FPG (2,690/mo)
       person2:
         age: 4

--- a/policyengine_us/tests/policy/baseline/gov/states/nh/dhhs/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nh/dhhs/ccap/integration.yaml
@@ -20,6 +20,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_400
         # $20,400/yr = $1,700/mo < $1,762.50 (100% FPG for 2)
       person2:
@@ -57,6 +58,7 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         # $24,000/yr = $2,000/mo
         # Family of 2: 100% FPG = $1,762.50; 138% FPG = $2,432.25
@@ -95,11 +97,13 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
         # $60,000/yr = $5,000/mo > $3,064.75 (138% FPG for 3)
         # Step 3: 7% * $5,000 / 4.33 = $80.77/week
       person2:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
       person3:
         age: 8
@@ -135,12 +139,14 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         # $24,000/yr = $2,000/mo
         # Family of 4: 100% FPG = $2,679.17/mo
         # $2,000 < $2,679.17 → Step 1 → $0
       person2:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
       person3:
         age: 1
@@ -184,6 +190,7 @@
     people:
       person1:
         age: 25
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000
         # Well above 85% SMI for family of 2
       person2:
@@ -217,6 +224,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
       person2:
         age: 14
@@ -250,6 +258,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_400
         # $20,400/yr = $1,700/mo < $1,762.50 (100% FPG for 2)
       person2:
@@ -290,12 +299,14 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         # $24,000/yr = $2,000/mo
         # Family of 3: 100% FPG = $2,220.83
         # $2,000 < $2,220.83 → Step 1 → $0 cost share
       person2:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
       person3:
         age: 5

--- a/policyengine_us/tests/policy/baseline/gov/states/nh/dhhs/ccap/nh_ccap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nh/dhhs/ccap/nh_ccap_eligible.yaml
@@ -9,6 +9,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
       person2:
         age: 5
@@ -169,6 +170,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
       person2:
         age: 17
@@ -217,6 +219,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
       person2:
         age: 5
@@ -239,6 +242,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
       person2:
         age: 5

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/edge_cases.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/edge_cases.yaml
@@ -18,6 +18,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 43_279
         immigration_status: CITIZEN
       person2:
@@ -45,6 +46,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 43_281
         immigration_status: CITIZEN
       person2:
@@ -72,6 +74,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 54_099
       person2:
         age: 4
@@ -94,6 +97,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 54_101
       person2:
         age: 4
@@ -119,6 +123,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 21_640
         immigration_status: CITIZEN
       person2:
@@ -150,6 +155,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 21_700
         immigration_status: CITIZEN
       person2:
@@ -183,6 +189,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 43_280
         immigration_status: CITIZEN
       person2:
@@ -216,6 +223,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 43_340
         immigration_status: CITIZEN
       person2:
@@ -251,6 +259,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -279,6 +288,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -435,6 +445,7 @@
     people:
       person1:
         age: 19
+        weekly_hours_worked_before_lsr: 40
         is_disabled: true
         is_tax_unit_dependent: true
         immigration_status: CITIZEN
@@ -452,6 +463,7 @@
     people:
       person1:
         age: 18
+        weekly_hours_worked_before_lsr: 40
         is_disabled: true
         is_tax_unit_dependent: true
         immigration_status: CITIZEN
@@ -472,10 +484,12 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 111_440
         immigration_status: CITIZEN
       person2:
         age: 38
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 1
@@ -526,6 +540,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -561,6 +576,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
     tax_units:
@@ -655,10 +671,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 50_000
         immigration_status: CITIZEN
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 1
@@ -857,10 +875,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 75_000
         immigration_status: CITIZEN
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 2
@@ -950,6 +970,7 @@
     people:
       person1:
         age: 20
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/edge_cases.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/edge_cases.yaml
@@ -445,7 +445,6 @@
     people:
       person1:
         age: 19
-        weekly_hours_worked_before_lsr: 40
         is_disabled: true
         is_tax_unit_dependent: true
         immigration_status: CITIZEN
@@ -463,7 +462,6 @@
     people:
       person1:
         age: 18
-        weekly_hours_worked_before_lsr: 40
         is_disabled: true
         is_tax_unit_dependent: true
         immigration_status: CITIZEN

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/integration.yaml
@@ -12,6 +12,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 31_000
         immigration_status: CITIZEN
       person2:
@@ -73,6 +74,7 @@
     people:
       person1:
         age: 25
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -138,10 +140,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 70_000
         immigration_status: CITIZEN
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 3
@@ -198,10 +202,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 66_000
         immigration_status: CITIZEN
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 4
@@ -268,10 +274,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 79_200
         immigration_status: CITIZEN
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 1
@@ -328,10 +336,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 62_836
         immigration_status: CITIZEN
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person3:
         age: 1
@@ -389,6 +399,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap.yaml
@@ -13,6 +13,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -50,6 +51,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 50_000
         immigration_status: CITIZEN
       person2:
@@ -81,6 +83,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 15_000
         immigration_status: CITIZEN
       person2:
@@ -116,6 +119,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -146,6 +150,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 42_000
         immigration_status: CITIZEN
       person2:
@@ -182,6 +187,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -60_000_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nj/njdhs/ccap/nj_ccap_eligible.yaml
@@ -10,6 +10,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -39,6 +40,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -65,6 +67,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 50_000
         immigration_status: CITIZEN
       person2:
@@ -147,6 +150,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
       person2:
         age: 4

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/dcy/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/dcy/ccap/integration.yaml
@@ -18,6 +18,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 2  # toddler
@@ -63,9 +64,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # 1,500/month
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # 1,500/month — total 3,000/month
       person3:
         age: 4  # preschool
@@ -103,6 +106,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 0.5  # infant
@@ -145,9 +149,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000  # 3,000/month, would otherwise owe a copay
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 4  # preschool
         immigration_status: CITIZEN
@@ -178,10 +184,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         ssi: 800  # monthly; person1 receives SSI
         employment_income: 12_000  # 1,000/month — excluded because of SSI
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month — counted
       person3:
         age: 2  # toddler
@@ -216,6 +224,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 2
@@ -243,6 +252,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000  # 10,000/month, far above 145% FPG
       person2:
         age: 2
@@ -274,6 +284,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -60_000  # -5,000/month, no other income
       person2:
         age: 4  # preschool
@@ -307,9 +318,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # 2,500/month
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # 1,500/month — total 4,000/month
       person3:
         age: 1  # infant
@@ -362,6 +375,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 2  # toddler
@@ -397,6 +411,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 2
@@ -428,6 +443,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000  # 10,000/month, far above 145% FPG
       person2:
         age: 4  # preschool
@@ -465,6 +481,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 2  # toddler

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/dcy/ccap/oh_ccap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/dcy/ccap/oh_ccap_eligible.yaml
@@ -12,6 +12,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 3
@@ -55,6 +56,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 14  # over age 13, not an eligible child
@@ -75,6 +77,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000  # 10,000/month, far above 145% FPG
       person2:
         age: 3
@@ -96,6 +99,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         bank_account_assets: 2_000_000
       person2:
@@ -117,6 +121,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 3
@@ -140,6 +145,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 4  # eligible
@@ -165,6 +171,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # 2,000/month
       person2:
         age: 1
@@ -187,9 +194,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # 2,500/month
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000  # 1,500/month — total 4,000/month
       person3:
         age: 1
@@ -222,6 +231,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 3
@@ -242,6 +252,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         bank_account_assets: 2_000_000
       person2:
         age: 3
@@ -290,6 +301,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         bank_account_assets: 2_000_000
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/oh/dcy/ccap/oh_ccap_income_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/oh/dcy/ccap/oh_ccap_income_eligible.yaml
@@ -15,9 +15,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000  # 3,000/month, below 3,221
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -36,9 +38,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 39_600  # 3,300/month, above 3,221 and below 3,332
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -57,9 +61,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 39_600  # 3,300/month, between 145% (3,221) and 150% (3,332)
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         has_developmental_delay: true
@@ -80,9 +86,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 42_000  # 3,500/month, above 145% but below 300%
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -102,9 +110,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 84_000  # 7,000/month, above 6,663
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -127,9 +137,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 84_000  # 7,000/month, far above 300%
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -152,9 +164,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 38_400  # 3,200/month, just below 3,221
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -173,9 +187,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 38_880  # 3,240/month, just above 3,221
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -195,9 +211,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 39_840  # 3,320/month, just below 3,332
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         has_developmental_delay: true
@@ -218,9 +236,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 40_080  # 3,340/month, just above 3,332
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         has_developmental_delay: true
@@ -242,9 +262,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 79_800  # 6,650/month, just below 6,663
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -264,9 +286,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 80_100  # 6,675/month, just above 6,663
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -288,6 +312,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # 2,500/month, below 2,556
       person2:
         age: 3
@@ -308,6 +333,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 33_000  # 2,750/month, above 2,556
       person2:
         age: 3
@@ -328,6 +354,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 3
         immigration_status: CITIZEN
@@ -349,10 +376,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 39_600  # 3,300/month, above 3,221 and below 3,332
         oh_ccap_owf_transitional: true
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -371,10 +400,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 40_080  # 3,340/month, above 3,332
         oh_ccap_owf_transitional: true
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -401,6 +432,7 @@
         oh_ccap_owf_transitional: true
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
     spm_units:
@@ -421,6 +453,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_head: true
         employment_income: 39_600  # 3,300/month, above 3,221 and below 3,332
         oh_ccap_owf_transitional: true

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/dhs/ccs/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/dhs/ccs/integration.yaml
@@ -5,6 +5,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # $2,500/month.
       person2:
         age: 3
@@ -36,6 +37,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 1
         ok_ccs_provider_setting: CHILD_CARE_HOME
@@ -66,6 +68,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000  # $5,000/month, above $4,525.
       person2:
         age: 3
@@ -91,6 +94,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # $2,500/month.
       person2:
         age: 3
@@ -117,6 +121,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -60_000  # -$5,000/month.
       person2:
         age: 3
@@ -146,9 +151,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         childcare_hours_per_day: 8
@@ -173,6 +180,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
       person2:
         age: 13
@@ -197,6 +205,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
       person2:
         age: 3
@@ -221,6 +230,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # $2,500/month.
       person2:
         age: 3
@@ -256,6 +266,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 72_000  # $6,000/month, above the $4,525 size-2 limit.
       person2:
         age: 3
@@ -290,6 +301,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
     spm_units:
       spm_unit:

--- a/policyengine_us/tests/policy/baseline/gov/states/ok/dhs/ccs/ok_ccs_activity_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ok/dhs/ccs/ok_ccs_activity_eligible.yaml
@@ -7,6 +7,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # $2,000/month.
       person2:
         age: 4
@@ -26,10 +27,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_head: true
         employment_income: 24_000  # $2,000/month.
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_spouse: true
       person3:
         age: 4
@@ -49,10 +52,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_head: true
         employment_income: 24_000  # $2,000/month.
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_spouse: true
         is_full_time_student: true
       person3:
@@ -73,6 +78,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -6_000  # -$500/month.
       person2:
         age: 4
@@ -92,6 +98,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
     spm_units:
@@ -111,6 +118,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         receives_or_needs_protective_services: true
       person2:
         age: 4
@@ -130,6 +138,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
     spm_units:
@@ -149,6 +158,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
     spm_units:
@@ -227,10 +237,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_head: true
         is_full_time_college_student: true
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_spouse: true
         is_full_time_college_student: true
       person3:
@@ -251,6 +263,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_head: true
         employment_income: 24_000
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/dhs/ccw/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/dhs/ccw/integration.yaml
@@ -20,6 +20,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -90,10 +91,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 48_000
         immigration_status: CITIZEN
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
       person3:
@@ -159,6 +162,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 54_000
         immigration_status: CITIZEN
       person2:
@@ -194,6 +198,7 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
@@ -261,6 +266,7 @@
     people:
       person1:
         age: 25
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -318,10 +324,12 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 42_000
         immigration_status: CITIZEN
       person2:
         age: 38
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
       person3:
@@ -398,6 +406,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/dhs/ccw/pa_ccw.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/dhs/ccw/pa_ccw.yaml
@@ -11,6 +11,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -43,6 +44,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
       person2:
@@ -72,6 +74,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000
         immigration_status: CITIZEN
       person2:
@@ -100,6 +103,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -60_000_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/pa/dhs/ccw/pa_ccw_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/pa/dhs/ccw/pa_ccw_eligible.yaml
@@ -12,6 +12,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
@@ -37,6 +38,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
       person2:
@@ -64,10 +66,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
         age: 20
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
     tax_units:
       tax_unit:
@@ -89,6 +93,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000
         immigration_status: CITIZEN
       person2:
@@ -114,6 +119,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/edge_cases/ri_ccap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/edge_cases/ri_ccap.yaml
@@ -9,6 +9,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 25_000
         immigration_status: CITIZEN
       person2:
@@ -56,6 +57,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         age: 4
@@ -92,6 +94,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 45_000
         immigration_status: CITIZEN
       person2:
@@ -132,6 +135,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 55_500
         immigration_status: CITIZEN
       person2:
@@ -174,6 +178,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 55_500
         immigration_status: CITIZEN
       person2:
@@ -206,6 +211,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 15_000
         immigration_status: CITIZEN
       person2:
@@ -244,6 +250,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -282,6 +289,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -323,6 +331,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -60_000_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/edge_cases/ri_ccap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/edge_cases/ri_ccap_eligible.yaml
@@ -7,6 +7,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         age: 5
@@ -59,6 +60,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 10_000
         immigration_status: CITIZEN
     tax_units:
@@ -80,6 +82,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -107,6 +110,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/eligibility/ri_ccap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/eligibility/ri_ccap_eligible.yaml
@@ -7,6 +7,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -32,6 +33,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 70_000
         immigration_status: CITIZEN
       person2:
@@ -60,6 +62,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
     tax_units:
@@ -82,6 +85,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -108,6 +112,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/integration.yaml
@@ -12,6 +12,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 40_000
         immigration_status: CITIZEN
       person2:
@@ -79,6 +80,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
         immigration_status: CITIZEN
       person2:
@@ -144,6 +146,7 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 72_000
         immigration_status: CITIZEN
       person2:
@@ -190,6 +193,7 @@
     people:
       person1:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
         immigration_status: CITIZEN
       person2:
@@ -252,6 +256,7 @@
     people:
       person1:
         age: 25
+        weekly_hours_worked_before_lsr: 40
         employment_income: 35_000
         immigration_status: CITIZEN
       person2:
@@ -310,6 +315,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 45_000
         immigration_status: CITIZEN
       person2:
@@ -372,6 +378,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -474,6 +481,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
       person2:
         age: 4
@@ -502,6 +510,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         age: 4

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/ri_ccap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/ri_ccap.yaml
@@ -9,6 +9,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -48,6 +49,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 70_000
         immigration_status: CITIZEN
       person2:
@@ -79,6 +81,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 15_000
         immigration_status: CITIZEN
       person2:
@@ -118,6 +121,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -148,6 +152,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         age: 4
@@ -184,6 +189,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 50_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/ri_child_care_subsidies.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ri/dhs/ccap/ri_child_care_subsidies.yaml
@@ -8,6 +8,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 40_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/dss/ccap/sc_ccap_copay.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/dss/ccap/sc_ccap_copay.yaml
@@ -19,9 +19,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_tax_unit_dependent: true
@@ -50,9 +52,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 50_400
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_tax_unit_dependent: true
@@ -85,9 +89,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_tax_unit_dependent: true
@@ -120,9 +126,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 66_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_tax_unit_dependent: true
@@ -157,9 +165,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 68_400
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_tax_unit_dependent: true
@@ -196,9 +206,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 80_400
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_tax_unit_dependent: true
@@ -232,6 +244,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
       person2:
         age: 5
@@ -258,6 +271,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
       person2:
         age: 5
@@ -284,6 +298,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
       person2:
         age: 5
@@ -310,6 +325,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 5
@@ -343,6 +359,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
       person2:
         age: 5
@@ -369,6 +386,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 40_000
       person2:
         age: 4
@@ -396,6 +414,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
       person2:
         age: 4
@@ -426,9 +445,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 48_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_tax_unit_dependent: true
@@ -465,6 +486,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 4
@@ -492,6 +514,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 42_000
       person2:
         age: 4
@@ -523,9 +546,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 12
         is_tax_unit_dependent: true
@@ -573,9 +598,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 108_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 12
         is_tax_unit_dependent: true
@@ -672,9 +699,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 132_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 12
         is_tax_unit_dependent: true
@@ -739,9 +768,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 132_000
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 12
         is_tax_unit_dependent: true

--- a/policyengine_us/tests/policy/baseline/gov/states/sc/dss/ccap/sc_ccap_maximum_weekly_benefit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sc/dss/ccap/sc_ccap_maximum_weekly_benefit.yaml
@@ -278,6 +278,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 3
         childcare_hours_per_week: 30
@@ -313,6 +314,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 3
         childcare_hours_per_week: 30
@@ -339,6 +341,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 3
         childcare_hours_per_week: 30
@@ -370,6 +373,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
         childcare_hours_per_week: 30

--- a/policyengine_us/tests/policy/baseline/gov/states/sd/dss/cca/eligibility/sd_cca_activity_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/sd/dss/cca/eligibility/sd_cca_activity_eligible.yaml
@@ -18,6 +18,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
     spm_units:
@@ -37,6 +38,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 4
     spm_units:
@@ -83,6 +85,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         self_employment_income: -12_000  # -1,000/mo
       person2:
         age: 4
@@ -106,6 +109,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         is_full_time_student: true  # school enrollment is an approved activity
       person2:
         age: 4
@@ -126,10 +130,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         is_tax_unit_head: true
       person2:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         is_tax_unit_spouse: true
     marital_units:
@@ -155,10 +161,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # employed
         is_tax_unit_head: true
       person2:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0  # available caretaker, not in any activity
         is_full_time_student: false
         is_tax_unit_spouse: true

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/eligibility/tx_dart_reduced_fare_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/dart/reduced_fare/eligibility/tx_dart_reduced_fare_eligible.yaml
@@ -3,6 +3,7 @@
   input:
     state_code: TX
     age: 67
+    weekly_hours_worked_before_lsr: 40
   output:
     tx_dart_reduced_fare_eligible: true
 
@@ -19,6 +20,7 @@
   input:
     state_code: TX
     age: 45
+    weekly_hours_worked_before_lsr: 40
     is_disabled: true
   output:
     tx_dart_reduced_fare_eligible: true
@@ -28,6 +30,7 @@
   input:
     state_code: TX
     age: 35
+    weekly_hours_worked_before_lsr: 40
     is_veteran: true
   output:
     tx_dart_reduced_fare_eligible: true
@@ -37,6 +40,7 @@
   input:
     state_code: TX
     age: 20
+    weekly_hours_worked_before_lsr: 40
     is_full_time_student: true
   output:
     tx_dart_reduced_fare_eligible: true
@@ -46,6 +50,7 @@
   input:
     state_code: TX
     age: 40
+    weekly_hours_worked_before_lsr: 40
     snap: 300
   output:
     tx_dart_reduced_fare_eligible: true
@@ -55,6 +60,7 @@
   input:
     state_code: TX
     age: 25
+    weekly_hours_worked_before_lsr: 40
     medicaid: 5_000
   output:
     tx_dart_reduced_fare_eligible: true
@@ -73,6 +79,7 @@
   input:
     state_code: TX
     age: 28
+    weekly_hours_worked_before_lsr: 40
     wic: 100
   output:
     tx_dart_reduced_fare_eligible: true
@@ -82,6 +89,7 @@
   input:
     state_code: TX
     age: 32
+    weekly_hours_worked_before_lsr: 40
     tanf: 400
   output:
     tx_dart_reduced_fare_eligible: true
@@ -91,6 +99,7 @@
   input:
     state_code: TX
     age: 68
+    weekly_hours_worked_before_lsr: 40
     is_medicare_eligible: true
   output:
     tx_dart_reduced_fare_eligible: true
@@ -100,6 +109,7 @@
   input:
     state_code: TX
     age: 35
+    weekly_hours_worked_before_lsr: 40
     is_disabled: false
     is_veteran: false
     is_full_time_student: false
@@ -113,6 +123,7 @@
   input:
     state_code: TX
     age: 24
+    weekly_hours_worked_before_lsr: 40
     is_veteran: true
     is_full_time_student: true
   output:
@@ -124,15 +135,18 @@
     people:
       veteran_parent:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         is_veteran: true
       spouse:
         age: 33
+        weekly_hours_worked_before_lsr: 40
         is_veteran: false
       child:
         age: 10
         is_veteran: false
       senior:
         age: 70
+        weekly_hours_worked_before_lsr: 40
         is_veteran: false
     spm_units:
       spm_unit:

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/twc/ccs/copay/tx_ccs_copay.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/twc/ccs/copay/tx_ccs_copay.yaml
@@ -5,9 +5,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000  # Annual income ($1,000/month)
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         is_disabled: false
@@ -33,9 +35,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # Annual income ($2,500/month)
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 4
         is_disabled: false
@@ -61,9 +65,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 48_000  # Annual income ($4,000/month)
       person2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 5
         is_disabled: false
@@ -94,9 +100,11 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 84_000  # Annual income ($7,000/month)
       person2:
         age: 38
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 8
         is_disabled: false
@@ -153,9 +161,11 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 96_000  # Annual income ($8,000/month)
       person2:
         age: 38
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 8
         is_disabled: false
@@ -188,6 +198,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 52_020  # Annual income ($4,335/month)
       person2:
         age: 4
@@ -217,9 +228,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 61_200  # Annual income ($5,100/month)
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         is_disabled: false
@@ -244,9 +257,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 1_200  # Annual income ($100/month)
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         is_disabled: false
@@ -271,6 +286,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
       person2:
         age: 14
@@ -294,9 +310,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
       person3:
         age: 3
         is_disabled: false

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/twc/ccs/tx_ccs.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/twc/ccs/tx_ccs.yaml
@@ -4,6 +4,7 @@
     people:
       parent1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000  # Annual income ($1,000/month, <20% SMI)
       child1:
         age: 3
@@ -29,9 +30,11 @@
     people:
       parent1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # Annual income ($2,500/month, ~35% SMI)
       parent2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
       child1:
         age: 4
         is_disabled: false
@@ -58,9 +61,11 @@
     people:
       parent1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 48_000  # Annual income ($4,000/month, ~55% SMI)
       parent2:
         age: 32
+        weekly_hours_worked_before_lsr: 40
       child1:
         age: 5
         is_disabled: false
@@ -94,6 +99,7 @@
     people:
       parent1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000  # Annual income ($2,000/month, ~34% SMI for family size 2)
       child1:
         age: 1
@@ -120,6 +126,7 @@
     people:
       parent1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
       teenager:
         age: 14  # Too old for CCS

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/uct/lifeline/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/uct/lifeline/integration.yaml
@@ -4,6 +4,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 15_000
     spm_units:
       spm_unit:
@@ -30,6 +31,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 21_870  # Exactly 150% of FPG for 1 person
     spm_units:
       spm_unit:
@@ -50,6 +52,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 22_000  # Just above 150% of FPG
     spm_units:
       spm_unit:
@@ -70,6 +73,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000  # Above income limits
     spm_units:
       spm_unit:
@@ -91,9 +95,11 @@
     people:
       parent1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 25_000
       parent2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
         employment_income: 10_000
       child1:
         age: 10
@@ -119,6 +125,7 @@
     people:
       person1:
         age: 70
+        weekly_hours_worked_before_lsr: 40
         ssi: 9_600  # Annual SSI
     spm_units:
       spm_unit:
@@ -138,6 +145,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         is_disabled: true
         medicaid_enrolled: true
     spm_units:
@@ -158,6 +166,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 18_000
     spm_units:
       spm_unit:
@@ -181,6 +190,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 15_000
     spm_units:
       spm_unit:
@@ -203,6 +213,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 10_000
     spm_units:
       spm_unit:
@@ -225,9 +236,11 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
       person2:
         age: 65
+        weekly_hours_worked_before_lsr: 40
         employment_income: 8_000
     spm_units:
       spm_unit1:

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/edge_cases/integration_edge.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/edge_cases/integration_edge.yaml
@@ -18,6 +18,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_659
         immigration_status: CITIZEN
       person2:
@@ -72,6 +73,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_661
         immigration_status: CITIZEN
       person2:
@@ -110,6 +112,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 70_013
         immigration_status: CITIZEN
       person2:
@@ -162,6 +165,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 72_000
         immigration_status: CITIZEN
       person2:
@@ -235,6 +239,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 48_000
         immigration_status: CITIZEN
       person2:
@@ -295,6 +300,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -344,6 +350,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/edge_cases/va_ccsp_edge.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/edge_cases/va_ccsp_edge.yaml
@@ -12,6 +12,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
@@ -42,6 +43,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
@@ -76,6 +78,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
@@ -109,6 +112,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         age: 5
@@ -141,6 +145,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
       person2:
@@ -175,6 +180,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 200_000
         immigration_status: CITIZEN
       person2:
@@ -206,6 +212,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
     tax_units:

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/integration.yaml
@@ -25,6 +25,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
@@ -91,10 +92,12 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
         immigration_status: CITIZEN
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person3:
@@ -159,6 +162,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
       person2:
@@ -208,6 +212,7 @@
     people:
       person1:
         age: 25
+        weekly_hours_worked_before_lsr: 40
         employment_income: 48_000
         immigration_status: CITIZEN
       person2:
@@ -266,6 +271,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 48_000
         immigration_status: CITIZEN
       person2:
@@ -303,6 +309,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -337,6 +344,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         age: 4

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp.yaml
@@ -8,6 +8,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 36_000
         immigration_status: CITIZEN
       person2:
@@ -49,6 +50,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 72_000
         immigration_status: CITIZEN
       person2:
@@ -87,6 +89,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000
         immigration_status: CITIZEN
       person2:
@@ -116,6 +119,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         age: 5

--- a/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/dss/ccsp/va_ccsp_eligible.yaml
@@ -7,6 +7,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -33,6 +34,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 120_000
         immigration_status: CITIZEN
       person2:
@@ -61,6 +63,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
     tax_units:
@@ -83,6 +86,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -108,6 +112,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/edge_cases.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/edge_cases.yaml
@@ -503,7 +503,6 @@
       person2:
         # Disabled child age 18 -> NOT < 18 -> ineligible
         age: 18
-        weekly_hours_worked_before_lsr: 40
         is_tax_unit_dependent: true
         has_developmental_delay: true
         immigration_status: CITIZEN

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/edge_cases.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/edge_cases.yaml
@@ -16,6 +16,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -47,6 +48,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # 185% FPL family of 2 = $39,127.50/yr
         employment_income: 39_000
         immigration_status: CITIZEN
@@ -79,6 +81,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # Just above 185% FPL family of 2 ($39,127.50/yr)
         employment_income: 39_200
         immigration_status: CITIZEN
@@ -115,6 +118,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # 185% FPL family of 3 = $49,302.50/yr
         employment_income: 48_000
         immigration_status: CITIZEN
@@ -146,6 +150,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 60_000
         immigration_status: CITIZEN
       person2:
@@ -172,6 +177,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # Just above 185% FPL family of 3 ($49,302.50/yr)
         employment_income: 50_000
         immigration_status: CITIZEN
@@ -207,6 +213,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # 185% FPL family of 11 = $130,702.50/yr
         employment_income: 131_000
         immigration_status: CITIZEN
@@ -232,6 +239,7 @@
         immigration_status: CITIZEN
       person7:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person8:
         age: 1
@@ -269,6 +277,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # Below 185% FPL family of 11 ($130,702.50/yr)
         employment_income: 100_000
         immigration_status: CITIZEN
@@ -294,6 +303,7 @@
         immigration_status: CITIZEN
       person7:
         age: 32
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person8:
         age: 1
@@ -336,6 +346,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 0
         immigration_status: CITIZEN
       person2:
@@ -371,6 +382,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 500_000
         immigration_status: CITIZEN
       person2:
@@ -401,6 +413,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -429,6 +442,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -455,6 +469,7 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -482,11 +497,13 @@
     people:
       person1:
         age: 45
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
         # Disabled child age 18 -> NOT < 18 -> ineligible
         age: 18
+        weekly_hours_worked_before_lsr: 40
         is_tax_unit_dependent: true
         has_developmental_delay: true
         immigration_status: CITIZEN
@@ -514,6 +531,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 12_000
         immigration_status: CITIZEN
     tax_units:
@@ -542,6 +560,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # 40% FPL family of 2 = 21_150 * 0.4 = 8_460/yr
         employment_income: 8_460
         immigration_status: CITIZEN
@@ -577,6 +596,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # Just above 40% FPL: need FPL ratio > 0.4001
         # 21_150 * 0.4001 = 8_462.12/yr; use 8_475 -> ratio ~0.4008
         employment_income: 8_475
@@ -618,6 +638,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # ~170% FPL family of 2: 21_150 * 1.7 = 35_955/yr.
         employment_income: 35_955
         immigration_status: CITIZEN
@@ -654,6 +675,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 42_000
         immigration_status: CITIZEN
       person2:
@@ -810,6 +832,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 30_000
         immigration_status: CITIZEN
       person2:
@@ -845,6 +868,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 31_000
         immigration_status: CITIZEN
       person2:
@@ -880,10 +904,12 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 15_000
         immigration_status: CITIZEN
     tax_units:
@@ -912,6 +938,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -942,6 +969,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -972,6 +1000,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1002,6 +1031,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1031,6 +1061,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1060,6 +1091,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1093,6 +1125,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1123,6 +1156,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1156,6 +1190,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 0.5 = 6 months -> INFANT (0-24 months)
@@ -1181,6 +1216,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 2.5 = 30 months -> TODDLER (25-36 months)
@@ -1206,6 +1242,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 3.25 = 39 months -> PRESCHOOL (37-59 months)
@@ -1231,6 +1268,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 6 = 72 months -> SCHOOL_AGE (60+ months)
@@ -1260,6 +1298,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         # Above 185% FPL family of 2 ($39,127.50/yr); TANF enrolled bypasses.
         employment_income: 60_000
         immigration_status: CITIZEN
@@ -1293,6 +1332,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1329,6 +1369,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:
@@ -1438,6 +1479,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -1486,6 +1528,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -1520,6 +1563,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 1.0 = 12 months -> INFANT (threshold at 25 months for TODDLER)
@@ -1546,6 +1590,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 2.0 = 24 months -> INFANT (threshold for TODDLER at 25 months)
@@ -1572,6 +1617,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 5.0 = 60 months -> SCHOOL_AGE (threshold at 60 months)
@@ -1602,6 +1648,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 1.5 = 18 months -> UNDER_2
@@ -1628,6 +1675,7 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
       person2:
         # Age 2.0 = 24 months; Appendix B INFANT covers 0-24 months
@@ -1659,6 +1707,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 20_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/integration.yaml
@@ -11,6 +11,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -73,6 +74,7 @@
     people:
       person1:
         age: 28
+        weekly_hours_worked_before_lsr: 40
         employment_income: 6_000
         immigration_status: CITIZEN
       person2:
@@ -158,6 +160,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:
@@ -213,6 +216,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
       person2:
         age: 4

--- a/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/wv_child_care_subsidies.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wv/dhhr/ccap/wv_child_care_subsidies.yaml
@@ -5,6 +5,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         employment_income: 24_000
         immigration_status: CITIZEN
       person2:

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/is_snap_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/is_snap_eligible.yaml
@@ -15,6 +15,7 @@
     meets_snap_net_income_test: true
     meets_snap_asset_test: false
     meets_snap_categorical_eligibility: true
+    weekly_hours_worked_before_lsr: 40
   output:
     is_snap_eligible: true
 
@@ -25,6 +26,7 @@
     meets_snap_net_income_test: true
     meets_snap_asset_test: true
     meets_snap_categorical_eligibility: false
+    weekly_hours_worked_before_lsr: 40
   output:
     is_snap_eligible: true
 
@@ -34,10 +36,13 @@
     people:
       person1:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
       person2:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
       person3:
         is_snap_ineligible_student: true
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit1:
         members: [person1, person2, person3]
@@ -90,6 +95,7 @@
     people:
       person1:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit1:
         members: [person1]
@@ -148,10 +154,12 @@
       personA:
         immigration_status: CITIZEN
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
       # Member B: ineligible student and not immigration eligible.
       personB:
         immigration_status: UNDOCUMENTED
         is_snap_ineligible_student: true
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit1:
         members: [personA, personB]

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_gross_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_gross_income_test.yaml
@@ -54,9 +54,12 @@
   period: 2026-01
   input:
     people:
-      person1: {}
-      person2: {}
-      person3: {}
+      person1:
+        weekly_hours_worked_before_lsr: 40
+      person2:
+        weekly_hours_worked_before_lsr: 40
+      person3:
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit:
         members: [person1, person2, person3]

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_net_income_test.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/meets_snap_net_income_test.yaml
@@ -44,9 +44,12 @@
   period: 2026-01
   input:
     people:
-      person1: {}
-      person2: {}
-      person3: {}
+      person1:
+        weekly_hours_worked_before_lsr: 40
+      person2:
+        weekly_hours_worked_before_lsr: 40
+      person3:
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit:
         members: [person1, person2, person3]

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/eligibility/work_requirements/meets_snap_abawd_work_requirements.yaml
@@ -903,3 +903,17 @@
     county_fips: "02013"
   output:
     meets_snap_abawd_work_requirements: true
+
+# Hardening: a working-age, non-exempt adult with NO hours input must fail
+# the ABAWD work-hours test. Before weekly_hours_worked_before_lsr defaulted
+# to 40, this person silently cleared the 20-hour test, making the whole
+# work requirement a no-op whenever the hours column was missing.
+- name: Case 59, missing hours input fails the ABAWD work-hours test (no silent 40-hour default).
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    age: 40
+    is_disabled: false
+    state_code: TX
+  output:
+    meets_snap_abawd_work_requirements: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/has_snap_elderly_disabled_member.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/has_snap_elderly_disabled_member.yaml
@@ -4,9 +4,11 @@
     people:
       person1:
         age: 30
+        weekly_hours_worked_before_lsr: 40
         is_usda_disabled: true
       person2:
         age: 33
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit:
         members: [person1, person2]

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/self_employment_income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/self_employment_income/integration.yaml
@@ -24,8 +24,10 @@
     people:
       person1:
         self_employment_income_before_lsr: 3_000
+        weekly_hours_worked_before_lsr: 40
       person2:
         employment_income_before_lsr: 1_000
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit:
         members: [person1, person2]

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_child_support_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_child_support_deduction.yaml
@@ -11,5 +11,6 @@
   input:
     child_support_expense: 500
     snap_child_support_gross_income_deduction: 0
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_child_support_deduction: 500

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_countable_child_support_expense.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_countable_child_support_expense.yaml
@@ -32,9 +32,11 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
         child_support_expense: 3_600
       person2:
         age: 20
+        weekly_hours_worked_before_lsr: 40
         is_snap_ineligible_student: true
         child_support_expense: 1_200
     spm_units:

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_excess_medical_expense_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_excess_medical_expense_deduction.yaml
@@ -26,6 +26,7 @@
     is_usda_disabled: true
     other_medical_expenses: 35.01 * 12
     state_code_str: CA
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_excess_medical_expense_deduction: 120 * 12
 
@@ -37,6 +38,7 @@
     is_usda_elderly: true
     other_medical_expenses: 155 * 12
     state_code_str: CA
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_excess_medical_expense_deduction: (155 - 35) * 12
 
@@ -47,6 +49,7 @@
     is_usda_elderly: true
     other_medical_expenses: 156 * 12
     state_code_str: CA
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_excess_medical_expense_deduction: (156 - 35) * 12
 

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_excess_shelter_expense_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_excess_shelter_expense_deduction.yaml
@@ -11,6 +11,7 @@
     snap_net_income_pre_shelter: 12_000
     housing_cost: 6_000
     snap_utility_allowance: 100
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_excess_shelter_expense_deduction: 100
 
@@ -20,14 +21,16 @@
     snap_net_income_pre_shelter: 6_000
     housing_cost: 6_000
     snap_utility_allowance: 0
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_excess_shelter_expense_deduction: 3_000 # Uncapped since less than 597 * 12 = $7,164.
 
 - name: Caps at $597 per month in contiguous US.
   period: 2022-01
   input:
-    housing_cost: 
+    housing_cost:
       2022: 600 * 12
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_excess_shelter_expense_deduction: 597
 
@@ -37,6 +40,7 @@
     state_code: TX
     housing_cost: 600 * 12
     has_snap_elderly_disabled_member: true
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_excess_shelter_expense_deduction: 600 * 12
 
@@ -79,9 +83,10 @@
     snap_net_income_pre_shelter: 0
     snap_region_str: GU
     housing_cost: 4_800 # 400 monthly 
-    snap_utility_allowance: 300 
+    snap_utility_allowance: 300
     has_snap_elderly_disabled_member: false
     is_homeless: false
+    weekly_hours_worked_before_lsr: 40
   output:
     # cap at 701, 
     snap_excess_shelter_expense_deduction: 700
@@ -92,6 +97,7 @@
   input:
     housing_cost:
       2027: 12_000
+    weekly_hours_worked_before_lsr: 40
   output:
     # 744 * 333.952 / 322.561
     snap_excess_shelter_expense_deduction: 770.27
@@ -103,6 +109,7 @@
     state_code: TX
     is_homeless: true
     housing_cost: 1
+    weekly_hours_worked_before_lsr: 40
   output:
     # 198.99 * 333.952 / 322.561
     snap_excess_shelter_expense_deduction: 206.02

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_standard_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_standard_deduction.yaml
@@ -3,6 +3,7 @@
   input:
     spm_unit_size: 4
     state_group: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_standard_deduction: 184
 
@@ -63,6 +64,7 @@
   input:
     spm_unit_size: 4
     state_group: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     # 223 * 333.952 / 322.561
     snap_standard_deduction: 230.88

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/federal_work_study_income_exclusion.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/federal_work_study_income_exclusion.yaml
@@ -12,6 +12,7 @@
   input:
     employment_income: 12_000
     is_federal_work_study_participant: false
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_countable_earner: true
     snap_earned_income: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/gross/snap_child_support_gross_income_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/gross/snap_child_support_gross_income_deduction.yaml
@@ -10,5 +10,6 @@
   input:
     state_code: AK
     child_support_expense: 100
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_child_support_gross_income_deduction: 100

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/ineligible_members/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/ineligible_members/integration.yaml
@@ -183,6 +183,7 @@
         age: 40
         employment_income: 12_000
         employment_income_before_lsr: 12_000
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 20
         dividend_income: 2_400
@@ -257,6 +258,7 @@
         age: 35
         self_employment_income: 24_000
         self_employment_income_before_lsr: 24_000
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 16
         is_in_k12_school: true
@@ -489,6 +491,7 @@
         age: 35
         employment_income: 24_000
         employment_income_before_lsr: 24_000
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 70
         immigration_status: UNDOCUMENTED

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/ineligible_members/snap_income_counted_share.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/ineligible_members/snap_income_counted_share.yaml
@@ -27,6 +27,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 20
         is_snap_ineligible_student: true

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/ineligible_members/snap_prorated_income_fraction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/ineligible_members/snap_prorated_income_fraction.yaml
@@ -28,6 +28,7 @@
     people:
       person1:
         age: 40
+        weekly_hours_worked_before_lsr: 40
       person2:
         age: 20
         is_snap_ineligible_student: true

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/snap_fpg.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/snap_fpg.yaml
@@ -4,6 +4,7 @@
   input:
     spm_unit_size: 3
     state_group_str: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     spm_unit_fpg: 14580 + 5140 * 2
     snap_fpg: (13590 + 4720 * 2) / 12 * 9 + (14580 + 5140 * 2) / 12 * 3
@@ -14,6 +15,7 @@
   input:
     spm_unit_size: 3
     state_group_str: CONTIGUOUS_US
+    weekly_hours_worked_before_lsr: 40
   output:
     spm_unit_fpg: 13590 + 4720 * 2
     snap_fpg: (12880 + 4540 * 2) / 12 * 9 + (13590 + 4720 * 2) / 12 * 3

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/snap_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/snap_unearned_income.yaml
@@ -14,5 +14,6 @@
   period: 2022
   input:
     retirement_distributions: 1_000
+    weekly_hours_worked_before_lsr: 40
   output:
     snap_unearned_income: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/integration.yaml
@@ -55,6 +55,7 @@
   input:
     # Consider a family of three
     spm_unit_size: 3
+    weekly_hours_worked_before_lsr: 40
     # with one full-time, minimum-wage worker [...]
     # Step 1 - Gross Income:
     # The federal minimum wage is currently $7.25 per hour.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/is_snap_excluded_member.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/is_snap_excluded_member.yaml
@@ -4,6 +4,7 @@
     people:
       person1:
         age: 35
+        weekly_hours_worked_before_lsr: 40
         immigration_status: CITIZEN
     households:
       household:

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap.yaml
@@ -46,6 +46,7 @@
     people:   
       person1:
         age: 55
+        weekly_hours_worked_before_lsr: 40
         is_blind: true
         employment_income: 30_600
     households:
@@ -66,6 +67,7 @@
     people:
       person1:
         age: 55
+        weekly_hours_worked_before_lsr: 40
         self_employment_income_before_lsr: 10_000
     households:
       household:
@@ -96,6 +98,7 @@
     people:
       person1:
         age: 55
+        weekly_hours_worked_before_lsr: 40
         self_employment_income_before_lsr: 10_000
     households:
       household:

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_min_allotment.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_min_allotment.yaml
@@ -13,6 +13,7 @@
   period: 2022-01
   input:
     spm_unit_size: 3
+    weekly_hours_worked_before_lsr: 40
   output:
     # Ineligible as a family of 3.
     snap_min_allotment: 0

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_unit_size.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/snap_unit_size.yaml
@@ -1,13 +1,16 @@
 - name: Household with one ineligible student
   period: 2022
   input:
-    people: 
+    people:
       person1:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
       person2:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
       person3:
         is_snap_ineligible_student: true
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit1:
         members: [person1, person2, person3]
@@ -18,13 +21,16 @@
 - name: Everybody eligible
   period: 2022
   input:
-    people: 
+    people:
       person1:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
       person2:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
       person3:
         is_snap_ineligible_student: false
+        weekly_hours_worked_before_lsr: 40
     spm_units:
       spm_unit1:
         members: [person1, person2, person3]
@@ -111,10 +117,13 @@
     people:
       person1:
         immigration_status: CITIZEN
+        weekly_hours_worked_before_lsr: 40
       person2:
         immigration_status: REFUGEE
+        weekly_hours_worked_before_lsr: 40
       person3:
         immigration_status: CITIZEN
+        weekly_hours_worked_before_lsr: 40
     households:
       household1:
         members: [person1, person2, person3]

--- a/policyengine_us/tests/policy/baseline/household/income/person/weekly_hours_worked.yaml
+++ b/policyengine_us/tests/policy/baseline/household/income/person/weekly_hours_worked.yaml
@@ -87,3 +87,12 @@
     weekly_hours_worked_behavioural_response_income_elasticity: 2.6666667e-05
     weekly_hours_worked_behavioural_response_substitution_elasticity: 5.3333333e-05
     weekly_hours_worked_behavioural_response: 8.0000000e-05
+
+# Hardening: when no hours input is provided, the value defaults to 0
+# (not full-time 40), so missing data fails the work-hours test loudly
+# rather than silently clearing every hours-conditioned work requirement.
+- name: Weekly hours worked defaults to zero when unspecified
+  period: 2026
+  input: {}
+  output:
+    weekly_hours_worked_before_lsr: 0

--- a/policyengine_us/tests/policy/baseline/household/marginal_tax_rate_including_health_benefits.yaml
+++ b/policyengine_us/tests/policy/baseline/household/marginal_tax_rate_including_health_benefits.yaml
@@ -3,6 +3,7 @@
   period: 2021
   input:
     age: 40
+    weekly_hours_worked_before_lsr: 40
     employment_income: 100_000
     taxable_interest_income: 100_000
     state_fips: 48  # TX
@@ -14,6 +15,7 @@
   period: 2025
   input:
     age: 30
+    weekly_hours_worked_before_lsr: 40
     state_fips: 54
     employment_income: 30_000
     healthcare_benefit_value: 0
@@ -25,6 +27,7 @@
   period: 2025
   input:
     age: 30
+    weekly_hours_worked_before_lsr: 40
     state_fips: 54
     employment_income: 30_000
     is_aca_ptc_eligible: true
@@ -36,6 +39,7 @@
   period: 2025
   input:
     age: 30
+    weekly_hours_worked_before_lsr: 40
     state_fips: 15 # HI
     employment_income: 0
     healthcare_benefit_value: 0
@@ -47,6 +51,7 @@
   period: 2025
   input:
     age: 30
+    weekly_hours_worked_before_lsr: 40
     state_fips: 26 # MI
     employment_income: 0
     is_medicaid_eligible: true

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/federal.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/federal.yaml
@@ -237,6 +237,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 0
+        weekly_hours_worked_before_lsr: 40
       spouse:
         age: 28
         is_tax_unit_head: false
@@ -245,6 +246,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 0
+        weekly_hours_worked_before_lsr: 40
     households:
       household:
         members: &id004
@@ -273,8 +275,9 @@
     spm_units:
       spm_unit:
         # Zero-income childless couple pins the 2-person maximum allotment
-        # directly (no TANF/SSI confound; weekly_hours_worked_before_lsr defaults
-        # to 40, so work requirements are met). Net income 0 -> contribution 0 ->
+        # directly (no TANF/SSI confound; weekly_hours_worked_before_lsr is set
+        # to 40 for both adults so work requirements are met). Net income 0 ->
+        # contribution 0 ->
         # benefit = max allotment: 9 x 546 + 3 x 565.28 = 6,609.84.
         snap: 6609.85
         is_snap_eligible: true
@@ -291,6 +294,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 20_000
+        weekly_hours_worked_before_lsr: 40
     households:
       household:
         members: &id005
@@ -384,6 +388,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 20_000
+        weekly_hours_worked_before_lsr: 40
       spouse:
         age: 28
         is_tax_unit_head: false
@@ -392,6 +397,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 0
+        weekly_hours_worked_before_lsr: 40
     households:
       household:
         members: &id007
@@ -1443,6 +1449,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 20_000
+        weekly_hours_worked_before_lsr: 40
       student:
         age: 20
         is_tax_unit_head: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ks.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/federal/nutrition/snap/ks.yaml
@@ -21,6 +21,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 27_395
+        weekly_hours_worked_before_lsr: 40
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -29,6 +30,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 0
+        weekly_hours_worked_before_lsr: 40
     households:
       household:
         members: &id001
@@ -77,6 +79,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 27_495
+        weekly_hours_worked_before_lsr: 40
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -85,6 +88,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 0
+        weekly_hours_worked_before_lsr: 40
     households:
       household:
         members: &id002
@@ -243,6 +247,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 20_000
+        weekly_hours_worked_before_lsr: 40
       spouse:
         age: 33
         is_tax_unit_head: false
@@ -251,6 +256,7 @@
         is_disabled: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 0
+        weekly_hours_worked_before_lsr: 40
     households:
       household:
         members: &id005

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/tx/ccs.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/tx/ccs.yaml
@@ -6,8 +6,8 @@
 # 7% of income. Benefit = min(childcare expense, board max rate) - copay.
 # tx_ccs_payment_rate is set directly (7,200/year = 600/month) to pin the
 # copay math independent of the provider-rate table; the work requirement
-# (25 hours/week single parent) passes via the weekly_hours_worked_before_lsr
-# default of 40.
+# (25 hours/week single parent) is satisfied by setting
+# weekly_hours_worked_before_lsr to 40 on the working parent.
 - name: tx_ccs_expense_capped_at_max_rate_copay_deducted (tx)
   period: 2026
   absolute_error_margin: 0.1
@@ -22,6 +22,7 @@
         is_full_time_student: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 30_000
+        weekly_hours_worked_before_lsr: 40
       child1:
         age: 5
         is_tax_unit_head: false
@@ -84,6 +85,7 @@
         # 62,500/year = 5,208.33/month, just below the 85% SMI limit of
         # 5,215.68/month (62,588.15/year).
         employment_income_before_lsr: 62_500
+        weekly_hours_worked_before_lsr: 40
       child1:
         age: 5
         is_tax_unit_head: false

--- a/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/tx/dart.yaml
+++ b/policyengine_us/tests/policy/baseline/partners/analytics_coverage/edge_cases/state/tx/dart.yaml
@@ -247,7 +247,8 @@
     people:
       head:
         # Age 30 has no age route; zero income makes the household
-        # SNAP-eligible, which qualifies for the Discount GoPass.
+        # SNAP-eligible, which qualifies for the Discount GoPass. Work hours
+        # are set so the childless adult meets the SNAP work requirement.
         age: 30
         is_tax_unit_head: true
         is_tax_unit_spouse: false
@@ -256,6 +257,7 @@
         is_full_time_student: false
         immigration_status_str: CITIZEN
         employment_income_before_lsr: 0
+        weekly_hours_worked_before_lsr: 40
     households:
       household:
         members: &id006

--- a/policyengine_us/tests/policy/contrib/snap_ea/snap_ca_ea_reform.yaml
+++ b/policyengine_us/tests/policy/contrib/snap_ea/snap_ca_ea_reform.yaml
@@ -4,6 +4,7 @@
   input:
     state_code: CA
     spm_unit_size: 3
+    weekly_hours_worked_before_lsr: 40
   output:
     # Assert that Jan/Feb/Mar/Apr are all $95, and following months are $0.
     snap_emergency_allotment:

--- a/policyengine_us/tests/policy/contrib/states/id/child_poverty_impact_dashboard/eitc/id_eitc.yaml
+++ b/policyengine_us/tests/policy/contrib/states/id/child_poverty_impact_dashboard/eitc/id_eitc.yaml
@@ -1,8 +1,9 @@
-# These cases use the minimal default household, which does not trigger any of
-# Idaho's baseline refundable credits (the grocery credit requires residency
-# details these synthetic cases don't set), so id_refundable_credits equals the
-# new EITC alone. Preservation of the baseline refundable credits when they DO
-# apply is covered by id_eitc_preserves_baseline_credits.yaml. See #8775.
+# These cases use the minimal default household with work hours set so the
+# adult meets the SNAP work requirement and receives SNAP (as under the model's
+# prior default); SNAP receipt precludes Idaho's grocery credit, so
+# id_refundable_credits equals the new EITC alone. Preservation of the baseline
+# refundable credits when they DO apply is covered by
+# id_eitc_preserves_baseline_credits.yaml. See #8775.
 - name: Case 1 - ID EITC with 10% match
   period: 2024
   reforms: policyengine_us.reforms.states.id.eitc.id_eitc
@@ -10,6 +11,7 @@
     gov.contrib.states.id.child_poverty_impact_dashboard.eitc.match: 0.1
     state_code: ID
     eitc: 1_000
+    weekly_hours_worked_before_lsr: 40
   output:
     id_eitc: 100
     id_refundable_credits: 100
@@ -21,6 +23,7 @@
     gov.contrib.states.id.child_poverty_impact_dashboard.eitc.match: 0.2
     state_code: ID
     eitc: 2_500
+    weekly_hours_worked_before_lsr: 40
   output:
     id_eitc: 500
     id_refundable_credits: 500
@@ -32,6 +35,7 @@
     gov.contrib.states.id.child_poverty_impact_dashboard.eitc.match: 0
     state_code: ID
     eitc: 1_000
+    weekly_hours_worked_before_lsr: 40
   output:
     id_eitc: 0
     id_refundable_credits: 0
@@ -43,6 +47,7 @@
     gov.contrib.states.id.child_poverty_impact_dashboard.eitc.match: 0.1
     state_code: ID
     eitc: 0
+    weekly_hours_worked_before_lsr: 40
   output:
     id_eitc: 0
     id_refundable_credits: 0

--- a/policyengine_us/variables/household/income/person/weekly_hours_worked.py
+++ b/policyengine_us/variables/household/income/person/weekly_hours_worked.py
@@ -23,7 +23,17 @@ class weekly_hours_worked_before_lsr(Variable):
     label = "average weekly hours worked (before labor supply responses)"
     unit = "hour"
     definition_period = YEAR
-    default_value = 40
+    documentation = (
+        "Usual weekly hours worked, before labor supply responses. Datasets "
+        "populate this from survey data; it is the input the SNAP ABAWD "
+        "(20-hour) and general (30-hour) work-requirement tests read. The "
+        "default is 0, not a full-time 40, so a household or dataset that "
+        "fails to populate it reads as 'no hours' and fails the work-hours "
+        "test loudly, rather than silently clearing every hours-conditioned "
+        "work requirement — the failure mode where a missing or degenerate "
+        "hours column makes work-requirement reforms a no-op."
+    )
+    default_value = 0
 
 
 class weekly_hours_worked_behavioural_response_income_elasticity(Variable):


### PR DESCRIPTION
Closes #9254.

## Problem
`weekly_hours_worked_before_lsr` defaulted to **40** (full-time). Any household or dataset that failed to populate it therefore read as working full-time and **silently cleared both** the 20-hour SNAP ABAWD test and the 30-hour general work-requirement test. That turns work-requirement reforms into a no-op whenever the hours column is missing or degenerate — the failure mode that hid a constant-40 hours column in a populace build (PolicyEngine/populace#613, #626) and made a hand-built fixture read `meets_abawd_work_requirement = true` for 0-hour adults.

Because 40 sits above every hours threshold, missing data was indistinguishable from "compliant" — it failed silently.

## Change
Default `weekly_hours_worked_before_lsr` to **0**. Missing hours now read as "no hours" and fail the work-hours test loudly instead of passing.

- Datasets and tests that provide the input are **unaffected** (input overrides the default), so the microsimulation on the populated national dataset does not change.
- Only situations/tests that omit hours change — they now correctly show a non-working person.

## Tests added
- `weekly_hours_worked.yaml`: `weekly_hours_worked_before_lsr` defaults to 0 when unspecified.
- `meets_snap_abawd_work_requirements.yaml` (Case 59): a working-age, non-exempt adult with no hours input now **fails** the ABAWD hours test.

## Draft — why
I could not run the full YAML suite locally (environment constraint). Opening as draft so CI can surface any existing unit tests that implicitly relied on the old 40-hour default (i.e. tests with working-age adults in hours-conditioned programs that omit hours). I'll update those to set hours explicitly once CI reports. Flagging the reviewer decision: default `0` (this PR, per the issue's recommendation) vs. a fallback formula from `hours_worked_last_week` — happy to switch approaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)