### PR TITLE
Fix Virginia age deduction: protect fixed pre-1939 amount from income phase-out

### DIFF
--- a/changelog.d/fix-va-age-deduction-fixed-amount.fixed.md
+++ b/changelog.d/fix-va-age-deduction-fixed-amount.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Virginia age deduction so the fixed $12,000 deduction for a filer born on or before January 1, 1939 is no longer reduced by the income-based phase-out that applies only to a spouse born after that date.

--- a/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/subtractions/va_age_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/va/tax/income/subtractions/va_age_deduction.yaml
@@ -130,7 +130,11 @@
   output:
     va_age_deduction: 7_000
 
-# married: jointly: both eligible for deduction: one born before 01/01/1939, the other born between 01/02/1939 and 01/01/1958: $12,000 + $12,000 - (AFAGI - $75,000)
+# married: jointly: both eligible for deduction: one born before 01/01/1939, the other born between 01/02/1939 and 01/01/1958.
+# Per Va. Code § 58.1-322.03(5), the born-before-1939 spouse's $12,000 is a
+# fixed deduction that is NOT income-tested; only the income-based spouse's
+# $12,000 is reduced by (AFAGI - $75,000). So the total is
+# $12,000 (fixed) + max($12,000 - ($90,000 - $75,000), 0) = $12,000 + $0 = $12,000.
 - name: If in Virginia, filed jointly as a married couple, both eligible for deduction, one born before 01/01/1939, the other born between 01/02/1939 and 01/01/1958
   period: 2022
   input:
@@ -140,7 +144,20 @@
     age_head: 89
     age_spouse: 75
   output:
-    va_age_deduction: 9_000
+    va_age_deduction: 12_000
+
+# married: jointly: mixed ages, income-based spouse phases out but the fixed
+# born-before-1939 deduction is protected (taxsim issue #1140).
+- name: VA joint elderly couple, one born before 1939 (fixed $12,000) and one income-based who fully phases out
+  period: 2022
+  input:
+    state_code: VA
+    va_age_deduction_agi: 160_294
+    filing_status: JOINT
+    age_head: 85  # born 1937, before 01/01/1939 -> fixed $12,000
+    age_spouse: 77  # born 1945, income-based -> max($12,000 - ($160,294 - $75,000), 0) = $0
+  output:
+    va_age_deduction: 12_000
 
 
 # married: separate, both born after 01/02/1958: $0

--- a/policyengine_us/variables/gov/states/va/tax/income/subtractions/age_deduction/va_age_deduction.py
+++ b/policyengine_us/variables/gov/states/va/tax/income/subtractions/age_deduction/va_age_deduction.py
@@ -38,16 +38,22 @@ class va_age_deduction(Variable):
             int
         ) + spouse_eligible_for_full_deduction.astype(int)
 
-        # Calculate the maximum allowable deduction amount per filing
-        maximum_allowable_deduction = p.amount * count_eligible
+        # Va. Code § 58.1-322.03(5) grants two distinct age deductions:
+        # (a) a fixed amount for filers born on or before the birth-year
+        # limit, which is *not* income-tested; and (b) an income-based amount
+        # for filers born after the limit, reduced dollar-for-dollar by the
+        # amount their adjusted federal AGI exceeds the threshold. The income
+        # test applies only to the (b) amount, so the fixed (a) amount must be
+        # protected from the reduction.
+        fixed_count = count_eligible_for_full_deduction
+        income_based_count = count_eligible - fixed_count
+
+        fixed_deduction = p.amount * fixed_count
+        income_based_maximum = p.amount * income_based_count
 
         # Calculate the amount that the adjusted federal AGI exceeds the threshold
         excess = max_(agi - p.threshold[filing_status], 0)
 
-        # Reduce by the entire excess, unless both head and spouse (or head only if single)
-        # are eligible for the full deduction
-        reduction = excess * where(
-            count_eligible == count_eligible_for_full_deduction, 0, 1
-        )
+        income_based_deduction = max_(income_based_maximum - excess, 0)
 
-        return max_(maximum_allowable_deduction - reduction, 0)
+        return fixed_deduction + income_based_deduction


### PR DESCRIPTION
Fixes #9302.

## What

Virginia grants two distinct age deductions under [Va. Code § 58.1-322.03(5)](https://law.lis.virginia.gov/vacode/title58.1/chapter3/section58.1-322.03/):

> (a) A deduction in the amount of $12,000 for individuals born on or before January 1, 1939.
> (b) A deduction in the amount of $12,000 for individuals born after January 1, 1939, who have attained the age of 65. **This deduction shall be reduced by $1 for every $1 that the taxpayer's adjusted federal adjusted gross income exceeds $50,000 for single taxpayers or $75,000 for married taxpayers.**

The income test appears **only** in subparagraph (b). The (a) fixed deduction is never reduced.

`va_age_deduction` previously computed a single combined maximum (`$12,000 × count_eligible`) and then subtracted the entire AFAGI excess from the whole thing whenever not every eligible filer qualified for the fixed amount. For a **mixed-age couple** — one spouse born on/before Jan 1, 1939 (fixed) and one born after (income-based) — this wiped out the protected fixed $12,000.

This PR splits the deduction into the fixed portion (never reduced) and the income-based portion (reduced by the excess), so only the (b) amount is means-tested.

## Impact

Only the mixed-age married case changes. All-fixed, all-income-based, and single-filer cases are unchanged.

## Failing case (taxsim [#1140](https://github.com/PolicyEngine/policyengine-taxsim/issues/1140))

Joint filers, TY2022: taxpayer born 1/1/1937 (fixed $12,000), spouse born 1/1/1945 (income-based), AFAGI $160,294 ≫ $75,000 married threshold so the (b) amount phases to $0.

- TaxAct Form 760: age deduction **$12,000**, VA taxable income 131,057.
- PolicyEngine before: **$0**, VA taxable income 143,058 (tax before credits $690 too high).
- PolicyEngine after: **$12,000**. ✓

## Tests

- Corrected the existing joint mixed-age test, which encoded the buggy value ($9,000) — the statute gives $12,000.
- Added the #1140 record as a regression test.
- All 18 `va_age_deduction` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)