### PR TITLE
Add contrib reform paying the Oklahoma Child Care/Child Tax Credit as refundable

### DIFF
--- a/changelog.d/ok-refundable-ctc.added.md
+++ b/changelog.d/ok-refundable-ctc.added.md
@@ -1,0 +1,1 @@
+Added a contrib reform that pays the Oklahoma Child Care/Child Tax Credit as a refundable credit.

--- a/policyengine_us/parameters/gov/contrib/states/ok/child_poverty_impact_dashboard/ctc/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ok/child_poverty_impact_dashboard/ctc/in_effect.yaml
@@ -1,0 +1,9 @@
+description: Oklahoma pays its Child Care/Child Tax Credit as a refundable credit when this parameter is in effect. By default, the credit is nonrefundable under 68 O.S. § 2357 ("neither credit shall exceed the tax imposed").
+
+values:
+  0000-01-01: false
+
+metadata:
+  unit: bool
+  period: year
+  label: Oklahoma refundable Child Care/Child Tax Credit in effect

--- a/policyengine_us/parameters/gov/contrib/states/ok/child_poverty_impact_dashboard/ctc/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/ok/child_poverty_impact_dashboard/ctc/in_effect.yaml
@@ -7,3 +7,6 @@ metadata:
   unit: bool
   period: year
   label: Oklahoma refundable Child Care/Child Tax Credit in effect
+  reference:
+    - title: 68 O.S. § 2357.43 - Oklahoma Child Care/Child Tax Credit (nonrefundable in baseline)
+      href: https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/individuals/current/511-NR-Pkt.pdf#page=11

--- a/policyengine_us/reforms/reforms.py
+++ b/policyengine_us/reforms/reforms.py
@@ -343,6 +343,9 @@ from .states.ut.child_poverty_eitc import (
 from .states.sc.child_poverty_eitc import (
     create_sc_fully_refundable_eitc_reform,
 )
+from .states.ok.ctc import (
+    create_ok_refundable_ctc_reform,
+)
 from policyengine_core.reforms import Reform
 import warnings
 
@@ -564,6 +567,7 @@ def create_structural_reforms_from_parameters(parameters, period):
     sc_fully_refundable_eitc = create_sc_fully_refundable_eitc_reform(
         parameters, period
     )
+    ok_refundable_ctc = create_ok_refundable_ctc_reform(parameters, period)
     working_parents_tax_relief_act = create_working_parents_tax_relief_act_reform(
         parameters, period
     )
@@ -704,6 +708,7 @@ def create_structural_reforms_from_parameters(parameters, period):
         oh_refundable_eitc,
         ut_fully_refundable_eitc,
         sc_fully_refundable_eitc,
+        ok_refundable_ctc,
         working_parents_tax_relief_act,
         refundable_credit_conversion,
     ]

--- a/policyengine_us/reforms/states/ok/ctc/__init__.py
+++ b/policyengine_us/reforms/states/ok/ctc/__init__.py
@@ -1,5 +1,4 @@
-from .dependent_exemption import create_ok_dependent_exemption_reform_fn
-from .ctc import (
+from .ok_refundable_ctc_reform import (
     create_ok_refundable_ctc,
     create_ok_refundable_ctc_reform,
     ok_refundable_ctc,

--- a/policyengine_us/reforms/states/ok/ctc/ok_refundable_ctc_reform.py
+++ b/policyengine_us/reforms/states/ok/ctc/ok_refundable_ctc_reform.py
@@ -1,0 +1,109 @@
+from policyengine_us.model_api import *
+from policyengine_core.periods import period as period_
+
+
+def create_ok_refundable_ctc() -> Reform:
+    """
+    Oklahoma Refundable Child Care/Child Tax Credit Reform
+
+    Converts the Oklahoma Child Care/Child Tax Credit (the greater of 20%
+    of the federal CDCC or 5% of the federal CTC) from a nonrefundable
+    credit to a refundable credit. By default the credit is nonrefundable
+    under 68 O.S. § 2357 ("neither credit shall exceed the tax imposed").
+    """
+
+    class ok_refundable_child_care_child_tax_credit(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "Oklahoma refundable Child Care/Child Tax Credit"
+        unit = USD
+        definition_period = YEAR
+        defined_for = StateCode.OK
+
+        def formula(tax_unit, period, parameters):
+            # `ok_child_care_child_tax_credit` is the worksheet value —
+            # uncapped, since the baseline applies the liability limit in
+            # `ok_income_tax_before_refundable_credits` — so the full
+            # credit is paid as a refund.
+            return tax_unit("ok_child_care_child_tax_credit", period)
+
+    class ok_non_refundable_credits(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "Oklahoma nonrefundable income tax credits"
+        unit = USD
+        definition_period = YEAR
+        defined_for = StateCode.OK
+        # The baseline variable computes via `adds`. We replace it with a
+        # formula, so clear the inherited computation modes to avoid mixing
+        # `formula` with `adds`/`subtracts` (rejected by the core engine).
+        adds = None
+        subtracts = None
+
+        def formula(tax_unit, period, parameters):
+            # Sum the baseline nonrefundable list with the Child Care/Child
+            # Tax Credit filtered out — it is paid as refundable under this
+            # reform. Oklahoma applies a simple (unordered) liability cap
+            # downstream in `ok_income_tax_before_refundable_credits`, so a
+            # filtered sum is exact.
+            credits = parameters(period).gov.states.ok.tax.income.credits.nonrefundable
+            filtered = [
+                credit
+                for credit in list(credits)
+                if credit != "ok_child_care_child_tax_credit"
+            ]
+            return add(tax_unit, period, filtered)
+
+    class ok_refundable_credits(Variable):
+        value_type = float
+        entity = TaxUnit
+        label = "Oklahoma refundable income tax credits"
+        unit = USD
+        definition_period = YEAR
+        defined_for = StateCode.OK
+        # Clear the baseline's `adds` mode (see ok_non_refundable_credits).
+        adds = None
+        subtracts = None
+
+        def formula(tax_unit, period, parameters):
+            # Baseline refundable credits (ok_ptc, ok_stc, ok_eitc), resolved
+            # from the parameter list, plus the now-refundable Child
+            # Care/Child Tax Credit.
+            refundable = parameters(period).gov.states.ok.tax.income.credits.refundable
+            other_refundable = add(tax_unit, period, refundable)
+            refundable_cctc = tax_unit(
+                "ok_refundable_child_care_child_tax_credit", period
+            )
+            return other_refundable + refundable_cctc
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(ok_refundable_child_care_child_tax_credit)
+            self.update_variable(ok_non_refundable_credits)
+            self.update_variable(ok_refundable_credits)
+
+    return reform
+
+
+def create_ok_refundable_ctc_reform(parameters, period, bypass: bool = False):
+    if bypass:
+        return create_ok_refundable_ctc()
+
+    p = parameters.gov.contrib.states.ok.child_poverty_impact_dashboard.ctc
+
+    reform_active = False
+    current_period = period_(period)
+
+    for i in range(5):
+        if p(current_period).in_effect:
+            reform_active = True
+            break
+        current_period = current_period.offset(1, "year")
+
+    if reform_active:
+        return create_ok_refundable_ctc()
+    else:
+        return None
+
+
+ok_refundable_ctc = create_ok_refundable_ctc_reform(None, None, bypass=True)

--- a/policyengine_us/reforms/states/ok/ctc/ok_refundable_ctc_reform.py
+++ b/policyengine_us/reforms/states/ok/ctc/ok_refundable_ctc_reform.py
@@ -94,7 +94,7 @@ def create_ok_refundable_ctc_reform(parameters, period, bypass: bool = False):
     reform_active = False
     current_period = period_(period)
 
-    for i in range(5):
+    for _ in range(5):
         if p(current_period).in_effect:
             reform_active = True
             break

--- a/policyengine_us/tests/policy/contrib/states/ok/child_poverty_impact_dashboard/ctc/ok_refundable_ctc.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ok/child_poverty_impact_dashboard/ctc/ok_refundable_ctc.yaml
@@ -1,0 +1,66 @@
+# The reform pays the Oklahoma Child Care/Child Tax Credit as a refundable
+# credit. The worksheet variable (ok_child_care_child_tax_credit) is already
+# uncapped in baseline — the liability limit is applied downstream — so these
+# tests drive the credit from its federal inputs (5% of the federal CTC in
+# 2026) and check that the full amount is paid regardless of liability.
+
+- name: Case 1 - OK credit is paid in full as a refund when reform active
+  period: 2026
+  reforms: policyengine_us.reforms.states.ok.ctc.ok_refundable_ctc
+  input:
+    state_code: OK
+    adjusted_gross_income: 35_000
+    ok_agi: 35_000
+    cdcc: 0
+    ok_federal_ctc: 4_400
+  output:
+    ok_child_care_child_tax_credit: 220  # 4,400 * 0.05
+    ok_refundable_child_care_child_tax_credit: 220
+    ok_non_refundable_credits: 0  # the credit left the nonrefundable bucket
+
+- name: Case 2 - liability no longer caps the credit
+  period: 2026
+  reforms: policyengine_us.reforms.states.ok.ctc.ok_refundable_ctc
+  input:
+    state_code: OK
+    adjusted_gross_income: 35_000
+    ok_agi: 35_000
+    cdcc: 0
+    ok_federal_ctc: 6_600
+    ok_income_tax_before_credits: 100
+    ok_ptc: 0
+    ok_stc: 0
+    ok_eitc: 0
+  output:
+    ok_child_care_child_tax_credit: 330  # 6,600 * 0.05
+    # Nonrefundable bucket is empty, so pre-refundable tax stays at 100...
+    ok_income_tax_before_refundable_credits: 100
+    # ...and the full credit refunds past it: 100 - 330 = -230.
+    ok_refundable_credits: 330
+    ok_income_tax: -230
+
+- name: Case 3 - baseline refundable credits still count
+  period: 2026
+  reforms: policyengine_us.reforms.states.ok.ctc.ok_refundable_ctc
+  input:
+    state_code: OK
+    adjusted_gross_income: 35_000
+    ok_agi: 35_000
+    cdcc: 0
+    ok_federal_ctc: 4_400
+    ok_ptc: 0
+    ok_stc: 120
+    ok_eitc: 50
+  output:
+    ok_refundable_credits: 390  # 120 + 50 + 220
+
+- name: Case 4 - no credit for non-OK residents
+  period: 2026
+  reforms: policyengine_us.reforms.states.ok.ctc.ok_refundable_ctc
+  input:
+    state_code: CA
+    adjusted_gross_income: 35_000
+    cdcc: 0
+    ok_federal_ctc: 4_400
+  output:
+    ok_refundable_child_care_child_tax_credit: 0

--- a/policyengine_us/tests/policy/contrib/states/ok/child_poverty_impact_dashboard/ctc/ok_refundable_ctc.yaml
+++ b/policyengine_us/tests/policy/contrib/states/ok/child_poverty_impact_dashboard/ctc/ok_refundable_ctc.yaml
@@ -64,3 +64,79 @@
     ok_federal_ctc: 4_400
   output:
     ok_refundable_child_care_child_tax_credit: 0
+
+- name: Case 5 - baseline caps the credit at liability (no reform; contrast to Case 2)
+  period: 2026
+  input:
+    state_code: OK
+    adjusted_gross_income: 35_000
+    ok_agi: 35_000
+    cdcc: 0
+    ok_federal_ctc: 6_600
+    ok_income_tax_before_credits: 100
+    ok_ptc: 0
+    ok_stc: 0
+    ok_eitc: 0
+  output:
+    # Same inputs as Case 2 but WITHOUT the reform: the $330 credit is
+    # nonrefundable, capped at the $100 liability, so tax floors at $0 and
+    # nothing refunds -- the direct baseline contrast to Case 2's -230.
+    ok_child_care_child_tax_credit: 330
+    ok_income_tax: 0
+
+- name: Case 6 - credit fully absorbed by ample liability (reform; net unchanged)
+  period: 2026
+  reforms: policyengine_us.reforms.states.ok.ctc.ok_refundable_ctc
+  input:
+    state_code: OK
+    adjusted_gross_income: 35_000
+    ok_agi: 35_000
+    cdcc: 0
+    ok_federal_ctc: 6_600
+    ok_income_tax_before_credits: 1_000
+    ok_ptc: 0
+    ok_stc: 0
+    ok_eitc: 0
+  output:
+    # Liability ($1,000) exceeds the $330 credit, so the whole credit is used
+    # against tax: 1,000 - 330 = 670. Refundability only matters when the
+    # credit exceeds liability, so net tax matches baseline Case 6b.
+    ok_income_tax: 670
+
+- name: Case 6b - same inputs without the reform give the same net tax (invariance control)
+  period: 2026
+  input:
+    state_code: OK
+    adjusted_gross_income: 35_000
+    ok_agi: 35_000
+    cdcc: 0
+    ok_federal_ctc: 6_600
+    ok_income_tax_before_credits: 1_000
+    ok_ptc: 0
+    ok_stc: 0
+    ok_eitc: 0
+  output:
+    # Baseline: the $330 credit is nonrefundable but fully absorbed by the
+    # $1,000 liability (1,000 - 330 = 670) -- identical to Case 6.
+    ok_income_tax: 670
+
+- name: Case 7 - CDCC branch (20% of the federal CDCC) is paid refundably
+  period: 2026
+  reforms: policyengine_us.reforms.states.ok.ctc.ok_refundable_ctc
+  input:
+    state_code: OK
+    adjusted_gross_income: 35_000
+    ok_agi: 35_000
+    cdcc: 3_000
+    ok_federal_ctc: 0
+    ok_income_tax_before_credits: 0
+    ok_ptc: 0
+    ok_stc: 0
+    ok_eitc: 0
+  output:
+    # Credit is the greater of 20% of the federal CDCC ($3,000 -> $600) or 5%
+    # of the federal CTC ($0), so the CDCC path yields $600, paid in full as a
+    # refund past the $0 liability.
+    ok_child_care_child_tax_credit: 600
+    ok_refundable_child_care_child_tax_credit: 600
+    ok_income_tax: -600


### PR DESCRIPTION
Fixes #9394.

Adds `gov.contrib.states.ok.child_poverty_impact_dashboard.ctc.in_effect`, mirroring the MO/UT/OH/SC make-refundable conversions. When active:

- `ok_refundable_child_care_child_tax_credit` pays the full worksheet value (`ok_child_care_child_tax_credit` is already uncapped in baseline — the liability limit applies downstream) through `ok_refundable_credits`.
- `ok_non_refundable_credits` sums the baseline nonrefundable parameter list with the credit filtered out, so it is neither double-counted nor liability-capped. Oklahoma's cap is a simple downstream `max_(0, ...)`, so a filtered sum is exact (no ordered-cap walk needed, unlike UT).
- Baseline refundable credits (`ok_ptc`, `ok_stc`, `ok_eitc`) stay in via the parameter list, avoiding the drop-baseline-refundables hazard.

Baseline law is unchanged with the flag off (68 O.S. § 2357: "neither credit shall exceed the tax imposed").

Tests: 4 contrib YAML cases (full refund at zero liability, liability-independence, baseline-refundable aggregation, non-OK residents); OK baseline suite passes (335 tests).

Motivation: the Child Poverty Impact Dashboard's Oklahoma analysis shows a federal CTC expansion strands over half of the linked state credit's value above families' liability (43M worksheet vs 1M actual in a 2026 statewide run); this contrib enables the refundability counterfactual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014p5C4W5UC1MvusNZLuzFTf