### PR TITLE
Align Medicaid senior-or-disabled pathway with Missouri MHABD budgeting

### DIFF
--- a/changelog.d/mo-mhabd-209b-fixes.fixed.md
+++ b/changelog.d/mo-mhabd-209b-fixes.fixed.md
@@ -1,0 +1,4 @@
+Align the Medicaid optional senior-or-disabled pathway with Missouri MHABD budgeting:
+- round the Missouri income standard up to the next whole monthly dollar, matching the Appendix J published amounts
+- apply the earned income exemption before the standard exemption and round countable income down to the whole dollar
+- count an ineligible spouse's gross income without the SSI FBR-differential deeming threshold

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_optional_senior_or_disabled_income_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_optional_senior_or_disabled_income_limit.yaml
@@ -1,6 +1,8 @@
 # Missouri MHABD tests blindness-based eligibility against 100% of the
 # poverty guideline but old-age and disability-based eligibility against
 # 85% (DSS Manual § 0805.015.45; current dollars in MHABD Appendix J).
+# Missouri publishes the standards as monthly dollar amounts, rounding
+# the percentage of the monthly guideline up to the next whole dollar.
 - name: Missouri blind single person gets the 100% FPL blind standard
   period: 2025
   input:
@@ -16,8 +18,8 @@
         members: [person1]
         state_code: MO
   output:
-    # 1.00 x 20,000
-    medicaid_optional_senior_or_disabled_income_limit: [20_000]
+    # ceil(1.00 x 20,000 / 12) = 1,667 monthly
+    medicaid_optional_senior_or_disabled_income_limit: [20_004]
 
 - name: Missouri non-blind single person gets the 85% FPL standard
   period: 2025
@@ -34,8 +36,8 @@
         members: [person1]
         state_code: MO
   output:
-    # 0.85 x 20,000
-    medicaid_optional_senior_or_disabled_income_limit: [17_000]
+    # ceil(0.85 x 20,000 / 12) = 1,417 monthly
+    medicaid_optional_senior_or_disabled_income_limit: [17_004]
 
 # The blind override is per person, so within one joint unit the blind
 # spouse gets the 100% standard while the other keeps the couple limit.
@@ -57,8 +59,80 @@
         members: [person1, person2]
         state_code: MO
   output:
-    # [1.00, 0.85] x 20,000
-    medicaid_optional_senior_or_disabled_income_limit: [20_000, 17_000]
+    # ceil([1.00, 0.85] x 20,000 / 12) = [1,667, 1,417] monthly
+    medicaid_optional_senior_or_disabled_income_limit: [20_004, 17_004]
+
+# Appendix J standards effective 04-01-2026: $1,131 and $1,533 monthly
+# for aged or disabled, $1,330 and $1,804 for blind. These derive from
+# the 2026 poverty guidelines ($15,960 for one person plus $5,680 per
+# additional person), so no tax_unit_fpg override is set here.
+- name: Missouri aged single person gets the published 2026 dollar standard
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # ceil(0.85 x 15,960 / 12) = 1,131 monthly
+    medicaid_optional_senior_or_disabled_income_limit: [13_572]
+
+- name: Missouri blind single person gets the published 2026 dollar standard
+  period: 2026
+  input:
+    people:
+      person1:
+        is_blind: true
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    # ceil(1.00 x 15,960 / 12) = 1,330 monthly
+    medicaid_optional_senior_or_disabled_income_limit: [15_960]
+
+- name: Missouri aged couple gets the published 2026 couple standard
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 70
+      person2:
+        age: 68
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    # ceil(0.85 x 21,640 / 12) = 1,533 monthly
+    medicaid_optional_senior_or_disabled_income_limit: [18_396, 18_396]
+
+- name: Missouri blind couple gets the published 2026 couple standard
+  period: 2026
+  input:
+    people:
+      person1:
+        is_blind: true
+      person2:
+        is_blind: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    # ceil(1.00 x 21,640 / 12) = 1,804 monthly
+    medicaid_optional_senior_or_disabled_income_limit: [21_648, 21_648]
 
 - name: Blindness does not change the limit outside Missouri
   period: 2025

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.yaml
@@ -20,3 +20,40 @@
         state_code: CT
   output:
     medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse: [11_610, 0]
+
+# Missouri MHABD considers the gross income of a married couple living
+# together (DSS Manual § 0805.015.05), so the spouse's income counts
+# even when it falls below the SSI FBR differential ($497 monthly in
+# 2026) that gates deeming under 20 CFR § 416.1163.
+- name: Case 2, Missouri counts spouse income below the SSI FBR differential.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 70
+        ssi_unearned_income: 17_400
+      person2:
+        age: 60
+        ssi_earned_income: 4_800
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        tax_unit_is_joint: true
+    marital_units:
+      marital_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    # The spouse's $400 monthly wage is below the $497 differential, so
+    # SSI deeming would not apply.
+    is_ssi_spousal_deeming_applies: [false, false]
+    # Couple budget, monthly: (400 - 65) x 0.5 + 1,450 - 20 = 1,597.50,
+    # rounded down to 1,597. Alone: 1,450 - 20 = 1,430. Deemed: 167.
+    medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse: [2_004, 0]
+    medicaid_optional_senior_or_disabled_countable_income: [19_164, 0]
+    # 1,597 monthly exceeds the $1,533 couple standard.
+    is_optional_senior_or_disabled_income_eligible: [false, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.yaml
@@ -57,3 +57,30 @@
     medicaid_optional_senior_or_disabled_countable_income: [19_164, 0]
     # 1,597 monthly exceeds the $1,533 couple standard.
     is_optional_senior_or_disabled_income_eligible: [false, false]
+
+- name: Case 3, Missouri deems nothing to an unmarried filer.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 70
+        ssi_unearned_income: 17_400
+    tax_units:
+      tax_unit:
+        members: [person1]
+    marital_units:
+      marital_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    is_ssi_spousal_deeming_applies: false
+    # No ineligible spouse is present, so the Missouri gross-income
+    # couple budget does not apply and nothing is deemed.
+    medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse: 0
+    # 1,450 - 20 = 1,430 monthly, or 17,160 annually.
+    medicaid_optional_senior_or_disabled_countable_income: 17_160
+    is_optional_senior_or_disabled_income_eligible: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/medicaid_optional_senior_or_disabled_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/medicaid_optional_senior_or_disabled_countable_income.yaml
@@ -73,3 +73,35 @@
   output:
     ssi_in_kind_support_and_maintenance: 4_108
     medicaid_optional_senior_or_disabled_countable_income: 3_868
+
+# Missouri MHABD budgets in the order of DSS Manual § 0805.015.00: the
+# $65-plus-one-half earned income exemption first (§ 0805.015.25), then
+# the $20 standard exemption from the combined total, then round down to
+# the nearest whole dollar (§ 0805.015.40). Under the SSI order, the
+# unused $20 would shift to earned income before the 50-percent
+# exclusion, yielding (2,368 - 85) x 0.5 = $1,141.50 monthly instead.
+- name: Missouri applies the earned income exemption before the standard exemption.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    age: 70
+    employment_income: 28_416
+    state_code: MO
+  output:
+    # Monthly, (2,368 - 65) x 0.5 - 20 = 1,131.50, rounded down to 1,131.
+    medicaid_optional_senior_or_disabled_countable_income: 13_572
+    # 1,131 equals the 2026 aged standard, and the standards are maxima.
+    is_optional_senior_or_disabled_income_eligible: true
+
+- name: Missouri rounds adjusted income down to the whole dollar.
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    age: 70
+    ssi_marital_unearned_income: 13_821
+    state_code: MO
+  output:
+    # Monthly, 1,151.75 - 20 = 1,131.75, rounded down to 1,131. Without
+    # rounding, 1,131.75 would exceed the $1,131 standard.
+    medicaid_optional_senior_or_disabled_countable_income: 13_572
+    is_optional_senior_or_disabled_income_eligible: true

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_optional_senior_or_disabled_income_limit.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_optional_senior_or_disabled_income_limit.py
@@ -13,6 +13,7 @@ class medicaid_optional_senior_or_disabled_income_limit(Variable):
     reference = (
         "https://www.law.cornell.edu/uscode/text/42/1396a#m",
         "https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-45-income-maximum/",
+        "https://dssmanuals.mo.gov/wp-content/uploads/2022/07/mhabd-appendix-j.pdf#page=1",
     )
 
     def formula(person, period, parameters):
@@ -34,10 +35,21 @@ class medicaid_optional_senior_or_disabled_income_limit(Variable):
         # old age or permanent and total disability.
         mo_mhabd = parameters(period).gov.states.mo.dss.mhabd.income_limit
         state_code = person.household("state_code", period)
+        is_mo = state_code == StateCode.MO
         is_blind = person("is_blind", period)
         limit_pct = where(
-            (state_code == StateCode.MO) & is_blind,
+            is_mo & is_blind,
             mo_mhabd.blind,
             limit_pct,
         )
-        return limit_pct * tax_unit("tax_unit_fpg", period)
+        fpg = tax_unit("tax_unit_fpg", period)
+        # Missouri publishes its MHABD standards as dollar amounts in
+        # Appendix J: the percentage of the monthly poverty guideline
+        # rounded up to the next whole dollar (e.g., $1,131 for one aged
+        # or disabled person and $1,804 for a blind couple in 2026).
+        mo_monthly_limit = np.ceil(limit_pct * fpg / MONTHS_IN_YEAR)
+        return where(
+            is_mo,
+            mo_monthly_limit * MONTHS_IN_YEAR,
+            limit_pct * fpg,
+        )

--- a/policyengine_us/variables/gov/hhs/medicaid/income/_apply_medicaid_optional_senior_or_disabled_exclusions.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/_apply_medicaid_optional_senior_or_disabled_exclusions.py
@@ -21,6 +21,29 @@ def _apply_ct_husky_c_exclusions(
     ) * MONTHS_IN_YEAR
 
 
+def _apply_mo_mhabd_exclusions(
+    earned_income: ArrayLike,
+    unearned_income: ArrayLike,
+    income_disregard: ArrayLike,
+    parameters: ParameterNode,
+    period: Period,
+) -> ArrayLike:
+    # Missouri MHABD budgets in the order of DSS Manual § 0805.015.00:
+    # deduct the $65-plus-one-half earned income exemption from gross
+    # earned income (§ 0805.015.25), add unearned income, subtract the
+    # standard exemption, then round the remaining income down to the
+    # nearest whole dollar (§ 0805.015.40). Unlike SSI, no unused portion
+    # of the standard exemption shifts to earned income before the
+    # 50-percent exclusion.
+    p = parameters(period).gov.ssa.ssi.income.exclusions
+    earned_monthly = earned_income / MONTHS_IN_YEAR
+    unearned_monthly = unearned_income / MONTHS_IN_YEAR
+
+    adjusted_earned = max_(earned_monthly - p.earned, 0) * (1.0 - p.earned_share)
+    adjusted = max_(adjusted_earned + unearned_monthly - income_disregard, 0)
+    return np.floor(adjusted) * MONTHS_IN_YEAR
+
+
 def _apply_medicaid_optional_senior_or_disabled_exclusions(
     earned_income: ArrayLike,
     unearned_income: ArrayLike,
@@ -29,16 +52,25 @@ def _apply_medicaid_optional_senior_or_disabled_exclusions(
     parameters: ParameterNode,
     period: Period,
 ) -> ArrayLike:
-    return where(
-        state == "CT",
-        _apply_ct_husky_c_exclusions(
-            earned_income,
-            unearned_income,
-            income_disregard,
-            parameters,
-            period,
-        ),
-        _apply_ssi_exclusions(
+    return select(
+        [state == "CT", state == "MO"],
+        [
+            _apply_ct_husky_c_exclusions(
+                earned_income,
+                unearned_income,
+                income_disregard,
+                parameters,
+                period,
+            ),
+            _apply_mo_mhabd_exclusions(
+                earned_income,
+                unearned_income,
+                income_disregard,
+                parameters,
+                period,
+            ),
+        ],
+        default=_apply_ssi_exclusions(
             earned_income,
             unearned_income,
             parameters,

--- a/policyengine_us/variables/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.py
@@ -11,7 +11,10 @@ class medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse(
     entity = Person
     label = "Medicaid optional senior or disabled income deemed from ineligible spouse"
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/cfr/text/20/416.1163"
+    reference = (
+        "https://www.law.cornell.edu/cfr/text/20/416.1163",
+        "https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-05/",
+    )
     defined_for = "is_ssi_eligible_individual"
     unit = USD
 
@@ -30,6 +33,25 @@ class medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse(
             period
         ).gov.hhs.medicaid.eligibility.categories.senior_or_disabled.income.disregard
         state = person.household("state_code_str", period)
+
+        # Missouri MHABD considers the gross income of a married couple
+        # living together (DSS Manual § 0805.015.05) rather than the SSI
+        # deeming methodology: the spouse's income counts without the
+        # FBR-differential threshold or ineligible-child allocations.
+        is_mo = state == "MO"
+        marital_unit = person.marital_unit
+        ineligible_spouse = person("is_ssi_ineligible_spouse", period)
+        spouse_gross_earned = (
+            marital_unit.sum(ineligible_spouse * individual_earned)
+            - ineligible_spouse * individual_earned
+        )
+        spouse_gross_unearned = (
+            marital_unit.sum(ineligible_spouse * individual_unearned)
+            - ineligible_spouse * individual_unearned
+        )
+        spouse_earned = where(is_mo, spouse_gross_earned, spouse_earned)
+        spouse_unearned = where(is_mo, spouse_gross_unearned, spouse_unearned)
+        deeming_applies = deeming_applies | is_mo
 
         alone_countable = _apply_medicaid_optional_senior_or_disabled_exclusions(
             individual_earned,

--- a/policyengine_us/variables/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.py
@@ -51,7 +51,8 @@ class medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse(
         )
         spouse_earned = where(is_mo, spouse_gross_earned, spouse_earned)
         spouse_unearned = where(is_mo, spouse_gross_unearned, spouse_unearned)
-        deeming_applies = deeming_applies | is_mo
+        has_ineligible_spouse = marital_unit.sum(ineligible_spouse) > 0
+        deeming_applies = deeming_applies | (is_mo & has_ineligible_spouse)
 
         alone_countable = _apply_medicaid_optional_senior_or_disabled_exclusions(
             individual_earned,

--- a/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_optional_senior_or_disabled_countable_income.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_optional_senior_or_disabled_countable_income.py
@@ -13,6 +13,10 @@ class medicaid_optional_senior_or_disabled_countable_income(Variable):
     reference = (
         "https://www.law.cornell.edu/uscode/text/42/1396a#m",
         "https://www.kff.org/medicaid/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey/",
+        # Missouri MHABD budgeting order and rounding
+        "https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/",
+        "https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-25/",
+        "https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-40/",
     )
 
     def formula(person, period, parameters):


### PR DESCRIPTION
## Summary
Fixes four discrepancies an API partner reported between the shared Medicaid optional senior-or-disabled pathway and Missouri's MHABD (MO HealthNet for the Aged, Blind, and Disabled) non-spend-down budget. Missouri is a 209(b) state, so its own budgeting methodology applies rather than the SSI methodology the pathway uses by default. Each fix is a Missouri-only branch inside the shared variables, following the existing CT HUSKY C and Missouri-blind-limit precedents; no other state's results change.

## Regulatory Authority
- [DSS Manual § 0805.015.00 Financial Need](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/) — six-step budgeting order
- [§ 0805.015.05 Persons Whose Income and Needs Are Considered](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-05/) — married couples living together
- [§ 0805.015.25 Standard Deductions From Gross Earned Income](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-25/)
- [§ 0805.015.40 Types of Need Determination](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-40/) — rounding
- [§ 0805.015.45 Income Maximum](https://dssmanuals.mo.gov/mo-healthnet-for-the-aged-blind-and-disabled/0805-000-00/0805-015-00/0805-015-45-income-maximum/) and [MHABD Appendix J](https://dssmanuals.mo.gov/wp-content/uploads/2022/07/mhabd-appendix-j.pdf#page=1) — published standards

## Changes
| Finding | Missouri rule | Before | After |
|---|---|---|---|
| Income standard | Appendix J publishes the standard as the percentage of the monthly FPL rounded up to the next dollar (verified against every published year 2006–2026, e.g. 2026 blind couple $1,803.33 → $1,804) | `pct × annual FPG` ($1,130.50/mo for aged single) | `ceil(pct × FPG / 12) × 12` ($1,131/mo), derived from FPG so it self-updates |
| Rounding | § 0805.015.40: "round the remaining income down to the nearest whole dollar amount to arrive at the adjusted gross income" | Decimal countable income | Monthly countable income floored |
| Deduction order | § 0805.015.00 steps 3–5: earned deductions ($65 + ½) first, add unearned, then subtract the standard exemption | SSI order (unused $20 shifted to earned income before the 50% exclusion) | Missouri order; $2,368/mo earned → $1,131.50 (was $1,141.50) |
| Spousal income | § 0805.015.05: "Consider the gross income of the couple in determining the adjusted income" | Spouse income counted only above the SSI FBR differential ($497/mo in 2026) | Ineligible spouse's gross income always counted for a couple living together |

## Not modeled (by design)
| What | Source | Why |
|---|---|---|
| § 0805.015.05 exceptions (spouse receiving SNC, SAB, or SP → treat as single) | § 0805.015.05 | Requires modeling spouse's program participation; couple income is always combined |
| Appendix J April 1 effective dates | Appendix J | Annual model applies calendar-year FPG; January–March uses the same standard as the rest of the year |

## Files
```
policyengine_us/variables/gov/hhs/medicaid/eligibility/categories/medicaid_optional_senior_or_disabled_income_limit.py
policyengine_us/variables/gov/hhs/medicaid/income/_apply_medicaid_optional_senior_or_disabled_exclusions.py
policyengine_us/variables/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.py
policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/medicaid_optional_senior_or_disabled_income_limit.yaml
policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/medicaid_optional_senior_or_disabled_countable_income.yaml
policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/deemed/from_ineligible_spouse/medicaid_optional_senior_or_disabled_income_deemed_from_ineligible_spouse.yaml
```

## Test plan
- [x] New tests pin all four 2026 Appendix J standards ($13,572 / $15,960 / $18,396 / $21,648 annual) and reproduce the partner's boundary cases (order, floor, spousal)
- [x] Full Medicaid suite, MS HMW (downstream consumer), and partner contract tests: 1,108 pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)