### PR TITLE
Add Illinois 2022 property tax rebate

### DIFF
--- a/changelog.d/il-property-tax-rebate.added.md
+++ b/changelog.d/il-property-tax-rebate.added.md
@@ -1,0 +1,1 @@
+Added the Illinois 2022 property tax rebate (Family Relief Plan), equal to the 2021 property tax credit capped at $300.

--- a/policyengine_us/parameters/gov/states/il/tax/income/credits/property_tax_rebate/cap.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/credits/property_tax_rebate/cap.yaml
@@ -1,0 +1,12 @@
+description: Illinois caps the 2022 property tax rebate at this amount.
+values:
+  2021-01-01: 300
+metadata:
+  unit: currency-USD
+  period: year
+  label: Illinois property tax rebate cap
+  reference:
+    - title: Illinois Family Relief Plan announcement (property tax rebates up to $300)
+      href: https://www.illinois.gov/news/release.html?releaseid=25425
+    - title: 2021 Form IL-1040-PTR Instructions
+      href: https://tax.illinois.gov/content/dam/soi/en/web/tax/forms/incometax/documents/currentyear/individual/il-1040-ptr-instr.pdf

--- a/policyengine_us/parameters/gov/states/il/tax/income/credits/property_tax_rebate/income_limit/joint.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/credits/property_tax_rebate/income_limit/joint.yaml
@@ -1,0 +1,10 @@
+description: Illinois disallows the 2022 property tax rebate for joint filers with adjusted gross income above this amount.
+values:
+  2021-01-01: 500_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Illinois property tax rebate income limit (joint)
+  reference:
+    - title: Illinois Family Relief Plan announcement (AGI over $500,000 MFJ ineligible)
+      href: https://www.illinois.gov/news/release.html?releaseid=25425

--- a/policyengine_us/parameters/gov/states/il/tax/income/credits/property_tax_rebate/income_limit/other.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/credits/property_tax_rebate/income_limit/other.yaml
@@ -1,0 +1,10 @@
+description: Illinois disallows the 2022 property tax rebate for non-joint filers with adjusted gross income above this amount.
+values:
+  2021-01-01: 250_000
+metadata:
+  unit: currency-USD
+  period: year
+  label: Illinois property tax rebate income limit (non-joint)
+  reference:
+    - title: Illinois Family Relief Plan announcement (AGI over $250,000 non-MFJ ineligible)
+      href: https://www.illinois.gov/news/release.html?releaseid=25425

--- a/policyengine_us/parameters/gov/states/il/tax/income/credits/refundable.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/credits/refundable.yaml
@@ -5,6 +5,7 @@ values:
     - il_pass_through_entity_tax_credit
     - il_eitc
     - il_income_tax_rebate
+    - il_property_tax_rebate
   2022-01-01:
     - il_pass_through_withholding
     - il_pass_through_entity_tax_credit

--- a/policyengine_us/tests/policy/baseline/gov/irs/integration/us_itemize.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/integration/us_itemize.yaml
@@ -49,7 +49,9 @@
         members: [person1]
         state_code: IL  # state income tax that does not depend on US tax
   output:
-    state_income_tax: 4_482.4375
+    # $300 lower than the pre-credit tax because the 2021 return now nets the
+    # 2022 Illinois property tax rebate (capped at $300; 5% of $6,000 = $300).
+    state_income_tax: 4_182.4375
     adjusted_gross_income: 100_000
     taxable_income_deductions_if_not_itemizing: 12_550
     taxable_income_deductions_if_itemizing: 8_000 + 10_000

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_property_tax_rebate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_property_tax_rebate.yaml
@@ -3,7 +3,7 @@
   input:
     tax_unit_is_joint: true
     adjusted_gross_income: 50_459
-    il_property_tax_credit: 71.60
+    il_property_tax_credit_potential: 71.60
     state_code: IL
   output:
     il_property_tax_rebate: 71.60
@@ -13,7 +13,7 @@
   input:
     tax_unit_is_joint: true
     adjusted_gross_income: 60_000
-    il_property_tax_credit: 450
+    il_property_tax_credit_potential: 450
     state_code: IL
   output:
     il_property_tax_rebate: 300
@@ -23,7 +23,7 @@
   input:
     tax_unit_is_joint: true
     adjusted_gross_income: 500_001
-    il_property_tax_credit: 200
+    il_property_tax_credit_potential: 200
     state_code: IL
   output:
     il_property_tax_rebate: 0
@@ -33,7 +33,7 @@
   input:
     tax_unit_is_joint: false
     adjusted_gross_income: 250_001
-    il_property_tax_credit: 200
+    il_property_tax_credit_potential: 200
     state_code: IL
   output:
     il_property_tax_rebate: 0
@@ -43,7 +43,7 @@
   input:
     tax_unit_is_joint: false
     adjusted_gross_income: 250_000
-    il_property_tax_credit: 120
+    il_property_tax_credit_potential: 120
     state_code: IL
   output:
     il_property_tax_rebate: 120

--- a/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_property_tax_rebate.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/il/tax/income/credits/il_property_tax_rebate.yaml
@@ -1,0 +1,49 @@
+- name: Property tax rebate equals the 2021 property tax credit (taxsim 1172).
+  period: 2021
+  input:
+    tax_unit_is_joint: true
+    adjusted_gross_income: 50_459
+    il_property_tax_credit: 71.60
+    state_code: IL
+  output:
+    il_property_tax_rebate: 71.60
+
+- name: Property tax rebate is capped at $300.
+  period: 2021
+  input:
+    tax_unit_is_joint: true
+    adjusted_gross_income: 60_000
+    il_property_tax_credit: 450
+    state_code: IL
+  output:
+    il_property_tax_rebate: 300
+
+- name: Joint filer above the $500,000 AGI limit gets no rebate.
+  period: 2021
+  input:
+    tax_unit_is_joint: true
+    adjusted_gross_income: 500_001
+    il_property_tax_credit: 200
+    state_code: IL
+  output:
+    il_property_tax_rebate: 0
+
+- name: Non-joint filer above the $250,000 AGI limit gets no rebate.
+  period: 2021
+  input:
+    tax_unit_is_joint: false
+    adjusted_gross_income: 250_001
+    il_property_tax_credit: 200
+    state_code: IL
+  output:
+    il_property_tax_rebate: 0
+
+- name: Non-joint filer at the $250,000 AGI limit still qualifies.
+  period: 2021
+  input:
+    tax_unit_is_joint: false
+    adjusted_gross_income: 250_000
+    il_property_tax_credit: 120
+    state_code: IL
+  output:
+    il_property_tax_rebate: 120

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_rebate.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_rebate.py
@@ -13,7 +13,10 @@ class il_property_tax_rebate(Variable):
     def formula(tax_unit, period, parameters):
         # The 2022 Illinois Family Relief Plan paid a one-time property tax
         # rebate equal to the property tax credit the filer qualified for on
-        # their 2021 return, capped at $300.
+        # their 2021 return, capped at $300. Filers could claim it on Form
+        # IL-1040-PTR even with no income tax liability, so it is based on the
+        # potential (pre-liability-limitation) property tax credit -- 5% of
+        # property tax paid -- not the applied credit.
         p = parameters(period).gov.states.il.tax.income.credits.property_tax_rebate
-        property_tax_credit = tax_unit("il_property_tax_credit", period)
+        property_tax_credit = tax_unit("il_property_tax_credit_potential", period)
         return min_(property_tax_credit, p.cap)

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_rebate.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_rebate.py
@@ -1,0 +1,19 @@
+from policyengine_us.model_api import *
+
+
+class il_property_tax_rebate(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Illinois property tax rebate"
+    unit = USD
+    definition_period = YEAR
+    defined_for = "il_property_tax_rebate_eligible"
+    reference = "https://www.illinois.gov/news/release.html?releaseid=25425"
+
+    def formula(tax_unit, period, parameters):
+        # The 2022 Illinois Family Relief Plan paid a one-time property tax
+        # rebate equal to the property tax credit the filer qualified for on
+        # their 2021 return, capped at $300.
+        p = parameters(period).gov.states.il.tax.income.credits.property_tax_rebate
+        property_tax_credit = tax_unit("il_property_tax_credit", period)
+        return min_(property_tax_credit, p.cap)

--- a/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_rebate_eligible.py
+++ b/policyengine_us/variables/gov/states/il/tax/income/credits/il_property_tax_rebate_eligible.py
@@ -1,0 +1,17 @@
+from policyengine_us.model_api import *
+
+
+class il_property_tax_rebate_eligible(Variable):
+    value_type = bool
+    entity = TaxUnit
+    label = "Eligible for the Illinois property tax rebate"
+    defined_for = StateCode.IL
+    definition_period = YEAR
+    reference = "https://www.illinois.gov/news/release.html?releaseid=25425"
+
+    def formula(tax_unit, period, parameters):
+        p = parameters(period).gov.states.il.tax.income.credits.property_tax_rebate
+        federal_agi = tax_unit("adjusted_gross_income", period)
+        joint = tax_unit("tax_unit_is_joint", period)
+        income_limit = where(joint, p.income_limit.joint, p.income_limit.other)
+        return federal_agi <= income_limit


### PR DESCRIPTION
Fixes #9418.

## Problem

PolicyEngine modeled the 2022 Illinois income tax rebate (`il_income_tax_rebate`) but not the companion **property tax rebate** from the same 2022 Illinois Family Relief Plan (PA 102-0700).

Per the [Illinois announcement](https://www.illinois.gov/news/release.html?releaseid=25425):
> The State of Illinois is also providing property tax rebates for eligible homeowners in an amount equal to the property tax credit they qualified for on their 2021 returns, up to a maximum of $300. The rebate is not allowed if a taxpayer's adjusted gross income for the taxable year exceeds $500,000 for [MFJ], or $250,000 for all other returns.

## Fix

Adds `il_property_tax_rebate` = min($300, 2021 IL property tax credit), gated on AGI ≤ $500,000 (joint) / $250,000 (other), as a 2021 refundable credit alongside `il_income_tax_rebate`.

## Impact (TAXSIM #1172)

IL 2021 joint, property tax $1,432 → property tax credit $71.62. Previously the total 2022 rebate was $100 (income-tax rebate only); now it is $171.62 ($100 + $71.62).

## Tests

- New unit test: exact-credit case, $300 cap, and the $500k/$250k AGI limits (at and above).
- Full IL suite passes (885 tests).

## Notes

The rebate is based on the potential (pre-limitation) 2021 property tax credit (`il_property_tax_credit_potential`), not the applied credit. 35 ILCS 5/208.5(a), added by Public Act 102-0700 Section 40-10, sets the rebate at the lesser of "the amount of the credit provided under Section 208 for tax year 2021, including any amounts that would otherwise reduce a taxpayer's liability to less than zero" or $300 per principal residence, so filers with no liability still receive it. The $500,000 / $250,000 AGI limits are Section 208's own limits on the underlying credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
