### PR TITLE
Align Texas TANF income sources with the Texas Works Handbook

### DIFF
--- a/changelog.d/tx-tanf-unearned-sources.fixed.md
+++ b/changelog.d/tx-tanf-unearned-sources.fixed.md
@@ -1,0 +1,1 @@
+Count cash gifts and contributions, guaranteed income payments, general assistance, veterans benefits, rental income, pensions, and survivor benefits as Texas TANF unearned income per Texas Works Handbook A-1320.

--- a/changelog.d/tx-tanf-unearned-sources.fixed.md
+++ b/changelog.d/tx-tanf-unearned-sources.fixed.md
@@ -1,1 +1,1 @@
-Correct Texas TANF income sources: count omitted cash assistance and recurring unearned income, exclude capital gains, and classify active farming as earned income.
+Correct Texas TANF unearned income sources by counting omitted cash assistance and recurring income and removing capital gains and active farming income.

--- a/changelog.d/tx-tanf-unearned-sources.fixed.md
+++ b/changelog.d/tx-tanf-unearned-sources.fixed.md
@@ -1,1 +1,1 @@
-Count cash gifts and contributions, guaranteed income payments, general assistance, veterans benefits, rental income, pensions, and survivor benefits as Texas TANF unearned income per Texas Works Handbook A-1320.
+Correct Texas TANF income sources: count omitted cash assistance and recurring unearned income, exclude capital gains, and classify active farming as earned income.

--- a/policyengine_us/parameters/gov/states/tx/tanf/income/sources/earned.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/income/sources/earned.yaml
@@ -4,6 +4,8 @@ values:
     - employment_income
     - self_employment_income
     - sstb_self_employment_income
+    # Active farming is self-employment under A-1323.4.1.
+    - farm_operations_income
 
 metadata:
   unit: list
@@ -11,6 +13,6 @@ metadata:
   label: Texas TANF earned income sources
   reference:
     - title: Texas Works Handbook - A-1320 Types of Income
-      href: https://www.hhs.texas.gov/handbooks/texas-works-handbook/a-1320-types-income
+      href: https://fhb.hhs.texas.gov/handbooks/texas-works-handbook/a-1320-types-income
     - title: 1 Tex. Admin. Code § 372.401 (a) - Income
       href: https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-401

--- a/policyengine_us/parameters/gov/states/tx/tanf/income/sources/earned.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/income/sources/earned.yaml
@@ -4,8 +4,6 @@ values:
     - employment_income
     - self_employment_income
     - sstb_self_employment_income
-    # Active farming is self-employment under A-1323.4.1.
-    - farm_operations_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
@@ -33,7 +33,9 @@ values:
     # is not modeled
     - financial_assistance
     - gi_cash_assistance
-    # Cash assistance from other programs is counted under the A-1320 catch-all
+    # A-1324 counts government payments unless exempted; cash assistance from
+    # other programs such as general assistance or refugee cash assistance is not
+    # exempted
     - general_assistance
     # A-1326.2 Child support (the $75 disregard is applied downstream)
     - child_support_received

--- a/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
@@ -1,20 +1,41 @@
 description: Texas counts these income sources as unearned income under the Temporary Assistance for Needy Families program.
 values:
-  # Regulations state all income other than its defined earned income sources is counted as unearned income.
-  # We list them here to avoid a circular reference.
+  # 1 TAC 372.401(a) defines unearned income as all income other than the
+  # defined earned income sources, and Texas Works Handbook A-1320 states that
+  # income not specifically listed in the handbook must be counted. We list
+  # the sources here to avoid a circular reference.
   2010-01-01:
+    # A-1324.16 Retirement, Survivors and Disability Insurance
     - social_security
+    - survivor_benefits
     - disability_benefits
     - workers_compensation
+    # A-1324.19 Unemployment compensation
     - unemployment_compensation
+    # A-1324.20 Veterans benefits
+    - veterans_benefits
+    # A-1324.23 Railroad retirement; other pensions counted under the A-1320 catch-all
+    - pension_income
     - retirement_distributions
     - alimony_income
+    # A-1325.1 Dividends and royalties (royalties included in rental income)
     - dividend_income
     - interest_income
+    # A-1323.4.2 Rental income is unearned unless the person manages the
+    # property at least 20 hours a week; we treat all rental income as unearned
+    - rental_income
     - farm_operations_income
     - farm_rent_income
     - capital_gains
     - miscellaneous_income
+    # A-1326.1 Cash gifts and contributions count as unearned income; the
+    # exemption for need-based nonprofit contributions up to $300 per quarter
+    # is not modeled
+    - financial_assistance
+    - gi_cash_assistance
+    # Cash assistance from other programs is counted under the A-1320 catch-all
+    - general_assistance
+    # A-1326.2 Child support (the $75 disregard is applied downstream)
     - child_support_received
 
 metadata:
@@ -23,6 +44,6 @@ metadata:
   label: Texas TANF unearned income sources
   reference:
     - title: Texas Works Handbook - A-1320 Types of Income
-      href: https://www.hhs.texas.gov/handbooks/texas-works-handbook/a-1320-types-income
+      href: https://fhb.hhs.texas.gov/handbooks/texas-works-handbook/a-1320-types-income
     - title: 1 Tex. Admin. Code § 372.401 (a) - Income
       href: https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-401

--- a/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
@@ -1,43 +1,42 @@
 description: Texas counts these income sources as unearned income under the Temporary Assistance for Needy Families program.
 values:
-  # 1 TAC 372.401(a) defines unearned income as all income other than the
-  # defined earned income sources, and Texas Works Handbook A-1320 states that
-  # income not specifically listed in the handbook must be counted. We list
-  # the sources here to avoid a circular reference.
   2010-01-01:
-    # A-1324.16 Retirement, Survivors and Disability Insurance
+    # A-1324.16: Social Security; other survivors benefits fall under A-1320.
     - social_security
     - survivor_benefits
+    # A-1321.2 and A-1321.4: disability insurance and workers compensation.
     - disability_benefits
     - workers_compensation
-    # A-1324.19 Unemployment compensation
+    # A-1324.19 and A-1324.20.
     - unemployment_compensation
-    # A-1324.20 Veterans benefits
     - veterans_benefits
-    # A-1324.23 Railroad retirement; other pensions counted under the A-1320 catch-all
+    # A-1326.9: pensions, including military retirement and recurring withdrawals.
     - pension_income
+    - military_retirement_pay
     - retirement_distributions
+    # A-1324.23: railroad retirement benefits.
+    - railroad_benefits
     - alimony_income
-    # A-1325.1 Dividends and royalties (royalties included in rental income)
+    # A-1325.1 and A-1326.6.
     - dividend_income
     - interest_income
-    # A-1323.4.2 Rental income is unearned unless the person manages the
-    # property at least 20 hours a week; we treat all rental income as unearned
+    # A-1323.4.2: passive property income. Active farming is in earned.yaml.
     - rental_income
-    - farm_operations_income
     - farm_rent_income
-    - capital_gains
+    # A-1320: recurring estate income; A-1326.21 separately names life estates.
+    - estate_income
+    # A-1326.28: lottery winnings; other gambling income falls under A-1320.
+    - gambling_winnings
+    # A-1320 catch-all for other recurring, non-exempt cash income.
+    - strike_benefits
     - miscellaneous_income
-    # A-1326.1 Cash gifts and contributions count as unearned income; the
-    # exemption for need-based nonprofit contributions up to $300 per quarter
-    # is not modeled
+    # A-1326.1: contributions, subject to the nonprofit exemption below.
     - financial_assistance
     - gi_cash_assistance
-    # A-1324 counts government payments unless exempted; cash assistance from
-    # other programs such as general assistance or refugee cash assistance is not
-    # exempted
+    # A-1324: otherwise non-exempt government cash aid. RCA and Match Grant
+    # require separate concurrent-benefit rules (A-1326.12 and A-1326.13).
     - general_assistance
-    # A-1326.2 Child support (the $75 disregard is applied downstream)
+    # A-1326.2: the child support disregard is applied downstream.
     - child_support_received
 
 metadata:
@@ -47,5 +46,20 @@ metadata:
   reference:
     - title: Texas Works Handbook - A-1320 Types of Income
       href: https://fhb.hhs.texas.gov/handbooks/texas-works-handbook/a-1320-types-income
-    - title: 1 Tex. Admin. Code § 372.401 (a) - Income
+    - title: Texas Works Handbook - A-1330 Types of Payments
+      href: https://fhb.hhs.texas.gov/handbooks/texas-works-handbook/a-1330-types-payments
+    - title: 1 Tex. Admin. Code § 372.401(a) - Overview of Income
       href: https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-401
+  # Excluded by omission: capital gains (A-1326.19), SSI (A-1324.17),
+  # TANF (A-1324.18), educational assistance (A-1322.1), jury duty pay
+  # (A-1326.22), canceled debt (A-1326.24), and foster/adoption assistance.
+  # The available inputs do not identify these conditional exclusions:
+  # - need-based nonprofit contributions: first $300 per fiscal quarter;
+  # - ABLE and school-savings interest/dividends;
+  # - once-yearly or less frequent lump sums under A-1331;
+  # - workers compensation reimbursements, recoupments, and attorney fees;
+  # - exempt VA payment components and nonavailable trust principal.
+  # Rental management hours and production expenses are not separately
+  # reported, so rental inputs are treated as passive net income. Broad
+  # cash-aid inputs cannot identify every exempt program. These are input
+  # limitations, not a claim that every payment in these categories counts.

--- a/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/tx/tanf/income/sources/unearned.yaml
@@ -20,9 +20,10 @@ values:
     # A-1325.1 and A-1326.6.
     - dividend_income
     - interest_income
-    # A-1323.4.2: passive property income. Active farming is in earned.yaml.
+    # A-1323.4.2: passive property income.
     - rental_income
     - farm_rent_income
+    # Active farming and Schedule J farm income are not modeled here.
     # A-1320: recurring estate income; A-1326.21 separately names life estates.
     - estate_income
     # A-1326.28: lottery winnings; other gambling income falls under A-1320.

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_countable_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_countable_unearned_income.yaml
@@ -47,3 +47,46 @@
   output:
     tx_tanf_countable_unearned_income: 0
     # 0 - 0 = 0
+
+- name: Case 6, cash aid reported as financial assistance flows through to countable unearned income.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    people:
+      person1:
+        age: 30
+        financial_assistance: 2_400
+      person2:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    # 2,400 / 12 = 200 per month, no child support deduction
+    tx_tanf_countable_unearned_income: 200
+
+- name: Case 7, veterans benefits plus child support with the $75 deduction applied.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    people:
+      person1:
+        age: 30
+        veterans_benefits: 6_000
+        child_support_received: 1_200
+      person2:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    # 500 veterans + 100 child support - 75 deduction = 525 per month
+    tx_tanf_countable_unearned_income: 525

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_gross_unearned_income.yaml
@@ -1,0 +1,53 @@
+- name: Case 1, cash gifts and contributions from outside the household count as unearned income (A-1326.1).
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    financial_assistance: 2_400
+    state_code: TX
+  output:
+    # 2,400 / 12 = 200 per month
+    tx_tanf_gross_unearned_income: 200
+
+- name: Case 2, guaranteed income payments and general assistance count under the A-1320 catch-all.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    gi_cash_assistance: 1_200
+    general_assistance: 1_800
+    state_code: TX
+  output:
+    # (1,200 + 1,800) / 12 = 250 per month
+    tx_tanf_gross_unearned_income: 250
+
+- name: Case 3, veterans benefits, rental income, pensions, and survivor benefits count as unearned income.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    veterans_benefits: 6_000
+    rental_income: 2_400
+    pension_income: 3_600
+    survivor_benefits: 1_200
+    state_code: TX
+  output:
+    # 500 + 200 + 300 + 100 = 1,100 per month
+    tx_tanf_gross_unearned_income: 1_100
+
+- name: Case 4, earned income is not unearned income.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    employment_income: 12_000
+    self_employment_income: 6_000
+    state_code: TX
+  output:
+    tx_tanf_gross_unearned_income: 0
+
+- name: Case 5, Supplemental Security Income and TANF are not counted.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    ssi: 11_000
+    tanf: 3_000
+    state_code: TX
+  output:
+    tx_tanf_gross_unearned_income: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_gross_unearned_income.yaml
@@ -51,3 +51,43 @@
     state_code: TX
   output:
     tx_tanf_gross_unearned_income: 0
+
+- name: Capital gains are exempt from TANF income under A-1326.19.
+  period: 2026-01
+  input:
+    state_code: TX
+    long_term_capital_gains: 12_000
+    short_term_capital_gains: 6_000
+  output:
+    tx_tanf_gross_unearned_income: 0
+    tx_tanf_gross_earned_income: 0
+
+- name: Active farming is earned income while passive farm rent is unearned.
+  period: 2026-01
+  input:
+    state_code: TX
+    farm_operations_income: 6_000
+    farm_rent_income: 2_400
+  output:
+    tx_tanf_gross_earned_income: 500
+    tx_tanf_gross_unearned_income: 200
+
+- name: Military retirement and railroad payments supplement other pensions.
+  period: 2026-01
+  input:
+    state_code: TX
+    pension_income: 2_400
+    military_retirement_pay: 3_600
+    railroad_benefits: 1_200
+  output:
+    tx_tanf_gross_unearned_income: 600
+
+- name: Lottery winnings and recurring estate and strike income are counted.
+  period: 2026-01
+  input:
+    state_code: TX
+    gambling_winnings: 1_200
+    estate_income: 600
+    strike_benefits: 600
+  output:
+    tx_tanf_gross_unearned_income: 200

--- a/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/tx/tanf/income/unearned/tx_tanf_gross_unearned_income.yaml
@@ -62,14 +62,15 @@
     tx_tanf_gross_unearned_income: 0
     tx_tanf_gross_earned_income: 0
 
-- name: Active farming is earned income while passive farm rent is unearned.
+- name: Farm rent is counted while other farming inputs remain unmodeled.
   period: 2026-01
   input:
     state_code: TX
     farm_operations_income: 6_000
+    farm_income: 1_200
     farm_rent_income: 2_400
   output:
-    tx_tanf_gross_earned_income: 500
+    tx_tanf_gross_earned_income: 0
     tx_tanf_gross_unearned_income: 200
 
 - name: Military retirement and railroad payments supplement other pensions.


### PR DESCRIPTION
Texas TANF omits several cash-income inputs and incorrectly counts capital gains as unearned income. This PR corrects the explicit state income lists against the Texas Works Handbook.

Closes #9381.

| Change | Authority |
|---|---|
| Count cash contributions and otherwise non-exempt cash aid | A-1326.1; A-1324; A-1320 catch-all |
| Count veterans benefits, pensions, military retirement, railroad payments, and non-Social-Security survivor benefits | A-1324.20, A-1324.23, A-1326.9; A-1320 |
| Count passive rental income, recurring estate income, lottery/gambling winnings, and strike benefits | A-1323.4.2, A-1326.21, A-1326.28; A-1320 |
| Exclude capital gains | A-1326.19 |

Sources: [Texas Works Handbook A-1320](https://fhb.hhs.texas.gov/handbooks/texas-works-handbook/a-1320-types-income), [A-1330 payment timing and reimbursements](https://fhb.hhs.texas.gov/handbooks/texas-works-handbook/a-1330-types-payments), and [1 TAC 372.401(a)](https://www.law.cornell.edu/regulations/texas/1-Tex-Admin-Code-SS-372-401).

Among the farming inputs, only `farm_rent_income` is counted, as unearned income. `farm_operations_income` is removed from the unearned list and is not added to earned income; `farm_income` is also absent. Active farming remains an unmodeled income source, rather than a policy exemption.

The list comments identify conditional rules that the current inputs cannot represent: need-based nonprofit contributions, exempt VA components, workers’ compensation deductions/reimbursements, ABLE and school-savings interest, lump sums, rental management hours/expenses, and the program identity of generic cash aid. In particular, RCA and Match Grant have TANF concurrent-benefit restrictions; they are not justified by a blanket assertion that all agency aid counts. These limitations remain and the PR does not claim exact treatment of every payment subtype.

TX CEAP continues to exclude `financial_assistance` (cash gifts) under 10 TAC 6.4(d)(9) and to count `general_assistance`. The shared TANF list is unchanged.

Validation: regression cases reproduce the pre-fix omissions and capital-gains inclusion. A farming-input case verifies that only farm rent is counted. All 128 Texas TANF tests, 11 Texas TANF/CEAP partner cases, and formatting/lint checks pass. Partner expected outputs are unchanged. All added cases are in the existing income test files on this PR branch.
