### PR TITLE
Remove Montana property tax rebate from non-refundable credit list

### DIFF
--- a/changelog.d/mt-property-tax-rebate.fixed.md
+++ b/changelog.d/mt-property-tax-rebate.fixed.md
@@ -1,0 +1,1 @@
+Removed the Montana property tax rebate from the state non-refundable credit list so it no longer reduces Montana income tax.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Removed the Montana property tax rebate from the state non-refundable credit list so it no longer reduces Montana income tax.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,0 @@
-- bump: patch
-  changes:
-    fixed:
-      - Removed the Montana property tax rebate from the state non-refundable credit list so it no longer reduces Montana income tax.

--- a/policyengine_us/parameters/gov/states/mt/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/mt/tax/income/credits/non_refundable.yaml
@@ -10,13 +10,15 @@ metadata:
   unit: list
   period: year
   label: Montana non-refundable tax credits
-  reference: 
+  reference:
     - title: 2023 Montana Form 2 Individual Income Tax Instructions, Net Long-Term Capital Gains Tax Rates
-      href: https://mtrevenue.gov/wp-content/uploads/dlm_uploads/2023/12/Form_2_2023_Instructions.pdf#page=6
+      href: https://revenuefiles.mt.gov/files/Forms/Montana-Individual-Income-Tax-Return-Form-2-Instructions/2023_Montana_Individual_Income_Tax_Return_Form_2_Instructions.pdf#page=6
     - title: 2021 Montana Form 2 Individual Income Tax Instructions, Line 19 Nonrefundable Credits
-      href: https://mtrevenue.gov/wp-content/uploads/mdocs/form%202%202021%20instructions.pdf#page=16
+      href: https://revenuefiles.mt.gov/files/Forms/Montana-Individual-Income-Tax-Return-Form-2-Instructions/2021_Montana_Individual_Income_Tax_Return_Form_2_Instructions.pdf#page=16
     - title: 2022 Montana Form 2 Individual Income Tax Instructions, Line 19 Nonrefundable Credits
-      href: https://mtrevenue.gov/wp-content/uploads/dlm_uploads/2022/12/Form-2-2022-Instructions.pdf#page=17
-    - title: 2025 Montana Form 2 Instructions
+      href: https://revenuefiles.mt.gov/files/Forms/Montana-Individual-Income-Tax-Return-Form-2-Instructions/2022_Montana_Individual_Income_Tax_Return_Form_2_Instructions.pdf#page=16
+    - title: 2023 Montana Form 2 Individual Income Tax Instructions, What's New - Property Tax Rebates (rebate claimed via TransAction Portal or Form MPTR23; exempt from Montana income tax, not a Form 2 nonrefundable credit)
+      href: https://revenuefiles.mt.gov/files/Forms/Montana-Individual-Income-Tax-Return-Form-2-Instructions/2023_Montana_Individual_Income_Tax_Return_Form_2_Instructions.pdf#page=5
+    - title: 2025 Montana Form 2 Instructions, Schedule III - Tax Credits, Part I - Nonrefundable Credits
       href: https://revenuefiles.mt.gov/files/Forms/Montana-Individual-Income-Tax-Return-Form-2-Instructions/2025_Montana_Individual_Income_Tax_Return_Form_2_Instructions.pdf#page=36
 

--- a/policyengine_us/parameters/gov/states/mt/tax/income/credits/non_refundable.yaml
+++ b/policyengine_us/parameters/gov/states/mt/tax/income/credits/non_refundable.yaml
@@ -5,7 +5,6 @@ values:
     - mt_income_tax_rebate
   2022-01-01:
     - mt_capital_gain_credit
-    - mt_property_tax_rebate
   2024-01-01: []
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/mt_property_tax_rebate_in_aggregate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/household/state_property_tax_credits/mt_property_tax_rebate_in_aggregate.yaml
@@ -1,0 +1,26 @@
+# Pins that the Montana property tax rebate is REROUTED into the state property
+# tax credits aggregate (taxsim_state_property_tax_credit), not dropped, after it
+# was removed from the Form 2 non-refundable credit list (issue 9347 / PR 9348).
+# mt_property_tax_rebate is in the year-keyed aggregate list from 2022-01-01.
+
+- name: MT property tax rebate flows into the state property tax credits aggregate
+  period: 2023
+  absolute_error_margin: 0.01
+  input:
+    people:
+      head:
+        age: 40
+        employment_income: 50_000
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [head]
+    households:
+      household:
+        members: [head]
+        state_code: MT
+  output:
+    # Non-elderly single filer: elderly homeowner/renter credit = 0, so the only
+    # contributor to the aggregate is the $675 property tax rebate.
+    mt_property_tax_rebate: 675
+    taxsim_state_property_tax_credit: 675

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/credits/rebate/mt_property_tax_rebate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/credits/rebate/mt_property_tax_rebate.yaml
@@ -6,10 +6,18 @@
   output:
     mt_property_tax_rebate: 600
 
-- name: Property tax less than rebate amount
+- name: Property tax greater than rebate amount
   period: 2023
   input:
     real_estate_taxes: 676
+    state_code: MT
+  output:
+    mt_property_tax_rebate: 675
+
+- name: Property tax equal to rebate amount
+  period: 2023
+  input:
+    real_estate_taxes: 675
     state_code: MT
   output:
     mt_property_tax_rebate: 675

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
@@ -589,13 +589,10 @@
     tax_units:
       tax_unit:
         members: [person1, person2, person3]
-    spm_units:
-      spm_unit:
-        members: [person1, person2, person3]
     households:
       household:
         members: [person1, person2, person3]
-        state_fips: 30
+        state_code: MT
   output:
     # The $675 standalone property tax rebate is still computed as its own variable
     mt_property_tax_rebate: 675
@@ -603,3 +600,63 @@
     # as a credit and projected onto every household member (675 x 3 = 2,025),
     # understating Montana income tax; it must contribute 0 to each person.
     mt_non_refundable_credits: [0, 0, 0]
+    # TaxAct-verified Montana income tax: pre-fix 3,683.16 wrongly subtracted the
+    # 2,025 phantom credit; post-fix the full 5,708.16 is owed.
+    mt_income_tax: 5_708.16
+
+- name: MT property tax rebate is not a Form 2 credit in 2022 either (issue 9347)
+  # The removed non-refundable list entry governed TY2022 and TY2023; 2023 is
+  # covered above, this case pins the 2022 tax year. In 2022 the non-refundable
+  # list is [mt_capital_gain_credit] only, so wage earners get 0 per person.
+  absolute_error_margin: 0.01
+  period: 2022
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 26
+        employment_income: 110_625.07
+        taxable_interest_income: 204.41
+        real_estate_taxes: 2_754.52
+      person2:
+        is_tax_unit_spouse: true
+        age: 25
+        employment_income: 3_414.32
+      person3:
+        is_tax_unit_dependent: true
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: MT
+  output:
+    # The $675 standalone property tax rebate is computed (amount defined 2022-01-01)
+    mt_property_tax_rebate: 675
+    # but it is not a Form 2 non-refundable credit, so it contributes 0 per person.
+    mt_non_refundable_credits: [0, 0, 0]
+
+- name: MT non-refundable credit list is empty in 2024 (issue 9347)
+  # The 2024-01-01 band of the non-refundable list is [], so the aggregate is a
+  # scalar 0 regardless of the property tax rebate.
+  absolute_error_margin: 0.01
+  period: 2024
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 40
+        employment_income: 50_000
+        long_term_capital_gains: 10_000
+        real_estate_taxes: 2_000
+    tax_units:
+      tax_unit:
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MT
+  output:
+    mt_non_refundable_credits: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mt/tax/income/integration.yaml
@@ -567,3 +567,39 @@
     # Files separately: 5,099.51 - 1,250 + 3,719.51 - 1,250 = 6,319.02
     # (old double-count subtracted $2,500 per column, understating tax by $2,500)
     mt_income_tax: 6_319.02
+
+- name: MT property tax rebate is not a Form 2 credit and is not tripled (issue 9347)
+  absolute_error_margin: 0.01
+  period: 2023
+  input:
+    people:
+      person1:
+        is_tax_unit_head: true
+        age: 26
+        employment_income: 110_625.07
+        taxable_interest_income: 204.41
+        real_estate_taxes: 2_754.52
+      person2:
+        is_tax_unit_spouse: true
+        age: 25
+        employment_income: 3_414.32
+      person3:
+        is_tax_unit_dependent: true
+        age: 10
+    tax_units:
+      tax_unit:
+        members: [person1, person2, person3]
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_fips: 30
+  output:
+    # The $675 standalone property tax rebate is still computed as its own variable
+    mt_property_tax_rebate: 675
+    # but it is not a Form 2 non-refundable credit. Before the fix it was booked
+    # as a credit and projected onto every household member (675 x 3 = 2,025),
+    # understating Montana income tax; it must contribute 0 to each person.
+    mt_non_refundable_credits: [0, 0, 0]

--- a/policyengine_us/variables/gov/states/mt/tax/income/credits/rebate/mt_property_tax_rebate.py
+++ b/policyengine_us/variables/gov/states/mt/tax/income/credits/rebate/mt_property_tax_rebate.py
@@ -11,6 +11,11 @@ class mt_property_tax_rebate(Variable):
     defined_for = StateCode.MT
 
     def formula(tax_unit, period, parameters):
+        # Modeling limitation: this does not encode the statutory eligibility
+        # conditions for the rebate (principal residence; at least 7 months of
+        # ownership and occupancy during the year; property taxes billed and
+        # paid; a timely rebate claim). Revisit if the rebate is ever wired
+        # into a benefit-side channel where those conditions would bind.
         p = parameters(period).gov.states.mt.tax.income.credits.rebate.property
         person = tax_unit.members
         mt_property_tax = person("real_estate_taxes", period)


### PR DESCRIPTION
## Summary

The Montana **Property Tax Rebate** (up to \$675 for TY2022 and TY2023) is a standalone rebate — homeowners claim it on a **separate application to the Department of Revenue** (tap.dor.mt.gov, window Aug 15 – Oct 1, 2024 for TY2023). It is **not** a Form 2 nonrefundable income-tax credit and does not reduce income tax liability.

It was listed in `gov.states.mt.tax.income.credits.non_refundable` (the `2022-01-01` entry), so `mt_income_tax_before_refundable_credits_joint` subtracted it. Two compounding defects:

1. **Misclassification** — a standalone direct-payment rebate booked as a Form 2 line-19 credit.
2. **Household multiplication** — `mt_non_refundable_credits` is a **Person** variable that `adds` the list; `mt_property_tax_rebate` is a **TaxUnit** variable (\$675), so PolicyEngine projected it onto every member of the tax unit (\$675 × 3 = **\$2,025** for a family of three).

Net effect: Montana income tax understated by \$675 per household member.

## Change

Remove `mt_property_tax_rebate` from the `2022-01-01` credit list, leaving `[mt_capital_gain_credit]`. The rebate variable still computes its \$675 value — it simply no longer reduces income tax. (The `2024-01-01: []` entry already drops it thereafter; `mt_income_tax_rebate` in the 2021 entry is untouched, as the emulator's `srebate` mechanism relies on it.)

## Testing

Verified on the issue household (MT joint 2023, ages 26/25, 1 dependent, \$114,039 wages, \$204 interest, \$2,755 property tax): `mt_non_refundable_credits` goes from `[675, 675, 675]` → `[0, 0, 0]` and `mt_income_tax` from **3,683.16 → 5,708.16**, matching the TaxAct Form 2 (line 18 = line 20 = \$5,708, credit schedule blank). Added a regression test to the Montana integration suite.

Found via PolicyEngine-TAXSIM discrepancy [#1152](https://github.com/PolicyEngine/policyengine-taxsim/issues/1152) (and its 2022 counterpart [#1150](https://github.com/PolicyEngine/policyengine-taxsim/issues/1150)), reported by @feenberg.

Sibling of #8970 (@PavelMakarchuk), which scopes the Montana *income* tax rebate — same subsystem, different rebate, no file overlap.

Fixes #9347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)