### PR TITLE
Add Illinois county eligibility filtering for CSFP

### DIFF
--- a/changelog.d/il-csfp-county-filtering.added.md
+++ b/changelog.d/il-csfp-county-filtering.added.md
@@ -1,0 +1,1 @@
+Add Illinois county eligibility filtering for the Commodity Supplemental Food Program.

--- a/policyengine_us/parameters/gov/states/il/dhs/csfp/counties.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/csfp/counties.yaml
@@ -1,12 +1,8 @@
 description: Illinois defines the following counties as covered counties under the Commodity Supplemental Food Program.
 
-# Counties are the service areas of the three local agencies under the Illinois
-# CSFP State Plan: Greater Chicago Food Depository (Cook), St. Louis Area Foodbank
-# (southwestern Illinois), and Tri-State Foodbank (southeastern Illinois).
-# The IDHS program page lists 24 counties; the IDHS-affiliated We Got You Illinois
-# site lists 29. The five additional counties (Calhoun, Lawrence, Monroe, Perry,
-# Wayne) are included here so income-eligible seniors are not wrongly excluded;
-# the IDHS grant notice names Calhoun in the Metro St. Louis service area.
+# Counties are the service areas of the three local agencies listed by IDHS:
+# Greater Chicago Food Depository (Cook), St. Louis Area Foodbank (southwestern
+# Illinois), and Tri-State Foodbank (southeastern Illinois).
 metadata:
   unit: list
   period: year
@@ -14,15 +10,10 @@ metadata:
   reference:
     - title: Illinois Department of Human Services Commodity Supplemental Food Program
       href: https://www.dhs.state.il.us/page.aspx?item=31874
-    - title: We Got You Illinois Commodity Supplemental Food Program
-      href: https://wegotyouillinois.org/csfp/
-    - title: Illinois Department of Human Services Commodity Supplemental Food Program grant notice (27-444-80-0667)
-      href: https://www.dhs.state.il.us/page.aspx?item=175757
 
 values:
   2025-01-01:
     - ALEXANDER_COUNTY_IL
-    - CALHOUN_COUNTY_IL
     - CLINTON_COUNTY_IL
     - COOK_COUNTY_IL
     - EDWARDS_COUNTY_IL
@@ -33,11 +24,8 @@ values:
     - JACKSON_COUNTY_IL
     - JERSEY_COUNTY_IL
     - JOHNSON_COUNTY_IL
-    - LAWRENCE_COUNTY_IL
     - MADISON_COUNTY_IL
     - MASSAC_COUNTY_IL
-    - MONROE_COUNTY_IL
-    - PERRY_COUNTY_IL
     - POPE_COUNTY_IL
     - PULASKI_COUNTY_IL
     - RANDOLPH_COUNTY_IL
@@ -47,6 +35,5 @@ values:
     - UNION_COUNTY_IL
     - WABASH_COUNTY_IL
     - WASHINGTON_COUNTY_IL
-    - WAYNE_COUNTY_IL
     - WHITE_COUNTY_IL
     - WILLIAMSON_COUNTY_IL

--- a/policyengine_us/parameters/gov/states/il/dhs/csfp/counties.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/csfp/counties.yaml
@@ -8,8 +8,10 @@ metadata:
   period: year
   label: Illinois Commodity Supplemental Food Program covered counties
   reference:
-    - title: Illinois Department of Human Services Commodity Supplemental Food Program
+    - title: Illinois Department of Human Services Commodity Supplemental Food Program (local agencies and counties served)
       href: https://www.dhs.state.il.us/page.aspx?item=31874
+    - title: Illinois Department of Human Services Commodity Supplemental Food Program (Internet Archive snapshot, 2026-03-20)
+      href: https://web.archive.org/web/20260320212109/https://www.dhs.state.il.us/page.aspx?item=31874
 
 values:
   2025-01-01:

--- a/policyengine_us/parameters/gov/states/il/dhs/csfp/counties.yaml
+++ b/policyengine_us/parameters/gov/states/il/dhs/csfp/counties.yaml
@@ -1,0 +1,52 @@
+description: Illinois defines the following counties as covered counties under the Commodity Supplemental Food Program.
+
+# Counties are the service areas of the three local agencies under the Illinois
+# CSFP State Plan: Greater Chicago Food Depository (Cook), St. Louis Area Foodbank
+# (southwestern Illinois), and Tri-State Foodbank (southeastern Illinois).
+# The IDHS program page lists 24 counties; the IDHS-affiliated We Got You Illinois
+# site lists 29. The five additional counties (Calhoun, Lawrence, Monroe, Perry,
+# Wayne) are included here so income-eligible seniors are not wrongly excluded;
+# the IDHS grant notice names Calhoun in the Metro St. Louis service area.
+metadata:
+  unit: list
+  period: year
+  label: Illinois Commodity Supplemental Food Program covered counties
+  reference:
+    - title: Illinois Department of Human Services Commodity Supplemental Food Program
+      href: https://www.dhs.state.il.us/page.aspx?item=31874
+    - title: We Got You Illinois Commodity Supplemental Food Program
+      href: https://wegotyouillinois.org/csfp/
+    - title: Illinois Department of Human Services Commodity Supplemental Food Program grant notice (27-444-80-0667)
+      href: https://www.dhs.state.il.us/page.aspx?item=175757
+
+values:
+  2025-01-01:
+    - ALEXANDER_COUNTY_IL
+    - CALHOUN_COUNTY_IL
+    - CLINTON_COUNTY_IL
+    - COOK_COUNTY_IL
+    - EDWARDS_COUNTY_IL
+    - FRANKLIN_COUNTY_IL
+    - GALLATIN_COUNTY_IL
+    - HAMILTON_COUNTY_IL
+    - HARDIN_COUNTY_IL
+    - JACKSON_COUNTY_IL
+    - JERSEY_COUNTY_IL
+    - JOHNSON_COUNTY_IL
+    - LAWRENCE_COUNTY_IL
+    - MADISON_COUNTY_IL
+    - MASSAC_COUNTY_IL
+    - MONROE_COUNTY_IL
+    - PERRY_COUNTY_IL
+    - POPE_COUNTY_IL
+    - PULASKI_COUNTY_IL
+    - RANDOLPH_COUNTY_IL
+    - RICHLAND_COUNTY_IL
+    - SALINE_COUNTY_IL
+    - ST_CLAIR_COUNTY_IL
+    - UNION_COUNTY_IL
+    - WABASH_COUNTY_IL
+    - WASHINGTON_COUNTY_IL
+    - WAYNE_COUNTY_IL
+    - WHITE_COUNTY_IL
+    - WILLIAMSON_COUNTY_IL

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.yaml
@@ -1,0 +1,101 @@
+- name: Case 1, Illinois household in Cook County served by the Greater Chicago Food Depository.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: COOK_COUNTY_IL
+  output:
+    il_dhs_csfp_county_eligible: true
+
+- name: Case 2, Illinois household in a county served by the St. Louis Area Foodbank.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: ST_CLAIR_COUNTY_IL
+  output:
+    il_dhs_csfp_county_eligible: true
+
+- name: Case 3, Illinois household in a county served by the Tri-State Foodbank.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: PULASKI_COUNTY_IL
+  output:
+    il_dhs_csfp_county_eligible: true
+
+- name: Case 4, Illinois household in a county listed only by We Got You Illinois.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: CALHOUN_COUNTY_IL
+  output:
+    il_dhs_csfp_county_eligible: true
+
+- name: Case 5, Illinois household in central Illinois outside CSFP covered counties.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: SANGAMON_COUNTY_IL
+  output:
+    il_dhs_csfp_county_eligible: false
+
+- name: Case 6, Illinois household in the Chicago suburbs outside Cook County.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: DUPAGE_COUNTY_IL
+  output:
+    il_dhs_csfp_county_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.yaml
@@ -49,7 +49,7 @@
   output:
     il_dhs_csfp_county_eligible: true
 
-- name: Case 4, Illinois household in a county listed only by We Got You Illinois.
+- name: Case 4, Illinois household in a Metro St. Louis county not listed by IDHS.
   period: 2025
   input:
     people:
@@ -64,7 +64,7 @@
         state_code: IL
         county_str: CALHOUN_COUNTY_IL
   output:
-    il_dhs_csfp_county_eligible: true
+    il_dhs_csfp_county_eligible: false
 
 - name: Case 5, Illinois household in central Illinois outside CSFP covered counties.
   period: 2025

--- a/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program_eligible.yaml
@@ -277,3 +277,39 @@
         county_str: BARNSTABLE_COUNTY_MA
   output:
     commodity_supplemental_food_program_eligible: false
+
+- name: Case 13, Illinois senior in a CSFP covered county is eligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+        school_meal_fpg_ratio: 1.4
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: COOK_COUNTY_IL
+  output:
+    commodity_supplemental_food_program_eligible: true
+
+- name: Case 14, Illinois senior outside CSFP covered counties is not eligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+        school_meal_fpg_ratio: 1.0
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: SANGAMON_COUNTY_IL
+  output:
+    commodity_supplemental_food_program_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/csfp/commodity_supplemental_food_program_eligible.yaml
@@ -305,11 +305,29 @@
     spm_units:
       spm_unit:
         members: [person1]
-        school_meal_fpg_ratio: 1.0
+        school_meal_fpg_ratio: 1.4
     households:
       household:
         members: [person1]
         state_code: IL
         county_str: SANGAMON_COUNTY_IL
+  output:
+    commodity_supplemental_food_program_eligible: false
+
+- name: Case 15, Illinois senior in a CSFP covered county with income above the limit is not eligible.
+  period: 2025
+  input:
+    people:
+      person1:
+        age: 65
+    spm_units:
+      spm_unit:
+        members: [person1]
+        school_meal_fpg_ratio: 2.5
+    households:
+      household:
+        members: [person1]
+        state_code: IL
+        county_str: COOK_COUNTY_IL
   output:
     commodity_supplemental_food_program_eligible: false

--- a/policyengine_us/variables/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.py
+++ b/policyengine_us/variables/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.py
@@ -7,7 +7,10 @@ class il_dhs_csfp_county_eligible(Variable):
     definition_period = YEAR
     label = "Illinois DHS CSFP county eligible"
     defined_for = StateCode.IL
-    reference = "https://www.dhs.state.il.us/page.aspx?item=31874"
+    reference = (
+        "https://www.dhs.state.il.us/page.aspx?item=31874",
+        "https://web.archive.org/web/20260320212109/https://www.dhs.state.il.us/page.aspx?item=31874",
+    )
 
     def formula(household, period, parameters):
         county = household("county_str", period)

--- a/policyengine_us/variables/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.py
+++ b/policyengine_us/variables/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.py
@@ -1,0 +1,18 @@
+from policyengine_us.model_api import *
+
+
+class il_dhs_csfp_county_eligible(Variable):
+    value_type = bool
+    entity = Household
+    definition_period = YEAR
+    label = "Illinois DHS CSFP county eligible"
+    defined_for = StateCode.IL
+    reference = (
+        "https://www.dhs.state.il.us/page.aspx?item=31874",
+        "https://wegotyouillinois.org/csfp/",
+    )
+
+    def formula(household, period, parameters):
+        county = household("county_str", period)
+        p = parameters(period).gov.states.il.dhs.csfp
+        return np.isin(county, p.counties)

--- a/policyengine_us/variables/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.py
+++ b/policyengine_us/variables/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.py
@@ -7,10 +7,7 @@ class il_dhs_csfp_county_eligible(Variable):
     definition_period = YEAR
     label = "Illinois DHS CSFP county eligible"
     defined_for = StateCode.IL
-    reference = (
-        "https://www.dhs.state.il.us/page.aspx?item=31874",
-        "https://wegotyouillinois.org/csfp/",
-    )
+    reference = "https://www.dhs.state.il.us/page.aspx?item=31874"
 
     def formula(household, period, parameters):
         county = household("county_str", period)

--- a/policyengine_us/variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py
+++ b/policyengine_us/variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py
@@ -21,12 +21,14 @@ class commodity_supplemental_food_program_eligible(Variable):
         in_tx = state_code == StateCode.TX
         in_ks = state_code == StateCode.KS
         in_ma = state_code == StateCode.MA
+        in_il = state_code == StateCode.IL
         income_eligible = where(in_tx, tx_income_eligible, federal_income_eligible)
         ks_county_eligible = person.household("ks_dcf_csfp_county_eligible", period)
         ma_county_eligible = person.household("ma_dese_csfp_county_eligible", period)
+        il_county_eligible = person.household("il_dhs_csfp_county_eligible", period)
         county_eligible = select(
-            [in_ks, in_ma],
-            [ks_county_eligible, ma_county_eligible],
+            [in_ks, in_ma, in_il],
+            [ks_county_eligible, ma_county_eligible, il_county_eligible],
             default=True,
         )
         return age_eligible & income_eligible & county_eligible


### PR DESCRIPTION
## Summary
Adds Illinois county eligibility filtering for the Commodity Supplemental Food Program (CSFP), following the Kansas (#8580) and Massachusetts (#8785) pattern.

Closes #9290

## Background
IDHS states CSFP is not statewide: "Please note, not all Illinois counties participate in this program." Before this change, `commodity_supplemental_food_program_eligible` treated every income-eligible Illinois senior as eligible in all 102 counties.

## Source
[IDHS Commodity Supplemental Food Program](https://www.dhs.state.il.us/page.aspx?item=31874) — lists the three local agencies and the counties each serves.

## Covered counties (24)
| Local agency | Counties served (verbatim from IDHS) |
|---|---|
| Greater Chicago Food Depository | Cook |
| St. Louis Area Foodbank | Clinton, Franklin, Jackson, Jersey, Madison, Randolph, St. Clair, Washington, Williamson |
| Tri-State Foodbank | Alexander, Edwards, Gallatin, Hamilton, Hardin, Johnson, Massac, Pope, Pulaski, Richland, Saline, Union, Wabash, White |

Note: the IDHS-affiliated outreach site [We Got You Illinois](https://wegotyouillinois.org/csfp/) lists five additional counties (Calhoun, Lawrence, Monroe, Perry, Wayne). This PR follows the official IDHS program page. The county list is local-agency service-area data, not statute, and may change with funding.

## Changes
- `parameters/gov/states/il/dhs/csfp/counties.yaml` — list of 24 `<COUNTY>_COUNTY_IL` enum values
- `variables/gov/states/il/dhs/csfp/il_dhs_csfp_county_eligible.py` — `Household`, `YEAR`, `defined_for = StateCode.IL`
- `variables/gov/usda/csfp/commodity_supplemental_food_program_eligible.py` — adds an `in_il` arm to the county-gate `select`
- Tests: 6 cases for the IL variable (all three agencies; ineligible Calhoun, Sangamon, DuPage) and 2 federal-level cases (Cases 13–14)

## Not changed
Illinois raised its CSFP income limit from 130% to 150% FPG effective SFY2026 (2025-07-01), while `gov/usda/csfp/fpg_limit` already moved to 150% on 2025-01-01. That six-month gap is separate from county coverage and is not addressed here.

## Test plan
- [x] 6 `il_dhs_csfp_county_eligible` tests pass
- [x] 30 `gov/usda/csfp` tests pass (incl. new Cases 13–14)
- [x] KS/MA/TX CSFP tests (9) and partner CSFP contract tests (12) unaffected
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
