### PR TITLE
Gate Arkansas separate filing to married couples (ATCQI over-credit)

### DIFF
--- a/changelog.d/fix-ar-atcqi-mfs-gate.fixed.md
+++ b/changelog.d/fix-ar-atcqi-mfs-gate.fixed.md
@@ -1,0 +1,1 @@
+Fix the Arkansas additional tax credit for qualified individuals, which was granted to unmarried head-of-household filers by routing them through the married-filing-separately path; only married couples can file separately on the Arkansas return.

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/ar_files_separately.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/ar_files_separately.yaml
@@ -211,3 +211,23 @@
     # After credits: joint $500-$120=$380 vs separate $400-$120=$280
     # Separate cheaper
     ar_files_separately: true
+
+- name: Head of household filer never files separately (regression, taxsim 1137)
+  period: 2022
+  input:
+    people:
+      head:
+        employment_income: 26_190
+        is_tax_unit_head: true
+      dependent1:
+        age: 8
+        is_tax_unit_dependent: true
+      dependent2:
+        age: 10
+        is_tax_unit_dependent: true
+    households:
+      household:
+        members: [head, dependent1, dependent2]
+        state_code: AR
+  output:
+    ar_files_separately: false

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_additional_tax_credit_for_qualified_individuals.yaml
@@ -1,0 +1,20 @@
+
+- name: HoH with net taxable income above the phase-out gets no credit (taxsim 1137)
+  period: 2022
+  input:
+    people:
+      head:
+        employment_income: 26_190
+        is_tax_unit_head: true
+      dependent1:
+        age: 8
+        is_tax_unit_dependent: true
+      dependent2:
+        age: 10
+        is_tax_unit_dependent: true
+    households:
+      household:
+        members: [head, dependent1, dependent2]
+        state_code: AR
+  output:
+    ar_additional_tax_credit_for_qualified_individuals: 0

--- a/policyengine_us/variables/gov/states/ar/tax/income/ar_files_separately.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/ar_files_separately.py
@@ -56,5 +56,17 @@ class ar_files_separately(Variable):
         sep_credit_person = max_(p.max_amount - reduction_sep, 0)
         head_or_spouse = person("is_tax_unit_head_or_spouse", period)
         credit_sep = tax_unit.sum(sep_credit_person * head_or_spouse)
+        # Only a married couple can file separately on the same Arkansas
+        # return; single, head-of-household, and surviving-spouse filers
+        # always take the combined (joint) path. Without this gate an
+        # unmarried filer could be routed to the separate path and pick up
+        # the separate-path additional tax credit for qualified individuals,
+        # which reads regular individual taxable income rather than the
+        # low-income-table net taxable income.
+        statuses = filing_status.possible_values
+        married = (filing_status == statuses.JOINT) | (
+            filing_status == statuses.SEPARATE
+        )
         # Compare after filing-method-sensitive credits.
-        return (itax_indiv - credit_sep) < (itax_joint - credit_joint)
+        separate_cheaper = (itax_indiv - credit_sep) < (itax_joint - credit_joint)
+        return married & separate_cheaper


### PR DESCRIPTION
Fixes #9299. Surfaced by [PolicyEngine/policyengine-taxsim#1137](https://github.com/PolicyEngine/policyengine-taxsim/issues/1137).

## Problem

`ar_files_separately` chose Arkansas's "married filing separately on the same return" path for **any** filer when it produced a lower net tax — ungated by marital status. For an unmarried head-of-household filer that routed the **additional tax credit for qualified individuals** (AR1000TC line 6) through the separate branch, which reads `ar_taxable_income_indiv` (AGI − standard deduction) rather than the low-income-table net taxable income (AR1000F line 28).

For a HoH filer on the low income tax table (standard deduction $0, so line 28 net income = AGI), the regular individual taxable income is AGI − $2,270, which can fall below the credit's $24,300 phase-out start — producing the full $60 credit where the return allows $0.

## Fix

Restrict `ar_files_separately` to married filers (`JOINT`/`SEPARATE`); single, head-of-household, and surviving-spouse filers always take the combined (joint) path, which uses net taxable income for the ATCQI.

## Result

The taxsim #1137 record (AR 2022 HoH, $26,190 wages, 2 dependents, net taxable income $26,190) now gets ATCQI = $0 (was $60), matching AR1000TC line 6. Full AR baseline suite passes (467 tests), including new HoH regression cases for `ar_files_separately` and the ATCQI.
