### PR TITLE
Add Medicaid CE short-term hardship exceptions: hospitalization and medical travel

### DIFF
--- a/changelog.d/medicaid-ce-hardship-exceptions.added.md
+++ b/changelog.d/medicaid-ce-hardship-exceptions.added.md
@@ -1,0 +1,1 @@
+Added Medicaid community engagement short-term hardship exceptions for hospitalization or intensive services and long-distance medical travel.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.yaml
@@ -370,3 +370,34 @@
     medicaid_community_engagement_pass_through_eligible: false
   output:
     medicaid_work_requirement_eligible: false
+
+- name: Case 38, hospitalized person qualifies for the short-term hardship exception.
+  period: 2027
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    is_hospitalized_for_medicaid_ce: true
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 39, long-distance medical travel qualifies for the short-term hardship exception.
+  period: 2027
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    has_long_distance_medical_travel_for_medicaid_ce: true
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: true
+
+- name: Case 40, no hardship and not otherwise exempt remains subject to the requirement.
+  period: 2027
+  input:
+    age: 30
+    monthly_hours_worked: 0
+    is_hospitalized_for_medicaid_ce: false
+    has_long_distance_medical_travel_for_medicaid_ce: false
+    medicaid_community_engagement_pass_through_eligible: false
+  output:
+    medicaid_work_requirement_eligible: false

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/has_long_distance_medical_travel_for_medicaid_ce.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/has_long_distance_medical_travel_for_medicaid_ce.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class has_long_distance_medical_travel_for_medicaid_ce(Variable):
+    value_type = bool
+    entity = Person
+    label = (
+        "Traveling a long distance for medical care for Medicaid community engagement"
+    )
+    documentation = (
+        "Whether the person qualifies for the Medicaid community engagement "
+        "short-term hardship exception because they must travel a long "
+        "distance to receive medical care (for themselves or a dependent). "
+        "The exception is applied when the circumstance is present; this input "
+        "lets household situations represent it since survey data lack a "
+        "medical-travel signal. It defaults to false, so it does not affect "
+        "microsimulation results."
+    )
+    definition_period = YEAR
+    default_value = False
+    reference = (
+        "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6",
+    )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/has_long_distance_medical_travel_for_medicaid_ce.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/has_long_distance_medical_travel_for_medicaid_ce.py
@@ -5,20 +5,26 @@ class has_long_distance_medical_travel_for_medicaid_ce(Variable):
     value_type = bool
     entity = Person
     label = (
-        "Traveling a long distance for medical care for Medicaid community engagement"
+        "Traveling outside their community for medical care for Medicaid "
+        "community engagement"
     )
     documentation = (
-        "Whether the person qualifies for the Medicaid community engagement "
-        "short-term hardship exception because they must travel a long "
-        "distance to receive medical care (for themselves or a dependent). "
-        "The exception is applied when the circumstance is present; this input "
-        "lets household situations represent it since survey data lack a "
-        "medical-travel signal. It defaults to false, so it does not affect "
+        "Whether the person is granted the optional Medicaid community "
+        "engagement short-term hardship exception (42 CFR 435.555(d)(4)) "
+        "because they, or their dependent, must travel outside their "
+        "community of residence for an extended period to receive medical "
+        "services necessary to treat a serious or complex medical condition "
+        "that are not available within their community. The exception is a "
+        "state option that the person (or someone acting on their behalf) "
+        "must request; this input asserts that the state has elected the "
+        "option and granted the exception. It lets household situations "
+        "represent the circumstance since survey data lack a medical-travel "
+        "signal, and defaults to false, so it does not affect "
         "microsimulation results."
     )
     definition_period = YEAR
     default_value = False
     reference = (
-        "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf",
-        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6",
+        "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf#page=126",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=7",
     )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_hospitalized_for_medicaid_ce.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_hospitalized_for_medicaid_ce.py
@@ -5,20 +5,24 @@ class is_hospitalized_for_medicaid_ce(Variable):
     value_type = bool
     entity = Person
     label = (
-        "Hospitalized or receiving intensive services for Medicaid community engagement"
+        "Hospitalized or receiving services of similar acuity for Medicaid "
+        "community engagement"
     )
     documentation = (
-        "Whether the person qualifies for the Medicaid community engagement "
-        "short-term hardship exception because they are hospitalized or "
-        "receiving intensive outpatient or inpatient services. The exception "
-        "is applied when the circumstance is present; this input lets "
-        "household situations represent it since survey data lack a hospital "
-        "utilization signal. It defaults to false, so it does not affect "
-        "microsimulation results."
+        "Whether the person is granted the optional Medicaid community "
+        "engagement short-term hardship exception (42 CFR 435.555(d)(1)) "
+        "because they receive inpatient hospital, nursing facility, ICF/IID, "
+        "or inpatient psychiatric hospital services, or other services of "
+        "similar acuity. The exception is a state option that the person (or "
+        "someone acting on their behalf) must request; this input asserts "
+        "that the state has elected the option and granted the exception. It "
+        "lets household situations represent the circumstance since survey "
+        "data lack a hospital utilization signal, and defaults to false, so "
+        "it does not affect microsimulation results."
     )
     definition_period = YEAR
     default_value = False
     reference = (
-        "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf",
+        "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf#page=126",
         "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6",
     )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_hospitalized_for_medicaid_ce.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/is_hospitalized_for_medicaid_ce.py
@@ -1,0 +1,24 @@
+from policyengine_us.model_api import *
+
+
+class is_hospitalized_for_medicaid_ce(Variable):
+    value_type = bool
+    entity = Person
+    label = (
+        "Hospitalized or receiving intensive services for Medicaid community engagement"
+    )
+    documentation = (
+        "Whether the person qualifies for the Medicaid community engagement "
+        "short-term hardship exception because they are hospitalized or "
+        "receiving intensive outpatient or inpatient services. The exception "
+        "is applied when the circumstance is present; this input lets "
+        "household situations represent it since survey data lack a hospital "
+        "utilization signal. It defaults to false, so it does not affect "
+        "microsimulation results."
+    )
+    definition_period = YEAR
+    default_value = False
+    reference = (
+        "https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf",
+        "https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6",
+    )

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -85,10 +85,12 @@ class medicaid_work_requirement_eligible(Variable):
         was_recently_incarcerated = person(
             "was_recently_incarcerated_for_medicaid_ce", period
         )
-        # Short-term hardship exceptions (applied when the circumstance is
-        # present): hospitalization / intensive services, and long-distance
-        # medical travel. County-unemployment-threshold and federal-disaster
-        # hardships require external data and are not modeled here (#8270).
+        # Optional short-term hardship exceptions (42 CFR 435.555(d)(1) and
+        # (d)(4)), elected by the state and requested by the person:
+        # hospitalization / services of similar acuity, and travel outside the
+        # community for medical care. The disaster-declaration and
+        # county-unemployment hardships require external data and are not
+        # modeled here (#8270).
         is_hospitalized = person("is_hospitalized_for_medicaid_ce", period)
         has_long_distance_medical_travel = person(
             "has_long_distance_medical_travel_for_medicaid_ce", period

--- a/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
+++ b/policyengine_us/variables/gov/hhs/medicaid/eligibility/medicaid_work_requirement_eligible.py
@@ -85,6 +85,14 @@ class medicaid_work_requirement_eligible(Variable):
         was_recently_incarcerated = person(
             "was_recently_incarcerated_for_medicaid_ce", period
         )
+        # Short-term hardship exceptions (applied when the circumstance is
+        # present): hospitalization / intensive services, and long-distance
+        # medical travel. County-unemployment-threshold and federal-disaster
+        # hardships require external data and are not modeled here (#8270).
+        is_hospitalized = person("is_hospitalized_for_medicaid_ce", period)
+        has_long_distance_medical_travel = person(
+            "has_long_distance_medical_travel_for_medicaid_ce", period
+        )
         # parent, guardian, caretaker of a dependent child 13 years of age or under  p.694 (III)
         child_age_eligible = age <= p.dependent_age_limit
         has_eligible_dependent_child = person.tax_unit.any(
@@ -105,6 +113,8 @@ class medicaid_work_requirement_eligible(Variable):
             | treatment_program_participant
             | is_incarcerated
             | was_recently_incarcerated
+            | is_hospitalized
+            | has_long_distance_medical_travel
         )
         meets_base_requirement = (
             meets_monthly_activity_hours


### PR DESCRIPTION
Part of #8270 (parent #7751).

Adds two person-level boolean inputs for Medicaid community engagement **short-term hardship exceptions** and ORs them into the `medicaid_work_requirement_eligible` exemption set:
- `is_hospitalized_for_medicaid_ce` — hospitalization or intensive services
- `has_long_distance_medical_travel_for_medicaid_ce` — long-distance medical travel

Both follow the existing hardship-input pattern (e.g. `is_in_medicaid_community_engagement_treatment_program`) and **default to false, so microsimulation results are unchanged** — they let household scenarios represent circumstances the survey data can't signal.

**Legal basis**: the short-term hardship exception is a **state option** — SSA §1902(xx)(3)(B), implemented at new 42 CFR 435.555 "Optional exception for short-term hardship events" ([IFC, June 3, 2026, p.125–126](https://www.govinfo.gov/content/pkg/FR-2026-06-03/pdf/2026-11094.pdf#page=126); [CIB 12/08/2025 p.6–7](https://www.medicaid.gov/federal-policy-guidance/downloads/cib12082025.pdf#page=6)). For the two events modeled here — §435.555(d)(1) hospitalization / nursing facility / ICF/IID / inpatient psychiatric / services of similar acuity, and §435.555(d)(4) travel outside the community for a serious or complex condition — the person (or someone acting on their behalf) must request the exception. The inputs therefore assert that the state has elected the option and granted the exception; the variable documentation says so.

**Deferred** (per the issue's scope): the county-unemployment-threshold and federal-disaster-declaration hardships (§435.555(d)(2)–(3)) require external data (county unemployment rates, disaster declarations); and a state-election parameter, since no state has yet elected the option in its State plan (requirement takes effect January 1, 2027).

Tests: added hospitalized → exempt, medical-travel → exempt, and a no-hardship control → subject. `medicaid_work_requirement_eligible` suite 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
