### PR TITLE
Add passive partnership/S-corp income input to the NIIT base

### DIFF
--- a/changelog.d/niit-passive-partnership-s-corp-income.added.md
+++ b/changelog.d/niit-passive-partnership-s-corp-income.added.md
@@ -1,0 +1,1 @@
+Passive partnership and S-corporation income input, included in the net investment income tax base.

--- a/policyengine_us/parameters/gov/irs/investment/income/sources.yaml
+++ b/policyengine_us/parameters/gov/irs/investment/income/sources.yaml
@@ -4,6 +4,7 @@ values:
     - taxable_interest_income
     - dividend_income
     - rental_income
+    - passive_partnership_s_corp_income
     - loss_limited_net_capital_gains
     - non_sch_d_capital_gains
     # Capital gain distributions received without filing Schedule D (Form 1040 line 7).

--- a/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/net_investment_income_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/tax/federal_income/net_investment_income_tax.yaml
@@ -20,7 +20,7 @@
   output:
     net_investment_income_tax: 0
 
-- name: Rental income just above threshold
+- name: Rental income calculation unchanged when passive income defaults to zero
   period: 2019
   input:
     taxable_interest_income: 0
@@ -32,7 +32,30 @@
   output:
     net_investment_income_tax: 190
 
-- name: Rental income just above threshold
+- name: Passive pass-through and other investment income above threshold
+  period: 2024
+  input:
+    adjusted_gross_income: 230_000
+    taxable_interest_income: 15_000
+    partnership_s_corp_income: 20_000
+    passive_partnership_s_corp_income: 20_000
+    filing_status: SINGLE
+  output:
+    net_investment_income: 35_000
+    net_investment_income_tax: 1_140
+
+- name: Passive pass-through income below the AGI threshold
+  period: 2024
+  input:
+    adjusted_gross_income: 199_000
+    partnership_s_corp_income: 50_000
+    passive_partnership_s_corp_income: 50_000
+    filing_status: SINGLE
+  output:
+    net_investment_income: 50_000
+    net_investment_income_tax: 0
+
+- name: Rental income well above threshold
   period: 2019
   input:
     taxable_interest_income: 0

--- a/policyengine_us/variables/input/passive_partnership_s_corp_income.py
+++ b/policyengine_us/variables/input/passive_partnership_s_corp_income.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class passive_partnership_s_corp_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Passive partnership and S-corporation income"
+    unit = USD
+    documentation = (
+        "The section 469 passive subset of partnership_s_corp_income. This "
+        "classifies income already counted in gross income and does not represent "
+        "additional gross income."
+    )
+    definition_period = YEAR
+    default_value = 0
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/26/1411#c_1_A_ii",
+        "https://www.irs.gov/instructions/i8960",
+    )


### PR DESCRIPTION
The NIIT source list (`gov.irs.investment.income.sources`) included rental income but omitted the section 1411(c)(1)(A)(ii) passive-business leg entirely, so passive pass-through income was never taxed under NIIT.

This adds a `passive_partnership_s_corp_income` input — the section 469 passive subset of `partnership_s_corp_income`, which is already in gross income, so including the subset in the NIIT base adds no income to AGI — and appends it to the source list from 2013 (NIIT has included passive business income since inception). It defaults to zero, so behavior is unchanged until a dataset supplies it; the Microcosm data side can populate it from the JCT/SOI passivity evidence gathered in Microcosm #530.

**Deliberately excluded**: the estate-income leg of #9304. `estate_income` is not in `gov.irs.gross_income.sources` today (placeholder comments mark the spot), and taxing income under NIIT before it enters AGI would be incoherent — that leg is blocked on gross-income inclusion first, re-scoped on the issue.

Tests: above-threshold NIIT computation with the new input (3.8% × min(NII, excess AGI)), below-threshold zero, and a default-zero regression case; also deduplicates two identically-named existing test cases.

Refs #9304

🤖 Generated with [Claude Code](https://claude.com/claude-code)