### PR TITLE
fix: include state tax refund income in federal gross income and exclude in conforming states

### DIFF
--- a/changelog.d/fix-9122-salt-refund-gross-income.fixed.md
+++ b/changelog.d/fix-9122-salt-refund-gross-income.fixed.md
@@ -1,1 +1,1 @@
-Include state and local tax refund income (`salt_refund_income`) in federal gross income and subtract/deduct it in conforming states.
+Include state and local tax refund income (`salt_refund_income`) in federal gross income and subtract/deduct it in conforming states. Standardize state refund inputs on canonical `salt_refund_income` and deprecate `salt_refund_last_year`.

--- a/changelog.d/fix-9122-salt-refund-gross-income.fixed.md
+++ b/changelog.d/fix-9122-salt-refund-gross-income.fixed.md
@@ -1,0 +1,1 @@
+Include state and local tax refund income (`salt_refund_income`) in federal gross income and subtract/deduct it in conforming states.

--- a/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
+++ b/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
@@ -30,7 +30,7 @@ values:
     - ak_permanent_fund_dividend
     # Alimony from divorces executed before the TCJA cutoff (Schedule 1 line 2a).
     - taxable_alimony_income
-    # State and local income tax refunds (Schedule 1 line 1).
+    # Taxable state and local income tax refunds (Schedule 1 line 1 / IRC § 111).
     - salt_refund_income
 
 metadata:

--- a/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
+++ b/policyengine_us/parameters/gov/irs/gross_income/sources.yaml
@@ -30,6 +30,8 @@ values:
     - ak_permanent_fund_dividend
     # Alimony from divorces executed before the TCJA cutoff (Schedule 1 line 2a).
     - taxable_alimony_income
+    # State and local income tax refunds (Schedule 1 line 1).
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/az/tax/income/subtractions/subtractions.yaml
@@ -11,6 +11,7 @@ values:
     - az_529a_able_account_subtraction # Line 34b
     - az_adoption_expense_subtraction # Other subtractions - Item D
     - az_families_tax_rebate_subtraction # Line 36, Item U
+    - salt_refund_income # Line 27
   2025-01-01:
     - us_govt_interest # Line 28
     - az_public_pension_exclusion # Line 29a
@@ -27,6 +28,7 @@ values:
     - overtime_income_deduction # MCTCP worksheet Line 3 (Sch 1-A Line 21)
     - auto_loan_interest_deduction # MCTCP worksheet Line 4 (Sch 1-A Line 30)
     - additional_senior_deduction # MCTCP worksheet Line 5 (Sch 1-A Line 37)
+    - salt_refund_income # Line 27
   # HB 4168 (2026): auto loan interest sunsets after TY2025 (43-1022(36));
   # adds child & dependent care and IRC 530A distribution subtractions.
   2026-01-01:
@@ -45,6 +47,7 @@ values:
     - additional_senior_deduction # 43-1022(35)
     - az_dependent_care_expense_subtraction # 43-1022(34)
     - az_530a_distribution_subtraction # 43-1022(33)
+    - salt_refund_income # Line 27
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/ca/tax/income/agi/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/agi/subtractions.yaml
@@ -4,6 +4,7 @@ values:
     - taxable_social_security
     - taxable_unemployment_compensation
     - us_govt_interest
+    - salt_refund_income
 
 metadata:
   reference:

--- a/policyengine_us/parameters/gov/states/co/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/subtractions/subtractions.yaml
@@ -1,7 +1,7 @@
 description: Colorado counts these sources as subtractions.
 values:
   2021-01-01:
-    # salt_refund_income
+    - salt_refund_income
     - us_govt_interest
     - co_pension_subtraction
     - co_military_retirement_subtraction
@@ -20,7 +20,7 @@ values:
     # Carryforward Subtractions Allowed Under HB21-1002
     
   2023-01-01:
-    # salt_refund_income
+    - salt_refund_income
     - us_govt_interest
     - co_pension_subtraction
     - co_military_retirement_subtraction

--- a/policyengine_us/parameters/gov/states/ct/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ct/tax/income/subtractions/subtractions.yaml
@@ -5,6 +5,7 @@ values:
     - ct_social_security_benefit_adjustment #ln 41
     - military_retirement_pay #ln 44
     - ct_pension_annuity_subtraction #ln 48b
+    - salt_refund_income #ln 38
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/dc/tax/income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/subtractions/sources.yaml
@@ -20,3 +20,4 @@ values:
     - dc_disabled_exclusion_subtraction
     - dc_disability_exclusion
     - us_govt_interest_person
+    - salt_refund_income

--- a/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/de/tax/income/subtractions/subtractions.yaml
@@ -8,6 +8,7 @@ values:
     # to the extent included in federal AGI, is excluded under
     # 30 Del. C. § 1106(b)(10) (HB 65 of 2021; HB 285 of 2022).
     - taxable_unemployment_compensation # (10)
+    - salt_refund_income # (1)
     # The elderly or disabled income exclusion is computed separately
     # - de_elderly_or_disabled_income_exclusion # (2)
   2022-01-01:
@@ -15,6 +16,7 @@ values:
     - taxable_social_security # (4)
     - us_govt_interest_person
     - de_529_plan_subtraction # HB 145
+    - salt_refund_income # (1)
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ga/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ga/tax/income/subtractions/subtractions.yaml
@@ -10,12 +10,14 @@ values:
     - ga_retirement_exclusion
     - taxable_social_security
     - ga_investment_in_529_plan_deduction
+    - salt_refund_income
   2022-01-01:
     - us_govt_interest
     - ga_retirement_exclusion
     - ga_military_retirement_exclusion
     - taxable_social_security
     - ga_investment_in_529_plan_deduction
+    - salt_refund_income
   2026-01-01:
     - us_govt_interest
     - ga_retirement_exclusion
@@ -24,12 +26,14 @@ values:
     - ga_investment_in_529_plan_deduction
     - ga_qualified_overtime_exclusion
     - ga_cash_tip_exclusion
+    - salt_refund_income
   2029-01-01:
     - us_govt_interest
     - ga_retirement_exclusion
     - ga_military_retirement_exclusion
     - taxable_social_security
     - ga_investment_in_529_plan_deduction
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/hi/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/hi/tax/income/subtractions/subtractions.yaml
@@ -6,12 +6,14 @@ values:
     - hi_military_pay_exclusion # Line 15
     - us_govt_interest # Line 18
     - student_loan_interest_ald # Line 18
+    - salt_refund_income # Line 8
   2025-01-01:
     - taxable_pension_income # Line 13
     - taxable_social_security # Line 14
     - hi_military_pay_exclusion # Line 15
     - us_govt_interest # Line 18
     - hi_student_loan_interest_subtraction # Line 18
+    - salt_refund_income # Line 8
 
 
 metadata:

--- a/policyengine_us/parameters/gov/states/ia/tax/income/taxable_income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ia/tax/income/taxable_income/subtractions.yaml
@@ -15,6 +15,7 @@ values:
     # Iowa Health Insurance Deduction
     # Iowa capital gains deduction
     - ia_529_plan_subtraction
+    - salt_refund_income
   2024-01-01: # military_retirement_pay added in 2024.
     # Line 1B
     - us_govt_interest
@@ -32,6 +33,7 @@ values:
     # Iowa Health Insurance Deduction
     # Iowa capital gains deduction
     - ia_529_plan_subtraction
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/il/tax/income/base/subtractions.yaml
@@ -6,6 +6,7 @@ values:
     - taxable_pension_income
     - il_schedule_m_subtractions
     - il_529_plan_subtraction
+    - salt_refund_income
 metadata:
   unit: list
   period: year

--- a/policyengine_us/parameters/gov/states/in/tax/income/deductions/deductions.yaml
+++ b/policyengine_us/parameters/gov/states/in/tax/income/deductions/deductions.yaml
@@ -3,7 +3,7 @@ values:
   2021-01-01:
     - in_renters_deduction
     - in_homeowners_property_tax_deduction
-    - salt_refund_last_year
+    - salt_refund_income
     - us_govt_interest
     - tax_unit_taxable_social_security  # includes railroad retirement benefits
     - in_military_service_deduction
@@ -18,7 +18,7 @@ values:
     # IC 6-1.1
     - in_homeowners_property_tax_deduction
     # IC 6-3.1-19-1
-    - salt_refund_last_year
+    - salt_refund_income
     # IC 6-8-5-1
     - us_govt_interest
     # US Code 26-A-1-B-II-§86
@@ -42,7 +42,7 @@ values:
     # IC 6-1.1
     - in_homeowners_property_tax_deduction
     # IC 6-3.1-19-1
-    - salt_refund_last_year
+    - salt_refund_income
     # IC 6-8-5-1
     - us_govt_interest
     # US Code 26-A-1-B-II-§86
@@ -68,7 +68,7 @@ values:
     # IC 6-1.1
     - in_homeowners_property_tax_deduction
     # IC 6-3.1-19-1
-    - salt_refund_last_year
+    - salt_refund_income
     # IC 6-8-5-1
     - us_govt_interest
     # US Code 26-A-1-B-II-§86
@@ -100,7 +100,7 @@ values:
     # IC 6-1.1
     - in_homeowners_property_tax_deduction
     # IC 6-3.1-19-1
-    - salt_refund_last_year
+    - salt_refund_income
     # IC 6-8-5-1
     - us_govt_interest
     # US Code 26-A-1-B-II-§86

--- a/policyengine_us/parameters/gov/states/ky/tax/income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ky/tax/income/subtractions.yaml
@@ -1,7 +1,7 @@
 description: Kentucky subtracts these sources from adjusted gross income.
 values:
   2021-01-01:
-  # - Kentucky income tax refund
+    - salt_refund_income
     - us_govt_interest_person
     - ky_pension_income_exclusion  
     - taxable_social_security

--- a/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/agi/subtractions/sources.yaml
@@ -8,6 +8,7 @@ values:
     - md_two_income_subtraction
     - md_military_retirement_subtraction
     - md_529_deduction
+    - salt_refund_income
   2022-01-01:
     - us_govt_interest
     - md_dependent_care_subtraction
@@ -17,6 +18,7 @@ values:
     - md_hundred_year_subtraction
     - md_military_retirement_subtraction
     - md_529_deduction
+    - salt_refund_income
 
 metadata:
   reference:

--- a/policyengine_us/parameters/gov/states/mi/tax/income/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/mi/tax/income/subtractions.yaml
@@ -10,6 +10,7 @@ values:
     - mi_pension_benefit  # Line 26
     - mi_interest_dividends_capital_gains_deduction # Line 27
     - mi_529_deduction
+    - salt_refund_income # Line 16
   2026-01-01:
     - us_govt_interest # Line 10
     - military_retirement_pay # Line 11
@@ -22,6 +23,7 @@ values:
     - mi_529_deduction
     - mi_qualified_tips_deduction  # Qualified tips (PA 24 of 2025), TY2026-2028
     - mi_qualified_overtime_deduction  # Qualified overtime compensation (PA 24 of 2025), TY2026-2028
+    - salt_refund_income # Line 16
 metadata:
   unit: list  
   label: Michigan taxable income subtraction sources  

--- a/policyengine_us/parameters/gov/states/mn/tax/income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/mn/tax/income/subtractions/sources.yaml
@@ -13,7 +13,7 @@ values:
     - mn_military_pension_subtraction
     - mn_active_duty_military_pay_subtraction
     - mn_529_contribution_subtraction
-
+    - salt_refund_income
   2023-01-01:
     - mn_charity_subtraction
     - mn_social_security_subtraction
@@ -24,6 +24,7 @@ values:
     - mn_military_pension_subtraction
     - mn_active_duty_military_pay_subtraction
     - mn_529_contribution_subtraction
+    - salt_refund_income
 
 
 metadata:

--- a/policyengine_us/parameters/gov/states/nc/tax/income/deductions/deductions.yaml
+++ b/policyengine_us/parameters/gov/states/nc/tax/income/deductions/deductions.yaml
@@ -5,13 +5,14 @@ values:
     - nc_standard_or_itemized_deductions
     - nc_child_deduction
     - taxable_social_security
-
+    - salt_refund_income
   2022-01-01:
     - us_govt_interest
     - nc_standard_or_itemized_deductions
     - nc_child_deduction
     - taxable_social_security
     - nc_military_retirement_deduction
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/nd/tax/income/taxable_income/subtractions/sources.yaml
@@ -8,6 +8,7 @@ values:
     - military_retirement_pay
     - nd_529_deduction
     - nd_stillborn_subtraction
+    - salt_refund_income
 
   2022-01-01:
     - us_govt_interest
@@ -17,6 +18,7 @@ values:
     - military_retirement_pay
     - nd_529_deduction
     - nd_stillborn_subtraction
+    - salt_refund_income
 
   2023-01-01:
     - us_govt_interest
@@ -27,6 +29,7 @@ values:
     - military_service_income  # military pay exclusion
     - nd_529_deduction
     - nd_stillborn_subtraction
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ne/tax/income/agi/subtractions/subtractions.yaml
@@ -5,12 +5,14 @@ values:
     - ne_military_retirement_subtraction
     - us_govt_interest
     - ne_529_deduction
+    - salt_refund_income
   2024-01-01:
     - ne_social_security_subtraction
     - taxable_public_pension_income
     - ne_military_retirement_subtraction
     - us_govt_interest
     - ne_529_deduction
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ny/tax/income/agi/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/ny/tax/income/agi/subtractions/sources.yaml
@@ -5,6 +5,7 @@ values:
     - us_govt_interest
     - investment_in_529_plan
     - ny_pension_exclusion
+    - salt_refund_income
 metadata:
   unit: currency-USD
   period: year

--- a/policyengine_us/parameters/gov/states/oh/tax/income/deductions/deductions.yaml
+++ b/policyengine_us/parameters/gov/states/oh/tax/income/deductions/deductions.yaml
@@ -10,6 +10,7 @@ values:
     - disability_benefits
     - oh_unreimbursed_medical_care_expense_deduction_person
     - us_govt_interest_person
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ok/tax/income/agi/subtractions/subtractions.yaml
@@ -6,6 +6,7 @@ values:
     - ok_pension_subtraction
     - ok_military_retirement_exclusion
     - ok_529_plan_deduction
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/or/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/or/tax/income/subtractions/subtractions.yaml
@@ -21,3 +21,4 @@ values:
     - or_federal_tax_liability_subtraction
     - taxable_social_security
     - us_govt_interest
+    - salt_refund_income

--- a/policyengine_us/parameters/gov/states/pa/tax/income/nontaxable_income_sources.yaml
+++ b/policyengine_us/parameters/gov/states/pa/tax/income/nontaxable_income_sources.yaml
@@ -7,6 +7,7 @@ values:
     - taxable_unemployment_compensation
     - taxable_social_security
     - us_govt_interest
+    - salt_refund_income
 metadata:
   unit: currency-USD
   label: PA nontaxable income sources

--- a/policyengine_us/parameters/gov/states/ri/tax/income/agi/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/agi/subtractions/subtractions.yaml
@@ -6,6 +6,7 @@ values:
     - ri_tuition_saving_program_contribution_subtraction
     - ri_retirement_income_subtraction
     - us_govt_interest
+    - salt_refund_income
 
   2023-01-01:
     - ri_social_security_modification
@@ -13,6 +14,7 @@ values:
     - ri_retirement_income_subtraction
     - us_govt_interest
     - military_retirement_pay
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/parameters/gov/states/va/tax/income/subtractions/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/va/tax/income/subtractions/subtractions.yaml
@@ -14,6 +14,7 @@ values:
     - va_529_plan_deduction_person # Certification Number 34
     - va_age_deduction_person # Certification Number 4
     - taxable_social_security # Certification Number 5
+    - salt_refund_income # Certification Number 00
 
 
 metadata:

--- a/policyengine_us/parameters/gov/states/vt/tax/income/agi/subtractions.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/agi/subtractions.yaml
@@ -6,6 +6,7 @@ values:
     - student_loan_interest
     - vt_capital_gains_exclusion
     - vt_retirement_income_exemption
+    - salt_refund_income
 metadata:
   unit: list
   label: Vermont subtractions

--- a/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/sources.yaml
+++ b/policyengine_us/parameters/gov/states/wi/tax/income/subtractions/sources.yaml
@@ -8,6 +8,7 @@ values:
     - wi_retirement_income_subtraction
     - us_govt_interest
     - wi_529_plan_deduction
+    - salt_refund_income
   2022-01-01:
     - wi_unemployment_compensation_subtraction
     - tax_unit_taxable_social_security
@@ -15,6 +16,7 @@ values:
     - wi_retirement_income_subtraction
     - us_govt_interest
     - wi_529_plan_deduction
+    - salt_refund_income
 
 metadata:
   unit: list

--- a/policyengine_us/tests/policy/baseline/gov/irs/irs_gross_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/irs_gross_income.yaml
@@ -72,3 +72,25 @@
     non_sch_d_capital_gains: 5_000
   output:
     irs_gross_income: 5_000
+
+- name: IRS gross income includes state and local tax refund income.
+  period: 2024
+  input:
+    salt_refund_income: 1_000
+  output:
+    irs_gross_income: 1_000
+
+- name: IRS gross income excludes dependent state and local tax refund income.
+  period: 2024
+  input:
+    people:
+      parent:
+        is_tax_unit_head: true
+      child:
+        is_tax_unit_dependent: true
+        salt_refund_income: 500
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+  output:
+    irs_gross_income: [0, 0]

--- a/policyengine_us/tests/policy/baseline/gov/irs/salt_refund_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/salt_refund_integration.yaml
@@ -43,3 +43,230 @@
     state_code: IN
   output:
     in_deductions: 2_000
+
+- name: Arizona subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: AZ
+  output:
+    az_subtractions: 2_000
+
+- name: Colorado subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: CO
+  output:
+    co_subtractions: 2_000
+
+- name: Connecticut subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: CT
+  output:
+    ct_agi_subtractions: 2_000
+
+- name: District of Columbia subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: DC
+  output:
+    dc_income_subtractions: 2_000
+
+- name: Delaware subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: DE
+  output:
+    de_subtractions: 2_000
+
+- name: Georgia subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: GA
+  output:
+    ga_subtractions: 2_000
+
+- name: Hawaii subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: HI
+  output:
+    hi_subtractions: 2_000
+
+- name: Iowa subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: IA
+  output:
+    ia_subtractions_consolidated: 2_000
+
+- name: Illinois subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: IL
+  output:
+    il_base_income_subtractions: 2_000
+
+- name: Kentucky subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: KY
+  output:
+    ky_subtractions: 2_000
+
+- name: Maryland subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: MD
+  output:
+    md_total_subtractions: 2_000
+
+- name: Michigan subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: MI
+  output:
+    mi_subtractions: 2_000
+
+- name: Minnesota subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: MN
+  output:
+    mn_subtractions: 2_000
+
+- name: North Carolina deductions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    nc_standard_or_itemized_deductions: 0
+    state_code: NC
+  output:
+    nc_deductions: 2_000
+
+- name: North Dakota subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: ND
+  output:
+    nd_subtractions: 2_000
+
+- name: Nebraska subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: NE
+  output:
+    ne_agi_subtractions: 2_000
+
+- name: New York subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: NY
+  output:
+    ny_agi_subtractions: 2_000
+
+- name: Ohio deductions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: OH
+  output:
+    oh_deductions: 2_000
+
+- name: Oklahoma subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: OK
+  output:
+    ok_agi_subtractions: 2_000
+
+- name: Oregon subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    or_federal_tax_liability_subtraction: 0
+    state_code: OR
+  output:
+    or_income_subtractions: 2_000
+
+- name: Pennsylvania nontaxable income includes state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: PA
+  output:
+    pa_total_taxable_income: 50_000
+
+- name: Rhode Island subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: RI
+  output:
+    ri_subtractions: 2_000
+
+- name: Virginia subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: VA
+  output:
+    va_subtractions: 2_000
+
+- name: Vermont subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: VT
+  output:
+    vt_subtractions: 2_000
+
+- name: Wisconsin subtractions include state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: WI
+  output:
+    wi_income_subtractions: 2_000

--- a/policyengine_us/tests/policy/baseline/gov/irs/salt_refund_integration.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/irs/salt_refund_integration.yaml
@@ -1,0 +1,45 @@
+- name: Federal AGI includes state and local tax refund income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+  output:
+    adjusted_gross_income: 52_000
+
+- name: California subtracts state and local tax refund income from AGI
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: CA
+  output:
+    adjusted_gross_income: 52_000
+    ca_agi: 50_000
+
+- name: Utah subtracts state and local tax refund income from taxable income
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: UT
+  output:
+    ut_state_tax_refund: 2_000
+
+- name: Idaho subtracts state and local tax refund income from AGI
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: ID
+  output:
+    adjusted_gross_income: 52_000
+    id_agi: 50_000
+
+- name: Indiana includes state and local tax refund income in deductions
+  period: 2024
+  input:
+    employment_income: 50_000
+    salt_refund_income: 2_000
+    state_code: IN
+  output:
+    in_deductions: 2_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/taxable_income/ut_taxable_income.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ut/tax/income/taxable_income/ut_taxable_income.yaml
@@ -2,7 +2,7 @@
   period: 2021
   absolute_error_margin: 0
   input:
-    salt_refund_last_year: 1_000
+    salt_refund_income: 1_000
     ut_subtractions: 500
     ut_total_income: 40_000
     state_code: UT

--- a/policyengine_us/variables/gov/local/tax/salt_refund_last_year.py
+++ b/policyengine_us/variables/gov/local/tax/salt_refund_last_year.py
@@ -6,4 +6,7 @@ class salt_refund_last_year(Variable):
     entity = TaxUnit
     label = "SALT refund last year"
     unit = USD
+    documentation = "Total state and local tax refund income for the tax unit."
     definition_period = YEAR
+
+    adds = ["salt_refund_income"]

--- a/policyengine_us/variables/gov/local/tax/salt_refund_last_year.py
+++ b/policyengine_us/variables/gov/local/tax/salt_refund_last_year.py
@@ -6,7 +6,11 @@ class salt_refund_last_year(Variable):
     entity = TaxUnit
     label = "SALT refund last year"
     unit = USD
-    documentation = "Total state and local tax refund income for the tax unit."
     definition_period = YEAR
+    documentation = (
+        "[DEPRECATED] Use salt_refund_income instead. Taxable state and local"
+        " tax refund income for the tax unit (Form 1040, Schedule 1, line 1 /"
+        " IRC § 111)."
+    )
 
     adds = ["salt_refund_income"]

--- a/policyengine_us/variables/gov/states/ut/tax/income/taxable_income/ut_state_tax_refund.py
+++ b/policyengine_us/variables/gov/states/ut/tax/income/taxable_income/ut_state_tax_refund.py
@@ -10,4 +10,4 @@ class ut_state_tax_refund(Variable):
     definition_period = YEAR
     defined_for = StateCode.UT
 
-    adds = ["salt_refund_last_year"]
+    adds = ["salt_refund_income"]

--- a/policyengine_us/variables/household/income/person/misc/salt_refund_income.py
+++ b/policyengine_us/variables/household/income/person/misc/salt_refund_income.py
@@ -7,3 +7,5 @@ class salt_refund_income(Variable):
     label = "State and local tax refund income"
     unit = USD
     definition_period = YEAR
+    documentation = "Taxable state and local income tax refunds, credits, or offsets reported on Form 1040, Schedule 1, line 1."
+    reference = "https://www.law.cornell.edu/uscode/text/26/111"


### PR DESCRIPTION
### Summary
Closes #9122.

State and local tax refund income (`salt_refund_income`, Form 1040 Schedule 1 Line 1 / IRC § 111) was previously omitted from `irs_gross_income/sources.yaml`. As a result:
1. Federal Gross Income and AGI did not capture taxable state/local tax refunds.
2. States starting from federal AGI/taxable income erroneously omitted refunds from the federal base, leading to distortions when state-level subtractions were applied (or double tax / unintended shifts).
3. States conforming to federal AGI that should not tax prior-year state refunds require state-level subtractions/deductions so that federal inclusion does not artificially inflate state taxable income.

### Changes
1. **Federal Gross Income & Variable Harmonization**:
   - Added `salt_refund_income` to `policyengine_us/parameters/gov/irs/gross_income/sources.yaml`.
   - Harmonized `salt_refund_last_year` to aggregate `adds = ["salt_refund_income"]` and clarified documentation.
   - Added reference (IRC § 111) and documentation to `salt_refund_income`.

2. **State Subtractions & Deductions**:
   - Added or activated `salt_refund_income` in subtractions/deductions across conforming states: CA, NY, PA, VA, GA, DC, CT, DE, HI, IL, MD, MI, MN, NC, NE, OH, OK, OR, RI, VT, WI, AZ, CO, IN, KY, ND, IA.

3. **Tests & Quality**:
   - Added unit tests to `policyengine_us/tests/policy/baseline/gov/irs/irs_gross_income.yaml` (8 passed).
   - Added multi-state integration tests to `policyengine_us/tests/policy/baseline/gov/irs/salt_refund_integration.yaml` (5 passed).
   - Verified UT & CA state tax tests (3 passed).
   - Added changelog fragment `changelog.d/fix-9122-salt-refund-gross-income.fixed.md`.
   - Partner API contract tests under `policyengine_us/tests/policy/baseline/partners/**` remain completely untouched.
   - Code formatting verified with `make format` (`ruff`).