### PR TITLE
Fix CCDF age group crashing on households with adults

### DIFF
--- a/changelog.d/fix-ccdf-age-group-enum.fixed.md
+++ b/changelog.d/fix-ccdf-age-group-enum.fixed.md
@@ -1,0 +1,1 @@
+Fixed `ccdf_age_group` crashing on anyone aged 13 or older by defaulting them to school age, so `ccdf_market_rate` and `spm_unit_ccdf_subsidy` compute for households that include adults.

--- a/policyengine_us/tests/policy/baseline/gov/hhs/ccdf/ccdf_age_group.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/ccdf/ccdf_age_group.yaml
@@ -43,3 +43,38 @@
     age: 10
   output:
     ccdf_age_group: SCHOOL_AGE
+
+# Everyone in the simulation gets an age group, not only eligible children.
+# Ages at or above the CCDF age limit (13) fall through to SCHOOL_AGE; without
+# an explicit select default they used to become an integer 0 that could not
+# be encoded as a CCDFAgeGroup, crashing every household with an adult in it.
+- name: Age 13, the CCDF age limit, still resolves to school age
+  period: 2026
+  input:
+    age: 13
+  output:
+    ccdf_age_group: SCHOOL_AGE
+
+- name: Adult resolves to school age rather than an unencodable value
+  period: 2026
+  input:
+    age: 35
+  output:
+    ccdf_age_group: SCHOOL_AGE
+
+- name: Household with two adults and a preschooler, adults listed first
+  period: 2026
+  input:
+    people:
+      worker:
+        age: 35
+      home:
+        age: 33
+      kid:
+        age: 3
+    households:
+      household:
+        members: [worker, home, kid]
+        state_code: VA
+  output:
+    ccdf_age_group: [SCHOOL_AGE, SCHOOL_AGE, PRESCHOOLER]

--- a/policyengine_us/tests/policy/baseline/gov/hhs/ccdf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/hhs/ccdf/integration.yaml
@@ -1,0 +1,91 @@
+# Integration tests for the federal CCDF subsidy chain on whole households.
+# Every person in a simulation is assigned a ccdf_age_group and a
+# ccdf_market_rate, so the chain must compute cleanly for adults, not only for
+# eligible children. These cases run the full path from ages, childcare hours,
+# and geography through ccdf_age_group, ccdf_market_rate, is_ccdf_eligible,
+# spm_unit_total_ccdf_copay, and spm_unit_ccdf_subsidy. Adults are listed
+# before the child in both cases; that ordering is the one that used to raise
+# "Invalid value(s) ['0', 'CCDFAgeGroup.PRESCHOOLER']" from the enum encoder.
+
+- name: Two-adult Virginia household with a preschooler and no childcare hours computes without error
+  period: 2026
+  input:
+    people:
+      worker:
+        age: 35
+        employment_income: 45_000
+      home:
+        age: 33
+        employment_income: 0
+      kid:
+        age: 3
+    marital_units:
+      marital_unit:
+        members: [worker, home]
+      kid_marital_unit:
+        members: [kid]
+    tax_units:
+      tax_unit:
+        members: [worker, home, kid]
+    spm_units:
+      spm_unit:
+        members: [worker, home, kid]
+    households:
+      household:
+        members: [worker, home, kid]
+        state_code: VA
+  output:
+    ccdf_age_group: [SCHOOL_AGE, SCHOOL_AGE, PRESCHOOLER]
+    is_ccdf_age_eligible: [false, false, true]
+    # No childcare hours, so the market rate annualizes to zero for everyone.
+    ccdf_market_rate: [0, 0, 0]
+    spm_unit_ccdf_subsidy: 0
+
+- name: Two-adult Nassau County household with a preschooler in full-time center care
+  period: 2026
+  absolute_error_margin: 0.1
+  input:
+    people:
+      worker:
+        age: 35
+        employment_income: 45_000
+      home:
+        age: 33
+        employment_income: 0
+      kid:
+        age: 3
+        childcare_hours_per_day: 8
+        childcare_days_per_week: 5
+    marital_units:
+      marital_unit:
+        members: [worker, home]
+      kid_marital_unit:
+        members: [kid]
+    tax_units:
+      tax_unit:
+        members: [worker, home, kid]
+    spm_units:
+      spm_unit:
+        members: [worker, home, kid]
+        # meets_ccdf_activity_test is a pure input; nothing derives it from hours.
+        meets_ccdf_activity_test: true
+        # Pinned so the copay does not move with poverty guideline updates.
+        spm_unit_fpg: 27_320
+    households:
+      household:
+        members: [worker, home, kid]
+        state_code: NY
+        county: NASSAU_COUNTY_NY
+  output:
+    ccdf_age_group: [SCHOOL_AGE, SCHOOL_AGE, PRESCHOOLER]
+    # 40 hours per week of care is the weekly duration; the adults have no
+    # hours and fall to the hourly duration with zero periods.
+    ccdf_duration_of_care: [HOURLY, HOURLY, WEEKLY]
+    ccdf_county_cluster: 1
+    # Cluster 1, DCC_SACC, weekly, preschooler: 310 per week x 52 weeks = 16,120.
+    ccdf_market_rate: [0, 0, 16_120]
+    is_ccdf_eligible: [false, false, true]
+    # Income above the pinned poverty guideline times the Nassau County share.
+    spm_unit_total_ccdf_copay: (45_000 - 27_320) * 0.2
+    # Market rate less the copay.
+    spm_unit_ccdf_subsidy: 310 * 52 - (45_000 - 27_320) * 0.2

--- a/policyengine_us/variables/gov/hhs/ccdf/ccdf_age_group.py
+++ b/policyengine_us/variables/gov/hhs/ccdf/ccdf_age_group.py
@@ -23,17 +23,21 @@ class ccdf_age_group(Variable):
     def formula(person, period, parameters):
         age = person("age", period)
         home_based = person("is_ccdf_home_based", period)
+        # Every person in the simulation gets an age group, including adults.
+        # Without an explicit default, numpy's select fills unmatched rows
+        # (age >= 13) with the integer 0, which cannot be encoded as a
+        # CCDFAgeGroup. Anyone past the school-age bracket stays SCHOOL_AGE;
+        # is_ccdf_age_eligible screens them out of the subsidy.
         return select(
             [
                 ((age < 1.5) & ~home_based) | ((age < 2) & home_based),
                 ((age < 2) & ~home_based) | ((age < 3) & home_based),
                 age < 6,
-                age < 13,
             ],
             [
                 CCDFAgeGroup.INFANT,
                 CCDFAgeGroup.TODDLER,
                 CCDFAgeGroup.PRESCHOOLER,
-                CCDFAgeGroup.SCHOOL_AGE,
             ],
+            default=CCDFAgeGroup.SCHOOL_AGE,
         )


### PR DESCRIPTION
## Summary

Calculating `spm_unit_ccdf_subsidy` (or `ccdf_market_rate`, or `ccdf_age_group` itself) crashed for any household containing a person aged 13 or older. For a Virginia household with two adults (35 and 33) and a 3-year-old, `Simulation(situation=...).calculate("spm_unit_ccdf_subsidy", 2026)` raised:

```
ValueError: Invalid value(s) ['0', 'CCDFAgeGroup.PRESCHOOLER'] for enum CCDFAgeGroup. Valid values are: ['INFANT', 'TODDLER', 'PRESCHOOLER', 'SCHOOL_AGE']
```

The exact text depends on who is listed first. A child listed first gives `AttributeError: 'int' object has no attribute 'index'`, and an adults-only household gives `Invalid value(s) ['0']`. The state path (`va_child_care_subsidies`) computed fine; only the federal generic path failed.

## Root cause

`ccdf_age_group` built its result with `select(conditions, [CCDFAgeGroup items])` and no `default`. `select` here is numpy's `np.select`, whose default is the integer `0`. For every person no condition matched (age ≥ 13, so every adult) the result was an object array mixing `0` with `CCDFAgeGroup` members.

policyengine-core's `Enum.encode` takes its Enum-item fast path only when the *first* element is an Enum. With an adult first, the array is cast to strings (`'0'`, `'CCDFAgeGroup.PRESCHOOLER'`) and the string lookup rejects both. With a child first, the fast path hits `AttributeError` on `0.index`.

Before policyengine-core 3.22.0 the string path encoded unmatched values as index 0 (INFANT) with no warning, so the adults-first case silently produced INFANT for adults and, because `str(CCDFAgeGroup.PRESCHOOLER)` is not a member name, for the children too. Core 3.22.0 added a warning and 3.23.0 (December 2025) made it raise. This repo requires core ≥ 3.30.1, which is what surfaced the bug. The child-first ordering has always raised.

## Fix

Drop the redundant `age < 13` branch and give the select an explicit `default=CCDFAgeGroup.SCHOOL_AGE`. Children under 13 get the same answer as before (verified over a dense age grid for both home-based and center-based care). Anyone 13 or older (the CCDF age limit in `gov.hhs.ccdf.age_limit`) now resolves to SCHOOL_AGE instead of an unencodable 0. `is_ccdf_age_eligible` already screens them out of the subsidy, so no subsidy amount changes for eligible children. `in_ccdf_age_group` already uses this pattern.

## Tests

- `ccdf_age_group.yaml`: age 13 boundary, an adult, and a mixed adult/preschooler household with the adults listed first.
- New `integration.yaml`: the reported Virginia household (computes, subsidy 0 with no childcare hours) and a Nassau County household with a preschooler in full-time center care ($310/wk × 52 = $16,120 market rate, $3,536 copay, $12,584 subsidy).
- All 71 tests under `policyengine_us/tests/policy/baseline/gov/hhs/ccdf` pass. All 5 new cases fail on unfixed `main` (04a961a) with the same ValueError: the three mixed-household cases with the exact message above, the two single-person cases with `Invalid value(s) ['0']`.
- A 55-person vectorised simulation with adults first across five states computes the whole chain without error.

## Related

- #9401 (commit 1 of #9355, split out) deletes this whole path; if it lands first, this PR closes. Issue #9283 and PR #9355 propose deleting the federal (legacy New York) CCDF path as inert; #7766 is the older tracking issue. This fix is small and self-contained so the crash stops for anyone calling these variables today. If #9355 lands first, this PR can simply close. If this lands first, #9355 needs a rebase that also deletes the new `integration.yaml`.
- Swept every Enum-valued variable for `select` calls without a `default` keyword: 111 calls, 5 without it. Three are exhaustive by construction (`pell_grant_household_type`, `state_filing_status_if_married_filing_separately_on_same_return`, `age_group`) and `il_personal_exemption_eligibility_status` passes its default positionally. `md_ccs_service_unit` would hit the same failure only for negative or NaN childcare hours, which its bracket maps to unit 0; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

