### PR TITLE
Fix TX CCS entity broadcast bug and wire into child care subsidies aggregate

### DIFF
--- a/changelog.d/fix-tx-ccs-microsim-7767.added.md
+++ b/changelog.d/fix-tx-ccs-microsim-7767.added.md
@@ -1,0 +1,1 @@
+Texas CCS to the federal child care subsidies aggregate.

--- a/changelog.d/fix-tx-ccs-microsim-7767.added.md
+++ b/changelog.d/fix-tx-ccs-microsim-7767.added.md
@@ -1,1 +1,2 @@
-Texas CCS to the federal child care subsidies aggregate.
+Fixed entity broadcast error in the Texas CCS work requirement eligibility formula that crashed vectorized simulations with multiple SPM units.
+Added Texas CCS to the federal child care subsidies aggregate.

--- a/changelog.d/fix-tx-ccs-microsim-7767.fixed.md
+++ b/changelog.d/fix-tx-ccs-microsim-7767.fixed.md
@@ -1,1 +1,0 @@
-Entity broadcast error in the Texas CCS work requirement eligibility formula that crashed vectorized simulations with multiple SPM units.

--- a/changelog.d/fix-tx-ccs-microsim-7767.fixed.md
+++ b/changelog.d/fix-tx-ccs-microsim-7767.fixed.md
@@ -1,0 +1,1 @@
+Entity broadcast error in the Texas CCS work requirement eligibility formula that crashed vectorized simulations with multiple SPM units.

--- a/policyengine_us/parameters/gov/hhs/ccdf/child_care_subsidy_programs.yaml
+++ b/policyengine_us/parameters/gov/hhs/ccdf/child_care_subsidy_programs.yaml
@@ -141,6 +141,7 @@ values:
     - dc_child_care_subsidies  # DC Child Care Subsidy Program
     - tn_child_care_subsidies  # Tennessee Child Care Certificate Program (Smart Steps)
     - wy_child_care_subsidies  # Wyoming Child Care, Purchase of Service
+    - tx_child_care_subsidies  # Texas Child Care Services (CCS)
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/twc/ccs/eligibility/tx_ccs_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/twc/ccs/eligibility/tx_ccs_work_requirement_eligible.yaml
@@ -129,6 +129,50 @@
   output:
     tx_ccs_work_requirement_eligible: true
 
+# Regression test for issue 7767: person-level and SPM-unit-level arrays
+# were combined directly, crashing when the simulation contains multiple
+# SPM units of different sizes (as in microsimulation).
+- name: Two SPM units of different sizes compute without broadcasting errors
+  period: 2025-01
+  input:
+    people:
+      parent1:
+        age: 30
+        weekly_hours_worked: 30
+      parent2:
+        age: 32
+        weekly_hours_worked: 0
+      child1:
+        age: 5
+        weekly_hours_worked: 0
+      parent3:
+        age: 28
+        weekly_hours_worked: 25
+      child2:
+        age: 4
+        weekly_hours_worked: 0
+    tax_units:
+      first_tax_unit:
+        members: [parent1, parent2, child1]
+      second_tax_unit:
+        members: [parent3, child2]
+    spm_units:
+      first_spm_unit:
+        members: [parent1, parent2, child1]
+      second_spm_unit:
+        members: [parent3, child2]
+    households:
+      first_household:
+        members: [parent1, parent2, child1]
+        state_code: TX
+      second_household:
+        members: [parent3, child2]
+        state_code: TX
+  output:
+    # First unit: two non-exempt parents working 30 combined hours < 50.
+    # Second unit: single parent working 25 hours meets the 25-hour rule.
+    tx_ccs_work_requirement_eligible: [false, true]
+
 - name: Two parents, both students, eligible
   period: 2024-01
   input:

--- a/policyengine_us/variables/gov/states/tx/twc/ccs/eligibility/tx_ccs_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/states/tx/twc/ccs/eligibility/tx_ccs_work_requirement_eligible.py
@@ -29,14 +29,8 @@ class tx_ccs_work_requirement_eligible(Variable):
         # If 2+ non-exempt parents: 50 hours
         requirement = where(num_non_exempt_parents > 1, p.two_parent, p.single_parent)
 
-        # Check each parent individually
-        # A parent meets requirements if they are:
-        # - Exempt from work, OR
-        # - Part of a household that meets the work hour requirement
+        # The SPM unit is eligible if the non-exempt parents' combined work
+        # hours meet the requirement, or if every parent is exempt.
         household_meets_work_requirement = total_work_hours >= requirement
-        parent_meets_requirement = is_exempt | household_meets_work_requirement
-
-        # SPM unit is eligible if ALL parents meet requirements
-        # (Non-parents automatically pass)
-        person_eligible = parent_meets_requirement | ~is_head_or_spouse
-        return spm_unit.all(person_eligible)
+        all_parents_exempt = num_non_exempt_parents == 0
+        return household_meets_work_requirement | all_parents_exempt

--- a/policyengine_us/variables/gov/states/tx/twc/ccs/tx_child_care_subsidies.py
+++ b/policyengine_us/variables/gov/states/tx/twc/ccs/tx_child_care_subsidies.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class tx_child_care_subsidies(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "Texas child care subsidies"
+    unit = USD
+    definition_period = YEAR
+    defined_for = StateCode.TX
+    adds = ["tx_ccs"]


### PR DESCRIPTION
Fixes #7767

## Summary

TX CCS crashed in vectorized simulations (microsimulation) because `tx_ccs_work_requirement_eligible` combined a person-level array with an SPM-unit-level array. This PR fixes the broadcast bug and wires `tx_ccs` into the federal `child_care_subsidies` aggregate.

## Reproduction (2026-08-13, current main)

- **Bug 1 (entity broadcast): still reproduces.** A two-SPM-unit simulation crashes with `ValueError: operands could not be broadcast together with shapes (5,) (2,)`; the full microsimulation crashes with `shapes (160858,) (76665,)`.
- **Bug 2 (missing historical copay brackets) and Bug 3 (missing region parameter data): no longer reproduce.** The system-level `backdate_parameters` (system.py) backdates all parameters to 2021-01-01, so `tx_ccs_copay` and `tx_ccs_workforce_board_region` now compute correctly for January 2024. No parameter changes are needed.

## Changes

1. **`tx_ccs_work_requirement_eligible`**: rewritten as pure SPM-unit logic. The unit is eligible if the non-exempt parents' combined work hours meet the requirement, or if every parent is exempt — logically equivalent to the previous per-person formulation (a non-exempt parent could only pass via the household-level hours test, so `all(parents pass)` reduces to `household_meets | all_parents_exempt`).
2. **`tx_child_care_subsidies`** (new): YEAR-level wrapper adding `tx_ccs`, matching the `ok_child_care_subsidies` / `mo_child_care_subsidies` pattern.
3. **`gov.hhs.ccdf.child_care_subsidy_programs`**: added `tx_child_care_subsidies`.
4. **Regression test**: a two-SPM-unit case (units of different sizes) that crashes on main and asserts per-unit results `[false, true]`.

## Verification

- All 8 YAML tests in `tx_ccs_work_requirement_eligible.yaml` pass (7 existing + 1 new).
- Full microsimulation now computes `tx_ccs` for 2024 and 2025 and `child_care_subsidies` for 2025 without errors.
- Eligibility chain verified in microdata: 428 TX SPM units eligible, 1,602 eligible children.

## Note: TX CCS contributes $0 to the microsim aggregate (expected)

`tx_ccs_payment_rate` multiplies a daily rate by `childcare_attending_days_per_month`, which is an API-partner input that is 0 for everyone in the Populace microdata. OK, MO, VA, and KY use the same pattern and also contribute $0 in microsim. This is a data-side limitation (attending days are not imputed), not a model bug — the wiring makes TX consistent with those states and will surface real amounts once the data imputes attending days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)