### PR TITLE
Fix Missouri TANF SSI exclusions and per-earner income disregards

### DIFF
--- a/changelog.d/mo-tanf-ssi-payee-only.fixed.md
+++ b/changelog.d/mo-tanf-ssi-payee-only.fixed.md
@@ -1,0 +1,1 @@
+Apply Missouri TANF earned income disregards to each earner separately, allow a caretaker payee-only grant when the only child in the home receives SSI, and exclude SSI recipients' person-level assets from the resource test.

--- a/changelog.d/mo-tanf-ssi-payee-only.fixed.md
+++ b/changelog.d/mo-tanf-ssi-payee-only.fixed.md
@@ -1,1 +1,1 @@
-Apply Missouri TANF earned income disregards to each earner separately, allow a caretaker payee-only grant when the only child in the home receives SSI, and exclude SSI recipients' person-level assets from the resource test.
+Apply Missouri TANF earned income disregards to each earner separately, allow a caretaker-only grant when the only child in the home receives SSI, and exclude SSI recipients' person-level assets from the resource test.

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/child_care_deduction/amount.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/child_care_deduction/amount.yaml
@@ -7,8 +7,8 @@ metadata:
   threshold_unit: year
   amount_unit: currency-USD
   reference:
-    - title: 13 CSR 40-2.120(6)(A)5
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(9)(A)5
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310
     - title: Missouri DSS Manual 0210.015.30
       href: https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30/
 

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/amount.yaml
@@ -1,7 +1,10 @@
 description: Missouri deducts this amount as the standard work exemption from gross earned income under the Temporary Assistance for Needy Families program.
 
 values:
-  1991-01-01: 90
+  # The disregard predates TANF; the start date marks the beginning of
+  # the modeled Missouri TANF period, aligned with the 1999-10-01 start
+  # of the two-thirds disregard (RSMo 208.040.5(1)).
+  1999-10-01: 90
 
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/amount.yaml
@@ -8,7 +8,7 @@ metadata:
   period: month
   label: Missouri TANF standard work exemption
   reference:
-    - title: 13 CSR 40-2.120(6)
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(9)(A)2
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310
     - title: Missouri DSS Manual 0210.015.30
       href: https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30/

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/flat_amount.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/flat_amount.yaml
@@ -1,7 +1,10 @@
 description: Missouri deducts this flat amount as part of the earned income disregard under the Temporary Assistance for Needy Families program.
 
 values:
-  1991-01-01: 30
+  # The disregard predates TANF; the start date marks the beginning of
+  # the modeled Missouri TANF period, aligned with the 1999-10-01 start
+  # of the two-thirds disregard (RSMo 208.040.5(1)).
+  1999-10-01: 30
 
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/flat_amount.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/flat_amount.yaml
@@ -8,7 +8,7 @@ metadata:
   period: month
   label: Missouri TANF thirty dollar disregard
   reference:
-    - title: 13 CSR 40-2.120(6)
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(9)(A)3
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310
     - title: Missouri DSS Manual 0210.015.30
       href: https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30/

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/percentage.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/percentage.yaml
@@ -8,7 +8,7 @@ metadata:
   period: month
   label: Missouri TANF one-third disregard percentage
   reference:
-    - title: 13 CSR 40-2.120(6)
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(9)(A)3
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310
     - title: Missouri DSS Manual 0210.015.30
       href: https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30/

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/percentage.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/thirty_plus_one_third/percentage.yaml
@@ -1,7 +1,10 @@
 description: Missouri excludes this share of remaining earned income as the one-third portion of the earned income disregard under the Temporary Assistance for Needy Families program.
 
 values:
-  1991-01-01: 0.3333333333333333
+  # The disregard predates TANF; the start date marks the beginning of
+  # the modeled Missouri TANF period, aligned with the 1999-10-01 start
+  # of the two-thirds disregard (RSMo 208.040.5(1)).
+  1999-10-01: 0.3333333333333333
 
 metadata:
   unit: /1

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/two_thirds_disregard/percentage.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/earned_income_disregard/two_thirds_disregard/percentage.yaml
@@ -1,13 +1,20 @@
 description: Missouri excludes this share of gross earned income as the two-thirds disregard under the Temporary Assistance for Needy Families program.
 
 values:
-  1991-01-01: 0.6666666666666666
+  # RSMo 208.040.5(1) (1999 S.B. 387) directed "increasing the earned
+  # income disregard to two-thirds by October 1, 1999"; DSS memo IM-109
+  # (08/13/99) confirms the October 1, 1999 effective date.
+  1999-10-01: 0.6666666666666666
 
 metadata:
   unit: /1
   period: month
   label: Missouri TANF two-thirds disregard percentage
   reference:
+    - title: RSMo 208.040.5(1)
+      href: https://revisor.mo.gov/main/OneSection.aspx?section=208.040
+    - title: Missouri DSS memo IM-109 (August 13, 1999)
+      href: https://dssmanuals.mo.gov/wp-content/themes/mogovwp_dssmanuals/public/memos/memos_99/im109_99.html
     - title: 13 CSR 40-2.310(9)(D)
       href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310
     - title: Missouri DSS Manual 0210.015.30

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/income_limit/max_table_size.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/income_limit/max_table_size.yaml
@@ -8,5 +8,5 @@ metadata:
   period: year
   label: Missouri TANF income limit maximum table size
   reference:
-    - title: 13 CSR 40-2.120(3)(A)1
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(13)
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/resource_limit/amount.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/resource_limit/amount.yaml
@@ -1,4 +1,4 @@
-description: Missouri limits countable resources to this amount at initial application under the Temporary Assistance for Needy Families program.
+description: Missouri limits countable resources to this amount under the Temporary Assistance for Needy Families program.
 
 values:
   1991-01-01: 1_000
@@ -6,9 +6,9 @@ values:
 metadata:
   unit: currency-USD
   period: month
-  label: Missouri TANF resource limit at application
+  label: Missouri TANF resource limit
   reference:
     - title: 13 CSR 40-2.310(3)
       href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310
-    - title: Missouri DSS Manual 0200.000.00
-      href: https://dssmanuals.mo.gov/temporary-assistance-case-management/0200-000-00/
+    - title: Missouri DSS Manual 0205.005.00
+      href: https://dssmanuals.mo.gov/temporary-assistance-case-management/0205-005-00/

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/standard_of_need/additional_person_increment.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/standard_of_need/additional_person_increment.yaml
@@ -8,5 +8,5 @@ metadata:
   period: month
   label: Missouri TANF standard of need increment
   reference:
-    - title: 13 CSR 40-2.120(3)(A)1
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(13)
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/standard_of_need/amount.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/standard_of_need/amount.yaml
@@ -9,8 +9,8 @@ metadata:
     - Assistance unit size
   label: Missouri TANF standard of need
   reference:
-    - title: 13 CSR 40-2.120(3)(A)1
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(13)
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310
     - title: Missouri DSS Manual 0210.010.05
       href: https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-010-05-185/
 

--- a/policyengine_us/parameters/gov/states/mo/dss/tanf/standard_of_need/base_table_max_size.yaml
+++ b/policyengine_us/parameters/gov/states/mo/dss/tanf/standard_of_need/base_table_max_size.yaml
@@ -8,5 +8,5 @@ metadata:
   period: year
   label: Missouri TANF standard of need base table size
   reference:
-    - title: 13 CSR 40-2.120(3)(A)1
-      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120
+    - title: 13 CSR 40-2.310(13)
+      href: https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/integration.yaml
@@ -422,8 +422,9 @@
     mo_tanf_eligible: true
     mo_tanf: 135.687
 
-- name: A family whose only child receives SSI has no eligible case
+- name: A family whose only child receives SSI gets a payee-only grant
   period: 2024-01
+  absolute_error_margin: 0.01
   input:
     people:
       parent:
@@ -443,8 +444,71 @@
         members: [parent, ssi_child]
         state_code: MO
   output:
-    # The SSI child cannot be in the unit, and without a dependent child
-    # in the unit there is no Temporary Assistance case.
+    # The SSI child is excluded from the unit but still establishes the
+    # case; the parent receives a size-1 payee-only grant (DSS Manual
+    # 0210.005.05: "when the only child in the EU receives SSI, explore
+    # Temporary Assistance (TA) eligibility for the payee and/or second
+    # parent").
+    mo_tanf_assistance_unit_size: 1
+    mo_tanf_eligible: true
+    mo_tanf: 135.69
+
+- name: An SSI child's own savings do not disqualify the payee-only unit
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 30
+        bank_account_assets: 400
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+        bank_account_assets: 1_500
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    # DSS Manual 0210.005.10 excludes the SSI participant's resources:
+    # only the parent's $400 counts against the $1,000 limit, so the
+    # $1,900 of total unit assets do not block the payee-only grant.
+    mo_tanf_countable_resources: 400
+    mo_tanf_resources_eligible: true
+    mo_tanf_assistance_unit_size: 1
+    mo_tanf_eligible: true
+    mo_tanf: 135.69
+
+- name: A family whose child and caretaker both receive SSI has no payable unit
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+        ssi: 750
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    # Both members are SSI recipients, so no one remains to pay.
     mo_tanf_assistance_unit_size: 0
     mo_tanf_eligible: false
     mo_tanf: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/integration.yaml
@@ -422,7 +422,7 @@
     mo_tanf_eligible: true
     mo_tanf: 135.687
 
-- name: A family whose only child receives SSI gets a payee-only grant
+- name: A family whose only child receives SSI gets a caretaker-only grant
   period: 2024-01
   absolute_error_margin: 0.01
   input:
@@ -445,7 +445,7 @@
         state_code: MO
   output:
     # The SSI child is excluded from the unit but still establishes the
-    # case; the parent receives a size-1 payee-only grant (DSS Manual
+    # case; the parent receives a size-1 caretaker-only grant (DSS Manual
     # 0210.005.05: "when the only child in the EU receives SSI, explore
     # Temporary Assistance (TA) eligibility for the payee and/or second
     # parent").
@@ -453,7 +453,7 @@
     mo_tanf_eligible: true
     mo_tanf: 135.69
 
-- name: An SSI child's own savings do not disqualify the payee-only unit
+- name: An SSI child's own savings do not disqualify the caretaker-only unit
   period: 2024-01
   absolute_error_margin: 0.01
   input:
@@ -479,7 +479,7 @@
   output:
     # DSS Manual 0210.005.10 excludes the SSI participant's resources:
     # only the parent's $400 counts against the $1,000 limit, so the
-    # $1,900 of total unit assets do not block the payee-only grant.
+    # $1,900 of total unit assets do not block the caretaker-only grant.
     mo_tanf_countable_resources: 400
     mo_tanf_resources_eligible: true
     mo_tanf_assistance_unit_size: 1
@@ -512,3 +512,237 @@
     mo_tanf_assistance_unit_size: 0
     mo_tanf_eligible: false
     mo_tanf: 0
+
+- name: Two-parent caretaker-only unit when the only child receives SSI
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 40
+      parent2:
+        age: 38
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, ssi_child]
+        spm_unit_cash_assets: 500
+    households:
+      household:
+        members: [parent1, parent2, ssi_child]
+        state_code: MO
+  output:
+    # DSS Manual 0210.005.05 extends the caretaker-only case to "the
+    # payee and/or second parent": both parents stay in the unit at the
+    # size-2 payment level while the SSI child is excluded.
+    mo_tanf_assistance_unit_size: 2
+    mo_tanf_eligible: true
+    mo_tanf: 234.09
+
+- name: An SSI child with an eligible sibling stays out of the unit
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 35
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+      sibling:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child, sibling]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child, sibling]
+        spm_unit_cash_assets: 500
+    households:
+      household:
+        members: [parent, ssi_child, sibling]
+        state_code: MO
+  output:
+    # The eligible sibling and parent form a size-2 unit; the SSI child
+    # remains excluded even though another payable child is present
+    # (13 CSR 40-2.310(1)(F); DSS Manual 0210.005.10).
+    mo_tanf_assistance_unit_size: 2
+    mo_tanf_eligible: true
+    mo_tanf: 234.09
+
+- name: A caretaker's own assets can still fail the resource test
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+        bank_account_assets: 1_200
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    # Only the SSI child's resources are excluded (DSS Manual
+    # 0210.005.10); the parent's $1,200 exceeds the $1,000 limit and
+    # blocks the caretaker-only grant.
+    mo_tanf_countable_resources: 1_200
+    mo_tanf_resources_eligible: false
+    mo_tanf_eligible: false
+    mo_tanf: 0
+
+- name: Two new-applicant earners end to end
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 30
+        employment_income_before_lsr: 2_400  # $200/month
+      parent2:
+        age: 30
+        employment_income_before_lsr: 2_400  # $200/month
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, child]
+        spm_unit_cash_assets: 500
+    households:
+      household:
+        members: [parent1, parent2, child]
+        state_code: MO
+  output:
+    # Per earner: $90 + $30 + ($200 - $120) / 3 = $146.67; x2 = $293.33
+    # (13 CSR 40-2.310(9)(A) applies the disregards to each participant).
+    # Countable: $400 - $293.33 = $106.67; benefit: $292.09 - $106.67.
+    mo_tanf_gross_earned_income: 400
+    mo_tanf_earned_income_deductions: 293.33
+    mo_tanf_countable_income: 106.67
+    mo_tanf_eligible: true
+    mo_tanf: 185.42
+
+- name: Two enrolled earners end to end
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 30
+        employment_income_before_lsr: 2_400  # $200/month
+      parent2:
+        age: 30
+        employment_income_before_lsr: 2_400  # $200/month
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, child]
+        spm_unit_cash_assets: 500
+        is_tanf_enrolled: true
+    households:
+      household:
+        members: [parent1, parent2, child]
+        state_code: MO
+  output:
+    # Per enrolled earner: two-thirds of $200 = $133.33, then the work
+    # exemption caps at the $66.67 left, deducting all $200; x2 = $400
+    # (DSS Manual 0210.015.30.20). Countable income is zero, so the unit
+    # receives the size-3 maximum benefit.
+    mo_tanf_earned_income_deductions: 400
+    mo_tanf_countable_income: 0
+    mo_tanf_eligible: true
+    mo_tanf: 292.09
+
+- name: A self-employment loss does not offset another earner's income
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 30
+        self_employment_income_before_lsr: -3_600  # -$300/month
+      parent2:
+        age: 30
+        employment_income_before_lsr: 5_760  # $480/month
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, child]
+        spm_unit_cash_assets: 500
+    households:
+      household:
+        members: [parent1, parent2, child]
+        state_code: MO
+  output:
+    # The loss earner's -$300 deduction cancels their -$300 gross, so
+    # countable income equals the wage earner's own result: $480 - $240
+    # = $240 (13 CSR 40-2.310(9)(A) applies the disregards per
+    # participant; no cross-earner loss offset). Benefit: $292.09 - $240.
+    mo_tanf_gross_earned_income: 180
+    mo_tanf_earned_income_deductions: -60
+    mo_tanf_countable_income: 240
+    mo_tanf: 52.09
+
+- name: A self-employment loss does not offset an enrolled earner's income
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 30
+        self_employment_income_before_lsr: -3_600  # -$300/month
+      parent2:
+        age: 30
+        employment_income_before_lsr: 5_760  # $480/month
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, child]
+        spm_unit_cash_assets: 500
+        is_tanf_enrolled: true
+    households:
+      household:
+        members: [parent1, parent2, child]
+        state_code: MO
+  output:
+    # Enrolled wage earner: two-thirds of $480 = $320, plus the $90
+    # work exemption = $410; the loss earner's -$300 cancels their own
+    # gross, leaving countable income $480 - $410 = $70.
+    mo_tanf_countable_income: 70
+    mo_tanf: 222.09

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_assistance_unit_size.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_assistance_unit_size.yaml
@@ -155,3 +155,28 @@
     # 13 CSR 40-2.310(1)(F): reported SSI receipt alone excludes the
     # parent, leaving a child-only unit.
     mo_tanf_assistance_unit_size: 1
+
+- name: An SSI child leaves a caretaker-only unit of one
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    # DSS Manual 0210.005.05: the SSI child establishes the case but only
+    # the caretaker is a payable member.
+    mo_tanf_assistance_unit_size: 1

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_child_care_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_child_care_deduction.yaml
@@ -205,7 +205,7 @@
         members: [person1, person2]
         state_code: MO
   output:
-    # Per 13 CSR 40-2.120(6)(A)5: incapacitated individual care at the
+    # Per 13 CSR 40-2.310(9)(A)5: incapacitated individual care at the
     # $175/month age-2+ tier. Expenses = 1,200 / 12 = 100/month.
     mo_tanf_child_care_deduction: 100
 

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_countable_resources.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_countable_resources.yaml
@@ -130,3 +130,57 @@
   output:
     mo_tanf_countable_resources: 800
     mo_tanf_resources_eligible: true
+
+- name: Countable resources exactly at the limit through the SSI exclusion path
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+        bank_account_assets: 1_000
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+        bank_account_assets: 1_500
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    # 13 CSR 40-2.310(3): eligible when countable resources do not
+    # exceed $1,000; the SSI child's $1,500 is excluded.
+    mo_tanf_countable_resources: 1_000
+    mo_tanf_resources_eligible: true
+
+- name: Countable resources just over the limit through the SSI exclusion path
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+        bank_account_assets: 1_001
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+        bank_account_assets: 1_500
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    mo_tanf_countable_resources: 1_001
+    mo_tanf_resources_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_countable_resources.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_countable_resources.yaml
@@ -1,0 +1,132 @@
+# DSS Manual 0210.005.10 excludes an SSI participant's resources. The
+# exclusion works by subtracting SSI recipients' person-level assets from
+# the unit aggregate, so it activates only when assets are attributed to
+# people; aggregate-only inputs keep the aggregate behavior.
+- name: Person-level assets of an SSI child are excluded
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+        bank_account_assets: 400
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+        bank_account_assets: 1_500
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    # $1,900 of unit assets minus the SSI child's $1,500.
+    mo_tanf_countable_resources: 400
+    mo_tanf_resources_eligible: true
+
+- name: A non-recipient's person-level assets count in full
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+        bank_account_assets: 1_200
+      child:
+        age: 8
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: MO
+  output:
+    mo_tanf_countable_resources: 1_200
+    mo_tanf_resources_eligible: false
+
+- name: Aggregate-only input cannot be attributed and counts in full
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+        spm_unit_cash_assets: 2_000
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    # Nothing identifies whose assets these are, so no exclusion applies.
+    mo_tanf_countable_resources: 2_000
+    mo_tanf_resources_eligible: false
+
+- name: SSI recipient assets larger than a directly supplied aggregate floor at zero
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        ssi: 750
+        bank_account_assets: 2_000
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+        spm_unit_cash_assets: 500
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    mo_tanf_countable_resources: 0
+    mo_tanf_resources_eligible: true
+
+- name: Reported SSI receipt also excludes the person's assets
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 30
+        bank_account_assets: 800
+      ssi_child:
+        age: 8
+        is_tax_unit_dependent: true
+        receives_ssi: true
+        bank_account_assets: 1_500
+    tax_units:
+      tax_unit:
+        members: [parent, ssi_child]
+    spm_units:
+      spm_unit:
+        members: [parent, ssi_child]
+    households:
+      household:
+        members: [parent, ssi_child]
+        state_code: MO
+  output:
+    mo_tanf_countable_resources: 800
+    mo_tanf_resources_eligible: true

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions.yaml
@@ -165,3 +165,62 @@
     # The student child's earnings are excluded from gross earned income
     # (DSS Manual 0210.015.35.10), so no disregard attaches to them.
     mo_tanf_earned_income_deductions: 0
+
+- name: An SSI-recipient earner generates no deduction
+  period: 2024-01
+  input:
+    people:
+      ssi_parent:
+        age: 30
+        ssi: 750
+        tanf_gross_earned_income: 300
+      parent2:
+        age: 30
+        tanf_gross_earned_income: 480
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [ssi_parent, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [ssi_parent, parent2, child]
+    households:
+      household:
+        members: [ssi_parent, parent2, child]
+        state_code: MO
+  output:
+    # The SSI parent is not an assistance unit member (13 CSR
+    # 40-2.310(1)(F)), so their $300 of earnings — excluded from gross
+    # earned income — also attach no disregard: only the other parent's
+    # $240 counts, not $420.
+    mo_tanf_earned_income_deductions: 240
+
+- name: An exempt student earner alongside a counted earner
+  period: 2024-01
+  input:
+    people:
+      parent:
+        age: 40
+        tanf_gross_earned_income: 300
+      student_child:
+        age: 17
+        is_tax_unit_dependent: true
+        is_in_secondary_school: true
+        tanf_gross_earned_income: 300
+    tax_units:
+      tax_unit:
+        members: [parent, student_child]
+    spm_units:
+      spm_unit:
+        members: [parent, student_child]
+    households:
+      household:
+        members: [parent, student_child]
+        state_code: MO
+  output:
+    # Only the parent's earnings are counted, so only the parent's $180
+    # disregard applies; the exempt student child's earnings (DSS Manual
+    # 0210.015.35.10) contribute no deduction.
+    mo_tanf_earned_income_deductions: 180

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions.yaml
@@ -1,97 +1,167 @@
-# New applicants (not enrolled in TA when employment began) get the $90
-# standard work exemption, then $30, then one-third of the remainder
-# (DSS Manual 0210.015.30.10). Active participants get two-thirds of
-# gross earnings first, then the work exemption (0210.015.30.20).
-- name: No earned income
+# The unit-level deduction sums each earner's separately computed
+# disregards (13 CSR 40-2.310(9)(A); DSS Manual 0210.015.30.10: "If more
+# than one person has earned income, apply the $30 plus 1/3 disregard to
+# each person's net income. Add together the $30 plus 1/3 disregard
+# amount from each person's income."), plus child care costs.
+- name: Single earner
   period: 2024-01
   input:
-    state_code: MO
-    mo_tanf_gross_earned_income: 0
-    mo_tanf_child_care_deduction: 0
+    people:
+      parent:
+        age: 30
+        tanf_gross_earned_income: 480
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+    households:
+      household:
+        members: [parent, child]
+        state_code: MO
   output:
-    mo_tanf_earned_income_deductions: 0
-
-- name: Earned income below the $90 work exemption
-  period: 2024-01
-  input:
-    state_code: MO
-    mo_tanf_gross_earned_income: 50
-    mo_tanf_child_care_deduction: 0
-  output:
-    # The work exemption caps at gross earnings; nothing remains for the
-    # $30 plus one-third disregard.
-    mo_tanf_earned_income_deductions: 50
-
-- name: Earned income at the $90 work exemption
-  period: 2024-01
-  input:
-    state_code: MO
-    mo_tanf_gross_earned_income: 90
-    mo_tanf_child_care_deduction: 0
-  output:
-    mo_tanf_earned_income_deductions: 90
-
-- name: DSS manual sequence for a new applicant earning $300
-  period: 2024-01
-  input:
-    state_code: MO
-    mo_tanf_gross_earned_income: 300
-    mo_tanf_child_care_deduction: 0
-  output:
-    # $300 - $90 = $210; $210 - $30 = $180; one-third of $180 = $60.
-    # Deductions: $90 + $30 + $60 = $180, leaving $120 countable
-    # (DSS Manual 0210.015.30.10).
-    mo_tanf_earned_income_deductions: 180
-
-- name: New applicant earning $480
-  period: 2024-01
-  input:
-    state_code: MO
-    mo_tanf_gross_earned_income: 480
-    mo_tanf_child_care_deduction: 0
-  output:
-    # $90 + $30 + (480 - 90 - 30) / 3 = $90 + $30 + $120.
+    # $90 + $30 + (480 - 90 - 30) / 3 = $240 — identical to the
+    # pre-refactor unit-level result for one earner.
     mo_tanf_earned_income_deductions: 240
+
+- name: Two earners each get their own disregard sequence
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 30
+        tanf_gross_earned_income: 200
+      parent2:
+        age: 30
+        tanf_gross_earned_income: 200
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, child]
+    households:
+      household:
+        members: [parent1, parent2, child]
+        state_code: MO
+  output:
+    # Per person: $90 + $30 + (200 - 120) / 3 = $146.67; x2 = $293.33.
+    # Pooling $400 would wrongly give $90 + $30 + $280 / 3 = $213.33.
+    mo_tanf_earned_income_deductions: 293.33
+
+- name: One earner below the work exemption does not lend cap room to the other
+  period: 2024-01
+  input:
+    people:
+      parent1:
+        age: 30
+        tanf_gross_earned_income: 50
+      parent2:
+        age: 30
+        tanf_gross_earned_income: 480
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, child]
+    households:
+      household:
+        members: [parent1, parent2, child]
+        state_code: MO
+  output:
+    # $50 (capped at earnings) + $240 = $290.
+    mo_tanf_earned_income_deductions: 290
+
+- name: Two enrolled earners each get the two-thirds disregard
+  period: 2024-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent1:
+        age: 30
+        tanf_gross_earned_income: 200
+      parent2:
+        age: 30
+        tanf_gross_earned_income: 200
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent1, parent2, child]
+    spm_units:
+      spm_unit:
+        members: [parent1, parent2, child]
+        is_tanf_enrolled: true
+    households:
+      household:
+        members: [parent1, parent2, child]
+        state_code: MO
+  output:
+    # Per person: two-thirds of $200 = $133.33, then the work exemption
+    # caps at the $66.67 left, deducting all $200; x2 = $400. Pooling
+    # would cap the exemption once: 2/3 x $400 + $90 = $356.67.
+    mo_tanf_earned_income_deductions: 400
 
 - name: Child care deduction adds to the earned income disregards
   period: 2024-01
   input:
-    state_code: MO
-    mo_tanf_gross_earned_income: 480
-    mo_tanf_child_care_deduction: 175
+    people:
+      parent:
+        age: 30
+        tanf_gross_earned_income: 480
+      child:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+        mo_tanf_child_care_deduction: 175
+    households:
+      household:
+        members: [parent, child]
+        state_code: MO
   output:
+    # $240 of disregards plus $175 of child care costs.
     mo_tanf_earned_income_deductions: 415
 
-- name: DSS manual sequence for an active participant earning $300
+- name: An exempt student child's earnings generate no deduction
   period: 2024-01
   input:
-    state_code: MO
-    is_tanf_enrolled: true
-    mo_tanf_gross_earned_income: 300
-    mo_tanf_child_care_deduction: 0
+    people:
+      parent:
+        age: 40
+      student_child:
+        age: 17
+        is_tax_unit_dependent: true
+        is_in_secondary_school: true
+        tanf_gross_earned_income: 300
+    tax_units:
+      tax_unit:
+        members: [parent, student_child]
+    spm_units:
+      spm_unit:
+        members: [parent, student_child]
+    households:
+      household:
+        members: [parent, student_child]
+        state_code: MO
   output:
-    # Two-thirds of $300 = $200 first, then the $90 work exemption,
-    # leaving $10 countable (DSS Manual 0210.015.30.20).
-    mo_tanf_earned_income_deductions: 290
-
-- name: Active participant with earnings below the work exemption
-  period: 2024-01
-  input:
-    state_code: MO
-    is_tanf_enrolled: true
-    mo_tanf_gross_earned_income: 90
-    mo_tanf_child_care_deduction: 0
-  output:
-    # Two-thirds of $90 = $60, then the exemption caps at the $30 left.
-    mo_tanf_earned_income_deductions: 90
-
-- name: Active participant earning $900 with child care costs
-  period: 2024-01
-  input:
-    state_code: MO
-    is_tanf_enrolled: true
-    mo_tanf_gross_earned_income: 900
-    mo_tanf_child_care_deduction: 100
-  output:
-    # Two-thirds of $900 = $600, plus the $90 exemption and $100 care.
-    mo_tanf_earned_income_deductions: 790
+    # The student child's earnings are excluded from gross earned income
+    # (DSS Manual 0210.015.35.10), so no disregard attaches to them.
+    mo_tanf_earned_income_deductions: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions.yaml
@@ -1,5 +1,5 @@
 # The unit-level deduction sums each earner's separately computed
-# disregards (13 CSR 40-2.310(9)(A); DSS Manual 0210.015.30.10: "If more
+# disregards (13 CSR 40-2.310(9)(A), (9)(D); DSS Manual 0210.015.30.10: "If more
 # than one person has earned income, apply the $30 plus 1/3 disregard to
 # each person's net income. Add together the $30 plus 1/3 disregard
 # amount from each person's income."), plus child care costs.

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions_person.yaml
@@ -9,7 +9,7 @@
     state_code: MO
     tanf_gross_earned_income: 0
   output:
-    mo_tanf_person_earned_income_deductions: 0
+    mo_tanf_earned_income_deductions_person: 0
 
 - name: Earned income below the $90 work exemption
   period: 2024-01
@@ -19,7 +19,7 @@
   output:
     # The work exemption caps at gross earnings; nothing remains for the
     # $30 plus one-third disregard.
-    mo_tanf_person_earned_income_deductions: 50
+    mo_tanf_earned_income_deductions_person: 50
 
 - name: Earned income at the $90 work exemption
   period: 2024-01
@@ -27,7 +27,7 @@
     state_code: MO
     tanf_gross_earned_income: 90
   output:
-    mo_tanf_person_earned_income_deductions: 90
+    mo_tanf_earned_income_deductions_person: 90
 
 - name: DSS manual sequence for a new applicant earning $300
   period: 2024-01
@@ -37,7 +37,7 @@
   output:
     # $300 - $90 = $210; $210 - $30 = $180; one-third of $180 = $60.
     # Deductions: $90 + $30 + $60 = $180 (DSS Manual 0210.015.30.10).
-    mo_tanf_person_earned_income_deductions: 180
+    mo_tanf_earned_income_deductions_person: 180
 
 - name: New applicant earning $480
   period: 2024-01
@@ -46,7 +46,7 @@
     tanf_gross_earned_income: 480
   output:
     # $90 + $30 + (480 - 90 - 30) / 3 = $90 + $30 + $120.
-    mo_tanf_person_earned_income_deductions: 240
+    mo_tanf_earned_income_deductions_person: 240
 
 - name: DSS manual sequence for an active participant earning $300
   period: 2024-01
@@ -57,7 +57,7 @@
   output:
     # Two-thirds of $300 = $200 first, then the $90 work exemption
     # (DSS Manual 0210.015.30.20).
-    mo_tanf_person_earned_income_deductions: 290
+    mo_tanf_earned_income_deductions_person: 290
 
 - name: Active participant with earnings below the work exemption
   period: 2024-01
@@ -67,7 +67,7 @@
     tanf_gross_earned_income: 90
   output:
     # Two-thirds of $90 = $60, then the exemption caps at the $30 left.
-    mo_tanf_person_earned_income_deductions: 90
+    mo_tanf_earned_income_deductions_person: 90
 
 - name: Active participant earning $900
   period: 2024-01
@@ -77,4 +77,24 @@
     tanf_gross_earned_income: 900
   output:
     # Two-thirds of $900 = $600, plus the $90 exemption.
-    mo_tanf_person_earned_income_deductions: 690
+    mo_tanf_earned_income_deductions_person: 690
+
+- name: New applicant earnings exactly exhaust the work exemption and thirty dollars
+  period: 2024-01
+  input:
+    state_code: MO
+    tanf_gross_earned_income: 120
+  output:
+    # $90 + $30 leaves nothing for the one-third disregard.
+    mo_tanf_earned_income_deductions_person: 120
+
+- name: Active participant earnings exactly exhaust both disregards
+  period: 2024-01
+  input:
+    state_code: MO
+    is_tanf_enrolled: true
+    tanf_gross_earned_income: 270
+  output:
+    # Two-thirds of $270 = $180; the $90 left exactly equals the work
+    # exemption, deducting all $270.
+    mo_tanf_earned_income_deductions_person: 270

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_earned_income_deductions_person.yaml
@@ -1,4 +1,4 @@
-# Per-earner disregard sequence (13 CSR 40-2.310(9)(A)). New applicants
+# Per-earner disregard sequence (13 CSR 40-2.310(9)(A), (9)(D)). New applicants
 # (not enrolled in TA when employment began) get the $90 standard work
 # exemption, then $30, then one-third of the remainder (DSS Manual
 # 0210.015.30.10). Active participants get two-thirds of gross earnings

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_eligible.yaml
@@ -68,3 +68,16 @@
     mo_tanf_resources_eligible: false
   output:
     mo_tanf_eligible: false
+
+- name: Ineligible when the unit has no payable member
+  period: 2024-01
+  input:
+    state_code: MO
+    mo_tanf_dependent_child: true
+    ssi: 750
+    mo_tanf_income_eligible: true
+    mo_tanf_resources_eligible: true
+  output:
+    # The SSI child establishes the case but is not a payable member, and
+    # no caretaker is present, so the unit is empty and nothing is paid.
+    mo_tanf_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_person_earned_income_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mo/dss/tanf/mo_tanf_person_earned_income_deductions.yaml
@@ -1,0 +1,80 @@
+# Per-earner disregard sequence (13 CSR 40-2.310(9)(A)). New applicants
+# (not enrolled in TA when employment began) get the $90 standard work
+# exemption, then $30, then one-third of the remainder (DSS Manual
+# 0210.015.30.10). Active participants get two-thirds of gross earnings
+# first, then the work exemption (0210.015.30.20).
+- name: No earned income
+  period: 2024-01
+  input:
+    state_code: MO
+    tanf_gross_earned_income: 0
+  output:
+    mo_tanf_person_earned_income_deductions: 0
+
+- name: Earned income below the $90 work exemption
+  period: 2024-01
+  input:
+    state_code: MO
+    tanf_gross_earned_income: 50
+  output:
+    # The work exemption caps at gross earnings; nothing remains for the
+    # $30 plus one-third disregard.
+    mo_tanf_person_earned_income_deductions: 50
+
+- name: Earned income at the $90 work exemption
+  period: 2024-01
+  input:
+    state_code: MO
+    tanf_gross_earned_income: 90
+  output:
+    mo_tanf_person_earned_income_deductions: 90
+
+- name: DSS manual sequence for a new applicant earning $300
+  period: 2024-01
+  input:
+    state_code: MO
+    tanf_gross_earned_income: 300
+  output:
+    # $300 - $90 = $210; $210 - $30 = $180; one-third of $180 = $60.
+    # Deductions: $90 + $30 + $60 = $180 (DSS Manual 0210.015.30.10).
+    mo_tanf_person_earned_income_deductions: 180
+
+- name: New applicant earning $480
+  period: 2024-01
+  input:
+    state_code: MO
+    tanf_gross_earned_income: 480
+  output:
+    # $90 + $30 + (480 - 90 - 30) / 3 = $90 + $30 + $120.
+    mo_tanf_person_earned_income_deductions: 240
+
+- name: DSS manual sequence for an active participant earning $300
+  period: 2024-01
+  input:
+    state_code: MO
+    is_tanf_enrolled: true
+    tanf_gross_earned_income: 300
+  output:
+    # Two-thirds of $300 = $200 first, then the $90 work exemption
+    # (DSS Manual 0210.015.30.20).
+    mo_tanf_person_earned_income_deductions: 290
+
+- name: Active participant with earnings below the work exemption
+  period: 2024-01
+  input:
+    state_code: MO
+    is_tanf_enrolled: true
+    tanf_gross_earned_income: 90
+  output:
+    # Two-thirds of $90 = $60, then the exemption caps at the $30 left.
+    mo_tanf_person_earned_income_deductions: 90
+
+- name: Active participant earning $900
+  period: 2024-01
+  input:
+    state_code: MO
+    is_tanf_enrolled: true
+    tanf_gross_earned_income: 900
+  output:
+    # Two-thirds of $900 = $600, plus the $90 exemption.
+    mo_tanf_person_earned_income_deductions: 690

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/assistance_unit/mo_tanf_is_assistance_unit_member.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/assistance_unit/mo_tanf_is_assistance_unit_member.py
@@ -20,8 +20,9 @@ class mo_tanf_is_assistance_unit_member(Variable):
         # Per 13 CSR 40-2.310(1)(F), SSI recipients are excluded entirely:
         # neither their needs nor their income count. Reported receipt
         # (receives_ssi) also excludes, covering people the model computes
-        # as $0. Their resources cannot be excluded because assets are
-        # modeled at the SPM-unit level only.
+        # as $0. Their resources are excluded in
+        # mo_tanf_countable_resources when assets are attributed at the
+        # person level.
         is_ssi_recipient = (person("ssi", period) > 0) | person("receives_ssi", period)
         dependent_child = person("mo_tanf_dependent_child", period)
         eligible_child = dependent_child & ~is_ssi_recipient
@@ -30,10 +31,17 @@ class mo_tanf_is_assistance_unit_member(Variable):
         # The dependent-flag guard keeps adult children who are claimed as
         # tax dependents from being counted as caretakers when the spouse
         # inference ranks them as the second adult.
+        # The caretaker test looks for any dependent child in the home, not
+        # only a payable one. Per DSS Manual 0210.005.05, "when the only
+        # child in the EU receives SSI, explore Temporary Assistance (TA)
+        # eligibility for the payee and/or second parent" — the SSI child is
+        # excluded from the unit but still establishes the case, and
+        # 0210.005.10 confirms such a child "may be included as a payee-only
+        # on a TA case."
         caretaker = (
             head_or_spouse
             & ~is_dependent
             & ~is_ssi_recipient
-            & person.tax_unit.any(eligible_child)
+            & person.tax_unit.any(dependent_child)
         )
         return eligible_child | caretaker

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/assistance_unit/mo_tanf_is_assistance_unit_member.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/assistance_unit/mo_tanf_is_assistance_unit_member.py
@@ -7,7 +7,9 @@ class mo_tanf_is_assistance_unit_member(Variable):
     label = "Missouri TANF assistance unit member"
     definition_period = MONTH
     reference = (
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-005-05/",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-005-10/",
+        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-300",
         "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
     )
     defined_for = StateCode.MO
@@ -23,6 +25,10 @@ class mo_tanf_is_assistance_unit_member(Variable):
         # as $0. Their resources are excluded in
         # mo_tanf_countable_resources when assets are attributed at the
         # person level.
+        # Not modeled: DSS Manual 0210.005.10 also excludes State
+        # Supplemental Payment (SP) and Supplemental Aid to the Blind
+        # (SAB) recipients; the regulation names only SSI, and SP/SAB
+        # receipt is not observable in microdata.
         is_ssi_recipient = (person("ssi", period) > 0) | person("receives_ssi", period)
         dependent_child = person("mo_tanf_dependent_child", period)
         eligible_child = dependent_child & ~is_ssi_recipient
@@ -31,13 +37,17 @@ class mo_tanf_is_assistance_unit_member(Variable):
         # The dependent-flag guard keeps adult children who are claimed as
         # tax dependents from being counted as caretakers when the spouse
         # inference ranks them as the second adult.
+        # 13 CSR 40-2.300(5)(C) admits only natural or adoptive parents,
+        # and a stepparent's needs are not taken into account per
+        # 2.310(8)(B)1.D.(II); the tax-unit structure cannot distinguish
+        # a stepparent from a parent, so a spouse who is not the child's
+        # parent is counted here.
         # The caretaker test looks for any dependent child in the home, not
         # only a payable one. Per DSS Manual 0210.005.05, "when the only
         # child in the EU receives SSI, explore Temporary Assistance (TA)
-        # eligibility for the payee and/or second parent" — the SSI child is
-        # excluded from the unit but still establishes the case, and
-        # 0210.005.10 confirms such a child "may be included as a payee-only
-        # on a TA case."
+        # eligibility for the payee and/or second parent" — the SSI child
+        # is excluded from the unit's needs but still establishes the case
+        # for the caretaker.
         caretaker = (
             head_or_spouse
             & ~is_dependent

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_countable_resources.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_countable_resources.py
@@ -7,6 +7,7 @@ class mo_tanf_countable_resources(Variable):
     label = "Missouri TANF countable resources"
     unit = USD
     definition_period = MONTH
+    quantity_type = STOCK
     reference = (
         "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-005-10/",
@@ -25,6 +26,9 @@ class mo_tanf_countable_resources(Variable):
         total = spm_unit("spm_unit_cash_assets", period.this_year)
         person = spm_unit.members
         is_ssi_recipient = (person("ssi", period) > 0) | person("receives_ssi", period)
+        # This component list must mirror spm_unit_cash_assets.adds: the
+        # subtraction below assumes the person-level components sum to the
+        # unit aggregate, so a divergence would under- or over-subtract.
         person_assets = add(
             person,
             period.this_year,

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_countable_resources.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_countable_resources.py
@@ -1,0 +1,34 @@
+from policyengine_us.model_api import *
+
+
+class mo_tanf_countable_resources(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "Missouri TANF countable resources"
+    unit = USD
+    definition_period = MONTH
+    reference = (
+        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-005-10/",
+    )
+    defined_for = StateCode.MO
+
+    def formula(spm_unit, period, parameters):
+        # Per DSS Manual 0210.005.10, an SSI participant's resources are
+        # excluded along with their needs and income ("Exclude the
+        # expenses, income, and resources"). The SSI recipients' share is
+        # subtracted from the unit aggregate rather than the total being
+        # rebuilt from person-level values, so households that supply only
+        # the spm_unit_cash_assets aggregate keep the aggregate behavior;
+        # the exclusion activates when assets are attributed to people
+        # through the person-level components of spm_unit_cash_assets.
+        total = spm_unit("spm_unit_cash_assets", period.this_year)
+        person = spm_unit.members
+        is_ssi_recipient = (person("ssi", period) > 0) | person("receives_ssi", period)
+        person_assets = add(
+            person,
+            period.this_year,
+            ["bank_account_assets", "stock_assets", "bond_assets"],
+        )
+        ssi_recipient_assets = spm_unit.sum(person_assets * is_ssi_recipient)
+        return max_(total - ssi_recipient_assets, 0)

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_eligible.py
@@ -19,9 +19,19 @@ class mo_tanf_eligible(Variable):
         # RSMo 208.040 grants Temporary Assistance only on behalf of a
         # dependent child; pregnancy alone does not qualify a household
         # (13 CSR 40-2.325 has no unborn-child provision).
+        # The child need not be a payable unit member: an SSI child is
+        # excluded from the unit but still establishes the case, and the
+        # caretaker can receive a payee-only grant (DSS Manual 0210.005.05:
+        # "when the only child in the EU receives SSI, explore Temporary
+        # Assistance (TA) eligibility for the payee and/or second parent").
         dependent_child = person("mo_tanf_dependent_child", period)
-        member = person("mo_tanf_is_assistance_unit_member", period)
-        has_eligible_child = spm_unit.any(dependent_child & member)
+        has_dependent_child = spm_unit.any(dependent_child)
+        # The unit must still contain someone to pay — a household whose
+        # child and caretaker are both SSI recipients has no payable
+        # members and receives no grant.
+        unit_size = spm_unit("mo_tanf_assistance_unit_size", period)
         income_eligible = spm_unit("mo_tanf_income_eligible", period)
         resources_eligible = spm_unit("mo_tanf_resources_eligible", period)
-        return has_eligible_child & income_eligible & resources_eligible
+        return (
+            has_dependent_child & (unit_size > 0) & income_eligible & resources_eligible
+        )

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_eligible.py
@@ -10,22 +10,26 @@ class mo_tanf_eligible(Variable):
         "https://revisor.mo.gov/main/OneSection.aspx?section=208.040",
         "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-325",
         "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-005-05/",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0200-000-00/",
     )
     defined_for = StateCode.MO
 
     def formula(spm_unit, period, parameters):
-        person = spm_unit.members
         # RSMo 208.040 grants Temporary Assistance only on behalf of a
         # dependent child; pregnancy alone does not qualify a household
         # (13 CSR 40-2.325 has no unborn-child provision).
         # The child need not be a payable unit member: an SSI child is
         # excluded from the unit but still establishes the case, and the
-        # caretaker can receive a payee-only grant (DSS Manual 0210.005.05:
-        # "when the only child in the EU receives SSI, explore Temporary
-        # Assistance (TA) eligibility for the payee and/or second parent").
-        dependent_child = person("mo_tanf_dependent_child", period)
-        has_dependent_child = spm_unit.any(dependent_child)
+        # caretaker can be the sole cash-eligible unit member (DSS Manual
+        # 0210.005.05: "when the only child in the EU receives SSI, explore
+        # Temporary Assistance (TA) eligibility for the payee and/or second
+        # parent").
+        # Not modeled: deprivation of parental support (2.310(5)(A)),
+        # citizenship and qualified-alien status (2.310(1)(B)-(C)),
+        # conduct-based exclusions (drug felony, fugitive), and the
+        # (9)(B) disregard-denial sanctions.
+        has_dependent_child = add(spm_unit, period, ["mo_tanf_dependent_child"]) > 0
         # The unit must still contain someone to pay — a household whose
         # child and caretaker are both SSI recipients has no payable
         # members and receives no grant.

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_resources_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_resources_eligible.py
@@ -8,12 +8,17 @@ class mo_tanf_resources_eligible(Variable):
     definition_period = MONTH
     reference = (
         "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
-        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0200-000-00/",
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0205-005-00/",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-005-10/",
     )
     defined_for = StateCode.MO
 
     def formula(spm_unit, period, parameters):
+        # 13 CSR 40-2.310(3) raises the limit to $5,000 for participants
+        # in an Individual Employment Plan (DSS Manual 0205.005.00: "$5,000
+        # for participant families who have entered into a self sufficiency
+        # pact"); IEP participation is not observable, so the $1,000 limit
+        # applies to all units.
         p = parameters(period).gov.states.mo.dss.tanf.resource_limit
         resources = spm_unit("mo_tanf_countable_resources", period)
         return resources <= p.amount

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_resources_eligible.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/eligibility/mo_tanf_resources_eligible.py
@@ -9,10 +9,11 @@ class mo_tanf_resources_eligible(Variable):
     reference = (
         "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0200-000-00/",
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-005-10/",
     )
     defined_for = StateCode.MO
 
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.mo.dss.tanf.resource_limit
-        resources = spm_unit("spm_unit_cash_assets", period.this_year)
+        resources = spm_unit("mo_tanf_countable_resources", period)
         return resources <= p.amount

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_child_care_deduction.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_child_care_deduction.py
@@ -8,7 +8,7 @@ class mo_tanf_child_care_deduction(Variable):
     unit = USD
     definition_period = MONTH
     reference = (
-        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120",
+        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30/",
     )
     defined_for = StateCode.MO
@@ -17,7 +17,7 @@ class mo_tanf_child_care_deduction(Variable):
         p = parameters(period).gov.states.mo.dss.tanf.child_care_deduction
         person = spm_unit.members
         dependent = person("is_tax_unit_dependent", period)
-        # Per 13 CSR 40-2.120(6)(A)5, the disregard also covers care of an
+        # Per 13 CSR 40-2.310(9)(A)5, the disregard also covers care of an
         # incapacitated individual living in the same home as the dependent
         # child, at the $175 age-two-or-older tier.
         incapacitated_adult = person("is_adult", period.this_year) & person(

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions.py
@@ -16,7 +16,7 @@ class mo_tanf_earned_income_deductions(Variable):
     defined_for = StateCode.MO
 
     def formula(spm_unit, period, parameters):
-        # 13 CSR 40-2.310(9)(A): the disregards apply to each
+        # 13 CSR 40-2.310(9)(A) and (9)(D): the disregards apply to each
         # participant's earned income separately, then the per-person
         # amounts are summed (DSS Manual 0210.015.30.10: "Add together
         # the $30 plus 1/3 disregard amount from each person's income").

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions.py
@@ -20,12 +20,15 @@ class mo_tanf_earned_income_deductions(Variable):
         # participant's earned income separately, then the per-person
         # amounts are summed (DSS Manual 0210.015.30.10: "Add together
         # the $30 plus 1/3 disregard amount from each person's income").
-        # The membership and exemption masks mirror
+        # The membership and exemption masks must stay identical to
         # mo_tanf_gross_earned_income so deductions attach only to
-        # earnings that are counted.
+        # earnings that are counted: a loss earner's negative deduction
+        # then cancels exactly against their negative gross in
+        # mo_tanf_countable_income. Diverging the masks (or flooring one
+        # side alone) breaks that cancellation.
         person = spm_unit.members
         member = person("mo_tanf_is_assistance_unit_member", period)
         exempt = person("is_mo_tanf_earned_income_exempt", period)
-        person_deductions = person("mo_tanf_person_earned_income_deductions", period)
+        person_deductions = person("mo_tanf_earned_income_deductions_person", period)
         child_care = spm_unit("mo_tanf_child_care_deduction", period)
         return spm_unit.sum(person_deductions * member * ~exempt) + child_care

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions.py
@@ -16,26 +16,16 @@ class mo_tanf_earned_income_deductions(Variable):
     defined_for = StateCode.MO
 
     def formula(spm_unit, period, parameters):
-        # Note: Missouri time-limits these disregards ($30 plus one-third
-        # for four consecutive months, $30-only for the following eight
-        # months, and the two-thirds disregard for up to 12 consecutive
-        # months). These month counts are not modeled.
-        p = parameters(period).gov.states.mo.dss.tanf.earned_income_disregard
-        gross_earned = spm_unit("mo_tanf_gross_earned_income", period)
-        is_enrolled = spm_unit("is_tanf_enrolled", period)
+        # 13 CSR 40-2.310(9)(A): the disregards apply to each
+        # participant's earned income separately, then the per-person
+        # amounts are summed (DSS Manual 0210.015.30.10: "Add together
+        # the $30 plus 1/3 disregard amount from each person's income").
+        # The membership and exemption masks mirror
+        # mo_tanf_gross_earned_income so deductions attach only to
+        # earnings that are counted.
+        person = spm_unit.members
+        member = person("mo_tanf_is_assistance_unit_member", period)
+        exempt = person("is_mo_tanf_earned_income_exempt", period)
+        person_deductions = person("mo_tanf_person_earned_income_deductions", period)
         child_care = spm_unit("mo_tanf_child_care_deduction", period)
-        # Not an active TA participant when employment began (DSS Manual
-        # 0210.015.30.10): deduct the standard work exemption first, then
-        # $30, then one-third of the remainder.
-        work_expense = min_(gross_earned, p.amount)
-        after_work_expense = max_(gross_earned - p.amount, 0)
-        thirty = min_(after_work_expense, p.thirty_plus_one_third.flat_amount)
-        one_third = (after_work_expense - thirty) * p.thirty_plus_one_third.percentage
-        new_applicant = work_expense + thirty + one_third
-        # Active TA participant when employment began (DSS Manual
-        # 0210.015.30.20; 13 CSR 40-2.310(9)(D)): apply the two-thirds
-        # disregard to gross earnings first, then the work exemption.
-        two_thirds = gross_earned * p.two_thirds_disregard.percentage
-        enrolled_work_expense = min_(gross_earned - two_thirds, p.amount)
-        enrolled = two_thirds + enrolled_work_expense
-        return where(is_enrolled, enrolled, new_applicant) + child_care
+        return spm_unit.sum(person_deductions * member * ~exempt) + child_care

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions_person.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions_person.py
@@ -1,7 +1,7 @@
 from policyengine_us.model_api import *
 
 
-class mo_tanf_person_earned_income_deductions(Variable):
+class mo_tanf_earned_income_deductions_person(Variable):
     value_type = float
     entity = Person
     label = "Missouri TANF earned income deductions for one earner"
@@ -24,6 +24,12 @@ class mo_tanf_person_earned_income_deductions(Variable):
         # for four consecutive months, $30-only for the following eight
         # months, and the two-thirds disregard for up to 12 consecutive
         # months). These month counts are not modeled.
+        # For a self-employment loss (negative gross), both branches
+        # return the negative gross unchanged, so the loss cancels exactly
+        # against the same person's gross in mo_tanf_countable_income.
+        # Do not floor earnings here without flooring
+        # mo_tanf_gross_earned_income in the same change — a one-sided
+        # floor breaks the cancellation.
         p = parameters(period).gov.states.mo.dss.tanf.earned_income_disregard
         gross_earned = person("tanf_gross_earned_income", period)
         is_enrolled = person.spm_unit("is_tanf_enrolled", period)

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions_person.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_earned_income_deductions_person.py
@@ -16,7 +16,7 @@ class mo_tanf_earned_income_deductions_person(Variable):
     defined_for = StateCode.MO
 
     def formula(person, period, parameters):
-        # 13 CSR 40-2.310(9)(A) applies the disregards to each
+        # 13 CSR 40-2.310(9)(A) and (9)(D) apply the disregards to each
         # participant's earned income separately; DSS Manual
         # 0210.015.30.10: "If more than one person has earned income,
         # apply the $30 plus 1/3 disregard to each person's net income."

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_person_earned_income_deductions.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/deductions/mo_tanf_person_earned_income_deductions.py
@@ -1,0 +1,44 @@
+from policyengine_us.model_api import *
+
+
+class mo_tanf_person_earned_income_deductions(Variable):
+    value_type = float
+    entity = Person
+    label = "Missouri TANF earned income deductions for one earner"
+    unit = USD
+    definition_period = MONTH
+    reference = (
+        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30/",
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30-10/",
+        "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-30-20/",
+    )
+    defined_for = StateCode.MO
+
+    def formula(person, period, parameters):
+        # 13 CSR 40-2.310(9)(A) applies the disregards to each
+        # participant's earned income separately; DSS Manual
+        # 0210.015.30.10: "If more than one person has earned income,
+        # apply the $30 plus 1/3 disregard to each person's net income."
+        # Note: Missouri time-limits these disregards ($30 plus one-third
+        # for four consecutive months, $30-only for the following eight
+        # months, and the two-thirds disregard for up to 12 consecutive
+        # months). These month counts are not modeled.
+        p = parameters(period).gov.states.mo.dss.tanf.earned_income_disregard
+        gross_earned = person("tanf_gross_earned_income", period)
+        is_enrolled = person.spm_unit("is_tanf_enrolled", period)
+        # Not an active TA participant when employment began (DSS Manual
+        # 0210.015.30.10): deduct the standard work exemption first, then
+        # $30, then one-third of the remainder.
+        work_expense = min_(gross_earned, p.amount)
+        after_work_expense = max_(gross_earned - p.amount, 0)
+        thirty = min_(after_work_expense, p.thirty_plus_one_third.flat_amount)
+        one_third = (after_work_expense - thirty) * p.thirty_plus_one_third.percentage
+        new_applicant = work_expense + thirty + one_third
+        # Active TA participant when employment began (DSS Manual
+        # 0210.015.30.20; 13 CSR 40-2.310(9)(D)): apply the two-thirds
+        # disregard to gross earnings first, then the work exemption.
+        two_thirds = gross_earned * p.two_thirds_disregard.percentage
+        enrolled_work_expense = min_(gross_earned - two_thirds, p.amount)
+        enrolled = two_thirds + enrolled_work_expense
+        return where(is_enrolled, enrolled, new_applicant)

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/income/is_mo_tanf_earned_income_exempt.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/income/is_mo_tanf_earned_income_exempt.py
@@ -7,14 +7,14 @@ class is_mo_tanf_earned_income_exempt(Variable):
     label = "Person whose earned income is exempt for Missouri TANF"
     definition_period = MONTH
     reference = (
-        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120",
+        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-35-10/",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-015-35-15/",
     )
     defined_for = StateCode.MO
 
     def formula(person, period, parameters):
-        # 13 CSR 40-2.120(6)(A)1 and DSS Manual 0210.015.35.10 exclude all
+        # 13 CSR 40-2.310(9)(A)1 and DSS Manual 0210.015.35.10 exclude all
         # earned income of a dependent child receiving TA who is a full-time
         # student or a part-time student not employed full-time (approximated
         # here by student status). The six-month calendar-year limitation on

--- a/policyengine_us/variables/gov/states/mo/dss/tanf/mo_tanf_standard_of_need.py
+++ b/policyengine_us/variables/gov/states/mo/dss/tanf/mo_tanf_standard_of_need.py
@@ -8,7 +8,7 @@ class mo_tanf_standard_of_need(Variable):
     unit = USD
     definition_period = MONTH
     reference = (
-        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-120",
+        "https://www.law.cornell.edu/regulations/missouri/13-CSR-40-2-310",
         "https://dssmanuals.mo.gov/temporary-assistance-case-management/0210-010-05-185/",
     )
     defined_for = StateCode.MO


### PR DESCRIPTION
## Summary

Three fixes to Missouri TANF from partner-reported findings, each verified against the DSS manual and 13 CSR 40-2.310:

1. **Per-earner income disregards** (Fixes #9268). 13 CSR 40-2.310(9)(A) applies the $90 work exemption, $30 plus one-third, and two-thirds disregards to "each participant's" earned income (DSS Manual 0210.015.30.10: "If more than one person has earned income, apply the $30 plus 1/3 disregard to each person's net income"). The unit-level formula previously ran the sequence once on pooled earnings, understating deductions by up to $80/month for two-earner units.
2. **Payee-only grant when the only child receives SSI.** DSS Manual 0210.005.05: "When the only child in the EU receives SSI, explore Temporary Assistance (TA) eligibility for the payee and/or second parent." The SSI child is excluded from the payment unit but still establishes the case; the caretaker now receives a size-1 grant ($135.69/month in 2024) instead of the whole case being zeroed. A household whose child and caretaker are both SSI recipients remains ineligible (no payable member).
3. **SSI recipients' resources excluded.** DSS Manual 0210.005.10: "Exclude the expenses, income, and resources" of SSI participants. An SSI child can hold up to $2,000 (the SSI limit) — double Missouri's $1,000 TANF resource limit — so their savings could single-handedly disqualify an otherwise eligible unit. The new `mo_tanf_countable_resources` subtracts SSI recipients' person-level assets from `spm_unit_cash_assets`; aggregate-only asset inputs keep the previous behavior since nothing attributes them to a person.

## Changes

- New `mo_tanf_person_earned_income_deductions` (person-level disregard sequence); `mo_tanf_earned_income_deductions` now sums it with the same membership/exemption masks as `mo_tanf_gross_earned_income`
- `mo_tanf_is_assistance_unit_member`: caretaker branch tests for any dependent child in the tax unit, not only payable ones
- `mo_tanf_eligible`: case established by any dependent child in the home, with a new non-empty-unit guard
- New `mo_tanf_countable_resources`; `mo_tanf_resources_eligible` compares it against the limit

## Testing

- Deduction tests ported to person-level inputs plus new multi-earner cases (two earners $200+$200 → $293.33, not the pooled $213.33; enrolled pair → $400; caps don't spill between earners)
- New countable-resources tests covering all three asset-input regimes
- Integration cases: payee-only grant, both-on-SSI ineligibility, SSI child's $1,500 savings not disqualifying the unit
- Full MO TANF folder: 133/133 pass locally

## Checklist

- [x] Tests pass locally
- [x] Code formatted (ruff)
- [x] Changelog entry created

🤖 Generated with [Claude Code](https://claude.com/claude-code)