### PR TITLE
Make person-level home_mortgage_interest the canonical interest input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ changelog.d/medicaid-ce-exclusions.md
 **DO NOT** edit `CHANGELOG.md` directly or use `changelog_entry.yaml` (deprecated).
 
 ## Project Requirements
-- Python >= 3.9, < 3.15 (`requires-python` in pyproject.toml; CI smoke-imports the package on 3.9–3.14)
+- Python >= 3.11, < 3.15 (`requires-python` in pyproject.toml; CI smoke-imports the package on 3.11–3.14)
 - Follow GitHub Flow with PRs targeting the `main` branch (the default branch is `main`, **not** `master`)
 - Every PR needs a changelog fragment in `changelog.d/`
 - **ALWAYS run `make format` before every commit** - this is mandatory

--- a/changelog.d/mortgage-atomic-input.changed.md
+++ b/changelog.d/mortgage-atomic-input.changed.md
@@ -1,0 +1,1 @@
+Made the person-level home_mortgage_interest input canonical for the federal mortgage interest deduction; the structured first and second home mortgage interest inputs are deprecated and now used only when no person-level interest is reported.

--- a/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/deductible_mortgage_interest.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/income/taxable_income/deductions/deductible_mortgage_interest.yaml
@@ -106,3 +106,41 @@
     first_home_mortgage_origination_year: 2018
   output:
     deductible_mortgage_interest_tax_unit: 37_500
+
+- name: Person-level input is canonical when both input styles are supplied (issue #9275)
+  period: 2024
+  input:
+    people:
+      head:
+        home_mortgage_interest: 12_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+        tax_unit_itemizes: true
+        standard_deduction: 0
+        first_home_mortgage_interest: 10_000
+  output:
+    # Person-level wins; the deprecated structured input is ignored when
+    # person-level interest is reported.
+    home_mortgage_interest_tax_unit: 12_000
+    deductible_mortgage_interest_tax_unit: 12_000
+    interest_deduction: 12_000
+
+- name: Person-level interest still passes through the acquisition-debt caps
+  period: 2024
+  input:
+    people:
+      head:
+        home_mortgage_interest: 45_000
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SINGLE
+        tax_unit_itemizes: true
+        standard_deduction: 0
+        first_home_mortgage_balance: 900_000
+        first_home_mortgage_origination_year: 2018
+  output:
+    # Post-TCJA cap: 45,000 x 750,000 / 900,000 = 37,500
+    deductible_mortgage_interest_tax_unit: 37_500

--- a/policyengine_us/variables/household/expense/tax_unit/mortgage_interest_structure.py
+++ b/policyengine_us/variables/household/expense/tax_unit/mortgage_interest_structure.py
@@ -60,8 +60,11 @@ class first_home_mortgage_interest(Variable):
     definition_period = YEAR
     default_value = 0
     documentation = (
-        "Interest paid on the first home acquisition mortgage used to "
-        "calculate the federal mortgage interest deduction."
+        "DEPRECATED (issue #9275): use the person-level home_mortgage_interest "
+        "input instead; the deduction only ever uses the first+second sum, and "
+        "this input is read only when no person-level interest is reported. "
+        "Kept temporarily so existing datasets that supply it keep working; "
+        "removal is scheduled once certified microdata stops exporting it."
     )
 
 
@@ -73,8 +76,11 @@ class second_home_mortgage_interest(Variable):
     definition_period = YEAR
     default_value = 0
     documentation = (
-        "Interest paid on the second home acquisition mortgage used to "
-        "calculate the federal mortgage interest deduction."
+        "DEPRECATED (issue #9275): use the person-level home_mortgage_interest "
+        "input instead; the deduction only ever uses the first+second sum, and "
+        "this input is read only when no person-level interest is reported. "
+        "Kept temporarily so existing datasets that supply it keep working; "
+        "removal is scheduled once certified microdata stops exporting it."
     )
 
 
@@ -105,19 +111,20 @@ class home_mortgage_interest_tax_unit(Variable):
     unit = USD
     definition_period = YEAR
     documentation = (
-        "Total home mortgage interest, taken from the structured first/second "
-        "mortgage inputs when provided, otherwise falling back to the reported "
-        "person-level home mortgage interest."
+        "Total home mortgage interest. The person-level home_mortgage_interest "
+        "input is canonical; the deprecated structured first/second interest "
+        "inputs are used only when no person-level interest is reported "
+        "(existing datasets still supply them — see issue #9275)."
     )
 
     def formula(tax_unit, period, parameters):
+        reported_interest = add(tax_unit, period, ["home_mortgage_interest"])
         structured_interest = add(
             tax_unit,
             period,
             ["first_home_mortgage_interest", "second_home_mortgage_interest"],
         )
-        reported_interest = add(tax_unit, period, ["home_mortgage_interest"])
-        return where(structured_interest > 0, structured_interest, reported_interest)
+        return where(reported_interest > 0, reported_interest, structured_interest)
 
 
 class deductible_mortgage_interest_tax_unit(Variable):


### PR DESCRIPTION
Stage 1 of the atomic-inputs migration — #9275 (see the issue for the full design rule, inventory, and staging).

## What changes

`home_mortgage_interest_tax_unit` now prefers the person-level `home_mortgage_interest` sum and reads the structured `first/second_home_mortgage_interest` inputs only when no person-level interest is reported (the exact inverse of the #9142 arbitration). The structured interest inputs are documented as deprecated, pointing at #9275.

## Why not just delete the structured inputs

Two verified mechanics force staging:
- **policyengine-core's dataset loader silently skips h5 columns whose variable doesn't exist** (`simulation.py`: `if variable_name not in self.tax_benefit_system.variables: continue`) — deleting the inputs today would silently zero mortgage interest for every existing certified h5. Core-side warning proposed separately.
- Certified microdata still exports the structured columns. In the microcosm build they are *derived* — the `mortgage_conversion` stage splits the person-level `home_mortgage_interest` total into the first/second slots, which the model then sums back — so they are round-trip redundancy even inside the data pipeline; only the balances/origination years carry independent information (the §163(h)(3)(F) two-vintage caps need them, and loans are jointly held, so tax_unit is their natural entity).

Deletion happens in stage 3 (#9275) once the microcosm export drops the columns (companion issue there).

## Behavior

- Structured-only datasets (current certified h5s): unchanged — fallback binds exactly as before.
- Person-level-only households (the #9004 path): unchanged.
- Both supplied: person-level now wins (previously structured won). On certified data the two agree by construction (split of the same stage total); a per-record reconciliation receipt on the current build is requested in the microcosm issue.

## Tests

New: double-supply case pinning person-level precedence end-to-end (`interest_deduction: 12,000`, structured 10k ignored), and person-level interest flowing through the acquisition-debt caps (45,000 × 750/900 = 37,500, hand-checked). All 10 cases in the mortgage file pass locally; existing structured-only and no-balance cases unchanged.

Drive-by: CLAUDE.md's Python floor updated to match `requires-python = ">=3.11,<3.15"` (it moved since the July docs pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)