### PR TITLE
Give md_ccs_service_unit an explicit UNIT_1 select default

### DIFF
--- a/changelog.d/fix-md-ccs-service-unit-enum-default.fixed.md
+++ b/changelog.d/fix-md-ccs-service-unit-enum-default.fixed.md
@@ -1,0 +1,1 @@
+Gave `md_ccs_service_unit` an explicit `UNIT_1` default so negative or NaN childcare hours resolve to one unit instead of an integer 0 that cannot be encoded as a service unit.

--- a/policyengine_us/tests/policy/baseline/gov/states/md/msde/ccs/edge_cases.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/msde/ccs/edge_cases.yaml
@@ -459,3 +459,36 @@
     # Negative self-employment income does not inflate benefit (benefit formula
     # uses expenses - copay, not income-based formula)
     md_ccs: 793
+
+# === Negative childcare hours ===
+
+- name: Case 38, negative childcare hours per day gets the hourly rate like zero hours.
+  period: 2025-01
+  absolute_error_margin: 0.1
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 50_000
+        is_tax_unit_head_or_spouse: true
+        weekly_hours_worked: 40
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+        immigration_status: CITIZEN
+        childcare_hours_per_day: -1
+        md_ccs_provider_type: LICENSED_CENTER
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+  output:
+    # -1 hrs/day -> unit_hours bracket returns 0 units -> select default UNIT_1
+    # -> $1/week, the same as zero hours (Case 36)
+    md_ccs_weekly_copay: 1

--- a/policyengine_us/tests/policy/baseline/gov/states/md/msde/ccs/md_ccs_payment_rate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/msde/ccs/md_ccs_payment_rate.yaml
@@ -216,3 +216,34 @@
     # 2027-01 uses post-2026-03-01 schedule (60th percentile of 2024 MRS).
     # Region W, Family, REGULAR (age 4), UNIT_3 (8hrs): $262/week
     md_ccs_payment_rate: [0, 262]
+
+- name: Licensed center, Region X (Howard), regular age, negative hours falls to one unit.
+  period: 2026-01
+  absolute_error_margin: 0.1
+  input:
+    people:
+      person1:
+        age: 30
+        employment_income: 40_000
+        is_tax_unit_head_or_spouse: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+        immigration_status: CITIZEN
+        childcare_hours_per_day: -1
+        md_ccs_provider_type: LICENSED_CENTER
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MD
+        county: HOWARD_COUNTY_MD
+  output:
+    # Negative hours -> 0 units from the bracket -> select default UNIT_1.
+    # Region X, Center, REGULAR (age 5), UNIT_3 base $381/week x 1/3 = $127/week
+    md_ccs_payment_rate: [0, 127]

--- a/policyengine_us/tests/policy/baseline/gov/states/md/msde/ccs/md_ccs_service_unit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/md/msde/ccs/md_ccs_service_unit.yaml
@@ -85,3 +85,55 @@
         state_code: MD
   output:
     md_ccs_service_unit: [UNIT_3]
+
+# Out-of-range hours. The unit_hours bracket returns 0 for negative hours,
+# which none of the three units match. The select's explicit UNIT_1 default
+# keeps those rows a valid MDCCSServiceUnit instead of an integer 0 that
+# cannot be encoded as one; UNIT_1 matches the treatment of zero hours.
+
+- name: Negative hours is UNIT_1 (out-of-range input falls to the lowest unit).
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 3
+        childcare_hours_per_day: -2
+    households:
+      household:
+        members: [person1]
+        state_code: MD
+  output:
+    md_ccs_service_unit: [UNIT_1]
+
+- name: Adult with no hours listed first, child with negative hours second.
+  period: 2025-01
+  input:
+    people:
+      parent:
+        age: 30
+      child:
+        age: 3
+        childcare_hours_per_day: -1
+    households:
+      household:
+        members: [parent, child]
+        state_code: MD
+  output:
+    md_ccs_service_unit: [UNIT_1, UNIT_1]
+
+- name: Child with negative hours listed first, full-time sibling second.
+  period: 2025-01
+  input:
+    people:
+      child1:
+        age: 3
+        childcare_hours_per_day: -1
+      child2:
+        age: 5
+        childcare_hours_per_day: 8
+    households:
+      household:
+        members: [child1, child2]
+        state_code: MD
+  output:
+    md_ccs_service_unit: [UNIT_1, UNIT_3]

--- a/policyengine_us/tests/test_md_ccs_service_unit_enum_default.py
+++ b/policyengine_us/tests/test_md_ccs_service_unit_enum_default.py
@@ -73,10 +73,13 @@ def test_negative_hours_encode_as_unit_1_regardless_of_row_order():
 
 def test_nan_hours_encode_as_unit_1():
     # Core rejects NaN as a direct input, so drive the formula with a NaN
-    # array to cover the other value the bracket maps to 0 units.
-    sim = _simulation({"child": 0.0})
+    # array to cover the other value the bracket maps to 0 units. Seed the
+    # input with full-time hours so a failed injection would surface as
+    # UNIT_3 rather than pass by coincidence.
+    sim = _simulation({"child": 8.0})
     holder = sim.persons.get_holder("childcare_hours_per_day")
     holder.put_in_cache(np.array([np.nan]), make_period(2025), sim.branch_name)
+    assert np.isnan(sim.calculate("childcare_hours_per_day", 2025)).all()
     assert _encode(sim, _raw_formula_output(sim)) == ["UNIT_1"]
 
 

--- a/policyengine_us/tests/test_md_ccs_service_unit_enum_default.py
+++ b/policyengine_us/tests/test_md_ccs_service_unit_enum_default.py
@@ -1,0 +1,86 @@
+"""Regression test for the `md_ccs_service_unit` select default.
+
+Follow-up to PolicyEngine/policyengine-us#9400, which fixed the same bug
+class in `ccdf_age_group`: a `select(conditions, [Enum items])` with no
+`default` fills unmatched rows with numpy's integer 0, and
+policyengine-core's `Enum.encode` rejects an object array that mixes
+Enum members with that 0 (`AttributeError: 'int' object has no attribute
+'index'` when an Enum member comes first, `ValueError: Invalid value(s)
+['0', ...]` otherwise).
+
+`md_ccs_service_unit` hit the unmatched case for negative or NaN
+`childcare_hours_per_day`, which its `unit_hours` bracket maps to 0 units.
+The full simulation happened not to crash because the variable's
+`defined_for` path in core turns a bare integer into an Enum index before
+encoding, and index 0 is UNIT_1. That is a coincidence of member order,
+not a rule, so these tests encode the raw formula output directly, which
+is the path a variable without `defined_for` takes.
+
+The Enum class is taken from the loaded variable rather than imported by
+package path: the tax-benefit system loads variable modules by file, so
+the package-path import is a distinct class object and `isinstance`
+against it is always False.
+"""
+
+import numpy as np
+from policyengine_core.periods import period as make_period
+
+from policyengine_us import Simulation
+
+PERIOD = "2025-01"
+
+
+def _simulation(hours_by_person: dict) -> Simulation:
+    people = {
+        name: {"age": {2025: 4}, "childcare_hours_per_day": {2025: hours}}
+        for name, hours in hours_by_person.items()
+    }
+    return Simulation(
+        situation={
+            "people": people,
+            "households": {
+                "household": {
+                    "members": list(people),
+                    "state_code": {2025: "MD"},
+                }
+            },
+        }
+    )
+
+
+def _raw_formula_output(sim: Simulation) -> np.ndarray:
+    variable = sim.tax_benefit_system.variables["md_ccs_service_unit"]
+    period = make_period(PERIOD)
+    formula = variable.get_formula(period)
+    return formula(sim.persons, period, sim.tax_benefit_system.parameters)
+
+
+def _encode(sim: Simulation, raw: np.ndarray) -> list:
+    enum_class = sim.tax_benefit_system.variables["md_ccs_service_unit"].possible_values
+    assert all(isinstance(item, enum_class) for item in raw), raw
+    return list(enum_class.encode(raw).decode_to_str())
+
+
+def test_negative_hours_encode_as_unit_1_regardless_of_row_order():
+    # Enum member first, then the unmatched row (the AttributeError shape).
+    sim = _simulation({"zero": 0.0, "negative": -1.0})
+    assert _encode(sim, _raw_formula_output(sim)) == ["UNIT_1", "UNIT_1"]
+
+    # Unmatched row first (the ValueError shape).
+    sim = _simulation({"negative": -1.0, "full_time": 8.0})
+    assert _encode(sim, _raw_formula_output(sim)) == ["UNIT_1", "UNIT_3"]
+
+
+def test_nan_hours_encode_as_unit_1():
+    # Core rejects NaN as a direct input, so drive the formula with a NaN
+    # array to cover the other value the bracket maps to 0 units.
+    sim = _simulation({"child": 0.0})
+    holder = sim.persons.get_holder("childcare_hours_per_day")
+    holder.put_in_cache(np.array([np.nan]), make_period(2025), sim.branch_name)
+    assert _encode(sim, _raw_formula_output(sim)) == ["UNIT_1"]
+
+
+def test_full_simulation_matches_zero_hours_treatment():
+    sim = _simulation({"negative": -1.0, "zero": 0.0, "full_time": 8.0})
+    units = sim.calculate("md_ccs_service_unit", PERIOD).decode_to_str()
+    assert list(units) == ["UNIT_1", "UNIT_1", "UNIT_3"]

--- a/policyengine_us/variables/gov/states/md/msde/ccs/payment/md_ccs_service_unit.py
+++ b/policyengine_us/variables/gov/states/md/msde/ccs/payment/md_ccs_service_unit.py
@@ -15,17 +15,24 @@ class md_ccs_service_unit(Variable):
     definition_period = MONTH
     defined_for = StateCode.MD
     label = "Maryland CCS service unit category"
-    reference = "https://regs.maryland.gov/us/md/exec/comar/13A.14.06.11"
+    reference = (
+        "https://regs.maryland.gov/us/md/exec/comar/13A.14.06.02",
+        "https://regs.maryland.gov/us/md/exec/comar/13A.14.06.11",
+    )
 
     def formula(person, period, parameters):
         hours_per_day = person("childcare_hours_per_day", period.this_year)
         p = parameters(period).gov.states.md.msde.ccs.copay
         units = p.unit_hours.calc(hours_per_day)
+        # COMAR 13A.14.06.02B(59): one unit is 3 hours or less per day, two
+        # units more than 3 but less than 6, three units 6 or more. The
+        # bracket returns 0 for negative or NaN hours, which no unit matches;
+        # without an explicit default numpy's select would fill those rows
+        # with the integer 0, which cannot be encoded as an MDCCSServiceUnit.
+        # Anything at or below the one-unit ceiling, including out-of-range
+        # hours, is one unit, matching how zero hours is already treated.
         return select(
-            [units == 3, units == 2, units == 1],
-            [
-                MDCCSServiceUnit.UNIT_3,
-                MDCCSServiceUnit.UNIT_2,
-                MDCCSServiceUnit.UNIT_1,
-            ],
+            [units == 3, units == 2],
+            [MDCCSServiceUnit.UNIT_3, MDCCSServiceUnit.UNIT_2],
+            default=MDCCSServiceUnit.UNIT_1,
         )

--- a/policyengine_us/variables/gov/states/md/msde/ccs/payment/md_ccs_service_unit.py
+++ b/policyengine_us/variables/gov/states/md/msde/ccs/payment/md_ccs_service_unit.py
@@ -26,11 +26,11 @@ class md_ccs_service_unit(Variable):
         units = p.unit_hours.calc(hours_per_day)
         # COMAR 13A.14.06.02B(59): one unit is 3 hours or less per day, two
         # units more than 3 but less than 6, three units 6 or more. The
-        # bracket returns 0 for negative or NaN hours, which no unit matches;
-        # without an explicit default numpy's select would fill those rows
-        # with the integer 0, which cannot be encoded as an MDCCSServiceUnit.
-        # Anything at or below the one-unit ceiling, including out-of-range
-        # hours, is one unit, matching how zero hours is already treated.
+        # bracket returns 0 for out-of-range hours (negative, NaN, infinite),
+        # which no unit matches; without an explicit default numpy's select
+        # would fill those rows with the integer 0, which cannot be encoded
+        # as an MDCCSServiceUnit. Unmatched values fall back to one unit as
+        # a defensive choice, consistent with how zero hours is treated.
         return select(
             [units == 3, units == 2],
             [MDCCSServiceUnit.UNIT_3, MDCCSServiceUnit.UNIT_2],


### PR DESCRIPTION
## Summary

Follow-up to [PolicyEngine/policyengine-us#9400](https://github.com/PolicyEngine/policyengine-us/pull/9400). That PR's sweep of Enum-valued variables found `md_ccs_service_unit` as the one remaining `select` whose conditions are not exhaustive. Its `unit_hours` bracket returns 0 units for negative or NaN `childcare_hours_per_day` (verified: `calc([-1, 0, 2, 3, 3.0001, 6, 10, nan])` gives `[0, 1, 1, 1, 2, 3, 3, 0]`), and no condition matched 0, so numpy's `select` filled those rows with the integer 0.

## What happens today

- The raw formula output for a household with an adult (0 hours) and a child with -1 hours is the object array `[UNIT_1, 0]`. Encoding that directly raises `AttributeError: 'int' object has no attribute 'index'`; with the unmatched row first it raises `ValueError: Invalid value(s) ['0', 'MDCCSServiceUnit.UNIT_1'] for enum MDCCSServiceUnit`.
- A full `Simulation` does **not** crash today. The variable has `defined_for = StateCode.MD`, and policyengine-core's `defined_for` path (`simulation.py`: `np.where(mask, array, default_value)` followed by `item.index if isinstance(item, Enum) else item`) passes the bare 0 through as Enum index 0, which happens to be UNIT_1. Setting `defined_for = None` on the loaded variable reproduces the crash. So the current answer is right by coincidence of member order; this PR makes it right by rule.

## Fix

Drop the redundant `units == 1` branch and give the select `default=MDCCSServiceUnit.UNIT_1`, mirroring #9400. UNIT_1 is the semantically right default: COMAR 13A.14.06.02B(59)(a) defines one unit as 3 hours or less per day, so anything at or below that ceiling, including out-of-range hours, is one unit. It also matches how zero hours is already treated. No output changes for any hours at or above 0 (units 1, 2, 3 map exactly as before); negative hours keep producing UNIT_1. The variable's `reference` now cites the definitions section (13A.14.06.02) alongside the payment section (.11).

Consumers are consistent with the zero-hours treatment: `md_ccs_weekly_copay` charges $1/week for UNIT_1 (eligible children only; eligibility does not depend on hours) and `md_ccs_payment_rate` scales the UNIT_3 base rate by 1/3.

Considered and not done: clamping with `max_(hours, 0)`. It is redundant given the default for negative hours, and `numpy.maximum` propagates NaN, so it would not cover the NaN case anyway. NaN cannot be supplied as a direct input (core rejects it in `set_input`); the default guards the computed path regardless.

## Tests

- `md_ccs_service_unit.yaml`: negative hours alone; an adult listed first with a negative-hours child second (the ordering that raises `AttributeError` on the raw path); a negative-hours child first with a full-time sibling (the `ValueError` ordering).
- `edge_cases.yaml` Case 38: negative hours give the $1/week copay, the same as Case 36 (zero hours).
- `md_ccs_payment_rate.yaml`: negative hours in a Region X licensed center give $127/week ($381 UNIT_3 base × 1/3).
- New `policyengine_us/tests/test_md_ccs_service_unit_enum_default.py` (collected by `make test-other-python`): encodes the raw formula output directly, which is the path a variable without `defined_for` takes, for both row orderings and for NaN. Two of its three tests fail on unfixed `main` (04a961a) with the object array `[UNIT_1, 0]`; all three pass with the fix.
- The YAML cases also pass on unfixed `main` because of the `defined_for` passthrough, so they pin the intended behaviour rather than catch the crash; the pytest is the regression guard.
- All 86 MD CCS YAML tests pass:

```
.venv/bin/policyengine-core test policyengine_us/tests/policy/baseline/gov/states/md/msde/ccs -c policyengine_us
```

- `uvx ruff@0.9.0 format` and `ruff check` are clean on the changed Python files. Local environment: Python 3.14.4, policyengine-core 3.30.2.

## Related

- [#9400](https://github.com/PolicyEngine/policyengine-us/pull/9400) fixes the same bug class in `ccdf_age_group` and left this variable for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
