### PR TITLE
Fix Arkansas inflation relief 2023 tables, sunset, and dead references

### DIFF
--- a/changelog.d/ar-inflation-relief-2023-values.fixed.md
+++ b/changelog.d/ar-inflation-relief-2023-values.fixed.md
@@ -1,0 +1,1 @@
+Corrected the Arkansas inflation relief credit's 2023 maximums ($150/$300, not $50/$100) and restored the missing 2023 joint phase-out start, sunset the parameters to $0 from 2024, and refreshed the dead DFA worksheet reference URLs.

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/max_amount.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/max_amount.yaml
@@ -5,28 +5,33 @@ metadata:
   label: Arkansas income-tax credit maximum amount 
   reference:
     # The inflation relief credit is not mentioned in the Arkansas statutes 
-    - title: Arkansas 2022 Individual Income Tax Forms and Instructions 
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=26
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
-    - title: Department of finance and administration, Bill HB1002 
-      href: https://www.arkleg.state.ar.us/Home/FTPDocument?path=%2FAssembly%2F2021%2F2022S3%2FFiscal+Impacts%2FHB1002-DFA1.pdf#page=2  
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Arkansas 2022 Individual Income Tax Forms and Instructions
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25
+    - title: Inflationary relief income-tax credit worksheet 2022
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Department of finance and administration, Bill HB1002
+      href: https://www.arkleg.state.ar.us/Home/FTPDocument?path=%2FAssembly%2F2021%2F2022S3%2FFiscal+Impacts%2FHB1002-DFA1.pdf#page=2
+    - title: Inflationary relief income-tax credit worksheet 2023
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
   breakdown:
     - filing_status
 JOINT:
   2022-01-01: 300
-  2023-01-01: 100
+  2023-01-01: 300
+  2024-01-01: 0
 SURVIVING_SPOUSE:
   2022-01-01: 150
-  2023-01-01: 50
+  2023-01-01: 150
+  2024-01-01: 0
 HEAD_OF_HOUSEHOLD:
   2022-01-01: 150
-  2023-01-01: 50
+  2023-01-01: 150
+  2024-01-01: 0
 SINGLE:
   2022-01-01: 150
-  2023-01-01: 50
+  2023-01-01: 150
+  2024-01-01: 0
 SEPARATE:
   2022-01-01: 150
-  2023-01-01: 50
+  2023-01-01: 150
+  2024-01-01: 0

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/max_amount.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/max_amount.yaml
@@ -2,9 +2,9 @@ description: Arkansas allows for this maximum inflationary relief tax credit amo
 metadata:
   period: year
   unit: currency-USD
-  label: Arkansas income-tax credit maximum amount 
+  label: Arkansas inflation relief credit maximum amount
   reference:
-    # The inflation relief credit is not mentioned in the Arkansas statutes 
+    # The inflation relief credit is not mentioned in the Arkansas statutes
     - title: Arkansas 2022 Individual Income Tax Forms and Instructions
       href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25
     - title: Inflationary relief income-tax credit worksheet 2022

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/amount.yaml
@@ -4,7 +4,7 @@ metadata:
   unit: currency-USD
   label: Arkansas inflation relief credit reduction amount
   reference:
-    # The inflation relief credit is not mentioned in the Arkansas statutes 
+    # The inflation relief credit is not mentioned in the Arkansas statutes
     # House bill did not specify reduction amount
     - title: Arkansas 2022 Individual Income Tax Forms and Instructions
       href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/amount.yaml
@@ -6,12 +6,12 @@ metadata:
   reference:
     # The inflation relief credit is not mentioned in the Arkansas statutes 
     # House bill did not specify reduction amount
-    - title: Arkansas 2022 Individual Income Tax Forms and Instructions 
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=26
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Arkansas 2022 Individual Income Tax Forms and Instructions
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25
+    - title: Inflationary relief income-tax credit worksheet 2022
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Inflationary relief income-tax credit worksheet 2023
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
   breakdown:
     - filing_status
 JOINT:

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/increment.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/increment.yaml
@@ -6,12 +6,12 @@ metadata:
   reference:
     # The inflation relief credit is not mentioned in the Arkansas statutes 
     # House bill did not specify reduction increment
-    - title: Arkansas 2022 Individual Income Tax Forms and Instructions 
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=26
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Arkansas 2022 Individual Income Tax Forms and Instructions
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25
+    - title: Inflationary relief income-tax credit worksheet 2022
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Inflationary relief income-tax credit worksheet 2023
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
 
   breakdown:
     - filing_status

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/increment.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/increment.yaml
@@ -2,9 +2,9 @@ description: Arkansas reduces the inflationary relief tax credit for each of the
 metadata:
   period: year
   unit: currency-USD
-  label: Arkansas income reduction increment
+  label: Arkansas inflation relief credit reduction increment
   reference:
-    # The inflation relief credit is not mentioned in the Arkansas statutes 
+    # The inflation relief credit is not mentioned in the Arkansas statutes
     # House bill did not specify reduction increment
     - title: Arkansas 2022 Individual Income Tax Forms and Instructions
       href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/start.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/start.yaml
@@ -1,7 +1,7 @@
 description: Arkansas provides inflationary relief tax credit to filers with taxable income above this amount, based on filing status.
 metadata:
   reference:
-    # The inflation relief credit is not mentioned in the Arkansas statutes 
+    # The inflation relief credit is not mentioned in the Arkansas statutes
     - title: Arkansas 2022 Individual Income Tax Forms and Instructions
       href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25
     - title: Inflationary relief income-tax credit worksheet 2022
@@ -10,7 +10,7 @@ metadata:
       href: https://www.arkleg.state.ar.us/Home/FTPDocument?path=%2FAssembly%2F2021%2F2022S3%2FFiscal+Impacts%2FHB1002-DFA1.pdf#page=2
     - title: Inflationary relief income-tax credit worksheet 2023
       href: https://www.dfa.arkansas.gov/wp-content/uploads/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
-  label: Arkansas inflation reduction credit reduction start
+  label: Arkansas inflation relief credit reduction start
   unit: currency-USD
   period: year
   breakdown:

--- a/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/start.yaml
+++ b/policyengine_us/parameters/gov/states/ar/tax/income/credits/inflationary_relief/reduction/start.yaml
@@ -2,22 +2,22 @@ description: Arkansas provides inflationary relief tax credit to filers with tax
 metadata:
   reference:
     # The inflation relief credit is not mentioned in the Arkansas statutes 
-    - title: Arkansas 2022 Individual Income Tax Forms and Instructions 
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=26
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
-    - title: Department of finance and administration, Bill HB1002 
+    - title: Arkansas 2022 Individual Income Tax Forms and Instructions
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_AR1000F_and_AR1000NR_Instructions.pdf#page=25
+    - title: Inflationary relief income-tax credit worksheet 2022
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2022_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Department of finance and administration, Bill HB1002
       href: https://www.arkleg.state.ar.us/Home/FTPDocument?path=%2FAssembly%2F2021%2F2022S3%2FFiscal+Impacts%2FHB1002-DFA1.pdf#page=2
-    - title: Inflationary relief income-tax credit worksheet
-      href: https://www.dfa.arkansas.gov/images/uploads/incomeTaxOffice/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
+    - title: Inflationary relief income-tax credit worksheet 2023
+      href: https://www.dfa.arkansas.gov/wp-content/uploads/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf#page=1
   label: Arkansas inflation reduction credit reduction start
   unit: currency-USD
   period: year
-  
   breakdown:
     - filing_status
 JOINT:
   2022-01-01: 174_000
+  2023-01-01: 179_200
 SURVIVING_SPOUSE:
   2022-01-01: 87_000
   2023-01-01: 89_600

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
@@ -38,7 +38,7 @@
   output:
     ar_inflation_relief_credit_person: 20
 
-- name: Single household with $100,000 taxable income
+- name: Separate couple with $10,000 and $90,000 individual taxable income
   period: 2022
   input:
     people:
@@ -58,26 +58,24 @@
   output:
     ar_inflation_relief_credit_person: [150, 120]
 
-- name: HoH household with $98,200 taxable income
+- name: Single-adult HoH household with $98,200 taxable income
   period: 2022
   input:
     people:
       person1:
         ar_taxable_income_indiv: 0
         ar_net_taxable_income_joint: 98_200
-      person2:
-        ar_taxable_income_indiv: 0
-        ar_net_taxable_income_joint: 0
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members: [person1]
         ar_files_separately: false
         filing_status: HEAD_OF_HOUSEHOLD
     households:
       household:
-        members: [person1, person2]
+        members: [person1]
         state_code: AR
   output:
+    # $150 - ceil((98,200 - 87,000) / 1,000) * $10 = $150 - 12 * $10 = $30
     ar_inflation_relief_credit_person: 30
 
 - name: Joint household with $175,000 taxable income
@@ -102,26 +100,24 @@
   output:
     ar_inflation_relief_credit_person: [140, 140]
 
-- name: Surviving spouse household with $80,000 taxable income
+- name: Single-adult surviving spouse household with $80,000 taxable income
   period: 2022
   input:
     people:
       person1:
         ar_taxable_income_indiv: 0
         ar_net_taxable_income_joint: 80_000
-      person2:
-        ar_taxable_income_indiv: 0
-        ar_net_taxable_income_joint: 0
     tax_units:
       tax_unit:
-        members: [person1, person2]
+        members: [person1]
         ar_files_separately: false
         filing_status: SURVIVING_SPOUSE
     households:
       household:
-        members: [person1, person2]
+        members: [person1]
         state_code: AR
   output:
+    # $80,000 < $87,000 start -> full $150 max
     ar_inflation_relief_credit_person: 150
 
 - name: Joint household with a dependent child does not credit the dependent
@@ -199,3 +195,139 @@
         state_code: AR
   output:
     ar_inflation_relief_credit_person: [0, 0]
+
+# 2023 coverage: locks the corrected 2023 max ($150 single-type / $300 joint)
+# and phase-out starts ($89,600 single-type / $179,200 joint).
+- name: Case 1, 2023 single filer at the phase-out start receives the full max.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 89_600
+    tax_units:
+      tax_unit:
+        members: [person1]
+        ar_files_separately: false
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: AR
+  output:
+    # $89,600 = start -> excess $0 -> full $150 max.
+    ar_inflation_relief_credit_person: 150
+  absolute_error_margin: 0.01
+
+- name: Case 2, 2023 single filer mid phase-out is partially reduced.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 96_600
+    tax_units:
+      tax_unit:
+        members: [person1]
+        ar_files_separately: false
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: AR
+  output:
+    # $150 - ceil((96,600 - 89,600) / 1,000) * $10 = $150 - 7 * $10 = $80.
+    ar_inflation_relief_credit_person: 80
+  absolute_error_margin: 0.01
+
+- name: Case 3, 2023 single filer above the phase-out end receives nothing.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 103_601
+    tax_units:
+      tax_unit:
+        members: [person1]
+        ar_files_separately: false
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: AR
+  output:
+    # $150 - ceil((103,601 - 89,600) / 1,000) * $10 = $150 - 15 * $10 = $0.
+    ar_inflation_relief_credit_person: 0
+  absolute_error_margin: 0.01
+
+- name: Case 4, 2023 joint filers at the phase-out start receive the full max.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 179_200
+      person2:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: false
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    # $179,200 = joint start -> full $300 max split in half -> $150 per spouse.
+    # Fails if the JOINT 2023 start row is missing (would inherit $174,000).
+    ar_inflation_relief_credit_person: [150, 150]
+  absolute_error_margin: 0.01
+
+- name: Case 5, 2023 joint filers above the phase-out end receive nothing.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 207_201
+      person2:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: false
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    # $300 - ceil((207,201 - 179,200) / 2,000) * $20 = $300 - 15 * $20 = $0.
+    ar_inflation_relief_credit_person: [0, 0]
+  absolute_error_margin: 0.01
+
+# 2024 coverage: locks the credit sunset (max_amount = 0 from 2024).
+- name: Case 6, 2024 single filer receives no credit after the sunset.
+  period: 2024
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 50_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+        ar_files_separately: false
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: AR
+  output:
+    # Credit sunset after TY2023 -> $0 max -> no credit in 2024.
+    ar_inflation_relief_credit_person: 0
+  absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ar/tax/income/credits/ar_inflation_relief_credit_person.yaml
@@ -331,3 +331,122 @@
     # Credit sunset after TY2023 -> $0 max -> no credit in 2024.
     ar_inflation_relief_credit_person: 0
   absolute_error_margin: 0.01
+
+- name: Case 7, 2023 single filer at the last dollar with a positive credit.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 103_600
+    tax_units:
+      tax_unit:
+        members: [person1]
+        ar_files_separately: false
+        filing_status: SINGLE
+    households:
+      household:
+        members: [person1]
+        state_code: AR
+  output:
+    # $150 - ceil((103,600 - 89,600) / 1,000) * $10 = $150 - 14 * $10 = $10.
+    # Pins the ceil zero-crossing: $103,600 -> $10, $103,601 -> $0 (Case 3).
+    ar_inflation_relief_credit_person: 10
+  absolute_error_margin: 0.01
+
+- name: Case 8, 2023 joint filers mid phase-out are partially reduced.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 185_200
+      person2:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: false
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    # $300 - ceil((185,200 - 179,200) / 2,000) * $20 = $300 - 3 * $20 = $240,
+    # split in half -> $120 per spouse. Exercises the joint phase-out slope.
+    ar_inflation_relief_credit_person: [120, 120]
+  absolute_error_margin: 0.01
+
+- name: Case 9, 2023 joint filers at the last dollar with a positive credit.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 207_200
+      person2:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: false
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    # $300 - ceil((207,200 - 179,200) / 2,000) * $20 = $300 - 14 * $20 = $20,
+    # split in half -> $10 per spouse ($207,201 -> $0 in Case 5).
+    ar_inflation_relief_credit_person: [10, 10]
+  absolute_error_margin: 0.01
+
+- name: Case 10, 2023 separate filers each use the single-type table on own income.
+  period: 2023
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 89_600
+      person2:
+        ar_taxable_income_indiv: 95_600
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: true
+        filing_status: SEPARATE
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    # SEPARATE uses the single-type 2023 table per person on individual income:
+    # person1 $89,600 = start -> $150; person2 $150 - ceil(6,000 / 1,000) * $10 = $90.
+    ar_inflation_relief_credit_person: [150, 90]
+  absolute_error_margin: 0.01
+
+- name: Case 11, 2024 joint filers receive no credit after the sunset.
+  period: 2024
+  input:
+    people:
+      person1:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 150_000
+      person2:
+        ar_taxable_income_indiv: 0
+        ar_net_taxable_income_joint: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        ar_files_separately: false
+        filing_status: JOINT
+    households:
+      household:
+        members: [person1, person2]
+        state_code: AR
+  output:
+    # Credit sunset after TY2023 -> $0 max for every status -> $0 per spouse.
+    ar_inflation_relief_credit_person: [0, 0]
+  absolute_error_margin: 0.01


### PR DESCRIPTION
## Summary

Follow-up to #9321, addressing the **pre-existing issues** @hua7450 surfaced during that review (thanks for the source-verification pass). All values verified against the official 2023 Inflationary Relief worksheet.

## Fixes

### 1. 2023 tables contradicted the worksheet by up to 3× (value bug)
`inflationary_relief/max_amount.yaml` stored 2023 maximums of **$50 / $100** — these were copied from the *State Political Contributions Credit* caps, a different credit. The 2023 worksheet keeps **$150 / $300**. Corrected.

`inflationary_relief/reduction/start.yaml`'s JOINT block had **no 2023 row**, so it inherited $174,000 — the correct `2023-01-01: 179_200` was added by #3807 but accidentally deleted by the WIDOW→SURVIVING_SPOUSE rename in #4130. Restored. The single-type 2023 start ($89,600) and `increment`/`amount` were already correct, so the 2023 tables now reproduce the worksheet exactly (single-type $89,600 → $103,600; joint $179,200 → $207,200).

### 2. Parameters outlived the credit's sunset
The credit doesn't exist for TY2024 (absent from the [2024 AR1000TC list](https://www.dfa.arkansas.gov/wp-content/uploads/2024_AR1000F_and_AR1000NR_Instructions.pdf#page=15)). `non_refundable.yaml` already drops it, but `max_amount.yaml` carried values forward, so the person-level variable still paid if queried directly in 2024+. Added `2024-01-01: 0` (all filing-status columns) so it's inert from 2024.

### 3. Dead reference URLs
DFA moved `/images/uploads/incomeTaxOffice/` → `/wp-content/uploads/` (same filenames). Refreshed the dead hrefs on all four `inflationary_relief` parameter files (each now resolves 200), fixed the 2022 booklet worksheet anchor (`#page=26` → `#page=25`), and disambiguated the two identical "Inflationary relief income-tax credit worksheet" titles by year.

### 4. Scalar-masked doubling tests + duplicate name
The existing HOH and SURVIVING_SPOUSE cases put two adults in the unit and asserted a scalar, so broadcasting reported double the per-return credit (the ÷2 divisor only halves true JOINT). Rewrote them as single-adult cases so the asserted value is the real per-return credit, and renamed the second "Single household with $100,000 taxable income" case (actually a SEPARATE couple).

## Tests
AR credits suite **47/47**. Added 2023 bracket/boundary coverage (full max, mid-phase-out, past the end, for both single-type and joint) plus a 2024-sunset case — the 2023/2024 years were previously untested. The joint $179,200 → $300 case specifically **fails if the restored JOINT 2023 row is missing**.

Source: [2023 Inflationary Relief worksheet](https://www.dfa.arkansas.gov/wp-content/uploads/2023_Final_InflationaryReliefIncomeTaxCredit_FI.pdf); [Act 2 of 2022, 3rd Ex. Sess.](https://www.arkleg.state.ar.us/Home/FTPDocument?path=/ACTS/2022S3/Public/ACT2.pdf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
