### PR TITLE
Add policyengine-us dependency-map and publish it per release

### DIFF
--- a/.github/workflows/dependency-map.yaml
+++ b/.github/workflows/dependency-map.yaml
@@ -1,0 +1,67 @@
+# Trace the parameter -> variable dependency map for each released version
+# and publish it as a GitHub release asset, so downstream tools (the app's
+# validation matching, the calibration dashboard's model-coverage page) can
+# fetch the map that matches the model version they run against.
+#
+# Runs on the same version-bump commit that triggers the PyPI publish, but as
+# its own workflow: a tracing failure never blocks a release. The release is
+# created with GITHUB_TOKEN, which deliberately does not trigger other
+# workflows.
+name: Dependency map
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      population:
+        description: "tests, microdata, or both"
+        default: tests
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  trace:
+    name: Trace and publish
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'PolicyEngine/policyengine-us'
+      && (github.event_name == 'workflow_dispatch'
+          || github.event.head_commit.message == 'Update PolicyEngine US')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(python -c "import re; print(re.search(r'version = \"(.+?)\"', open('pyproject.toml').read()).group(1))")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Trace the dependency map
+        run: |
+          uv run policyengine-us dependency-map \
+            --population "${{ github.event.inputs.population || 'tests' }}" \
+            --output dependency-map.json
+          gzip -k -9 dependency-map.json
+          ls -la dependency-map.json dependency-map.json.gz
+      - name: Publish as a release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if ! gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release create "$VERSION" \
+              --target "$GITHUB_SHA" \
+              --title "policyengine-us $VERSION" \
+              --notes "Dependency map traced from policyengine-us $VERSION. See policyengine_us/tools/dependency_map.py."
+          fi
+          gh release upload "$VERSION" dependency-map.json.gz --clobber

--- a/changelog.d/dependency-map.added.md
+++ b/changelog.d/dependency-map.added.md
@@ -1,0 +1,1 @@
+Add `policyengine-us dependency-map`, which traces which variables read each parameter and which variables feed which, and publish the map as a release asset.

--- a/policyengine_us/cli.py
+++ b/policyengine_us/cli.py
@@ -1,0 +1,29 @@
+"""The ``policyengine-us`` console entry point.
+
+Subcommands:
+    dependency-map   trace which variables read each parameter and which
+                     variables feed which (see tools/dependency_map.py)
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if not argv or argv[0] in ("-h", "--help"):
+        print(__doc__.strip())
+        return 0 if argv else 2
+    command, rest = argv[0], argv[1:]
+    if command == "dependency-map":
+        from policyengine_us.tools.dependency_map import main as run
+
+        return run(rest)
+    print(f"policyengine-us: unknown command {command!r}", file=sys.stderr)
+    print(__doc__.strip(), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/policyengine_us/tests/test_dependency_map.py
+++ b/policyengine_us/tests/test_dependency_map.py
@@ -42,7 +42,9 @@ def test_ctc_tests_record_bracket_parameter_reads_and_variable_edges():
     assert not any(path.startswith("gov.abolitions.") for path in readers)
 
 
-def test_iter_yaml_tests_skips_reforms_and_inline_parameter_changes(tmp_path: Path):
+def test_iter_yaml_tests_skips_reforms_inline_changes_and_covered_outputs(
+    tmp_path: Path,
+):
     (tmp_path / "cases.yaml").write_text(
         """
 - name: plain
@@ -61,12 +63,22 @@ def test_iter_yaml_tests_skips_reforms_and_inline_parameter_changes(tmp_path: Pa
 - name: no output
   period: 2024
   input: {age: 30}
+- name: same output again
+  period: 2024
+  input: {age: 12}
+  output: {is_adult: false}
+- name: new output
+  period: 2024
+  input: {age: 12}
+  output: {is_adult: false, is_child: true}
 """
     )
 
     names = [test["name"] for _, test in iter_yaml_tests([tmp_path])]
+    every = [test["name"] for _, test in iter_yaml_tests([tmp_path], every_test=True)]
 
-    assert names == ["plain"]
+    assert names == ["plain", "new output"]
+    assert every == ["plain", "same output again", "new output"]
 
 
 def test_merge_edges_unions_both_sides():

--- a/policyengine_us/tests/test_dependency_map.py
+++ b/policyengine_us/tests/test_dependency_map.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from policyengine_us import CountryTaxBenefitSystem
+from policyengine_us.tools.dependency_map import (
+    DEFAULT_TESTS_ROOT,
+    iter_yaml_tests,
+    merge_edges,
+    trace_yaml_tests,
+)
+
+CTC_TESTS = DEFAULT_TESTS_ROOT / "gov" / "irs" / "credits" / "ctc"
+
+
+def reachable(consumers: dict[str, set[str]], start: str) -> set[str]:
+    seen: set[str] = set()
+    frontier = [start]
+    while frontier:
+        name = frontier.pop()
+        for user in consumers.get(name, ()):
+            if user not in seen:
+                seen.add(user)
+                frontier.append(user)
+    return seen
+
+
+def test_ctc_tests_record_bracket_parameter_reads_and_variable_edges():
+    (readers, consumers), stats = trace_yaml_tests(
+        CountryTaxBenefitSystem(), [CTC_TESTS]
+    )
+
+    assert stats["tests"] > 0
+    # p.base.calc(age) is a scale read: recorded at the scale node.
+    assert "ctc_child_individual_maximum" in readers["gov.irs.credits.ctc.amount.base"]
+    # A yearly formula read, which core's tracer misses without the workaround.
+    assert (
+        "refundable_ctc" in readers["gov.irs.credits.ctc.refundable.fully_refundable"]
+    )
+    # The maximum feeds both credit outputs a few formula hops downstream.
+    downstream = reachable(consumers, "ctc_maximum")
+    assert {"ctc", "refundable_ctc"} <= downstream
+    # Neutralisation switches are noise, not reform levers.
+    assert not any(path.startswith("gov.abolitions.") for path in readers)
+
+
+def test_iter_yaml_tests_skips_reforms_and_inline_parameter_changes(tmp_path: Path):
+    (tmp_path / "cases.yaml").write_text(
+        """
+- name: plain
+  period: 2024
+  input: {age: 30}
+  output: {is_adult: true}
+- name: with reform
+  period: 2024
+  reforms: policyengine_us.reforms.some_reform
+  input: {age: 30}
+  output: {is_adult: true}
+- name: inline parameter change
+  period: 2024
+  input: {age: 30, gov.irs.credits.ctc.amount.adult_dependent: 1000}
+  output: {is_adult: true}
+- name: no output
+  period: 2024
+  input: {age: 30}
+"""
+    )
+
+    names = [test["name"] for _, test in iter_yaml_tests([tmp_path])]
+
+    assert names == ["plain"]
+
+
+def test_merge_edges_unions_both_sides():
+    readers, consumers = merge_edges(
+        ({"gov.a": {"x"}}, {"x": {"y"}}),
+        ({"gov.a": {"z"}, "gov.b": {"w"}}, {"x": {"q"}}),
+    )
+
+    assert readers == {"gov.a": {"x", "z"}, "gov.b": {"w"}}
+    assert consumers == {"x": {"y", "q"}}

--- a/policyengine_us/tools/dependency_map.py
+++ b/policyengine_us/tools/dependency_map.py
@@ -169,22 +169,34 @@ def collect_edges(simulation, readers=None, consumers=None) -> Edges:
     return readers, consumers
 
 
-def iter_yaml_tests(paths: Iterable[Path]):
-    """Yield (file, test) for every baseline test we can trace as-is."""
+def iter_yaml_tests(paths: Iterable[Path], every_test: bool = False):
+    """Yield (file, test) for the baseline tests worth tracing.
+
+    Tests in one file mostly vary inputs for the same outputs, and a traced
+    formula records the same edges whatever the inputs, so by default a
+    test is kept only when it names an output variable no earlier test in
+    the file did. That cuts the suite by roughly four fifths for a near
+    identical edge set; ``every_test`` traces them all.
+    """
     for path in paths:
         files = sorted(path.rglob("*.yaml")) if path.is_dir() else [path]
         for file in files:
             tests = yaml.safe_load(file.read_text()) or []
             if not isinstance(tests, list):
                 continue
+            covered: set[str] = set()
             for test in tests:
                 inputs = test.get("input") or {}
                 if test.get("reforms") or test.get("extensions"):
                     continue
                 if any("." in key for key in inputs):
                     continue  # inline parameter change: not the baseline system
-                if not test.get("output"):
+                outputs = test.get("output") or {}
+                if not outputs:
                     continue
+                if not every_test and covered >= set(outputs):
+                    continue
+                covered |= set(outputs)
                 yield file, test
 
 
@@ -192,12 +204,13 @@ def trace_yaml_tests(
     system,
     paths: Iterable[Path] = (DEFAULT_TESTS_ROOT,),
     progress: Progress | None = None,
+    every_test: bool = False,
 ) -> tuple[Edges, dict[str, int]]:
     install_tracer_patches()
     readers: dict[str, set[str]] = defaultdict(set)
     consumers: dict[str, set[str]] = defaultdict(set)
     stats = {"tests": 0, "failed": 0}
-    for index, (file, test) in enumerate(iter_yaml_tests(paths)):
+    for index, (file, test) in enumerate(iter_yaml_tests(paths, every_test)):
         period = test.get("period")
         try:
             builder = SimulationBuilder()
@@ -268,6 +281,7 @@ def merge_edges(*edge_sets: Edges) -> Edges:
 def build_dependency_map(
     population: str = "tests",
     tests_root: Path = DEFAULT_TESTS_ROOT,
+    every_test: bool = False,
     households: int = 2000,
     year: int = 2026,
     progress: Progress | None = None,
@@ -280,11 +294,12 @@ def build_dependency_map(
     started = time.time()
     if population in ("tests", "both"):
         edges, stats = trace_yaml_tests(
-            CountryTaxBenefitSystem(), [tests_root], progress
+            CountryTaxBenefitSystem(), [tests_root], progress, every_test
         )
         edge_sets.append(edges)
         populations["tests"] = {
             "root": tests_root.relative_to(PACKAGE_ROOT).as_posix(),
+            "everyTest": every_test,
             **stats,
         }
     if population in ("microdata", "both"):
@@ -331,6 +346,11 @@ def main(argv: list[str] | None = None) -> int:
         default="tests",
     )
     parser.add_argument("--tests-root", type=Path, default=DEFAULT_TESTS_ROOT)
+    parser.add_argument(
+        "--every-test",
+        action="store_true",
+        help="trace every test instead of one per newly covered output variable",
+    )
     parser.add_argument("--households", type=int, default=2000)
     parser.add_argument("--year", type=int, default=2026)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
@@ -342,6 +362,7 @@ def main(argv: list[str] | None = None) -> int:
     payload = build_dependency_map(
         population=args.population,
         tests_root=args.tests_root,
+        every_test=args.every_test,
         households=args.households,
         year=args.year,
         progress=progress,

--- a/policyengine_us/tools/dependency_map.py
+++ b/policyengine_us/tools/dependency_map.py
@@ -1,0 +1,359 @@
+"""Trace the parameter → variable dependency map from the model.
+
+Downstream tools (validation matching in the app, the calibration
+dashboard's model-coverage page, reform classifiers) need to know which
+variables a parameter path moves and which variables feed which. Static
+scans of formula source miss bracket, scale, and vectorised reads; the only
+exact record is what the model reads at run time. This module runs
+simulations under policyengine-core's ``FullTracer`` and folds the trace
+trees into two edge sets:
+
+    readers[parameter_path] -> variables whose formula read that parameter
+    consumers[variable]     -> variables whose formula read that variable
+
+Parameter paths are recorded at the node the formula indexed, so a bracket
+read ``p.base.calc(age)`` is recorded as ``gov.irs.credits.ctc.amount.base``.
+
+Populations
+-----------
+``tests``      builds a simulation for every baseline YAML test (skipping
+               tests that apply reforms, extensions, or inline parameter
+               changes) and calculates the test's outputs. Deterministic, no
+               data download, and the tests deliberately exercise every
+               program and state.
+``microdata``  calculates every variable over a subsample of the default
+               microdata. Broad, but a formula behind ``defined_for`` only
+               runs when someone in the sample qualifies.
+``both``       the union.
+
+policyengine-core quirks
+------------------------
+Two tracer gaps are worked around here until they are fixed upstream:
+
+* PolicyEngine/policyengine-core#541 — the yearly ``ParameterNodeAtInstant``
+  is cached before core's own tracing recast, so yearly formulas record no
+  parameter reads. We flag the parameter root for tracing and clear the
+  at-instant caches before calculating.
+* PolicyEngine/policyengine-core#542 — ``TracingParameterNodeAtInstant``
+  only records scalar leaves, so scale/bracket reads are invisible. We
+  record every child that is neither a node nor a scalar leaf.
+
+Both patches switch off once the installed core reports a version at or
+above ``CORE_TRACER_FIXED_VERSION``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from importlib.metadata import version
+from pathlib import Path
+from typing import Callable, Iterable
+
+import yaml
+
+from policyengine_core import parameters as core_parameters
+from policyengine_core import tracers
+from policyengine_core.periods import ETERNITY
+from policyengine_core.simulations import SimulationBuilder
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TESTS_ROOT = PACKAGE_ROOT / "tests" / "policy" / "baseline"
+DEFAULT_OUTPUT = Path("dependency-map.json")
+
+# First policyengine-core release with #541 and #542 fixed. None until one ships.
+CORE_TRACER_FIXED_VERSION: str | None = None
+
+# Neutralisation switches mirror every variable 1:1 and carry no reform meaning.
+IGNORED_PARAMETER_PREFIXES = ("gov.abolitions.",)
+
+Edges = tuple[dict[str, set[str]], dict[str, set[str]]]
+Progress = Callable[[str], None]
+
+_patched = False
+
+
+def _version_tuple(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", text)[:3])
+
+
+def core_tracer_needs_patches() -> bool:
+    if CORE_TRACER_FIXED_VERSION is None:
+        return True
+    return _version_tuple(version("policyengine-core")) < _version_tuple(
+        CORE_TRACER_FIXED_VERSION
+    )
+
+
+def install_tracer_patches() -> None:
+    """Work around policyengine-core#542 and drop retained trace values."""
+    global _patched
+    if _patched:
+        return
+    _patched = True
+    # Trace values are never read back; dropping them keeps memory flat.
+    tracers.FullTracer.record_calculation_result = lambda self, value: None
+    if not core_tracer_needs_patches():
+        return
+
+    original = tracers.TracingParameterNodeAtInstant.get_traced_child
+
+    def get_traced_child(self, child, key):
+        is_node = isinstance(
+            child,
+            (
+                core_parameters.ParameterNodeAtInstant,
+                core_parameters.VectorialParameterNodeAtInstant,
+            ),
+        )
+        is_leaf = isinstance(child, core_parameters.ALLOWED_PARAM_TYPES) or hasattr(
+            child, "shape"
+        )
+        if not is_node and not is_leaf:
+            node = self.parameter_node_at_instant
+            name = node._name if not isinstance(key, str) else f"{node._name}.{key}"
+            self.tracer.record_parameter_access(
+                name, node._instant_str, self.branch_name, None
+            )
+        return original(self, child, key)
+
+    tracers.TracingParameterNodeAtInstant.get_traced_child = get_traced_child
+
+
+def enable_tracing(simulation) -> None:
+    """Switch tracing on, working around policyengine-core#541."""
+    simulation.trace = True
+    if not core_tracer_needs_patches():
+        return
+    root = simulation.tax_benefit_system.parameters
+    root.trace = True
+    root.tracer = simulation.tracer
+    root.branch_name = simulation.branch_name
+
+    def clear(node) -> None:
+        cache = getattr(node, "_at_instant_cache", None)
+        if cache is not None:
+            cache.clear()
+        children = getattr(node, "children", None)
+        if isinstance(children, dict):
+            for child in children.values():
+                clear(child)
+
+    clear(root)
+
+
+def collect_edges(simulation, readers=None, consumers=None) -> Edges:
+    """Fold a traced simulation's trees into the two edge sets."""
+    readers = defaultdict(set) if readers is None else readers
+    consumers = defaultdict(set) if consumers is None else consumers
+    seen: set[int] = set()
+
+    def walk(node) -> None:
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        for parameter in node.parameters:
+            if not parameter.name.startswith(IGNORED_PARAMETER_PREFIXES):
+                readers[parameter.name].add(node.name)
+        for child in node.children:
+            if child.name != node.name:
+                consumers[child.name].add(node.name)
+            walk(child)
+
+    for tree in simulation.tracer.trees:
+        walk(tree)
+    return readers, consumers
+
+
+def iter_yaml_tests(paths: Iterable[Path]):
+    """Yield (file, test) for every baseline test we can trace as-is."""
+    for path in paths:
+        files = sorted(path.rglob("*.yaml")) if path.is_dir() else [path]
+        for file in files:
+            tests = yaml.safe_load(file.read_text()) or []
+            if not isinstance(tests, list):
+                continue
+            for test in tests:
+                inputs = test.get("input") or {}
+                if test.get("reforms") or test.get("extensions"):
+                    continue
+                if any("." in key for key in inputs):
+                    continue  # inline parameter change: not the baseline system
+                if not test.get("output"):
+                    continue
+                yield file, test
+
+
+def trace_yaml_tests(
+    system,
+    paths: Iterable[Path] = (DEFAULT_TESTS_ROOT,),
+    progress: Progress | None = None,
+) -> tuple[Edges, dict[str, int]]:
+    install_tracer_patches()
+    readers: dict[str, set[str]] = defaultdict(set)
+    consumers: dict[str, set[str]] = defaultdict(set)
+    stats = {"tests": 0, "failed": 0}
+    for index, (file, test) in enumerate(iter_yaml_tests(paths)):
+        period = test.get("period")
+        try:
+            builder = SimulationBuilder()
+            builder.set_default_period(period)
+            simulation = builder.build_from_dict(system, test.get("input") or {})
+            simulation.default_calculation_period = builder.default_period
+            enable_tracing(simulation)
+            for output in test["output"]:
+                try:
+                    simulation.calculate(output, period)
+                except Exception:  # noqa: BLE001 — a failing test still traced what ran
+                    pass
+            collect_edges(simulation, readers, consumers)
+            stats["tests"] += 1
+        except Exception:  # noqa: BLE001 — unbuildable situation, skip it
+            stats["failed"] += 1
+        if progress and index % 500 == 0:
+            progress(f"  {index} tests traced ({file.relative_to(PACKAGE_ROOT)})")
+    return (readers, consumers), stats
+
+
+def trace_microdata(
+    households: int = 2000,
+    year: int = 2026,
+    progress: Progress | None = None,
+) -> tuple[Edges, dict[str, int]]:
+    install_tracer_patches()
+    from policyengine_us import Microsimulation
+
+    simulation = Microsimulation()
+    simulation = simulation.subsample(n=households, seed=0) or simulation
+    enable_tracing(simulation)
+    variables = simulation.tax_benefit_system.variables
+    stats = {"variables": 0, "failed": 0}
+    for index, name in enumerate(sorted(variables)):
+        variable = variables[name]
+        if variable.definition_period == ETERNITY:
+            periods = [ETERNITY]
+        elif variable.definition_period == "month":
+            periods = [f"{year}-01"]
+        else:
+            periods = [year, f"{year}-01"]
+        for period in periods:
+            try:
+                simulation.calculate(name, period)
+                stats["variables"] += 1
+                break
+            except Exception:  # noqa: BLE001 — any formula failure just skips the variable
+                continue
+        else:
+            stats["failed"] += 1
+        if progress and index % 500 == 0:
+            progress(f"  {index}/{len(variables)} variables")
+    return collect_edges(simulation), stats
+
+
+def merge_edges(*edge_sets: Edges) -> Edges:
+    readers: dict[str, set[str]] = defaultdict(set)
+    consumers: dict[str, set[str]] = defaultdict(set)
+    for edge_readers, edge_consumers in edge_sets:
+        for path, names in edge_readers.items():
+            readers[path] |= names
+        for name, users in edge_consumers.items():
+            consumers[name] |= users
+    return readers, consumers
+
+
+def build_dependency_map(
+    population: str = "tests",
+    tests_root: Path = DEFAULT_TESTS_ROOT,
+    households: int = 2000,
+    year: int = 2026,
+    progress: Progress | None = None,
+) -> dict:
+    from policyengine_us import CountryTaxBenefitSystem
+    from policyengine_us.build_metadata import get_runtime_metadata
+
+    edge_sets: list[Edges] = []
+    populations: dict[str, dict] = {}
+    started = time.time()
+    if population in ("tests", "both"):
+        edges, stats = trace_yaml_tests(
+            CountryTaxBenefitSystem(), [tests_root], progress
+        )
+        edge_sets.append(edges)
+        populations["tests"] = {
+            "root": tests_root.relative_to(PACKAGE_ROOT).as_posix(),
+            **stats,
+        }
+    if population in ("microdata", "both"):
+        edges, stats = trace_microdata(households, year, progress)
+        edge_sets.append(edges)
+        populations["microdata"] = {"households": households, "year": year, **stats}
+    if not edge_sets:
+        raise ValueError(f"unknown population {population!r}")
+
+    readers, consumers = merge_edges(*edge_sets)
+    runtime = get_runtime_metadata()
+    return {
+        "generatedAt": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "model": {
+            "package": runtime["name"],
+            "version": runtime["version"],
+            "gitSha": runtime["git_sha"],
+            "dataBuildFingerprint": runtime["data_build_fingerprint"],
+            "coreVersion": version("policyengine-core"),
+        },
+        "populations": populations,
+        "tracingSeconds": round(time.time() - started),
+        "readers": {path: sorted(names) for path, names in sorted(readers.items())},
+        "consumers": {name: sorted(users) for name, users in sorted(consumers.items())},
+    }
+
+
+def write_dependency_map(payload: dict, output: Path = DEFAULT_OUTPUT) -> Path:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, separators=(",", ":")) + "\n")
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="policyengine-us dependency-map",
+        description="Trace which variables read each parameter and which variables feed which.",
+    )
+    parser.add_argument(
+        "--population",
+        choices=["tests", "microdata", "both"],
+        default="tests",
+    )
+    parser.add_argument("--tests-root", type=Path, default=DEFAULT_TESTS_ROOT)
+    parser.add_argument("--households", type=int, default=2000)
+    parser.add_argument("--year", type=int, default=2026)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args(argv)
+
+    def progress(message: str) -> None:
+        print(message, file=sys.stderr, flush=True)
+
+    payload = build_dependency_map(
+        population=args.population,
+        tests_root=args.tests_root,
+        households=args.households,
+        year=args.year,
+        progress=progress,
+    )
+    output = write_dependency_map(payload, args.output)
+    progress(
+        f"wrote {output}: {len(payload['readers'])} parameter paths, "
+        f"{len(payload['consumers'])} consumed variables, "
+        f"{payload['tracingSeconds']}s"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [project.scripts]
-policyengine-us = "policyengine_us:main"
+policyengine-us = "policyengine_us.cli:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Why

Downstream tools need to know which model variables a parameter path moves and which variables feed which: validation matching in the app (PolicyEngine/policyengine-app-v2#1180 matches a reform's provisions to scorecard programs through it, and the calibration-dashboard side is next), the calibration dashboard's model-coverage page (which currently derives the same edges by grepping formula source), and reform classifiers. Static scans miss bracket, scale, and vectorised reads, so the map is traced from the model at run time instead. The map is a fact about the model, so it ships with the model.

## What

- **`policyengine_us/tools/dependency_map.py`** runs simulations under policyengine-core's `FullTracer` and folds the trace trees into `readers` (parameter path → variables whose formula read it) and `consumers` (variable → variables whose formula read it). Bracket reads are recorded at the scale node (`p.base.calc(age)` → `gov.irs.credits.ctc.amount.base`). `gov.abolitions.*` switches are dropped as noise.
- **Populations.** `tests` (default) builds a simulation per baseline YAML test and calculates its outputs: deterministic, no data download. Tests in a file mostly vary inputs for the same outputs and record the same edges, so by default one test is kept per newly covered output variable in the file (5,338 of 27,593); `--every-test` traces all of them. `microdata` calculates every variable over a subsample of the default dataset (broader, but a `defined_for` formula only runs if someone in the sample qualifies); `both` unions them.
- **Provenance.** The output is stamped with the package version, git sha, the data-build fingerprint from `build_metadata.py` (the exact cache key: the map can only change when entities, parameters, variables, or system change), and the core version.
- **CLI.** `pyproject.toml` pointed the `policyengine-us` console script at `policyengine_us:main`, which does not exist. It now routes to `policyengine_us/cli.py`, whose first subcommand is `dependency-map`.
- **Workflow.** `.github/workflows/dependency-map.yaml` runs on the same version-bump commit that triggers Publish, but as its own workflow so a tracing failure never blocks a release. It traces the map, gzips it, and publishes it as a GitHub release asset for that version, creating the release if none exists. The release is created with `GITHUB_TOKEN`, which deliberately triggers no other workflow. Consumers fetch `https://github.com/PolicyEngine/policyengine-us/releases/download/<version>/dependency-map.json.gz`.

## policyengine-core workarounds

Two tracer gaps make the map near-empty without patches, filed as PolicyEngine/policyengine-core#541 (the yearly `ParameterNodeAtInstant` is cached before core's tracing recast, so yearly formulas record no parameter reads) and PolicyEngine/policyengine-core#542 (`TracingParameterNodeAtInstant` only records scalar leaves, so scale/bracket reads are invisible). Both are worked around here behind `CORE_TRACER_FIXED_VERSION`; set that constant once a core release ships the fixes and the patches switch off.

## Test

- `policyengine_us/tests/test_dependency_map.py` traces the CTC test directory and asserts the scale read, the yearly read, the downstream chain to `ctc` and `refundable_ctc`, and the abolition filter; plus selection and merge unit tests. ~45s.
- `uv run policyengine-us --help` and `uv run policyengine-us dependency-map` resolve through the new entry point.
- Full `tests` population run locally: numbers below.

## Local run

`policyengine-us dependency-map --population tests` on this branch (policyengine-us 1.808.0, core 3.30.2, M-series laptop):

| | |
|---|---|
| tests traced | 5,337 (1 failed to build) |
| wall time | 62 min |
| parameter paths with readers | 5,074 |
| variables with consumers | 5,497 |
| output size | 1.2 MB raw, 175 KB gzipped |

Against a `microdata` run over 2,000 households (8 min): 4,602 parameter paths appear in both, 472 only in the tests run, 125 only in microdata; 5,200 consumed variables in both, 297 only in tests, 210 only in microdata. `both` is the most complete map and costs the extra 8 minutes, but needs the dataset download in CI; the workflow defaults to `tests` until that is wired in (a `workflow_dispatch` input already accepts `both`).

## Follow-ups

- Set `CORE_TRACER_FIXED_VERSION` when core ships #541/#542.
- policyengine-app-v2: fetch the release asset for the API's model version at build time instead of committing the map.
- calibration-diagnostics: replace the static scan in `generate_model_coverage.py` with the asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
