### PR TITLE
Correct North Dakota TANF unearned income sources

### DIFF
--- a/changelog.d/nd_tanf-general-assistance.fixed.md
+++ b/changelog.d/nd_tanf-general-assistance.fixed.md
@@ -1,1 +1,1 @@
-Count general assistance cash payments as unearned income for North Dakota TANF.
+Correct North Dakota TANF unearned income by counting general assistance and workers compensation and excluding ordinary interest and dividends.

--- a/changelog.d/nd_tanf-general-assistance.fixed.md
+++ b/changelog.d/nd_tanf-general-assistance.fixed.md
@@ -1,0 +1,1 @@
+Count general assistance cash payments as unearned income for North Dakota TANF.

--- a/policyengine_us/parameters/gov/states/nd/dhs/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/nd/dhs/tanf/income/sources/unearned.yaml
@@ -1,6 +1,5 @@
 description: North Dakota counts these income sources as unearned income under the Temporary Assistance for Needy Families program.
-# Preserve the inherited baseline list and its start date; this corrects the
-# omitted general assistance source rather than introducing a new policy.
+# Preserve the inherited start date while correcting the modeled sources.
 values:
   2010-07-01:
     - veterans_benefits
@@ -9,11 +8,12 @@ values:
     - child_support_received
     - alimony_income
     - financial_assistance
-    - dividend_income
-    - interest_income
+    # Section 400-19-55-25 excludes ordinary investment interest/dividends.
     - miscellaneous_income
+    # Regular pension payments, including their interest, remain countable.
     - pension_income
     - unemployment_compensation
+    - workers_compensation
     - gi_cash_assistance
     - social_security
     # Direct GA cash is countable. Section 400-19-55-25 separately excludes

--- a/policyengine_us/parameters/gov/states/nd/dhs/tanf/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/nd/dhs/tanf/income/sources/unearned.yaml
@@ -1,0 +1,34 @@
+description: North Dakota counts these income sources as unearned income under the Temporary Assistance for Needy Families program.
+# Preserve the inherited baseline list and its start date; this corrects the
+# omitted general assistance source rather than introducing a new policy.
+values:
+  2010-07-01:
+    - veterans_benefits
+    - survivor_benefits
+    - rental_income
+    - child_support_received
+    - alimony_income
+    - financial_assistance
+    - dividend_income
+    - interest_income
+    - miscellaneous_income
+    - pension_income
+    - unemployment_compensation
+    - gi_cash_assistance
+    - social_security
+    # Direct GA cash is countable. Section 400-19-55-25 separately excludes
+    # GA reimbursements, third-party payments and complementary assistance
+    # for needs not covered by TANF; those are not represented by this input.
+    - general_assistance
+
+metadata:
+  unit: list
+  period: year
+  label: North Dakota TANF unearned income sources
+  reference:
+    - title: North Dakota TANF Manual, 400-19-55-20-15 - Countable Unearned Income Types
+      href: https://www.nd.gov/dhs/policymanuals/40019/400_19_55_20_15.htm
+    - title: North Dakota TANF Manual, 400-19-55-25 - Disregard of Certain Income
+      href: https://www.nd.gov/dhs/policymanuals/40019/400_19_55_25.htm
+    - title: North Dakota TANF Manual, 400-19-55-20-15, item 22 (2015 edition)
+      href: https://www.nd.gov/dhs/policymanuals/40019/Archive%20Documents/2016%20-%20ML3482/400_19_55_20_15%20ML%203482.htm

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/integration.yaml
@@ -963,3 +963,63 @@
     nd_tanf_eligible: true
     # Benefit = $739 - $438 = $301
     nd_tanf: 301
+
+# General assistance is unearned cash income: $2,400/year = $200/month.
+# With no earnings, subtract it dollar for dollar from the existing cash benefit.
+# $24,000/year = $2,000/month exceeds the income limit.
+
+- name: Case 27, general assistance reduces the cash benefit.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 2_400
+      person2:
+        age: 8
+      person3:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: ND
+  output:
+    nd_tanf_standard_of_need: 962
+    nd_tanf_countable_earned_income: 0
+    nd_tanf_countable_unearned_income: 200
+    nd_tanf_countable_income: 200
+    nd_tanf_income_eligible: true
+    nd_tanf_eligible: true
+    nd_tanf: 762
+
+- name: Case 28, general assistance makes the family income ineligible.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 24_000
+      person2:
+        age: 8
+      person3:
+        age: 5
+    spm_units:
+      spm_unit:
+        members: [person1, person2, person3]
+    households:
+      household:
+        members: [person1, person2, person3]
+        state_code: ND
+  output:
+    nd_tanf_standard_of_need: 962
+    nd_tanf_countable_earned_income: 0
+    nd_tanf_countable_unearned_income: 2_000
+    nd_tanf_countable_income: 2_000
+    nd_tanf_income_eligible: false
+    nd_tanf_eligible: false
+    nd_tanf: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/integration.yaml
@@ -1023,3 +1023,45 @@
     nd_tanf_income_eligible: false
     nd_tanf_eligible: false
     nd_tanf: 0
+
+- name: Workers compensation reduces the monthly cash benefit.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 30
+        workers_compensation: 2400
+      child:
+        age: 8
+    spm_units:
+      unit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+        state_code: ND
+  output:
+    nd_tanf: 539
+
+- name: Ordinary interest and dividends do not reduce the monthly TANF benefit.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 30
+        taxable_interest_income: 1200
+        tax_exempt_interest_income: 1200
+        dividend_income: 2400
+      child:
+        age: 8
+    spm_units:
+      unit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+        state_code: ND
+  output:
+    nd_tanf: 739

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/nd_tanf_countable_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/nd_tanf_countable_unearned_income.yaml
@@ -113,3 +113,24 @@
     # Gross unearned: $100 + $500 = $600
     # Less child support: $600 - $500 = $100
     nd_tanf_countable_unearned_income: 100
+
+- name: Case 6, general assistance and child support across members.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 2_400
+      person2:
+        age: 8
+        child_support_received: 3_600
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: ND
+  output:
+    # Gross $200 GA + $300 child support; existing child support rules apply.
+    nd_tanf_countable_unearned_income: 200

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/nd_tanf_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/nd_tanf_gross_unearned_income.yaml
@@ -1,0 +1,38 @@
+- name: Case 1, general assistance is counted monthly and the federal baseline is unchanged.
+  period: 2026-01
+  input:
+    state_code: ND
+    general_assistance: 2_400
+  output:
+    nd_tanf_gross_unearned_income: 200
+    tanf_gross_unearned_income: 0
+
+- name: Case 2, existing unearned sources are preserved without general assistance.
+  period: 2026-01
+  input:
+    state_code: ND
+    general_assistance: 0
+    social_security: 3_600
+    child_support_received: 1_200
+    financial_assistance: 600
+  output:
+    nd_tanf_gross_unearned_income: 450
+    tanf_gross_unearned_income: 450
+
+- name: Case 3, earnings and SSI are excluded from gross unearned income.
+  period: 2026-01
+  input:
+    state_code: ND
+    employment_income_before_lsr: 12_000
+    ssi: 6_000
+    general_assistance: 2_400
+  output:
+    nd_tanf_gross_unearned_income: 200
+
+- name: Case 4, state gross unearned income is zero outside the state.
+  period: 2026-01
+  input:
+    state_code: ME
+    general_assistance: 2_400
+  output:
+    nd_tanf_gross_unearned_income: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/nd_tanf_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/nd/dhs/tanf/nd_tanf_gross_unearned_income.yaml
@@ -36,3 +36,42 @@
     general_assistance: 2_400
   output:
     nd_tanf_gross_unearned_income: 0
+
+- name: Workers compensation is countable unearned income.
+  period: 2026-01
+  input:
+    state_code: ND
+    workers_compensation: 2400
+  output:
+    nd_tanf_gross_unearned_income: 200
+
+- name: Ordinary savings and investment interest and dividends are excluded.
+  period: 2026-01
+  input:
+    state_code: ND
+    taxable_interest_income: 1200
+    tax_exempt_interest_income: 1200
+    dividend_income: 2400
+  output:
+    nd_tanf_gross_unearned_income: 0
+
+- name: Regular pension payments remain countable alongside excluded investment income.
+  period: 2026-01
+  input:
+    state_code: ND
+    pension_income: 2400
+    taxable_interest_income: 1200
+    dividend_income: 1200
+  output:
+    nd_tanf_gross_unearned_income: 200
+
+- name: Excluded investment income does not offset workers compensation or general assistance.
+  period: 2026-01
+  input:
+    state_code: ND
+    workers_compensation: 2400
+    general_assistance: 1200
+    taxable_interest_income: 1200
+    dividend_income: 1200
+  output:
+    nd_tanf_gross_unearned_income: 300

--- a/policyengine_us/variables/gov/states/nd/dhs/tanf/income/nd_tanf_countable_unearned_income.py
+++ b/policyengine_us/variables/gov/states/nd/dhs/tanf/income/nd_tanf_countable_unearned_income.py
@@ -12,6 +12,6 @@ class nd_tanf_countable_unearned_income(Variable):
 
     # Child support received assigned to Child Support Division is excluded.
     # Result cannot be negative since child_support_received is a component
-    # of tanf_gross_unearned_income.
-    adds = ["tanf_gross_unearned_income"]
+    # of nd_tanf_gross_unearned_income.
+    adds = ["nd_tanf_gross_unearned_income"]
     subtracts = ["child_support_received"]

--- a/policyengine_us/variables/gov/states/nd/dhs/tanf/income/nd_tanf_gross_unearned_income.py
+++ b/policyengine_us/variables/gov/states/nd/dhs/tanf/income/nd_tanf_gross_unearned_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class nd_tanf_gross_unearned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "North Dakota TANF gross unearned income"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://www.nd.gov/dhs/policymanuals/40019/400_19_55_20_15.htm"
+    defined_for = StateCode.ND
+
+    adds = "gov.states.nd.dhs.tanf.income.sources.unearned"


### PR DESCRIPTION
North Dakota TANF omits General Assistance and workers’ compensation and counts ordinary interest and dividends inherited from the shared TANF baseline. This PR adds an explicit North Dakota list and gross-income variable, counts the two missing sources, and removes ordinary interest and dividends. The existing child-support subtraction is preserved.

For a parent and child in January 2026, $200/month of workers’ compensation now reduces TANF from $739 to $539. Ordinary savings interest or investment dividends no longer reduce the grant.

[Manual 400-19-55-20-15](https://www.nd.gov/dhs/policymanuals/40019/400_19_55_20_15.htm) explicitly counts General Assistance and Workforce Safety and Insurance benefits. [400-19-55-25](https://www.nd.gov/dhs/policymanuals/40019/400_19_55_25.htm) excludes ordinary savings/checking and investment interest and dividends, with an exception for interest in regular withdrawals. Regular pension payments remain counted through `pension_income`, with a regression covering this distinction. The generic interest/dividend inputs do not identify withdrawal frequency; this PR does not implement every investment-withdrawal subtype.

GA reimbursements, third-party payments, and complementary assistance for needs not covered by TANF remain separately exempt under 400-19-55-25. The GA input must represent direct countable cash. The [2015 edition, item 22](https://www.nd.gov/dhs/policymanuals/40019/Archive%20Documents/2016%20-%20ML3482/400_19_55_20_15%20ML%203482.htm) distinguishes county/BIA cash from vouchers.

Addresses the North Dakota portion of #9390. Companion PRs: #9412 and #9414. Keep #9390 open until all three fixes merge. The inherited parameter start date and shared federal list are unchanged; the date does not imply a newly enacted policy.

Validation: all 95 North Dakota TANF tests pass, including GA and workers’ compensation benefit reductions, excluded taxable/tax-exempt interest and dividends, regular pension payments, mixed income, child support, state scoping, and income ineligibility. Formatting/lint and git diff checks pass. The additional review regressions are in existing test files; partner tests are unchanged.
