### PR TITLE
Fix Arkansas inflation relief credit for combined filers

### DIFF
--- a/changelog.d/fix-ar-inflation-relief-combined-table.fixed.md
+++ b/changelog.d/fix-ar-inflation-relief-combined-table.fixed.md
@@ -1,0 +1,1 @@
+Fixed the Arkansas inflation relief income-tax credit for married couples filing combined (status 4), which now uses the per-spouse single-filer table (maximum $150, phased out from $87,000) instead of the joint table (maximum $300, phased out from $174,000) split between spouses.

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
@@ -151,3 +151,51 @@
         state_code: AR
   output:
     ar_inflation_relief_credit_person: [150, 150, 0]
+
+# Married couple filing combined (status 4): each spouse uses the single-filer
+# table on their own net income, not the joint table split in half (taxsim #1143).
+- name: Married couple filing combined uses the per-spouse single-filer table
+  period: 2022
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 90_877
+      person2:
+        ar_taxable_income_indiv: 165_258
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: true
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    # person1: $150 - ceil(3,877 / 1,000) * $10 = $150 - $40 = $110
+    # person2: $165,258 > $101,000 -> $0
+    ar_inflation_relief_credit_person: [110, 0]
+
+# The same couple filing a true joint return uses the joint table on combined
+# income ($256,135 > $174,000 -> $0), split in half.
+- name: Married couple filing a true joint return uses the joint table on combined income
+  period: 2022
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 90_877
+      person2:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 165_258
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: false
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    ar_inflation_relief_credit_person: [0, 0]

--- a/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.py
+++ b/policyengine_us/variables/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.py
@@ -22,16 +22,27 @@ class ar_inflation_relief_credit_person(Variable):
         income = where(filing_separately, indiv_income, joint_income)
         p = parameters(period).gov.states.ar.tax.income.credits.inflationary_relief
         filing_status = person.tax_unit("filing_status", period)
-        max_amount = p.max_amount[filing_status]
-        reduction_start = p.reduction.start[filing_status]
-        increment = p.reduction.increment[filing_status]
-        reduction_per_increment = p.reduction.amount[filing_status]
+        statuses = filing_status.possible_values
+        # A married couple filing combined (status 4) computes the credit for
+        # each spouse separately in the single-filer table (max $150, phased
+        # out from $87,000), per the Inflationary Relief Credit Worksheet.
+        # Only a true joint return (status 2) uses the joint table (max $300,
+        # phased out from $174,000) on combined income and splits it in half.
+        credit_status = statuses.encode(
+            where(filing_separately, statuses.SEPARATE, filing_status.decode())
+        )
+        max_amount = p.max_amount[credit_status]
+        reduction_start = p.reduction.start[credit_status]
+        increment = p.reduction.increment[credit_status]
+        reduction_per_increment = p.reduction.amount[credit_status]
         excess = max_(income - reduction_start, 0)
         increments = np.ceil(excess / increment)
         total_reduction_amount = increments * reduction_per_increment
-        # Attribute the maximum amount to each spouse equally when married filing jointly
-        joint = filing_status == filing_status.possible_values.JOINT
-        divisor = where(joint, 2, 1)
+        # Attribute the maximum amount to each spouse equally only when the
+        # couple files a true joint return (combined filers already use their
+        # own individual income above).
+        true_joint = (filing_status == statuses.JOINT) & ~filing_separately
+        divisor = where(true_joint, 2, 1)
         credit = max_(max_amount - total_reduction_amount, 0) / divisor
         # The credit is only allocated to the head and spouse, not dependents.
         head_or_spouse = person("is_tax_unit_head_or_spouse", period)


### PR DESCRIPTION
Fixes #9320.

## What

For a married couple filing a **combined** Arkansas return (filing status 4, `ar_files_separately = True`), the inflationary relief credit is looked up **per spouse in the single-filer table** (max $150, phased out from $87,000, gone at $101,000), per the Arkansas Inflationary Relief Income-Tax Credit Worksheet, Filing Status 4. The joint table (max $300, phased out from $174,000) applies only to a true joint return (status 2) on one combined income.

`ar_inflation_relief_credit_person` keyed the table off `filing_status`, which is `JOINT` for any married couple, so combined filers wrongly used the joint table split 50/50. This PR uses the single-filer (SEPARATE) table per spouse for combined filers, reserving the joint table and the halving split for a true joint return.

## Failing case (taxsim [#1143](https://github.com/PolicyEngine/policyengine-taxsim/issues/1143))

Joint couple, TY2022, $88,000 + $162,381 wages, $10,294 interest, 1 dependent — files combined. Per-spouse net income (AR1000F line 28): primary $90,877, spouse $165,258 (PolicyEngine computes the same split).

- TaxAct worksheet (single-filer table per spouse): $110 + $0 = **$110** (AR1000TC line 7; net tax 11,925).
- PolicyEngine before (joint table, 50/50): $150 + $150 = **$300** (net tax 11,739, ~$186 low).
- PolicyEngine after: **$110**. ✓

## Impact

Only the combined-married case changes. True-joint, single, head-of-household, surviving-spouse, and separate cases are unchanged (verified against the existing tests).

## Tests

- Added the #1143 combined-filing case ([110, 0]) and a true-joint contrast on the same incomes ([0, 0], combined income $256,135 > $174,000).
- Full Arkansas suite passes (469 tests).

## Related

The credit now differs by filing method ($110 combined vs $0 joint here), so the combined-vs-joint selection in `ar_files_separately` should ideally weigh it, as it already does for the additional tax credit for qualified individuals (#9300). Left as a follow-up to keep this change focused and avoid a circular dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)