### PR TITLE
Zero out FUTA credit reduction for states that exited credit-reduction status

### DIFF
--- a/changelog.d/fix-futa-credit-reduction-zero-out.fixed.md
+++ b/changelog.d/fix-futa-credit-reduction-zero-out.fixed.md
@@ -1,0 +1,1 @@
+Return the FUTA credit reduction rate to zero for AR, AZ, CT, DE, FL, GA, and IL in the year each state exited credit-reduction status, per IRS Schedule A (Form 940).

--- a/policyengine_us/parameters/gov/irs/payroll/federal_unemployment/credit_reduction_rate.yaml
+++ b/policyengine_us/parameters/gov/irs/payroll/federal_unemployment/credit_reduction_rate.yaml
@@ -12,8 +12,8 @@ metadata:
       href: https://www.irs.gov/pub/irs-prior/f940sa--2013.pdf
     - title: Schedule A (Form 940) for 2014
       href: https://www.irs.gov/pub/irs-prior/f940sa--2014.pdf
-    - title: Schedule A (Form 940) for 2023
-      href: https://www.irs.gov/pub/irs-prior/f940sa--2023.pdf
+    - title: Schedule A (Form 940) for 2023 (credit-reduction jurisdictions listed in the instructions)
+      href: https://www.irs.gov/pub/irs-prior/f940sa--2023.pdf#page=2
 AA:
   0000-01-01: 0
 AE:

--- a/policyengine_us/parameters/gov/irs/payroll/federal_unemployment/credit_reduction_rate.yaml
+++ b/policyengine_us/parameters/gov/irs/payroll/federal_unemployment/credit_reduction_rate.yaml
@@ -8,6 +8,12 @@ metadata:
   reference:
     - title: Historical FUTA Credit Reductions
       href: https://oui.doleta.gov/unemploy/docs/reduced_credit_states_2010-2025.xlsx
+    - title: Schedule A (Form 940) for 2013
+      href: https://www.irs.gov/pub/irs-prior/f940sa--2013.pdf
+    - title: Schedule A (Form 940) for 2014
+      href: https://www.irs.gov/pub/irs-prior/f940sa--2014.pdf
+    - title: Schedule A (Form 940) for 2023
+      href: https://www.irs.gov/pub/irs-prior/f940sa--2023.pdf
 AA:
   0000-01-01: 0
 AE:
@@ -23,9 +29,11 @@ AR:
   2011-01-01: 0.003
   2012-01-01: 0.006
   2013-01-01: 0.009
+  2014-01-01: 0
 AZ:
   0000-01-01: 0
   2012-01-01: 0.003
+  2013-01-01: 0
 CA:
   0000-01-01: 0
   2011-01-01: 0.003
@@ -51,21 +59,25 @@ CT:
   2015-01-01: 0.021
   2016-01-01: 0
   2022-01-01: 0.003
+  2023-01-01: 0
 DC:
   0000-01-01: 0
 DE:
   0000-01-01: 0
   2012-01-01: 0.003
   2013-01-01: 0.006
+  2014-01-01: 0
 FL:
   0000-01-01: 0
   2011-01-01: 0.003
   2012-01-01: 0.006
+  2013-01-01: 0
 GA:
   0000-01-01: 0
   2011-01-01: 0.003
   2012-01-01: 0.006
   2013-01-01: 0.009
+  2014-01-01: 0
 GU:
   0000-01-01: 0
 HI:
@@ -79,6 +91,7 @@ IL:
   2011-01-01: 0.003
   2012-01-01: 0
   2022-01-01: 0.003
+  2023-01-01: 0
 IN:
   0000-01-01: 0
   2010-01-01: 0.003

--- a/policyengine_us/tests/policy/baseline/gov/irs/payroll/unemployment/employer_federal_unemployment_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/payroll/unemployment/employer_federal_unemployment_tax.yaml
@@ -21,3 +21,48 @@
   output:
     employer_federal_unemployment_tax_rate: 0.018
     employer_federal_unemployment_tax: 126
+
+- name: Florida's credit reduction applies in 2012.
+  period: 2012
+  input:
+    state_code: FL
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.012
+    employer_federal_unemployment_tax: 84
+
+- name: Florida returns to the standard rate in 2013 after repaying its loans.
+  period: 2013
+  input:
+    state_code: FL
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: Georgia returns to the standard rate in 2014 after repaying its loans.
+  period: 2014
+  input:
+    state_code: GA
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: Connecticut returns to the standard rate in 2023 after repaying its loans.
+  period: 2023
+  input:
+    state_code: CT
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: Illinois returns to the standard rate in 2023 after repaying its loans.
+  period: 2023
+  input:
+    state_code: IL
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42

--- a/policyengine_us/tests/policy/baseline/gov/irs/payroll/unemployment/employer_federal_unemployment_tax.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/payroll/unemployment/employer_federal_unemployment_tax.yaml
@@ -66,3 +66,68 @@
   output:
     employer_federal_unemployment_tax_rate: 0.006
     employer_federal_unemployment_tax: 42
+
+- name: Arizona returns to the standard rate in 2013 after repaying its loans.
+  period: 2013
+  input:
+    state_code: AZ
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: Arkansas returns to the standard rate in 2014 after repaying its loans.
+  period: 2014
+  input:
+    state_code: AR
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: Delaware returns to the standard rate in 2014 after repaying its loans.
+  period: 2014
+  input:
+    state_code: DE
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: Florida stays at the standard rate in 2015, two years after exiting (the zero persists).
+  period: 2015
+  input:
+    state_code: FL
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: Florida stays at the standard rate in 2026, well after exiting (the zero does not carry a stale rate forward).
+  period: 2026
+  input:
+    state_code: FL
+    payroll_tax_gross_wages: 10_000
+  output:
+    employer_federal_unemployment_tax_rate: 0.006
+    employer_federal_unemployment_tax: 42
+
+- name: California is still a credit-reduction state in 2023, so the reduction still applies.
+  period: 2023
+  input:
+    state_code: CA
+    payroll_tax_gross_wages: 10_000
+  output:
+    # 2023 credit reduction 0.006 on top of the 0.006 net FUTA rate.
+    employer_federal_unemployment_tax_rate: 0.012
+    employer_federal_unemployment_tax: 84
+
+- name: Connecticut is still reduced in 2022, the year before it exits.
+  period: 2022
+  input:
+    state_code: CT
+    payroll_tax_gross_wages: 10_000
+  output:
+    # 2022 credit reduction 0.003 on top of the 0.006 net FUTA rate.
+    employer_federal_unemployment_tax_rate: 0.009
+    employer_federal_unemployment_tax: 63


### PR DESCRIPTION
Fixes #9325

## What

`gov/irs/payroll/federal_unemployment/credit_reduction_rate.yaml` recorded the years each state entered FUTA credit-reduction status but, for seven states, never returned the rate to zero after the state repaid its Title XII loans — so the last nonzero rate carried forward indefinitely and the model overcharged those states 0.3–0.9pp on FUTA taxable wages every year since (≈$1.1B/year in aggregate on the national dataset).

Adds the missing zero-out entries, each verified against the IRS Schedule A (Form 940) for the exit year (the form prints every state's reduction rate):

| State | Last entry | Added | Source |
|---|---|---|---|
| AZ | 2012: 0.003 | `2013-01-01: 0` | [Schedule A 2013](https://www.irs.gov/pub/irs-prior/f940sa--2013.pdf): AZ × .000 |
| FL | 2012: 0.006 | `2013-01-01: 0` | [Schedule A 2013](https://www.irs.gov/pub/irs-prior/f940sa--2013.pdf): FL × .000 |
| AR | 2013: 0.009 | `2014-01-01: 0` | [Schedule A 2014](https://www.irs.gov/pub/irs-prior/f940sa--2014.pdf): AR × .000 |
| DE | 2013: 0.006 | `2014-01-01: 0` | [Schedule A 2014](https://www.irs.gov/pub/irs-prior/f940sa--2014.pdf): DE × .000 |
| GA | 2013: 0.009 | `2014-01-01: 0` | [Schedule A 2014](https://www.irs.gov/pub/irs-prior/f940sa--2014.pdf): GA × .000 |
| CT | 2022: 0.003 | `2023-01-01: 0` | [Schedule A 2023](https://www.irs.gov/pub/irs-prior/f940sa--2023.pdf) instructions: 2023 credit-reduction states are CA, NY, VI only |
| IL | 2022: 0.003 | `2023-01-01: 0` | Same |

The three Schedule A form PDFs are added to the parameter's references. All other entries were checked against the same forms and left unchanged (e.g., DE's 0.006 is correctly still in force in 2013; CT's 1.7% in 2014 matches).

## Tests

Adds regression tests to `employer_federal_unemployment_tax.yaml` covering FL in 2012 (add-on still applies: 1.2% × $7,000 = $84) and the exit years for FL (2013), GA (2014), CT (2023), and IL (2023), each back at the standard 0.6% × $7,000 = $42. The unemployment and employer_payroll_tax suites pass locally.

Not changed here: CA's `2025: 0.012` and VI's `2025: 0.045` carry forward into 2026+ as last-known values; whether to project DOL's 0.3pp/year escalation is a separate modeling decision (noted in #9325).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPoZoUr5EF2ZsBbubBPuHu