### PR TITLE
Count general assistance and workers compensation in Minnesota MFIP

### DIFF
--- a/changelog.d/mn_mfip-general-assistance.fixed.md
+++ b/changelog.d/mn_mfip-general-assistance.fixed.md
@@ -1,0 +1,1 @@
+Count general assistance cash payments as unearned income for Minnesota MFIP.

--- a/changelog.d/mn_mfip-general-assistance.fixed.md
+++ b/changelog.d/mn_mfip-general-assistance.fixed.md
@@ -1,1 +1,1 @@
-Count general assistance cash payments as unearned income for Minnesota MFIP.
+Count general assistance and workers compensation as Minnesota MFIP unearned income.

--- a/policyengine_us/parameters/gov/states/mn/dcyf/mfip/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/mn/dcyf/mfip/income/sources/unearned.yaml
@@ -1,6 +1,5 @@
 description: Minnesota counts these income sources as unearned income under the Minnesota Family Investment Program.
-# Preserve the inherited baseline list and its start date; this corrects the
-# omitted general assistance source rather than introducing a new policy.
+# Preserve the inherited start date while correcting the modeled sources.
 values:
   2010-07-01:
     - veterans_benefits
@@ -14,6 +13,7 @@ values:
     - miscellaneous_income
     - pension_income
     - unemployment_compensation
+    - workers_compensation
     - gi_cash_assistance
     - social_security
     # MFIP counts GA, RCA and cash benefits already issued (0017.12.03).

--- a/policyengine_us/parameters/gov/states/mn/dcyf/mfip/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/mn/dcyf/mfip/income/sources/unearned.yaml
@@ -1,0 +1,32 @@
+description: Minnesota counts these income sources as unearned income under the Minnesota Family Investment Program.
+# Preserve the inherited baseline list and its start date; this corrects the
+# omitted general assistance source rather than introducing a new policy.
+values:
+  2010-07-01:
+    - veterans_benefits
+    - survivor_benefits
+    - rental_income
+    - child_support_received
+    - alimony_income
+    - financial_assistance
+    - dividend_income
+    - interest_income
+    - miscellaneous_income
+    - pension_income
+    - unemployment_compensation
+    - gi_cash_assistance
+    - social_security
+    # MFIP counts GA, RCA and cash benefits already issued (0017.12.03).
+    # Receipt-of-other-assistance rules in 0011.21 are separate eligibility
+    # rules; this input represents cash received by an assistance-unit member.
+    - general_assistance
+
+metadata:
+  unit: list
+  period: year
+  label: Minnesota MFIP unearned income sources
+  reference:
+    - title: Minnesota Combined Manual, 0017.12.03 - Unearned Income, MFIP
+      href: https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=cm_00171203
+    - title: Minnesota Combined Manual, 0011.21 - Receipt of Other Assistance
+      href: https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=cm_001121

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/integration.yaml
@@ -292,3 +292,67 @@
     # Gross: max(3201-0, 0) = 3,201
     # Cash: max(3201-1844, 0) = 1,357
     mn_mfip: 1_357
+
+# General assistance is unearned cash income: $2,400/year = $200/month.
+# With no earnings, subtract it dollar for dollar from the existing cash benefit.
+# $24,000/year = $2,000/month exceeds the income limit.
+
+- name: Case 8, general assistance reduces the cash benefit.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 2_400
+      person2:
+        age: 8
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        spm_unit_cash_assets: 5_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MN
+  output:
+    spm_unit_count_children: 1
+    mn_mfip_countable_earned_income: 0
+    mn_mfip_countable_unearned_income: 200
+    mn_mfip_cash_portion: 642
+    mn_mfip_food_portion: 445
+    mn_mfip_family_wage_level: 1_195.7
+    mn_mfip_income_eligible: true
+    mn_mfip_resources_eligible: true
+    mn_mfip_eligible: true
+    mn_mfip: 442
+
+- name: Case 9, general assistance makes the family income ineligible.
+  period: 2025-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 24_000
+      person2:
+        age: 8
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        spm_unit_cash_assets: 5_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MN
+  output:
+    spm_unit_count_children: 1
+    mn_mfip_countable_earned_income: 0
+    mn_mfip_countable_unearned_income: 2_000
+    mn_mfip_cash_portion: 642
+    mn_mfip_food_portion: 445
+    mn_mfip_family_wage_level: 1_195.7
+    mn_mfip_income_eligible: false
+    mn_mfip_resources_eligible: true
+    mn_mfip_eligible: false
+    mn_mfip: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/integration.yaml
@@ -356,3 +356,44 @@
     mn_mfip_resources_eligible: true
     mn_mfip_eligible: false
     mn_mfip: 0
+
+- name: Workers compensation reduces the monthly cash benefit.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 30
+        workers_compensation: 2400
+      child:
+        age: 8
+    spm_units:
+      unit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+        state_code: MN
+  output:
+    mn_mfip: 461
+
+- name: Interest and dividends continue to reduce the monthly cash benefit.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 30
+        taxable_interest_income: 1200
+        dividend_income: 1200
+      child:
+        age: 8
+    spm_units:
+      unit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+        state_code: MN
+  output:
+    mn_mfip: 461

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/mn_mfip_countable_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/mn_mfip_countable_unearned_income.yaml
@@ -1,0 +1,20 @@
+- name: Case 1, general assistance and child support across members.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 2_400
+      person2:
+        age: 8
+        child_support_received: 3_600
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MN
+  output:
+    # Gross $200 GA + $300 child support; existing child support rules apply.
+    mn_mfip_countable_unearned_income: 400

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/mn_mfip_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/mn_mfip_gross_unearned_income.yaml
@@ -1,0 +1,38 @@
+- name: Case 1, general assistance is counted monthly and the federal baseline is unchanged.
+  period: 2026-01
+  input:
+    state_code: MN
+    general_assistance: 2_400
+  output:
+    mn_mfip_gross_unearned_income: 200
+    tanf_gross_unearned_income: 0
+
+- name: Case 2, existing unearned sources are preserved without general assistance.
+  period: 2026-01
+  input:
+    state_code: MN
+    general_assistance: 0
+    social_security: 3_600
+    child_support_received: 1_200
+    financial_assistance: 600
+  output:
+    mn_mfip_gross_unearned_income: 450
+    tanf_gross_unearned_income: 450
+
+- name: Case 3, earnings and SSI are excluded from gross unearned income.
+  period: 2026-01
+  input:
+    state_code: MN
+    employment_income_before_lsr: 12_000
+    ssi: 6_000
+    general_assistance: 2_400
+  output:
+    mn_mfip_gross_unearned_income: 200
+
+- name: Case 4, state gross unearned income is zero outside the state.
+  period: 2026-01
+  input:
+    state_code: ME
+    general_assistance: 2_400
+  output:
+    mn_mfip_gross_unearned_income: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/mn_mfip_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/mn/dcyf/mfip/mn_mfip_gross_unearned_income.yaml
@@ -36,3 +36,23 @@
     general_assistance: 2_400
   output:
     mn_mfip_gross_unearned_income: 0
+
+- name: Workers compensation is countable unearned income.
+  period: 2026-01
+  input:
+    state_code: MN
+    workers_compensation: 2400
+  output:
+    mn_mfip_gross_unearned_income: 200
+
+- name: Workers compensation adds to general assistance, interest, and dividends.
+  period: 2026-01
+  input:
+    state_code: MN
+    workers_compensation: 2400
+    general_assistance: 1200
+    taxable_interest_income: 600
+    tax_exempt_interest_income: 600
+    dividend_income: 1200
+  output:
+    mn_mfip_gross_unearned_income: 500

--- a/policyengine_us/variables/gov/states/mn/dcyf/mfip/income/unearned/mn_mfip_countable_unearned_income.py
+++ b/policyengine_us/variables/gov/states/mn/dcyf/mfip/income/unearned/mn_mfip_countable_unearned_income.py
@@ -11,5 +11,5 @@ class mn_mfip_countable_unearned_income(Variable):
     defined_for = StateCode.MN
     # Per MN Stat. 256P.06, Subd. 3:
     # Gross unearned income minus child support exclusion (up to $100/1 child, $200/2+).
-    adds = ["tanf_gross_unearned_income"]
+    adds = ["mn_mfip_gross_unearned_income"]
     subtracts = ["mn_mfip_child_support_income_exclusion"]

--- a/policyengine_us/variables/gov/states/mn/dcyf/mfip/income/unearned/mn_mfip_gross_unearned_income.py
+++ b/policyengine_us/variables/gov/states/mn/dcyf/mfip/income/unearned/mn_mfip_gross_unearned_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class mn_mfip_gross_unearned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Minnesota MFIP gross unearned income"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=cm_00171203"
+    defined_for = StateCode.MN
+
+    adds = "gov.states.mn.dcyf.mfip.income.sources.unearned"


### PR DESCRIPTION
Minnesota MFIP omits General Assistance and workers’ compensation because its unearned-income calculation uses the shared TANF baseline. This PR adds an explicit Minnesota list and gross-income variable, then uses it in the existing countable-income calculation. Interest, dividends, and the child-support exclusion retain their existing treatment.

For a parent and child in January 2026, $200/month of workers’ compensation now reduces MFIP cash from $661 to $461. General Assistance is also counted as unearned income.

[Combined Manual 0017.12.03](https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=cm_00171203) explicitly lists workers’ compensation and GA as unearned income. [0011.21](https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=cm_001121) separately governs receipt of other assistance; concurrent-program eligibility and transition administration remain outside this change.

Addresses the Minnesota portion of #9390. Companion PRs: #9413 and #9414. Keep #9390 open until all three fixes merge.

The list retains the inherited start date to preserve model history, rather than implying a new enactment date. Shared federal parameters are unchanged. This corrects the identified omissions, rather than claiming a complete audit of every income subtype.

Validation: all 71 Minnesota MFIP tests pass, including General Assistance and workers’ compensation benefit reductions, combined-source aggregation, interest/dividend controls, child support, state scoping, and income ineligibility. Formatting/lint and git diff checks pass. The additional review regressions are in existing test files; partner tests are unchanged.
