### PR TITLE
Use shared childcare attendance inputs in CalWORKs child care

### DIFF
--- a/changelog.d/ca-calworks-childcare-shared-inputs.fixed.md
+++ b/changelog.d/ca-calworks-childcare-shared-inputs.fixed.md
@@ -1,0 +1,1 @@
+Use the shared childcare_attending_days_per_month and childcare_days_per_week inputs in the CalWORKs child care time coefficient instead of CA-only day and week counts that defaulted every California child care payment to zero.

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/tanf/child_care/ca_calworks_child_care_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/tanf/child_care/ca_calworks_child_care_integration.yaml
@@ -70,3 +70,54 @@
         state_code: CA
   output:
     ca_calworks_child_care_eligible: true
+
+# The following cases exercise the default (weekly) billing path without
+# pinning ca_calworks_child_care_time_category.
+- name: Default weekly billing pays the weekly ceiling for every week of the month when shared childcare attendance inputs are set.
+  period: 2023-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 30
+        earned_income: 12_000
+      child:
+        age: 3
+        childcare_days_per_week: 5
+        childcare_attending_days_per_month: 20
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+        ca_tanf: 100
+        spm_unit_pre_subsidy_childcare_expenses: 14_400
+    households:
+      household:
+        members: [parent, child]
+        state_code: CA
+  output:
+    # Part-time weekly child care center ceiling of 227.58 for a
+    # three-year-old, times 52 / 12 weeks per month = 986.18, below the
+    # 1,200 monthly expense cap.
+    ca_calworks_child_care: 986.18
+
+- name: Without any childcare attendance inputs the default weekly billing pays zero.
+  period: 2023-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      parent:
+        age: 30
+        earned_income: 12_000
+      child:
+        age: 3
+    spm_units:
+      spm_unit:
+        members: [parent, child]
+        ca_tanf: 100
+        spm_unit_pre_subsidy_childcare_expenses: 14_400
+    households:
+      household:
+        members: [parent, child]
+        state_code: CA
+  output:
+    ca_calworks_child_care: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/tanf/child_care/reimbursement/ca_calworks_child_care_time_coefficient.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ca/cdss/tanf/child_care/reimbursement/ca_calworks_child_care_time_coefficient.yaml
@@ -1,43 +1,62 @@
-- name: Hourly child care service time coefficient equals to hours per day times days per month.
+- name: Hourly time coefficient equals hours per day times attending days per month.
   period: 2023-01
   input:
     ca_calworks_child_care_time_category: HOURLY
     childcare_hours_per_day: 5
-    ca_calworks_child_care_days_per_month: 10
-    ca_calworks_child_care_weeks_per_month: 1
+    childcare_attending_days_per_month: 10
+    childcare_days_per_week: 3
     state_code: CA
   output:
     ca_calworks_child_care_time_coefficient: 50
 
-- name: Hourly child care service time coefficient equals to days per month.
+- name: Daily time coefficient equals attending days per month.
   period: 2023-01
   input:
     ca_calworks_child_care_time_category: DAILY
     childcare_hours_per_day: 5
-    ca_calworks_child_care_days_per_month: 10
-    ca_calworks_child_care_weeks_per_month: 1
+    childcare_attending_days_per_month: 10
+    childcare_days_per_week: 3
     state_code: CA
   output:
     ca_calworks_child_care_time_coefficient: 10
 
-- name: Hourly child care service time coefficient equals to days per month.
+- name: Weekly time coefficient covers every week of the month when weekly attendance is reported.
+  period: 2023-01
+  absolute_error_margin: 0.01
+  input:
+    ca_calworks_child_care_time_category: WEEKLY
+    childcare_days_per_week: 2
+    state_code: CA
+  output:
+    # 52 weeks / 12 months.
+    ca_calworks_child_care_time_coefficient: 4.33
+
+- name: Weekly time coefficient also applies when only monthly attending days are reported.
+  period: 2023-01
+  absolute_error_margin: 0.01
+  input:
+    ca_calworks_child_care_time_category: WEEKLY
+    childcare_attending_days_per_month: 10
+    state_code: CA
+  output:
+    # 52 weeks / 12 months.
+    ca_calworks_child_care_time_coefficient: 4.33
+
+- name: Weekly time coefficient is zero when no attendance is reported.
   period: 2023-01
   input:
     ca_calworks_child_care_time_category: WEEKLY
-    childcare_hours_per_day: 5
-    ca_calworks_child_care_days_per_month: 10
-    ca_calworks_child_care_weeks_per_month: 2
     state_code: CA
   output:
-    ca_calworks_child_care_time_coefficient: 2
+    ca_calworks_child_care_time_coefficient: 0
 
-- name: Hourly child care service time coefficient equals to days per month.
+- name: Monthly time coefficient is one.
   period: 2023-01
   input:
     ca_calworks_child_care_time_category: MONTHLY
     childcare_hours_per_day: 5
-    ca_calworks_child_care_days_per_month: 10
-    ca_calworks_child_care_weeks_per_month: 2
+    childcare_attending_days_per_month: 10
+    childcare_days_per_week: 3
     state_code: CA
   output:
     ca_calworks_child_care_time_coefficient: 1

--- a/policyengine_us/variables/gov/states/ca/cdss/tanf/child_care/child_care_time/ca_calworks_child_care_days_per_month.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/tanf/child_care/child_care_time/ca_calworks_child_care_days_per_month.py
@@ -1,9 +1,0 @@
-from policyengine_us.model_api import *
-
-
-class ca_calworks_child_care_days_per_month(Variable):
-    value_type = int
-    entity = Person
-    label = "California CalWORKs Child Care days per month"
-    definition_period = MONTH
-    defined_for = StateCode.CA

--- a/policyengine_us/variables/gov/states/ca/cdss/tanf/child_care/child_care_time/ca_calworks_child_care_weeks_per_month.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/tanf/child_care/child_care_time/ca_calworks_child_care_weeks_per_month.py
@@ -1,9 +1,0 @@
-from policyengine_us.model_api import *
-
-
-class ca_calworks_child_care_weeks_per_month(Variable):
-    value_type = int
-    entity = Person
-    label = "California CalWORKs Child Care weeks per month"
-    definition_period = MONTH
-    defined_for = StateCode.CA

--- a/policyengine_us/variables/gov/states/ca/cdss/tanf/child_care/reimbursement/ca_calworks_child_care_time_coefficient.py
+++ b/policyengine_us/variables/gov/states/ca/cdss/tanf/child_care/reimbursement/ca_calworks_child_care_time_coefficient.py
@@ -4,7 +4,7 @@ from policyengine_us.model_api import *
 class ca_calworks_child_care_time_coefficient(Variable):
     value_type = float
     entity = Person
-    label = "California CalWORKs Child Care hours per month"
+    label = "California CalWORKs Child Care time coefficient"
     definition_period = MONTH
     defined_for = StateCode.CA
     reference = "http://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/index.htm?&area=general&type=responsivehelp&ctxid=&project=ePolicyMaster#t=mergedProjects%2FChild%20Care%2FChild_Care%2F1210_8_Regional_Market_Rate_Ceilings%2F1210_8_Regional_Market_Rate_Ceilings.htm%23Contactbc-13&rhtocid=_3_3_8_12"
@@ -13,8 +13,12 @@ class ca_calworks_child_care_time_coefficient(Variable):
         time_category = person("ca_calworks_child_care_time_category", period)
         time_categories = time_category.possible_values
         hours_per_day = person("childcare_hours_per_day", period.this_year)
-        days_per_month = person("ca_calworks_child_care_days_per_month", period)
-        weeks_per_month = person("ca_calworks_child_care_weeks_per_month", period)
+        days_per_month = person("childcare_attending_days_per_month", period.this_year)
+        days_per_week = person("childcare_days_per_week", period.this_year)
+        # Weekly billing covers each week of the month; care reported through
+        # either shared attendance input implies care every week.
+        in_care = (days_per_week > 0) | (days_per_month > 0)
+        weeks_per_month = in_care * WEEKS_IN_YEAR / MONTHS_IN_YEAR
 
         return select(
             [


### PR DESCRIPTION
## Summary

Replaces the CA-only `ca_calworks_child_care_days_per_month` and `ca_calworks_child_care_weeks_per_month` inputs with the shared `childcare_attending_days_per_month` and `childcare_days_per_week` variables. The CA-only variables were `int` inputs with no default, so the default `WEEKLY` billing category multiplied every California child care payment (CalWORKs Stage 1, Stage 2, Stage 3, and CAPP) by a coefficient of 0.

Fixes #9286

## Changes

- `ca_calworks_child_care_time_coefficient` now reads the shared attendance inputs that 17 other state child care programs already use:
  - `HOURLY`: `childcare_hours_per_day` × `childcare_attending_days_per_month` (hours input was already shared)
  - `DAILY`: `childcare_attending_days_per_month`
  - `WEEKLY`: 52/12 weeks per month when attendance is reported through either shared input, following the existing `WEEKS_IN_YEAR / MONTHS_IN_YEAR` idiom in LA CCAP (`la_ccap_monthly_days`); zero when no attendance is reported
  - `MONTHLY`: unchanged (coefficient 1)
- Deletes `ca_calworks_child_care_days_per_month` and `ca_calworks_child_care_weeks_per_month` (their only reader was the coefficient formula; verified with a repo-wide sweep)
- Adds integration tests that exercise the default (weekly) billing path without pinning `ca_calworks_child_care_time_category: MONTHLY`, which every prior money test did — including a case asserting the weekly ceiling payout ($227.58 × 52/12 = $986.18 for a part-time three-year-old at a child care center) and a case documenting that no attendance inputs still means $0

## Partner impact

The API partner has been informed and approved this change: their integration pins `ca_calworks_child_care_time_category: MONTHLY`, which bypasses the changed branch entirely. The partner contract tests under `tests/policy/baseline/partners/analytics_coverage/edge_cases/state/ca/` are untouched and pass unchanged. Note this also does not change microsimulation output: the shared attendance inputs are zero across the Populace microdata, as they are for every other attending-days state.

## Testing

- 53 CalWORKs Stage 1 child care tests pass (`tests/policy/baseline/gov/states/ca/cdss/tanf/child_care`)
- 49 Stage 2 / Stage 3 / CAPP tests pass (`tests/policy/baseline/gov/states/ca/cdss/child_care`)
- 3 CA partner contract tests pass with no edits to the partner file

## Checklist

- [x] Tests pass locally
- [x] Code formatted (ruff)
- [x] Changelog entry created

🤖 Generated with [Claude Code](https://claude.com/claude-code)