### PR TITLE
Remove repealed low-income AGI cap on Vermont 2022 child and dependent care credit

### DIFF
--- a/changelog.d/fix-vt-cdcc-2022-income-cap.fixed.md
+++ b/changelog.d/fix-vt-cdcc-2022-income-cap.fixed.md
@@ -1,0 +1,1 @@
+Removed the incorrect low-income AGI cap on the Vermont child and dependent care credit for tax year 2022, which 2022 Act 138 repealed retroactively to January 1, 2022.

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
@@ -1,9 +1,12 @@
 description: Vermont limits the Child and Dependent Care Credit to filers with adjusted gross income at or below the low-income threshold when this is in effect.
 values:
-  # 2022 Act 138, Sec. 3 retained the 5828c low-income adjusted gross income
-  # cap for 2022; 2023 Act 72, Sec. 14 removed it effective 2023.
-  2022-01-01: true
-  2023-01-01: false
+  # 2022 Act 138, Sec. 3 struck the 5828c low-income adjusted gross income cap
+  # (and the certified-facility requirement) and raised the match from 50% to
+  # 72%, renaming the section from "Low-income child and dependent care credit"
+  # to "Child and dependent care credit." Per Sec. 13(b) this took effect
+  # retroactively to January 1, 2022, so the 72% credit has never been
+  # income-limited.
+  2022-01-01: false
 metadata:
   unit: bool
   period: year
@@ -11,5 +14,5 @@ metadata:
   reference:
     - title: 2022 Act 138, Sec. 3 (amending 32 V.S.A. § 5828c)
       href: https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3
-    - title: 2023 Act 72, Sec. 14 (amending 32 V.S.A. § 5828c)
-      href: https://legislature.vermont.gov/Documents/2024/Docs/ACTS/ACT072/ACT072%20As%20Enacted.pdf#page=14
+    - title: 2022 Form IN-112 Vermont Tax Adjustments and Credits, Part II line 2
+      href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf#page=2

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
@@ -1,11 +1,14 @@
 description: Vermont limits the Child and Dependent Care Credit to filers with adjusted gross income at or below the low-income threshold when this is in effect.
 values:
+  # Through 2021 the Vermont credit under 32 V.S.A. § 5828c was the low-income
+  # child and dependent care credit, limited to filers with AGI below the
+  # $30,000 / $40,000 threshold.
+  2021-01-01: true
   # 2022 Act 138, Sec. 3 struck the 5828c low-income adjusted gross income cap
   # (and the certified-facility requirement) and raised the match from 50% to
   # 72%, renaming the section from "Low-income child and dependent care credit"
   # to "Child and dependent care credit." Per Sec. 13(b) this took effect
-  # retroactively to January 1, 2022, so the 72% credit has never been
-  # income-limited.
+  # retroactively to January 1, 2022, so the 72% credit is not income-limited.
   2022-01-01: false
 metadata:
   unit: bool

--- a/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/credits/cdcc/income_limit_in_effect.yaml
@@ -17,5 +17,17 @@ metadata:
   reference:
     - title: 2022 Act 138, Sec. 3 (amending 32 V.S.A. § 5828c)
       href: https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3
+    # 2021 Schedule IN-112 line 1 is the "Low Income Child & Dependent Care
+    # Credit," limited to AGI of $30,000 ($40,000 MFJ) or less: income limit
+    # in effect.
+    - title: 2021 Form IN-112 Vermont Tax Adjustments and Credits, Part II line 1
+      href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2021.pdf#page=2
+    # 2022 onward Schedule IN-112 line 2 is the "Vermont Child and Dependent
+    # Care Credit" at 72% of the federal credit with no income test: income
+    # limit not in effect.
     - title: 2022 Form IN-112 Vermont Tax Adjustments and Credits, Part II line 2
       href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf#page=2
+    - title: 2023 Form IN-112 Vermont Tax Adjustments and Credits, Part II line 2
+      href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2023.pdf#page=2
+    - title: 2024 Form IN-112 Vermont Tax Adjustments and Credits, Part II line 2
+      href: https://tax.vermont.gov/sites/tax/files/documents/IN-112-2024.pdf#page=2

--- a/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_cdcc.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/vt/tax/income/credits/cdcc/vt_cdcc.yaml
@@ -14,26 +14,26 @@
   output:
     vt_cdcc: 1440 
 
-- name: Vermont CDCC 2022 above the low-income AGI cap gets no credit, 2022 Act 138 Sec. 3
+- name: Vermont CDCC 2022 high-AGI filer still gets the full 72% credit; 2022 Act 138 Sec. 3 struck the low-income AGI cap
   period: 2022
   input:
     capped_cdcc: 1_000
     adjusted_gross_income: 50_000
     state_code: VT
   output:
-    vt_cdcc: 0
+    vt_cdcc: 720
 
-- name: Vermont CDCC 2022 joint filer at the 40,000 AGI threshold keeps the credit
+- name: Vermont CDCC 2022 high-income joint filer keeps the credit; no AGI cap after Act 138
   period: 2022
   input:
     capped_cdcc: 1_000
-    adjusted_gross_income: 40_000
+    adjusted_gross_income: 100_000
     filing_status: JOINT
     state_code: VT
   output:
     vt_cdcc: 720
 
-- name: Vermont CDCC 2023 has no AGI cap, 2023 Act 72 Sec. 14
+- name: Vermont CDCC 2023 has no AGI cap
   period: 2023
   input:
     capped_cdcc: 1_000


### PR DESCRIPTION
Fixes #9262. Surfaced by [PolicyEngine/policyengine-taxsim#1125](https://github.com/PolicyEngine/policyengine-taxsim/issues/1125).

## Problem

For tax year **2022**, PolicyEngine gated the Vermont Child and Dependent Care Credit (`vt_cdcc`, 72% of the federal CDCC) behind a low-income AGI cap ($30,000 single/HoH, $40,000 joint) via the `income_limit_in_effect` parameter. Filers with AGI above the threshold were denied the credit entirely.

That cap does not apply to 2022. [2022 Act 138, Sec. 3](https://legislature.vermont.gov/Documents/2022/Docs/ACTS/ACT138/ACT138%20As%20Enacted.pdf#page=3) **struck** the AGI cap and the certified-facility requirement from 32 V.S.A. § 5828c, renamed the section from "~~Low-income~~ child and dependent care credit," and raised the match from 50% to 72% — effective **retroactively to January 1, 2022** (Sec. 13(b)). The [2022 Schedule IN-112, line 2](https://tax.vermont.gov/sites/tax/files/documents/IN-112-2022.pdf#page=2) confirms it: "MULTIPLY Line 1 by 72% (0.72)" with no income test. The prior parameter comment attributed the repeal to 2023 Act 72, but Act 138 already did it for 2022.

## Fix

- `income_limit_in_effect` set to `false` from 2022-01-01 (the 72% credit only exists from 2022 and was never income-limited).
- Updated `vt_cdcc.yaml` tests, which previously asserted the buggy `vt_cdcc: 0` for a 2022 high-AGI filer.

## Impact

A 2022 head-of-household filer with $38,805 AGI and a $690 federal CDCC now receives the $497 Vermont credit (72% × $690) instead of $0, matching TaxAct.
