### PR TITLE
Map taxsim_pprofinc to SSTB self-employment income

### DIFF
--- a/changelog.d/taxsim-pprofinc-sstb.fixed.md
+++ b/changelog.d/taxsim-pprofinc-sstb.fixed.md
@@ -1,0 +1,1 @@
+taxsim_pprofinc maps SSTB self-employment income of the head and spouse instead of assuming zero.

--- a/policyengine_us/tests/policy/contrib/taxsim/taxsim_pprofinc.yaml
+++ b/policyengine_us/tests/policy/contrib/taxsim/taxsim_pprofinc.yaml
@@ -1,0 +1,42 @@
+- name: No SSTB income yields zero pprofinc.
+  period: 2024
+  input:
+    people:
+      head:
+        self_employment_income: 50_000
+    tax_units:
+      tax_unit:
+        members: [head]
+  output:
+    taxsim_pprofinc: 0
+
+- name: Head SSTB self-employment income maps to pprofinc.
+  period: 2024
+  input:
+    people:
+      head:
+        sstb_self_employment_income: 40_000
+    tax_units:
+      tax_unit:
+        members: [head]
+  output:
+    taxsim_pprofinc: 40_000
+
+- name: Head and spouse SSTB income sum; dependent SSTB income is excluded.
+  period: 2024
+  input:
+    people:
+      head:
+        age: 45
+        sstb_self_employment_income: 30_000
+      spouse:
+        age: 45
+        sstb_self_employment_income: 20_000
+      dependent:
+        age: 16
+        sstb_self_employment_income: 5_000
+    tax_units:
+      tax_unit:
+        members: [head, spouse, dependent]
+  output:
+    taxsim_pprofinc: 50_000

--- a/policyengine_us/variables/contrib/taxsim/taxsim_pprofinc.py
+++ b/policyengine_us/variables/contrib/taxsim/taxsim_pprofinc.py
@@ -4,6 +4,14 @@ from policyengine_us.model_api import *
 class taxsim_pprofinc(Variable):
     value_type = float
     entity = TaxUnit
-    label = "SSTB income for the primary taxpayer (TAXSIM). Assumed zero."
+    label = "SSTB income of the primary and secondary taxpayer (TAXSIM)"
     unit = USD
     definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        person = tax_unit.members
+        is_head_or_spouse = person("is_tax_unit_head", period) | person(
+            "is_tax_unit_spouse", period
+        )
+        sstb = person("sstb_self_employment_income", period)
+        return tax_unit.sum(sstb * is_head_or_spouse)


### PR DESCRIPTION
`taxsim_pprofinc` (TAXSIM v28, SSTB income of the primary and secondary taxpayer) carried no formula and was labeled "Assumed zero" — so every emulator comparison told TAXSIM no SSTB income exists, while the SSTB slice also never reached `taxsim_psemp` (which reads `self_employment_income`, the non-SSTB variable). SSTB income simply vanished from TAXSIM inputs.

This maps `taxsim_pprofinc = sstb_self_employment_income` summed over the head and spouse per the v28 definition. No double-boxing (Feenberg's rule from the 2026-07-24 meeting): psemp already excludes the SSTB variable. With the Microcosm occupation-classified SSTB split (Microcosm #530), the QBID comparison becomes meaningful above the thresholds for the first time.

Tests: zero without SSTB income, head-only mapping, and head+spouse summation with dependent exclusion.

Fixes PolicyEngine/policyengine-taxsim#1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)