### PR TITLE
Correct Wyoming POWER unearned income sources

### DIFF
--- a/changelog.d/wy_power-general-assistance.fixed.md
+++ b/changelog.d/wy_power-general-assistance.fixed.md
@@ -1,1 +1,1 @@
-Count general assistance cash payments as unearned income for Wyoming POWER.
+Correct Wyoming POWER unearned income by counting general assistance and workers compensation and excluding interest.

--- a/changelog.d/wy_power-general-assistance.fixed.md
+++ b/changelog.d/wy_power-general-assistance.fixed.md
@@ -1,0 +1,1 @@
+Count general assistance cash payments as unearned income for Wyoming POWER.

--- a/policyengine_us/parameters/gov/states/wy/dfs/power/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/wy/dfs/power/income/sources/unearned.yaml
@@ -1,6 +1,5 @@
 description: Wyoming counts these income sources as unearned income under the Personal Opportunities With Employment Responsibilities program.
-# Preserve the inherited baseline list and its start date; this corrects the
-# omitted general assistance source rather than introducing a new policy.
+# Preserve the inherited start date while correcting the modeled sources.
 values:
   2010-07-01:
     - veterans_benefits
@@ -10,10 +9,11 @@ values:
     - alimony_income
     - financial_assistance
     - dividend_income
-    - interest_income
+    # Section 901(J) excludes interest income; dividends remain countable.
     - miscellaneous_income
     - pension_income
     - unemployment_compensation
+    - workers_compensation
     - gi_cash_assistance
     - social_security
     # Section 901(J) treats state, local and tribal GA as nonexempt income.
@@ -25,5 +25,5 @@ metadata:
   period: year
   label: Wyoming POWER unearned income sources
   reference:
-    - title: Wyoming SNAP and POWER Policy Manual, 901(J) - Income Table, General Assistance
+    - title: Wyoming SNAP and POWER Policy Manual, 901(J) - Income Table
       href: https://dfs.wyo.gov/about/policy-manuals/snap-and-power-policy-manual/

--- a/policyengine_us/parameters/gov/states/wy/dfs/power/income/sources/unearned.yaml
+++ b/policyengine_us/parameters/gov/states/wy/dfs/power/income/sources/unearned.yaml
@@ -1,0 +1,29 @@
+description: Wyoming counts these income sources as unearned income under the Personal Opportunities With Employment Responsibilities program.
+# Preserve the inherited baseline list and its start date; this corrects the
+# omitted general assistance source rather than introducing a new policy.
+values:
+  2010-07-01:
+    - veterans_benefits
+    - survivor_benefits
+    - rental_income
+    - child_support_received
+    - alimony_income
+    - financial_assistance
+    - dividend_income
+    - interest_income
+    - miscellaneous_income
+    - pension_income
+    - unemployment_compensation
+    - gi_cash_assistance
+    - social_security
+    # Section 901(J) treats state, local and tribal GA as nonexempt income.
+    # Vendor payments for purposes not covered by POWER are separately exempt.
+    - general_assistance
+
+metadata:
+  unit: list
+  period: year
+  label: Wyoming POWER unearned income sources
+  reference:
+    - title: Wyoming SNAP and POWER Policy Manual, 901(J) - Income Table, General Assistance
+      href: https://dfs.wyo.gov/about/policy-manuals/snap-and-power-policy-manual/

--- a/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/integration.yaml
@@ -754,3 +754,63 @@
 
     wy_power: 561
     # max(961 - 400, 0) = $561
+
+# General assistance is unearned cash income: $2,400/year = $200/month.
+# With no earnings, subtract it dollar for dollar from the existing cash benefit.
+# $24,000/year = $2,000/month exceeds the income limit.
+
+- name: Case 19, general assistance reduces the cash benefit.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 2_400
+      person2:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        wy_power_shelter_qualified: true
+        spm_unit_cash_assets: 2_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: WY
+  output:
+    wy_power_earned_income_disregard: 600
+    wy_power_countable_income: 200
+    wy_power_income_eligible: true
+    wy_power_resources_eligible: true
+    wy_power_eligible: true
+    wy_power_payment_standard: 847
+    wy_power: 647
+  absolute_error_margin: 0.01
+
+- name: Case 20, general assistance makes the family income ineligible.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 24_000
+      person2:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        wy_power_shelter_qualified: true
+        spm_unit_cash_assets: 2_000
+    households:
+      household:
+        members: [person1, person2]
+        state_code: WY
+  output:
+    wy_power_earned_income_disregard: 600
+    wy_power_countable_income: 2_000
+    wy_power_income_eligible: false
+    wy_power_resources_eligible: true
+    wy_power_eligible: false
+    wy_power_payment_standard: 847
+    wy_power: 0
+  absolute_error_margin: 0.01

--- a/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/integration.yaml
@@ -814,3 +814,44 @@
     wy_power_payment_standard: 847
     wy_power: 0
   absolute_error_margin: 0.01
+
+- name: Workers compensation reduces the monthly cash benefit.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 30
+        workers_compensation: 2400
+      child:
+        age: 8
+    spm_units:
+      unit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+        state_code: WY
+  output:
+    wy_power: 647
+
+- name: Interest does not reduce the monthly POWER benefit.
+  period: 2026-01
+  absolute_error_margin: 0.01
+  input:
+    people:
+      adult:
+        age: 30
+        taxable_interest_income: 1200
+        tax_exempt_interest_income: 1200
+      child:
+        age: 8
+    spm_units:
+      unit:
+        members: [adult, child]
+    households:
+      household:
+        members: [adult, child]
+        state_code: WY
+  output:
+    wy_power: 847

--- a/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/wy_power_countable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/wy_power_countable_income.yaml
@@ -1,0 +1,20 @@
+- name: Case 1, general assistance and child support across members.
+  period: 2026-01
+  input:
+    people:
+      person1:
+        age: 30
+        general_assistance: 2_400
+      person2:
+        age: 8
+        child_support_received: 3_600
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: WY
+  output:
+    # Gross $200 GA + $300 child support; existing child support rules apply.
+    wy_power_countable_income: 500

--- a/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/wy_power_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/wy_power_gross_unearned_income.yaml
@@ -36,3 +36,30 @@
     general_assistance: 2_400
   output:
     wy_power_gross_unearned_income: 0
+
+- name: Workers compensation is countable unearned income.
+  period: 2026-01
+  input:
+    state_code: WY
+    workers_compensation: 2400
+  output:
+    wy_power_gross_unearned_income: 200
+
+- name: Taxable and tax-exempt interest are excluded.
+  period: 2026-01
+  input:
+    state_code: WY
+    taxable_interest_income: 1200
+    tax_exempt_interest_income: 1200
+  output:
+    wy_power_gross_unearned_income: 0
+
+- name: Dividends and workers compensation count while interest is excluded.
+  period: 2026-01
+  input:
+    state_code: WY
+    workers_compensation: 2400
+    dividend_income: 2400
+    taxable_interest_income: 2400
+  output:
+    wy_power_gross_unearned_income: 400

--- a/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/wy_power_gross_unearned_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/wy/dfs/power/wy_power_gross_unearned_income.yaml
@@ -1,0 +1,38 @@
+- name: Case 1, general assistance is counted monthly and the federal baseline is unchanged.
+  period: 2026-01
+  input:
+    state_code: WY
+    general_assistance: 2_400
+  output:
+    wy_power_gross_unearned_income: 200
+    tanf_gross_unearned_income: 0
+
+- name: Case 2, existing unearned sources are preserved without general assistance.
+  period: 2026-01
+  input:
+    state_code: WY
+    general_assistance: 0
+    social_security: 3_600
+    child_support_received: 1_200
+    financial_assistance: 600
+  output:
+    wy_power_gross_unearned_income: 450
+    tanf_gross_unearned_income: 450
+
+- name: Case 3, earnings and SSI are excluded from gross unearned income.
+  period: 2026-01
+  input:
+    state_code: WY
+    employment_income_before_lsr: 12_000
+    ssi: 6_000
+    general_assistance: 2_400
+  output:
+    wy_power_gross_unearned_income: 200
+
+- name: Case 4, state gross unearned income is zero outside the state.
+  period: 2026-01
+  input:
+    state_code: ME
+    general_assistance: 2_400
+  output:
+    wy_power_gross_unearned_income: 0

--- a/policyengine_us/variables/gov/states/wy/dfs/power/income/wy_power_countable_income.py
+++ b/policyengine_us/variables/gov/states/wy/dfs/power/income/wy_power_countable_income.py
@@ -15,5 +15,5 @@ class wy_power_countable_income(Variable):
     # Per Section 1101: Countable income = Countable earned + Gross unearned
     adds = [
         "wy_power_countable_earned_income",
-        "tanf_gross_unearned_income",
+        "wy_power_gross_unearned_income",
     ]

--- a/policyengine_us/variables/gov/states/wy/dfs/power/income/wy_power_gross_unearned_income.py
+++ b/policyengine_us/variables/gov/states/wy/dfs/power/income/wy_power_gross_unearned_income.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class wy_power_gross_unearned_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Wyoming POWER gross unearned income"
+    unit = USD
+    definition_period = MONTH
+    reference = "https://dfs.wyo.gov/about/policy-manuals/snap-and-power-policy-manual/"
+    defined_for = StateCode.WY
+
+    adds = "gov.states.wy.dfs.power.income.sources.unearned"


### PR DESCRIPTION
Wyoming POWER omits General Assistance and workers’ compensation and counts excluded interest inherited from the shared TANF baseline. This PR adds an explicit Wyoming list and gross-unearned-income variable, counts the two missing sources, and excludes interest. Dividends remain countable, and unearned income is added after earned-income deductions.

For a parent and child in January 2026, $200/month of workers’ compensation now reduces POWER from $847 to $647. The same amount of interest no longer reduces the $847 benefit.

The [SNAP and POWER Policy Manual, section 901(J)](https://dfs.wyo.gov/about/policy-manuals/snap-and-power-policy-manual/) explicitly marks General Assistance and workers’ compensation nonexempt, interest exempt, and dividends nonexempt. Section 1101 adds unearned income after earned-income deductions. Vendor payments for purposes not covered by POWER remain separately exempt; the GA input represents direct cash.

Addresses the Wyoming portion of #9390. Companion PRs: #9412 and #9413. Keep #9390 open until all three fixes merge.

The inherited parameter start date is retained to preserve model history, rather than imply a new enactment date. Shared federal parameters are unchanged. Other payment-subtype limitations remain outside this targeted correction.

Validation: all 149 Wyoming POWER tests pass, including GA and workers’ compensation benefit reductions, excluded taxable/tax-exempt interest, countable dividends, mixed income, member aggregation, state scoping, and income ineligibility. Formatting/lint and git diff checks pass. The additional review regressions are in existing test files; partner tests are unchanged.
