### PR TITLE
Filter SNAP individual utility allowance to incurred utility expenses

### DIFF
--- a/changelog.d/fix-snap-iua-filter-incurred.fixed.md
+++ b/changelog.d/fix-snap-iua-filter-incurred.fixed.md
@@ -1,0 +1,1 @@
+Filter the SNAP individual utility allowance to the utility expenses the household actually incurs, restoring the fix from #3867 that was reverted during the #3903 decomposition.

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_individual_utility_allowance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_individual_utility_allowance.yaml
@@ -67,8 +67,24 @@
     snap_utility_allowance_type: IUA
     snap_utility_region_str: MO
     pre_subsidy_electricity_expense: 1_200
+    # Overriding electricity_expense to 0 pins that the formula reads the
+    # pre-subsidy variable. No naturally occurring household can distinguish
+    # the two by value: the only subsidies (ca_care, ca_fera, ca_la_ez_save)
+    # are California-only and CA's electricity standard is 0.
+    electricity_expense: 0
   output:
     # MO FY26 electricity standard
+    snap_individual_utility_allowance: 162
+
+- name: MO gas-only household receives the gas standard in 2026
+  period: 2026-01
+  input:
+    snap_utility_allowance_type: IUA
+    snap_utility_region_str: MO
+    gas_expense: 2_400
+  output:
+    # MO FY26 gas standard, read via the gas_and_fuel_expense -> gas_expense
+    # variable mapping
     snap_individual_utility_allowance: 162
 
 # HI individual utility allowances vary by household size
@@ -169,5 +185,37 @@
   input:
     snap_utility_allowance_type: IUA
     snap_utility_region_str: MO
+  output:
+    snap_individual_utility_allowance: 0
+
+# The individual allowance is 0 on the non-IUA paths even when the household
+# incurs utility expenses; snap_utility_allowance sums the SUA, LUA, and IUA
+# components, so a nonzero value here would double count.
+- name: SUA household receives no individual allowance despite utility bills
+  period: 2026-01
+  input:
+    snap_utility_allowance_type: SUA
+    snap_utility_region_str: MO
+    heating_cooling_expense: 2_400
+    phone_expense: 600
+  output:
+    snap_individual_utility_allowance: 0
+
+- name: LUA household receives no individual allowance despite utility bills
+  period: 2026-01
+  input:
+    snap_utility_allowance_type: LUA
+    snap_utility_region_str: MO
+    water_expense: 480
+    trash_expense: 360
+  output:
+    snap_individual_utility_allowance: 0
+
+- name: NONE-type household receives no individual allowance despite a utility bill
+  period: 2026-01
+  input:
+    snap_utility_allowance_type: NONE
+    snap_utility_region_str: MO
+    phone_expense: 600
   output:
     snap_individual_utility_allowance: 0

--- a/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_individual_utility_allowance.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/snap/income/deductions/snap_individual_utility_allowance.yaml
@@ -1,3 +1,5 @@
+# Households receive an individual standard only for each utility expense
+# they actually incur (7 CFR 273.9(d)(6)(iii)(A)).
 - name: Test in 2022 with phone expenses
   period: 2022-01
   absolute_error_margin: 1
@@ -18,68 +20,136 @@
   output:
     snap_individual_utility_allowance: 19
 
-- name: Test in 2022 with trash expenses
+- name: Trash-only household receives only the trash standard in 2022
   period: 2022-01
   input:
     snap_utility_allowance_type: IUA
     snap_utility_region_str: AK_C
     trash_expense: 20
   output:
-    snap_individual_utility_allowance: 380
-    # AK_C FY22: elec=110 + gas=114 + water=56 + sewer=55 + trash=30 + phone=15
+    # AK_C FY22 trash standard only, not the sum of all six standards
+    snap_individual_utility_allowance: 30
 
-- name: Test in 2024 with trash expenses
+- name: Trash-only household receives only the trash standard in 2024
   period: 2024-01
   input:
     snap_utility_allowance_type: IUA
     snap_utility_region_str: AK_C
     trash_expense: 20
   output:
-    snap_individual_utility_allowance: 638
+    # AK_C FY24 trash standard only
+    snap_individual_utility_allowance: 36
+
+- name: Water and sewage household receives both incurred standards in 2022
+  period: 2022-01
+  input:
+    snap_utility_allowance_type: IUA
+    snap_utility_region_str: AK_C
+    water_expense: 240
+    sewage_expense: 240
+  output:
+    # AK_C FY22: water=56 + sewage=55
+    snap_individual_utility_allowance: 111
+
+- name: MO phone-only household receives the telephone standard in 2026
+  period: 2026-01
+  input:
+    snap_utility_allowance_type: IUA
+    snap_utility_region_str: MO
+    phone_expense: 972
+  output:
+    # MO FY26 phone standard, not the $891 sum of all six standards
+    snap_individual_utility_allowance: 81
+
+- name: MO electricity-only household receives the electricity standard in 2026
+  period: 2026-01
+  input:
+    snap_utility_allowance_type: IUA
+    snap_utility_region_str: MO
+    pre_subsidy_electricity_expense: 1_200
+  output:
+    # MO FY26 electricity standard
+    snap_individual_utility_allowance: 162
 
 # HI individual utility allowances vary by household size
 # HH1 FY2025: elec=291 + gas=291 + water=65 + sewage=97 + trash=97 + phone=42 = 883
-- name: HI IUA HH size 1 in FY2025
+- name: HI IUA HH size 1 with all utility expenses in FY2025
   period: 2025-01
   absolute_error_margin: 1
   input:
     snap_utility_allowance_type: IUA
     snap_utility_region_str: HI
     spm_unit_size: 1
+    pre_subsidy_electricity_expense: 1_200
+    gas_expense: 240
+    water_expense: 240
+    sewage_expense: 240
+    phone_expense: 240
+    trash_expense: 240
   output:
     snap_individual_utility_allowance: 883
 
 # HH3 FY2025: elec=366 + gas=366 + water=81 + sewage=97 + trash=97 + phone=42 = 1049
-- name: HI IUA HH size 3 in FY2025
+- name: HI IUA HH size 3 with all utility expenses in FY2025
   period: 2025-01
   absolute_error_margin: 1
   input:
     snap_utility_allowance_type: IUA
     snap_utility_region_str: HI
     spm_unit_size: 3
+    pre_subsidy_electricity_expense: 1_200
+    gas_expense: 240
+    water_expense: 240
+    sewage_expense: 240
+    phone_expense: 240
+    trash_expense: 240
   output:
     snap_individual_utility_allowance: 1_049
 
+- name: HI IUA HH size 3 with only electricity expenses in FY2025
+  period: 2025-01
+  absolute_error_margin: 1
+  input:
+    snap_utility_allowance_type: IUA
+    snap_utility_region_str: HI
+    spm_unit_size: 3
+    pre_subsidy_electricity_expense: 1_200
+  output:
+    # HI HH3 FY2025 electricity standard only
+    snap_individual_utility_allowance: 366
+
 # GU individual utility allowances vary by household size
 # HH1 FY2025: elec=188 + gas=36 + water=38 + sewage/trash/phone uprated from FY2024
-- name: GU IUA HH size 1 in FY2025
+- name: GU IUA HH size 1 with all utility expenses in FY2025
   period: 2025-01
   absolute_error_margin: 3
   input:
     snap_utility_allowance_type: IUA
     snap_utility_region_str: GU
     spm_unit_size: 1
+    pre_subsidy_electricity_expense: 1_200
+    gas_expense: 240
+    water_expense: 240
+    sewage_expense: 240
+    phone_expense: 240
+    trash_expense: 240
   output:
     snap_individual_utility_allowance: 350
 
 # HH2 FY2025: elec=218 + gas=36 + water=50 + sewage/trash/phone uprated from FY2024
-- name: GU IUA HH size 2 in FY2025
+- name: GU IUA HH size 2 with all utility expenses in FY2025
   period: 2025-01
   absolute_error_margin: 3
   input:
     snap_utility_allowance_type: IUA
     snap_utility_region_str: GU
     spm_unit_size: 2
+    pre_subsidy_electricity_expense: 1_200
+    gas_expense: 240
+    water_expense: 240
+    sewage_expense: 240
+    phone_expense: 240
+    trash_expense: 240
   output:
     snap_individual_utility_allowance: 392
 
@@ -90,5 +160,14 @@
     snap_utility_allowance_type: IUA
     snap_utility_region_str: NC
     spm_unit_size: 1
+    phone_expense: 240
   output:
     snap_individual_utility_allowance: 41
+
+- name: Household with no utility expenses receives no individual allowance
+  period: 2025-01
+  input:
+    snap_utility_allowance_type: IUA
+    snap_utility_region_str: MO
+  output:
+    snap_individual_utility_allowance: 0

--- a/policyengine_us/variables/gov/usda/snap/income/deductions/shelter/snap_individual_utility_allowance.py
+++ b/policyengine_us/variables/gov/usda/snap/income/deductions/shelter/snap_individual_utility_allowance.py
@@ -17,6 +17,9 @@ class snap_individual_utility_allowance(Variable):
     unit = USD
     documentation = "The individual utility allowance deduction for SNAP"
     definition_period = MONTH
+    reference = (
+        "https://www.ecfr.gov/current/title-7/section-273.9#p-273.9(d)(6)(iii)(A)"
+    )
 
     def formula(spm_unit, period, parameters):
         utility = parameters(period).gov.usda.snap.income.deductions.utility
@@ -36,8 +39,6 @@ class snap_individual_utility_allowance(Variable):
 
         hh_size_utilities = {"electricity", "gas_and_fuel", "water"}
 
-        # Households receive an individual standard only for each utility
-        # expense they actually incur (7 CFR 273.9(d)(6)(iii)(A)).
         sum_of_individual_allowances = 0
         for expense in expense_types:
             util_name = expense.replace("_expense", "")

--- a/policyengine_us/variables/gov/usda/snap/income/deductions/shelter/snap_individual_utility_allowance.py
+++ b/policyengine_us/variables/gov/usda/snap/income/deductions/shelter/snap_individual_utility_allowance.py
@@ -1,5 +1,14 @@
 from policyengine_us.model_api import *
 
+# Expense input variables that differ from the <type>_expense naming of the
+# utility_types parameter entries. Electricity uses pre-subsidy expenses to
+# avoid circular references since electricity subsidies depend on SNAP
+# enrollment.
+EXPENSE_VARIABLE_OVERRIDES = {
+    "electricity_expense": "pre_subsidy_electricity_expense",
+    "gas_and_fuel_expense": "gas_expense",
+}
+
 
 class snap_individual_utility_allowance(Variable):
     value_type = float
@@ -26,23 +35,14 @@ class snap_individual_utility_allowance(Variable):
         safe_region = where(is_hh_size_state, region, "HI")
 
         hh_size_utilities = {"electricity", "gas_and_fuel", "water"}
+
         # Households receive an individual standard only for each utility
         # expense they actually incur (7 CFR 273.9(d)(6)(iii)(A)).
-        # Use pre-subsidy electricity expenses to avoid circular references
-        # since electricity subsidies depend on SNAP enrollment.
-        expense_variables = {
-            "electricity": "pre_subsidy_electricity_expense",
-            "gas_and_fuel": "gas_expense",
-            "water": "water_expense",
-            "sewage": "sewage_expense",
-            "phone": "phone_expense",
-            "trash": "trash_expense",
-        }
-
         sum_of_individual_allowances = 0
         for expense in expense_types:
             util_name = expense.replace("_expense", "")
-            incurs_expense = spm_unit(expense_variables[util_name], period) > 0
+            expense_variable = EXPENSE_VARIABLE_OVERRIDES.get(expense, expense)
+            incurs_expense = spm_unit(expense_variable, period) > 0
             flat_val = utility.single[util_name][region]
             if util_name in hh_size_utilities:
                 hh_val = utility.single.by_household_size[util_name][safe_region][

--- a/policyengine_us/variables/gov/usda/snap/income/deductions/shelter/snap_individual_utility_allowance.py
+++ b/policyengine_us/variables/gov/usda/snap/income/deductions/shelter/snap_individual_utility_allowance.py
@@ -26,20 +26,32 @@ class snap_individual_utility_allowance(Variable):
         safe_region = where(is_hh_size_state, region, "HI")
 
         hh_size_utilities = {"electricity", "gas_and_fuel", "water"}
+        # Households receive an individual standard only for each utility
+        # expense they actually incur (7 CFR 273.9(d)(6)(iii)(A)).
+        # Use pre-subsidy electricity expenses to avoid circular references
+        # since electricity subsidies depend on SNAP enrollment.
+        expense_variables = {
+            "electricity": "pre_subsidy_electricity_expense",
+            "gas_and_fuel": "gas_expense",
+            "water": "water_expense",
+            "sewage": "sewage_expense",
+            "phone": "phone_expense",
+            "trash": "trash_expense",
+        }
 
         sum_of_individual_allowances = 0
         for expense in expense_types:
             util_name = expense.replace("_expense", "")
+            incurs_expense = spm_unit(expense_variables[util_name], period) > 0
             flat_val = utility.single[util_name][region]
             if util_name in hh_size_utilities:
                 hh_val = utility.single.by_household_size[util_name][safe_region][
                     capped_size
                 ]
-                sum_of_individual_allowances += where(
-                    is_hh_size_state, hh_val, flat_val
-                )
+                allowance = where(is_hh_size_state, hh_val, flat_val)
             else:
-                sum_of_individual_allowances += flat_val
+                allowance = flat_val
+            sum_of_individual_allowances += incurs_expense * allowance
 
         return where(
             allowance_type == allowance_types.IUA,


### PR DESCRIPTION
## Summary

Restores the individual utility allowance (IUA) expense filtering that #3867 added and the #3903 SUA/LUA/IUA decomposition silently reverted two weeks later. Households on the IUA path now receive an individual standard only for each utility expense they actually incur, per 7 CFR 273.9(d)(6)(iii)(A) ("an individual standard for each type of utility expense").

Fixes #9343

## The defect

`snap_individual_utility_allowance` summed the standards for **all** types in `utility.single.utility_types` regardless of the household's actual bills. Example (MO, FY2026): a phone-only household received $891/month (5 × $162 electricity/gas/water/sewage/trash + $81 phone) instead of the $81 telephone standard — more than MO's 2-bill LUA ($373) or full heating SUA ($508), an ordering inversion where fewer utilities produced a larger deduction.

## Changes

- `snap_individual_utility_allowance.py`: each utility-type standard now counts only when the household's corresponding expense is positive. Electricity checks `pre_subsidy_electricity_expense` to avoid the SNAP-enrollment circularity, matching `count_distinct_utility_expenses`. The HI/GU household-size handling is unchanged, just gated by expense.
- Tests: the AK_C trash-only cases now assert the single trash standard ($30 FY22 / $36 FY24) instead of the all-six sum; HI/GU household-size cases supply all six expenses (same totals, now legitimately); new regression cases for MO phone-only ($81 FY26), MO electricity-only ($162), AK water+sewage stacking ($111 = 56 + 55), and no-expense ($0).

Multi-utility stacking for incurred expenses is preserved — that part is correct under the federal rule. Partner contract tests are unaffected: they exercise only the SUA (heating/cooling) and LUA (two-bill) paths.

## Impact

- **Population microsimulation: no change.** The utility expense input variables are unpopulated in the certified datasets (empty groups in `enhanced_cps_2024.h5`; absent from `populace_us_2024.h5`), so `count_distinct_utility_expenses` is 0 everywhere and no unit routes to the IUA branch — measured SNAP aggregate delta is exactly $0, with 0 weighted units changed. The aggregate is nil *because* the data is unpopulated, not because the effect is small; if utility expenses are ever imputed into the datasets, this fix lowers SNAP for IUA households (the allowance is strictly non-increasing under the filter).
- **Household calculator / API: real, and can be large.** Any API consumer supplying utility expense inputs for an IUA-path household will see a smaller allowance. Example (MO, single person, $1,000/month rent, phone bill only, 2026): `snap_individual_utility_allowance` drops 891 → 81 and `snap_excess_shelter_expense_deduction` drops 744 (pinned at the shelter cap) → 81, up to ≈$199/month less SNAP at the 30% benefit-reduction rate, and possible loss of eligibility via the net income test. Mandatory-SUA states (e.g. CA, MA, WA, CO) and any household on the SUA/LUA paths are unaffected.

## Test plan

- [x] 14 IUA unit tests pass
- [x] Full SNAP baseline suite passes (605 tests)
- [x] CI passes (33/33 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
