### PR TITLE
Update the Texas CEAP registry note to its remaining income-counting gaps

### DIFF
--- a/changelog.d/tx-ceap-registry-complete.fixed.md
+++ b/changelog.d/tx-ceap-registry-complete.fixed.md
@@ -1,0 +1,1 @@
+Texas CEAP is marked complete in the program registry now that SSI categorical eligibility requires SSI receipt.

--- a/changelog.d/tx-ceap-registry-complete.fixed.md
+++ b/changelog.d/tx-ceap-registry-complete.fixed.md
@@ -1,1 +1,1 @@
-Texas CEAP is marked complete in the program registry now that SSI categorical eligibility requires SSI receipt.
+Texas CEAP's registry note now lists its remaining income-counting gaps (net gambling winnings, the Medicare premium deduction from Social Security, means-tested veterans' pensions) instead of the SSI categorical-eligibility gap fixed in #9409; the entry stays partial.

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -823,11 +823,12 @@ programs:
         full_name: Illinois Low Income Home Energy Assistance Program
         variable: il_liheap
       - state: TX
-        status: complete
+        status: partial
         name: Texas CEAP
         full_name: Texas Comprehensive Energy Assistance Program
         variable: tx_ceap
         parameter_prefix: gov.states.tx.tdhca.ceap
+        notes: Models the FPG income limit, the FY2024-only SMI limit, benefit amounts, and categorical eligibility through TANF enrollment, SNAP eligibility, and SSI receipt. Not modeled - net rather than gross gambling winnings, the Medicare premium deduction from counted Social Security, and the exclusion of means-tested veterans' pensions from counted income (10 TAC 6.4(c))
 
   # --- SSA programs ---
   - id: ssi

--- a/policyengine_us/programs.yaml
+++ b/policyengine_us/programs.yaml
@@ -823,12 +823,11 @@ programs:
         full_name: Illinois Low Income Home Energy Assistance Program
         variable: il_liheap
       - state: TX
-        status: partial
+        status: complete
         name: Texas CEAP
         full_name: Texas Comprehensive Energy Assistance Program
         variable: tx_ceap
         parameter_prefix: gov.states.tx.tdhca.ceap
-        notes: Models the FPG income limit, the FY2024-only SMI limit, benefit amounts, and categorical eligibility through TANF enrollment, SNAP eligibility, and SSI. Known gap - the SSI route uses is_ssi_eligible, which omits the SSI income test, so a household with an aged, blind, or disabled member who passes the resource and immigration tests qualifies at any income (policyengine-us#9408)
 
   # --- SSA programs ---
   - id: ssi


### PR DESCRIPTION
Follow-up to #9407 and #9409. The registry marked Texas CEAP partial because of the SSI categorical-eligibility shortcut (#9408), which #9409 fixed. Review of this PR surfaced the remaining documented gaps in the income source list (`parameters/gov/states/tx/tdhca/ceap/income/sources.yaml`): gross rather than net gambling winnings, Social Security counted without the Medicare premium deduction, and veterans benefits counted including means-tested pensions. The entry therefore stays partial and its note now names those gaps instead of the fixed one. Registry-only change plus a changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)