### PR TITLE
Apply Missouri's rounded monthly-dollar MAGI income limits to Medicaid/CHIP eligibility

### DIFF
--- a/changelog.d/mo-magi-dollar-income-limits.fixed.md
+++ b/changelog.d/mo-magi-dollar-income-limits.fixed.md
@@ -1,0 +1,1 @@
+Missouri MAGI Medicaid and CHIP eligibility follows Appendix A's rounded monthly-dollar income maximums, so income at the published dollar limit is eligible.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/chip/is_chip_eligible_child.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/chip/is_chip_eligible_child.yaml
@@ -199,3 +199,47 @@
   output:
     has_chip_disqualifying_health_coverage: True
     is_chip_eligible_child: False
+
+# Missouri applies the CHIP 75 limit (300% FPL plus the 5% disregard) as the
+# Appendix A monthly-dollar maximum, rounded up to the next whole dollar:
+# household of 2 in 2026, 21,640 x 3.05 / 12 = 5,500.17 -> $5,501.
+- name: MO child at exactly the $5,501 CHIP 75 maximum is CHIP-eligible although the exact ratio is 3.0505
+  period: 2026
+  input:
+    people:
+      head:
+        age: 30
+        employment_income: 66_012
+      child:
+        age: 8
+        immigration_status: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, child]
+    households:
+      household:
+        members: [head, child]
+        state_code: MO
+  output:
+    is_medicaid_eligible: [false, false]
+    is_chip_eligible_child: [false, true]
+
+- name: MO child $1 above the $5,501 CHIP 75 maximum is not CHIP-eligible
+  period: 2026
+  input:
+    people:
+      head:
+        age: 30
+        employment_income: 66_024
+      child:
+        age: 8
+        immigration_status: CITIZEN
+    tax_units:
+      tax_unit:
+        members: [head, child]
+    households:
+      household:
+        members: [head, child]
+        state_code: MO
+  output:
+    is_chip_eligible_child: [false, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_adult_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_adult_for_medicaid.yaml
@@ -216,3 +216,121 @@
   output:
     is_adult_for_medicaid_nfc: true
     is_adult_for_medicaid: false
+
+# Missouri applies the AEG adult limit (133% FPL plus the 5% disregard) as
+# the Appendix A monthly-dollar maximum, rounded up to the next whole
+# dollar: household of 1 in 2026, 15,960 x 1.38 / 12 = 1,835.40 -> $1,836.
+- name: MO adult at exactly the Appendix A $1,836 monthly maximum, eligible although the exact ratio is 1.3805
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 22_032
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    is_adult_for_medicaid_fc: true
+    is_adult_for_medicaid: true
+
+- name: MO adult $1 above the Appendix A monthly maximum ($1,837), ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 22_044
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    is_adult_for_medicaid_fc: false
+    is_adult_for_medicaid: false
+
+# For a household of 4 in 2026 the exact AEG threshold is already a whole
+# dollar, 33,000 x 1.38 / 12 = $3,795.00, so no rounding occurs and $3,795 is
+# the last eligible dollar.
+- name: MO adult at exactly the $3,795 monthly maximum, eligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 45_540
+      person2:
+        age: 40
+      person3:
+        age: 12
+      person4:
+        age: 12
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: MO
+  output:
+    is_adult_for_medicaid_fc: [true, true, true, true]
+
+# KNOWN LIMITATION: medicaid_income_level measures Missouri income from the
+# whole dollar just below monthly income (ceil(m) - 1). When the exact
+# threshold is a whole dollar, the household $1 above it measures at exactly
+# the limit ($3,795 x 12 / 33,000 = 1.38), and the strict-less-than test
+# still passes because the float32 level compares below the float64
+# parameter, although Missouri would find $3,796 ineligible. This case pins
+# that behavior so a change to it is deliberate rather than silent.
+- name: MO adult $1 above the whole-dollar maximum ($3,796) still measures at the limit (known limitation)
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 45_552
+      person2:
+        age: 40
+      person3:
+        age: 12
+      person4:
+        age: 12
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: MO
+  output:
+    is_adult_for_medicaid_fc: [true, true, true, true]
+
+- name: MO adult $2 above the whole-dollar maximum ($3,797), ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 40
+        employment_income: 45_564
+      person2:
+        age: 40
+      person3:
+        age: 12
+      person4:
+        age: 12
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3, person4]
+    households:
+      household:
+        members: [person1, person2, person3, person4]
+        state_code: MO
+  output:
+    is_adult_for_medicaid_fc: [false, false, false, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_older_child_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_older_child_for_medicaid.yaml
@@ -51,3 +51,48 @@
     state_code: MO
   output:
     is_older_child_for_medicaid: false
+
+# Missouri applies the MHK ages 1-18 limit (148% FPL plus the 5% disregard)
+# as the Appendix A monthly-dollar maximum, rounded up to the next whole
+# dollar: household of 3 in 2026, 27,320 x 1.53 / 12 = 3,483.30 -> $3,484.
+- name: MO children at exactly the Appendix A $3,484 monthly maximum, eligible although the exact ratio is 1.5303
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 41_808
+      person2:
+        age: 8
+      person3:
+        age: 12
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MO
+  output:
+    is_older_child_for_medicaid: [false, true, true]
+
+- name: MO children $1 above the Appendix A monthly maximum ($3,485), ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 41_820
+      person2:
+        age: 8
+      person3:
+        age: 12
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MO
+  output:
+    is_older_child_for_medicaid: [false, false, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_parent_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_parent_for_medicaid.yaml
@@ -127,6 +127,7 @@
 
 # Restructured from PR #9200 with an actual dependent child, which the
 # caretaker-relative check requires.
+# $300/month is just below the size-3 MHF limit of $301/month.
 - name: Missouri parent just below the size-3 MHF limit is eligible
   period: 2025
   input:
@@ -135,12 +136,11 @@
         age: 34
         is_tax_unit_head: true
         medicaid_household_size: 3
-        medicaid_income_level: 0.13553
+        employment_income: 3_600
       child:
         age: 5
         is_tax_unit_dependent: true
         medicaid_household_size: 3
-        medicaid_income_level: 0.13553
     tax_units:
       tax_unit:
         members: [person1, child]
@@ -593,3 +593,43 @@
         state_code: TX
   output:
     is_parent_for_medicaid: [true, false]
+
+# Missouri finds income at or below the published Appendix A dollar maximum
+# eligible; the MHF/MPW MHF row for a household of 2 is $241 per month.
+- name: Missouri parent at exactly the $241 MHF monthly limit is eligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 34
+        employment_income: 2_892
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, child]
+    households:
+      household:
+        members: [person1, child]
+        state_code: MO
+  output:
+    is_parent_for_medicaid: [true, false]
+
+- name: Missouri parent $1 above the MHF monthly limit ($242) is ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 34
+        employment_income: 2_904
+      child:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, child]
+    households:
+      household:
+        members: [person1, child]
+        state_code: MO
+  output:
+    is_parent_for_medicaid: [false, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_pregnant_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_pregnant_for_medicaid.yaml
@@ -79,3 +79,47 @@
     medicaid_income_level: 2.06
   output:
     is_pregnant_for_medicaid: false
+
+# Missouri applies the MPW limit (196% FPL plus the 5% disregard) as the
+# Appendix A monthly-dollar maximum, rounded up to the next whole dollar.
+# The unborn child counts in the applicant's household, so a pregnant
+# person living alone is a household of 2 in 2026:
+# 21,640 x 2.01 / 12 = 3,624.67 -> $3,625.
+- name: MO pregnant person at exactly the Appendix A $3,625 monthly maximum, eligible although the exact ratio is 2.0102
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_pregnant: true
+        employment_income: 43_500
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    medicaid_household_size: 2
+    is_pregnant_for_medicaid_fc: true
+    is_pregnant_for_medicaid: true
+
+- name: MO pregnant person $1 above the Appendix A monthly maximum ($3,626), ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        is_pregnant: true
+        employment_income: 43_512
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MO
+  output:
+    is_pregnant_for_medicaid_fc: false
+    is_pregnant_for_medicaid: false

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_young_child_for_medicaid.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/is_young_child_for_medicaid.yaml
@@ -51,3 +51,44 @@
     state_code: MO
   output:
     is_young_child_for_medicaid: false
+
+# Missouri applies the MHK ages 1-18 limit (148% FPL plus the 5% disregard)
+# as the Appendix A monthly-dollar maximum, rounded up to the next whole
+# dollar: household of 2 in 2026, 21,640 x 1.53 / 12 = 2,759.10 -> $2,760.
+- name: MO child at exactly the Appendix A $2,760 monthly maximum, eligible although the exact ratio is 1.5305
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 33_120
+      person2:
+        age: 3
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    is_young_child_for_medicaid: [false, true]
+
+- name: MO child $1 above the Appendix A monthly maximum ($2,761), ineligible
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 33_132
+      person2:
+        age: 3
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    is_young_child_for_medicaid: [false, false]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/parent/medicaid_parent_income_limit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/categories/parent/medicaid_parent_income_limit.yaml
@@ -151,7 +151,7 @@
         state_code: MO
         state_group_str: CONTIGUOUS_US
   output:
-    medicaid_parent_income_limit: 0.113461
+    medicaid_parent_income_limit: 0.113277
   absolute_error_margin: 0.0001
 
 - name: Case 11, Missouri uses the same dollar limit but a lower FPL ratio in 2026.
@@ -167,10 +167,11 @@
         state_code: MO
         state_group_str: CONTIGUOUS_US
   output:
-    medicaid_parent_income_limit: 0.110197
+    medicaid_parent_income_limit: 0.110018
   absolute_error_margin: 0.0001
 
-# $301/month * 12 / ($15,650 + 2 * $5,500) = 0.1355347.
+# Missouri limits sit on the same whole-dollar-minus-one scale as its
+# medicaid_income_level: ($301 - $1) x 12 / ($15,650 + 2 x $5,500) = 0.1350844.
 - name: Case 12, Missouri uses the size-3 MHF monthly dollar parent limit.
   period: 2025
   input:
@@ -184,11 +185,11 @@
         state_code: MO
         state_group_str: CONTIGUOUS_US
   output:
-    medicaid_parent_income_limit: 0.135535
+    medicaid_parent_income_limit: 0.135084
   absolute_error_margin: 0.0001
 
-# ($1,120/month + 3 * $42/month) * 12
-# / ($15,650 + 24 * $5,500) = 0.1012665.
+# ($1,120/month + 3 x $42/month - $1) x 12
+# / ($15,650 + 24 x $5,500) = 0.1011852.
 - name: Case 13, Missouri extends the MHF table for a size-25 household.
   period: 2025
   input:
@@ -202,14 +203,14 @@
         state_code: MO
         state_group_str: CONTIGUOUS_US
   output:
-    medicaid_parent_income_limit: 0.101267
+    medicaid_parent_income_limit: 0.101185
   absolute_error_margin: 0.0001
 
 # Before the adult expansion (effective July 1, 2021), the 5% FPL
 # disregard applied at the MHF level: the archived Appendix A (revised
 # 11/2020) publishes an "MHF Adult" row of $392 for a household of 3,
-# i.e. $301 + 5% x $1,810 monthly FPG.
-# $301 x 12 / $21,720 (2020 FPG for 3) + 0.05 = 0.216298.
+# i.e. $301 + 5% x $1,810 monthly FPG = $391.50, rounded up.
+# ($392 - $1) x 12 / $21,720 (2020 FPG for 3) = 0.216022.
 - name: Case 14, Missouri MHF limit included the 5% FPL disregard before the adult expansion.
   period: 2020
   input:
@@ -223,12 +224,12 @@
         state_code: MO
         state_group_str: CONTIGUOUS_US
   output:
-    medicaid_parent_income_limit: 0.216298
+    medicaid_parent_income_limit: 0.216022
   absolute_error_margin: 0.0001
 
 # Both sides of the 2021 transition at year granularity:
 # 2021 reads the January 1 value, so the disregard still applies.
-# $301 x 12 / $21,960 (2021 FPG for 3) + 0.05 = 0.214481.
+# $301 + 5% x $1,830 = $392.50 -> $393; ($393 - $1) x 12 / $21,960 = 0.214208.
 - name: Case 15, Missouri MHF limit keeps the disregard in 2021, the expansion's first year.
   period: 2021
   input:
@@ -242,10 +243,10 @@
         state_code: MO
         state_group_str: CONTIGUOUS_US
   output:
-    medicaid_parent_income_limit: 0.214481
+    medicaid_parent_income_limit: 0.214208
   absolute_error_margin: 0.0001
 
-# $301 x 12 / $23,030 (2022 FPG for 3) with no disregard = 0.156839.
+# ($301 - $1) x 12 / $23,030 (2022 FPG for 3) with no disregard = 0.156318.
 - name: Case 16, Missouri MHF limit drops the disregard from 2022.
   period: 2022
   input:
@@ -259,5 +260,5 @@
         state_code: MO
         state_group_str: CONTIGUOUS_US
   output:
-    medicaid_parent_income_limit: 0.156839
+    medicaid_parent_income_limit: 0.156318
   absolute_error_margin: 0.0001

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/medicaid_income_level.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/income/medicaid_income_level.yaml
@@ -138,3 +138,50 @@
     medicaid_income_level: [1, 1.262231]
     tax_unit_medicaid_income_level: 1
   absolute_error_margin: 0.001
+
+# Missouri applies its MAGI limits as the Appendix A monthly-dollar maximums,
+# rounded up from the exact FPL threshold (household of 2 in 2026: MHK ages
+# 1-18 at 148% + 5% = 21,640 x 1.53 / 12 = 2,759.10 -> $2,760), so the level
+# is measured from the whole dollar just below monthly income: at $2,760/month
+# it is 2,759 x 12 / 21,640 = 1.52995 rather than the exact 1.53049.
+- name: Case 5, Missouri measures the level from the whole dollar below monthly income.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 33_120
+      person2:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MO
+  output:
+    medicaid_household_size: [2, 2]
+    medicaid_household_income: [33_120, 33_120]
+    medicaid_income_level: [1.52995, 1.52995]
+  absolute_error_margin: 0.00001
+
+- name: Case 6, outside Missouri the level is the exact income-to-FPG ratio.
+  period: 2026
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 33_120
+      person2:
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: KS
+  output:
+    medicaid_income_level: [1.53049, 1.53049]
+  absolute_error_margin: 0.00001

--- a/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income_level.py
@@ -29,7 +29,13 @@ class medicaid_income_level(Variable):
         # when the whole dollar just below m (ceil(m) - 1) is strictly under
         # the exact threshold, so Missouri's level is measured from that
         # dollar figure and the downstream FPL-ratio comparisons reproduce the
-        # published dollar boundaries.
+        # published dollar boundaries. When the exact threshold is itself a
+        # whole dollar (no rounding), income $1 above it measures at exactly
+        # the limit, which the "at or below" categories accept and the
+        # strict-less-than categories also accept once the float32 level is
+        # compared with the float64 parameter, so that single dollar of
+        # income remains eligible; the whole-dollar case is rare (in 2026
+        # only the size-4 and size-9 adult thresholds, $3,795 and $7,061).
         monthly_income = np.round(income / MONTHS_IN_YEAR, 2)
         mo_income = max_(np.ceil(monthly_income) - 1, 0) * MONTHS_IN_YEAR
         countable_income = where(state_code == StateCode.MO, mo_income, income)

--- a/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income_level.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/income/medicaid_income_level.py
@@ -11,10 +11,26 @@ class medicaid_income_level(Variable):
     reference = (
         "https://www.law.cornell.edu/cfr/text/42/435.603",
         "https://www.medicaid.gov/state-resource-center/mac-learning-collaboratives/downloads/household-composition-and-income-training.pdf",
+        # Missouri applies its MAGI limits as the Appendix A monthly-dollar
+        # maximums, each FPL percentage converted to monthly dollars and
+        # rounded up to the next whole dollar.
+        "https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-030-00/1805-030-20/1805-030-20-20/1805-030-20-20-05/",
+        "https://dssmanuals.mo.gov/wp-content/uploads/2019/03/MAGIappendix-a.pdf#page=1",
     )
 
     def formula(person, period, parameters):
         income = person("medicaid_household_income", period)
         size = person("medicaid_household_size", period)
         state_group = person.household("state_group_str", period)
-        return income / fpg(size, state_group, period, parameters)
+        state_code = person.household("state_code", period)
+        # Missouri finds monthly income at or below the Appendix A dollar
+        # maximum eligible, and that maximum is the exact FPL threshold rounded
+        # up to the next whole dollar. Income m passes such a limit exactly
+        # when the whole dollar just below m (ceil(m) - 1) is strictly under
+        # the exact threshold, so Missouri's level is measured from that
+        # dollar figure and the downstream FPL-ratio comparisons reproduce the
+        # published dollar boundaries.
+        monthly_income = np.round(income / MONTHS_IN_YEAR, 2)
+        mo_income = max_(np.ceil(monthly_income) - 1, 0) * MONTHS_IN_YEAR
+        countable_income = where(state_code == StateCode.MO, mo_income, income)
+        return countable_income / fpg(size, state_group, period, parameters)

--- a/policyengine_us/variables/gov/states/mo/dss/mhf/mo_mhf_parent_income_limit.py
+++ b/policyengine_us/variables/gov/states/mo/dss/mhf/mo_mhf_parent_income_limit.py
@@ -22,14 +22,20 @@ class mo_mhf_parent_income_limit(Variable):
         additional_people = max_(size - p.max_household_size, 0)
 
         monthly_limit = p.amount[capped_size] + additional_people * p.additional_person
-        annual_limit = monthly_limit * MONTHS_IN_YEAR
         state_group = person.household("state_group_str", period)
-        limit_ratio = annual_limit / fpg(size, state_group, period, parameters)
+        monthly_fpg = fpg(size, state_group, period, parameters) / MONTHS_IN_YEAR
         # The conditional 5-point MAGI disregard in 1805.030.20.20.05 applies
         # only at the highest standard under which the person may qualify
         # (42 CFR 435.603(d)(4)). Since the adult expansion took effect
-        # (July 1, 2021) that is the AEG, so the current schedule is the raw
-        # ratio; before the expansion, Appendix A published a separate "MHF
-        # Adult" row equal to this schedule plus 5% of the FPG, captured by
+        # (July 1, 2021) that is the AEG, so the current schedule is the
+        # published dollar limit itself; before the expansion, Appendix A
+        # published a separate "MHF Adult" row equal to this schedule plus 5%
+        # of the monthly FPG, rounded up to the next whole dollar, captured by
         # the dated fpl_disregard parameter.
-        return limit_ratio + p.fpl_disregard
+        published_limit = np.ceil(
+            np.round(monthly_limit + p.fpl_disregard * monthly_fpg, 2)
+        )
+        # medicaid_income_level measures Missouri income from the whole dollar
+        # just below monthly income, so the limit is expressed on the same
+        # scale: income at the published dollar maximum is eligible.
+        return (published_limit - 1) / monthly_fpg


### PR DESCRIPTION
## Summary
Missouri applies its MAGI Medicaid and CHIP income limits as the monthly-dollar maximums published in Appendix A — each FPL threshold (with the 5% disregard folded in) converted to monthly dollars and rounded up to the next whole dollar — and income at the published dollar is eligible. PolicyEngine compared the exact income-to-FPG ratio against 1.53 / 3.05, so a household exactly at Missouri's boundary landed just above the ratio cutoff and was found ineligible. Same mechanism as the premium-tier fix in #9195, on the eligibility side.

Fixes #9296

## Sources
- MO DSS MAGI Manual § 1805.030.20.20.05: "Always refer to Appendix A – MAGI Income With 5% of FPL Included and CHIP Premium Amounts for current monthly income maximums with the 5% Disregard included in the income threshold." https://dssmanuals.mo.gov/family-mo-healthnet-magi/1805-000-00/1805-030-00/1805-030-20/1805-030-20-20/1805-030-20-20-05/
- Appendix A (Revised 04/26, table headed 7/1/2026–3/31/2027): https://dssmanuals.mo.gov/wp-content/uploads/2019/03/MAGIappendix-a.pdf#page=1

| Size | 148% MHK ages 1–18 (153% w/ disregard) | 300% SMHB & CHIP 75 (305%) | MHF/MPW MHF |
|---|---|---|---|
| 2 | $2,760 (21,640 × 1.53 / 12 = 2,759.10) | $5,501 (5,500.17) | $241 |
| 3 | $3,484 (3,483.30) | $6,944 (6,943.83) | $301 |

## Approach (one point of change)
`medicaid_income_level` now measures Missouri's income level from the whole dollar just below monthly income:

```python
mo_income = max_(np.ceil(monthly_income) - 1, 0) * MONTHS_IN_YEAR
countable_income = where(state_code == StateCode.MO, mo_income, income)
```

Missouri's test `m ≤ ceil(FPG × r / 12)` is exactly `(ceil(m) − 1) × 12 / FPG < r`, so every downstream category comparison against its FPL ratio reproduces the published dollar boundaries with no change to the federal category variables. Other states are untouched.

`mo_mhf_parent_income_limit` (Missouri's own dollar-based parent limit, compared with `<=`) is expressed on the same scale — `(published_limit − 1) / monthly_fpg`, with the pre-2021 5% disregard now rounded up like the archived Appendix A "MHF Adult" row ($392 for size 3) — so the parent boundary stays exact ($241 eligible, $242 not).

## Behavior at the boundaries (2026, verified by tests)
| Case | Missouri | Before | After |
|---|---|---|---|
| size 2, $2,760/mo, child 5 | MHK | not Medicaid → CHIP | MHK |
| size 2, $2,761/mo | CHIP | CHIP | CHIP |
| size 3, $3,484/mo, children 8/12 | MHK | not Medicaid | MHK |
| size 2, $5,501/mo | CHIP | ineligible | CHIP |
| size 2, $5,502/mo | ineligible | ineligible | ineligible |
| size 2 parent, $241 / $242 | eligible / not | eligible / not | eligible / not |

## Known residuals
- When the exact FPL threshold is itself a whole dollar (no rounding), the household $1 above the published maximum still measures at exactly the limit and is found eligible in every category: the `<=` categories (CHIP child/pregnant/FCEP, infant, basic health program in BHP states) accept equality outright, and the `<` categories accept it too because the float32 level compares below the float64 parameter. Whole-dollar thresholds are rare: in 2026 only the size-4 and size-9 AEG adult thresholds ($3,795 and $7,061). The size-4 case is pinned as a "known limitation" test in `is_adult_for_medicaid.yaml` ($3,795 eligible / $3,796 still eligible / $3,797 ineligible).
- The infant category's `np.isclose` (rtol 1e-5) also admits the household $1 above the maximum when the ceiling rounded up by less than about $0.10 (in 2026 only size 10, $11,237–$11,238); pre-existing tolerance, not introduced here.
- `medicaid_income_level` is a visible output; a Missouri household at $5,501/mo shows 3.0499 rather than 3.0505.
- Missouri applies each year's FPG mid-year (the current Appendix A table runs 7/1/2026–3/31/2027); the annual eligibility variables keep the January 1 switch.

## Boundary sweep (local, not committed)
Every MAGI category (adult, pregnant, infant, young child, older child, CHIP child) at ceil(FPG × ratio / 12) − $1 / + $0 / + $1 for 2026, sizes 1–12 (201 checks; also run 2018–2025 as a regression check): all match Missouri's dollar rule except the whole-dollar and isclose cases above. 2026 MHF parent row ($141…$532) and CHIP premium tier rows (185%/225%/300% ±$1) match Appendix A exactly.

## Files
- `variables/gov/hhs/medicaid/income/medicaid_income_level.py`
- `variables/gov/states/mo/dss/mhf/mo_mhf_parent_income_limit.py`
- tests: `medicaid_income_level.yaml`, `is_young_child_for_medicaid.yaml`, `is_older_child_for_medicaid.yaml`, `is_adult_for_medicaid.yaml`, `is_pregnant_for_medicaid.yaml`, `is_chip_eligible_child.yaml`, `is_parent_for_medicaid.yaml`, `parent/medicaid_parent_income_limit.yaml`
- `changelog.d/mo-magi-dollar-income-limits.fixed.md`

## Test plan
- [x] New boundary cases (young child, older child, adult, pregnant, CHIP child) fail on `main`, pass here
- [x] 1,240 tests across `gov/hhs/medicaid`, `gov/hhs/chip`, `gov/states/mo`, `basic_health_program` pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

