### PR TITLE
Add CPS work-experience person input variables (industry recodes, worked-last-year)

### DIFF
--- a/changelog.d/work-experience-person-inputs.added.md
+++ b/changelog.d/work-experience-person-inputs.added.md
@@ -1,0 +1,1 @@
+Detailed and major industry recode and worked-last-year person input variables from the CPS ASEC work-experience block (WEIND, WEMIND, WORKYN).

--- a/policyengine_us/variables/household/demographic/person/detailed_industry_recode.py
+++ b/policyengine_us/variables/household/demographic/person/detailed_industry_recode.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class detailed_industry_recode(Variable):
+    value_type = int
+    entity = Person
+    label = "CPS detailed industry recode of previous year"
+    documentation = (
+        "This variable is the WEIND variable in the Current Population Survey."
+    )
+    definition_period = YEAR

--- a/policyengine_us/variables/household/demographic/person/major_industry_recode.py
+++ b/policyengine_us/variables/household/demographic/person/major_industry_recode.py
@@ -1,0 +1,11 @@
+from policyengine_us.model_api import *
+
+
+class major_industry_recode(Variable):
+    value_type = int
+    entity = Person
+    label = "CPS major industry recode of previous year"
+    documentation = (
+        "This variable is the WEMIND variable in the Current Population Survey."
+    )
+    definition_period = YEAR

--- a/policyengine_us/variables/household/demographic/person/worked_last_year.py
+++ b/policyengine_us/variables/household/demographic/person/worked_last_year.py
@@ -1,0 +1,15 @@
+from policyengine_us.model_api import *
+
+
+class worked_last_year(Variable):
+    value_type = bool
+    entity = Person
+    label = "worked at any time in the previous year"
+    documentation = (
+        "Whether the person worked at any time during the previous year: "
+        "the WKSWORK variable in the Current Population Survey exceeding "
+        "zero, which is the universe condition of the work-experience "
+        "longest-job recodes (detailed_occupation_recode, "
+        "detailed_industry_recode, major_industry_recode)."
+    )
+    definition_period = YEAR


### PR DESCRIPTION
Adds three person-level input variables from the CPS ASEC work-experience block, mirroring `detailed_occupation_recode` (POCCU2):

- `detailed_industry_recode` — WEIND, "IND. OF LONGEST JOB BY DETAILED GROUPS" (0:23; 22 = Military, 23 = Never worked; 0 = NIU)
- `major_industry_recode` — WEMIND, "IND. OF LONGEST JOB BY MAJOR IND. GROUPS" (0:15)
- `worked_last_year` — WORKYN == 1, "Did ... work at a job or business at any time during 20..?"

All three are verified against the official ASEC public-use data dictionary (`asec2024_ddl_pub_full.pdf`) and are reference-period-coherent with the longest-job occupation recode the model already carries (the survey-week `A_DTIND`/`A_MJIND` recodes would describe a different job than `POCCU2`).

These are the engine-side consumers for the microcosm `work_experience_inputs` source stage (PolicyEngine/microcosm#719): the Living Wage Institute county-microdata MVP commits every person record to carry a working indicator, industry, and occupation. Microcosm's release input-coverage gate requires manifest columns to exist in the locked PolicyEngine-US, so the companion microcosm PR bumps its lock to the release containing this change.

Input variables only — no formulas, parameters, or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)