### PR TITLE
Use propagate_metadata_to_children for uprating in breakdown parameters

### DIFF
--- a/changelog.d/simplify-breakdown-uprating.changed.md
+++ b/changelog.d/simplify-breakdown-uprating.changed.md
@@ -1,0 +1,1 @@
+Simplified uprating metadata in breakdown parameters using `propagate_metadata_to_children`.

--- a/policyengine_us/parameters/gov/contrib/harris/lift/middle_class_tax_credit/phase_out/start.yaml
+++ b/policyengine_us/parameters/gov/contrib/harris/lift/middle_class_tax_credit/phase_out/start.yaml
@@ -1,57 +1,32 @@
 description: The Middle Class Tax Credit is phased-out for filers with adjusted gross income above this threshold, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: nearest
+      interval: 50
   unit: currency-USD
   period: year
   breakdown:
   - filing_status
   label: Middle Class Tax Credit phase-out start
-  reference: 
-    - title: S.4 - LIFT (Livable Incomes for Families Today) the Middle Class Act SEC. 36A. (a)(2)(A)
-      href: https://www.congress.gov/bill/116th-congress/senate-bill/4/text
+  reference:
+  - title: S.4 - LIFT (Livable Incomes for Families Today) the Middle Class Act SEC. 36A. (a)(2)(A)
+    href: https://www.congress.gov/bill/116th-congress/senate-bill/4/text
 
 SINGLE:
   values:
     2019-01-01: 30_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2019-01-01: 60_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 JOINT:
   values:
     2019-01-01: 60_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2019-01-01: 30_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 SEPARATE:
   values:
     2019-01-01: 30_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50

--- a/policyengine_us/parameters/gov/contrib/harris/lift/middle_class_tax_credit/phase_out/width.yaml
+++ b/policyengine_us/parameters/gov/contrib/harris/lift/middle_class_tax_credit/phase_out/width.yaml
@@ -1,57 +1,32 @@
 description: The Middle Class Tax Credit is phased-out for filers with adjusted gross income above this threshold, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: nearest
+      interval: 50
   unit: currency-USD
   period: year
   breakdown:
   - filing_status
   label: Middle Class Tax Credit phase-out width
-  reference: 
-    - title: S.4 - LIFT (Livable Incomes for Families Today) the Middle Class Act SEC. 36A. (a)(2)(A)
-      href: https://www.congress.gov/bill/116th-congress/senate-bill/4/text
+  reference:
+  - title: S.4 - LIFT (Livable Incomes for Families Today) the Middle Class Act SEC. 36A. (a)(2)(A)
+    href: https://www.congress.gov/bill/116th-congress/senate-bill/4/text
 
 SINGLE:
   values:
     2019-01-01: 20_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2019-01-01: 20_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 JOINT:
   values:
     2019-01-01: 40_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2019-01-01: 20_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50
 SEPARATE:
   values:
     2019-01-01: 20_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 50

--- a/policyengine_us/parameters/gov/contrib/states/dc/property_tax/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/dc/property_tax/amount.yaml
@@ -1,6 +1,11 @@
 description: DC provides the following property tax credit amount, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 25
   label: DC property tax credit amount
   period: year
   unit: currency-USD
@@ -11,45 +16,15 @@ metadata:
 JOINT:
   values:
     2025-01-01: 1_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 HEAD_OF_HOUSEHOLD:
   values:
     2025-01-01: 1_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SURVIVING_SPOUSE:
   values:
     2025-01-01: 1_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SINGLE:
   values:
     2025-01-01: 1_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SEPARATE:
   values:
     2025-01-01: 1_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25

--- a/policyengine_us/parameters/gov/contrib/states/dc/property_tax/income_limit/elderly.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/dc/property_tax/income_limit/elderly.yaml
@@ -1,6 +1,11 @@
 description: DC limits the property tax credit to households with at least one elderly head or spouse with adjusted gross income below this threshold, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 25
   label: DC property tax credit elderly income limit
   period: year
   unit: currency-USD
@@ -10,45 +15,15 @@ metadata:
 JOINT:
   values:
     2025-01-01: 89_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 HEAD_OF_HOUSEHOLD:
   values:
     2025-01-01: 89_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SURVIVING_SPOUSE:
   values:
     2025-01-01: 89_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SINGLE:
   values:
     2025-01-01: 89_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SEPARATE:
   values:
     2025-01-01: 89_400
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25

--- a/policyengine_us/parameters/gov/contrib/states/dc/property_tax/income_limit/non_elderly.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/dc/property_tax/income_limit/non_elderly.yaml
@@ -1,6 +1,11 @@
 description: DC limits the property tax credit to households with no elderly heads or spouses with adjusted gross income below this threshold, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 25
   label: DC property tax credit non-elderly income limit
   period: year
   unit: currency-USD
@@ -10,45 +15,15 @@ metadata:
 JOINT:
   values:
     2025-01-01: 65_600
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 HEAD_OF_HOUSEHOLD:
   values:
     2025-01-01: 65_600
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SURVIVING_SPOUSE:
   values:
     2025-01-01: 65_600
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SINGLE:
   values:
     2025-01-01: 65_600
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25
 SEPARATE:
   values:
     2025-01-01: 65_600
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 25

--- a/policyengine_us/parameters/gov/irs/deductions/itemized/limitation/applicable_amount.yaml
+++ b/policyengine_us/parameters/gov/irs/deductions/itemized/limitation/applicable_amount.yaml
@@ -20,12 +20,6 @@ JOINT:
     2033-01-01: 468_600
     2034-01-01: 477_900
     2035-01-01: 487_400
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SINGLE:
   values:
     2009-01-01: 166_800
@@ -47,12 +41,6 @@ SINGLE:
     2033-01-01: 390_500
     2034-01-01: 398_250
     2035-01-01: 406_200
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2009-01-01: 125_100
@@ -74,12 +62,6 @@ SEPARATE:
     2033-01-01: 234_300
     2034-01-01: 238_950
     2035-01-01: 243_700
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2009-01-01: 208_500
@@ -101,12 +83,6 @@ HEAD_OF_HOUSEHOLD:
     2033-01-01: 429_550
     2034-01-01: 438_100
     2035-01-01: 446_800
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE: # Same as joint
   values:
     2009-01-01: 250_200
@@ -128,14 +104,13 @@ SURVIVING_SPOUSE: # Same as joint
     2033-01-01: 468_600
     2034-01-01: 477_900
     2035-01-01: 487_400
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   label: Itemized deductions applicable amount
   period: year
   unit: currency-USD
@@ -143,23 +118,23 @@ metadata:
   - filing_status
   reference:
     # This section of the legal code was repealed between 2010-2012 and 2018-2025.
-    - title: 26 U.S. Code § 68 - Overall limitation on itemized deductions (b)(1)
-      href: https://www.law.cornell.edu/uscode/text/26/68#b_1
-    - title: 2009 Form 1040 - Limit on Itemized Deductions
-      href: https://www.irs.gov/pub/irs-prior/i1040gi--2009.pdf#page=6
-    - title: 2013 Instruction 1040 Schedule A
-      href: https://www.irs.gov/pub/irs-prior/i1040sca--2013.pdf#page=13
-    - title: 2014 Instruction 1040 Schedule A
-      href: https://www.irs.gov/pub/irs-prior/i1040sca--2014.pdf#page=12
-    - title: 2015 Instruction 1040 Schedule A
-      href: https://www.irs.gov/pub/irs-prior/i1040sca--2015.pdf#page=12
-    - title: 2016 Instructions for Schedule A (Form 1040)
-      href: https://www.irs.gov/pub/irs-prior/i1040sca--2016.pdf#page=12
-    - title: 2017 Instructions for Schedule A (Form 1040)
-      href: https://www.irs.gov/pub/irs-prior/i1040sca--2017.pdf#page=1
-    - title: CBO Tax Parameters and Effective Marginal Tax Rates | Feb 2024
+  - title: 26 U.S. Code § 68 - Overall limitation on itemized deductions (b)(1)
+    href: https://www.law.cornell.edu/uscode/text/26/68#b_1
+  - title: 2009 Form 1040 - Limit on Itemized Deductions
+    href: https://www.irs.gov/pub/irs-prior/i1040gi--2009.pdf#page=6
+  - title: 2013 Instruction 1040 Schedule A
+    href: https://www.irs.gov/pub/irs-prior/i1040sca--2013.pdf#page=13
+  - title: 2014 Instruction 1040 Schedule A
+    href: https://www.irs.gov/pub/irs-prior/i1040sca--2014.pdf#page=12
+  - title: 2015 Instruction 1040 Schedule A
+    href: https://www.irs.gov/pub/irs-prior/i1040sca--2015.pdf#page=12
+  - title: 2016 Instructions for Schedule A (Form 1040)
+    href: https://www.irs.gov/pub/irs-prior/i1040sca--2016.pdf#page=12
+  - title: 2017 Instructions for Schedule A (Form 1040)
+    href: https://www.irs.gov/pub/irs-prior/i1040sca--2017.pdf#page=1
+  - title: CBO Tax Parameters and Effective Marginal Tax Rates | Feb 2024
       # 1. Tax Parameters.
-      href: https://www.cbo.gov/system/files/2024-02/53724-2024-02-Tax-Parameters.xlsx
-    - title: CBO Tax Parameters and Effective Marginal Tax Rates | Jan 2025
+    href: https://www.cbo.gov/system/files/2024-02/53724-2024-02-Tax-Parameters.xlsx
+  - title: CBO Tax Parameters and Effective Marginal Tax Rates | Jan 2025
       # 1. Tax Parameters.
-      href: https://www.cbo.gov/system/files/2025-01/53724-2025-01-Tax-Parameters.xlsx
+    href: https://www.cbo.gov/system/files/2025-01/53724-2025-01-Tax-Parameters.xlsx

--- a/policyengine_us/parameters/gov/states/ca/tax/income/amt/exemption/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/amt/exemption/amount.yaml
@@ -1,6 +1,7 @@
 description: California provides the following alternative minimum tax exemption amount.
 metadata:
   propagate_metadata_to_children: true
+  uprating: gov.states.ca.cpi
   label: California exemption amount
   period: year
   unit: currency-USD
@@ -28,8 +29,6 @@ JOINT:
     2023-01-01: 116_229
     2024-01-01: 120_065
     2025-01-01: 123_667
-  metadata:
-    uprating: gov.states.ca.cpi
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 78_070
@@ -37,8 +36,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 87_171
     2024-01-01: 90_048
     2025-01-01: 92_749
-  metadata:
-    uprating: gov.states.ca.cpi
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 104_094
@@ -46,8 +43,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 116_229
     2024-01-01: 120_065
     2025-01-01: 123_667
-  metadata:
-    uprating: gov.states.ca.cpi
 SINGLE:
   values:
     2021-01-01: 78_070
@@ -55,8 +50,6 @@ SINGLE:
     2023-01-01: 87_171
     2024-01-01: 90_048
     2025-01-01: 92_749
-  metadata:
-    uprating: gov.states.ca.cpi
 SEPARATE:
   values:
     2021-01-01: 52_044
@@ -64,5 +57,3 @@ SEPARATE:
     2023-01-01: 58_111
     2024-01-01: 60_029
     2025-01-01: 61_830
-  metadata:
-    uprating: gov.states.ca.cpi

--- a/policyengine_us/parameters/gov/states/ca/tax/income/amt/exemption/amti/threshold/lower.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/amt/exemption/amti/threshold/lower.yaml
@@ -1,6 +1,7 @@
 description: California provides a flat alternative minimum tax exemption amount for filers with alternative minimum taxable income below this amount, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating: gov.states.ca.cpi
   label: California alternative minimum tax exemption lower AMTI threshold
   period: year
   unit: currency-USD
@@ -28,8 +29,6 @@ JOINT:
     2023-01-01: 435_855
     2024-01-01: 450_238
     2025-01-01: 463_745
-  metadata:
-    uprating: gov.states.ca.cpi
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 292_763
@@ -37,8 +36,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 326_891
     2024-01-01: 337_678
     2025-01-01: 347_808
-  metadata:
-    uprating: gov.states.ca.cpi
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 390_351
@@ -46,8 +43,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 435_855
     2024-01-01: 450_238
     2025-01-01: 463_745
-  metadata:
-    uprating: gov.states.ca.cpi
 SINGLE:
   values:
     2021-01-01: 292_763
@@ -55,8 +50,6 @@ SINGLE:
     2023-01-01: 326_891
     2024-01-01: 337_678
     2025-01-01: 347_808
-  metadata:
-    uprating: gov.states.ca.cpi
 SEPARATE:
   values:
     2021-01-01: 195_172
@@ -64,5 +57,3 @@ SEPARATE:
     2023-01-01: 217_924
     2024-01-01: 225_115
     2025-01-01: 231_868
-  metadata:
-    uprating: gov.states.ca.cpi

--- a/policyengine_us/parameters/gov/states/ca/tax/income/amt/exemption/amti/threshold/upper.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/amt/exemption/amti/threshold/upper.yaml
@@ -1,6 +1,7 @@
 description: California limits the alternative minimum tax exemption amount to filers with alternative minimum taxable income above this threshold, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating: gov.states.ca.cpi
   label: California alternative minimum tax exemption upper AMTI threshold
   period: year
   unit: currency-USD
@@ -28,8 +29,6 @@ JOINT:
     2023-01-01: 900_771
     2024-01-01: 930_498
     2025-01-01: 958_413
-  metadata:
-    uprating: gov.states.ca.cpi
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 605_043
@@ -37,8 +36,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 675_575
     2024-01-01: 697_870
     2025-01-01: 718_804
-  metadata:
-    uprating: gov.states.ca.cpi
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 806_727
@@ -46,8 +43,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 900_771
     2024-01-01: 930_498
     2025-01-01: 958_413
-  metadata:
-    uprating: gov.states.ca.cpi
 SINGLE:
   values:
     2021-01-01: 605_043
@@ -55,8 +50,6 @@ SINGLE:
     2023-01-01: 675_575
     2024-01-01: 697_870
     2025-01-01: 718_804
-  metadata:
-    uprating: gov.states.ca.cpi
 SEPARATE:
   values:
     2021-01-01: 403_348
@@ -64,5 +57,3 @@ SEPARATE:
     2023-01-01: 450_368
     2024-01-01: 465_231
     2025-01-01: 479_188
-  metadata:
-    uprating: gov.states.ca.cpi

--- a/policyengine_us/parameters/gov/states/ca/tax/income/deductions/itemized/limit/agi_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/deductions/itemized/limit/agi_threshold.yaml
@@ -1,6 +1,7 @@
 description: Federal AGI above which CA itemized deductions are limited.
 metadata:
   propagate_metadata_to_children: true
+  uprating: gov.states.ca.cpi
   label: California itemized deduction limitation threshold
   period: year
   unit: currency-USD
@@ -28,8 +29,6 @@ JOINT:
     2023-01-01: 474_075
     2024-01-01: 489_719
     2025-01-01: 504_411
-  metadata:
-    uprating: gov.states.ca.cpi
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 318_437
@@ -37,8 +36,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 355_558
     2024-01-01: 367_291
     2025-01-01: 378_310
-  metadata:
-    uprating: gov.states.ca.cpi
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 424_581
@@ -46,8 +43,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 474_075
     2024-01-01: 489_719
     2025-01-01: 504_411
-  metadata:
-    uprating: gov.states.ca.cpi
 SINGLE:
   values:
     2021-01-01: 212_288
@@ -55,8 +50,6 @@ SINGLE:
     2023-01-01: 237_035
     2024-01-01: 244_857
     2025-01-01: 252_203
-  metadata:
-    uprating: gov.states.ca.cpi
 SEPARATE:
   values:
     2021-01-01: 212_288
@@ -64,5 +57,3 @@ SEPARATE:
     2023-01-01: 237_035
     2024-01-01: 244_857
     2025-01-01: 252_203
-  metadata:
-    uprating: gov.states.ca.cpi

--- a/policyengine_us/parameters/gov/states/ca/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/deductions/standard/amount.yaml
@@ -1,6 +1,7 @@
 description: California provides filers a standard deduction of this amount, depending on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating: gov.states.ca.cpi
   label: California standard deduction
   period: year
   unit: currency-USD
@@ -28,8 +29,6 @@ JOINT:
     2023-01-01: 10_726
     2024-01-01: 11_080
     2025-01-01: 11_412
-  metadata:
-    uprating: gov.states.ca.cpi
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 9_606
@@ -37,8 +36,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 10_726
     2024-01-01: 11_080
     2025-01-01: 11_412
-  metadata:
-    uprating: gov.states.ca.cpi
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 9_606
@@ -46,8 +43,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 10_726
     2024-01-01: 11_080
     2025-01-01: 11_412
-  metadata:
-    uprating: gov.states.ca.cpi
 SINGLE:
   values:
     2021-01-01: 4_803
@@ -55,8 +50,6 @@ SINGLE:
     2023-01-01: 5_363
     2024-01-01: 5_540
     2025-01-01: 5_706
-  metadata:
-    uprating: gov.states.ca.cpi
 SEPARATE:
   values:
     2021-01-01: 4_803
@@ -64,5 +57,3 @@ SEPARATE:
     2023-01-01: 5_363
     2024-01-01: 5_540
     2025-01-01: 5_706
-  metadata:
-    uprating: gov.states.ca.cpi

--- a/policyengine_us/parameters/gov/states/ca/tax/income/exemptions/phase_out/start.yaml
+++ b/policyengine_us/parameters/gov/states/ca/tax/income/exemptions/phase_out/start.yaml
@@ -7,8 +7,6 @@ SINGLE:
     2023-01-01: 237_035
     2024-01-01: 244_857
     2025-01-01: 252_203
-  metadata:
-    uprating: gov.states.ca.cpi
 SEPARATE:
   values:
     1991-01-01: 100_000
@@ -17,8 +15,6 @@ SEPARATE:
     2023-01-01: 237_035
     2024-01-01: 244_857
     2025-01-01: 252_203
-  metadata:
-    uprating: gov.states.ca.cpi
 SURVIVING_SPOUSE:
   values:
     1991-01-01: 200_000
@@ -27,8 +23,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 474_075
     2024-01-01: 489_719
     2025-01-01: 504_411
-  metadata:
-    uprating: gov.states.ca.cpi
 JOINT:
   values:
     1991-01-01: 200_000
@@ -37,8 +31,6 @@ JOINT:
     2023-01-01: 474_075
     2024-01-01: 489_719
     2025-01-01: 504_411
-  metadata:
-    uprating: gov.states.ca.cpi
 HEAD_OF_HOUSEHOLD:
   values:
     1991-01-01: 150_000
@@ -47,11 +39,9 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 355_558
     2024-01-01: 367_291
     2025-01-01: 378_310
-  metadata:
-    uprating: gov.states.ca.cpi
-
 metadata:
   propagate_metadata_to_children: true
+  uprating: gov.states.ca.cpi
   period: year
   unit: currency-USD
   breakdown:

--- a/policyengine_us/parameters/gov/states/co/tax/income/credits/family_affordability/reduction/threshold.yaml
+++ b/policyengine_us/parameters/gov/states/co/tax/income/credits/family_affordability/reduction/threshold.yaml
@@ -1,60 +1,35 @@
 description: Colorado reduces the family affordability tax credit starting at this adjusted gross income threshold, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: nearest
+      interval: 1_000
   period: year
   unit: currency-USD
   label: Colorado family affordability tax credit income-based reduction start
   breakdown:
-    - filing_status
+  - filing_status
   reference:
-    - title: Colorado General Assembly House Bill 24-1311 Family Affordability Tax Credit
-      href: https://leg.colorado.gov/bills/hb24-1311
-    - title: 2024 Colorado Child Tax Credit Instructions, Section C
-      href: https://tax.colorado.gov/sites/tax/files/documents/DR_0104CN_2024.pdf#page=3
-    - title: 2025 Colorado Individual Tax Filing Guide 104 Book, Section C
-      href: https://tax.colorado.gov/sites/tax/files/documents/Book104_2025.pdf#page=27
+  - title: Colorado General Assembly House Bill 24-1311 Family Affordability Tax Credit
+    href: https://leg.colorado.gov/bills/hb24-1311
+  - title: 2024 Colorado Child Tax Credit Instructions, Section C
+    href: https://tax.colorado.gov/sites/tax/files/documents/DR_0104CN_2024.pdf#page=3
+  - title: 2025 Colorado Individual Tax Filing Guide 104 Book, Section C
+    href: https://tax.colorado.gov/sites/tax/files/documents/Book104_2025.pdf#page=27
 SINGLE:
   values:
     2024-01-01: 15_000
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 1_000
 HEAD_OF_HOUSEHOLD:
   values:
     2024-01-01: 15_000
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 1_000
 JOINT:
   values:
     2024-01-01: 25_000
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 1_000
 SURVIVING_SPOUSE:
   values:
     2024-01-01: 15_000
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 1_000
 SEPARATE:
   values:
     2024-01-01: 15_000
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: nearest
-        interval: 1_000

--- a/policyengine_us/parameters/gov/states/dc/tax/income/credits/ctc/income_threshold.yaml
+++ b/policyengine_us/parameters/gov/states/dc/tax/income/credits/ctc/income_threshold.yaml
@@ -1,57 +1,32 @@
-description: DC limits its Child Tax Credit to filers with taxable income below the following amount, based on filing status. 
+description: DC limits its Child Tax Credit to filers with taxable income below the following amount, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 100
   label: DC Child Tax Credit taxable income threshold
   unit: currency_USD
   period: year
   breakdown:
-    - filing_status
+  - filing_status
   reference:
-    - title: Code of the District of Columbia § 47-1806.17(e)(5)
-      href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.17#(e)(5)
-    
+  - title: Code of the District of Columbia § 47-1806.17(e)(5)
+    href: https://code.dccouncil.gov/us/dc/council/code/sections/47-1806.17#(e)(5)
+
 SINGLE:
   values:
     2026-01-01: 55_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 100
 JOINT:
   values:
     2026-01-01: 70_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 100
 SEPARATE:
   values:
     2026-01-01: 35_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 100
 HEAD_OF_HOUSEHOLD:
   values:
     2026-01-01: 55_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 100
 SURVIVING_SPOUSE:
   values:
     2026-01-01: 55_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 100

--- a/policyengine_us/parameters/gov/states/md/tax/income/deductions/standard/max.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/deductions/standard/max.yaml
@@ -1,26 +1,31 @@
 description: Maryland provides a standard deduction of up to this amount.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   label: Maryland maximum standard deduction
   period: year
   unit: currency-USD
   breakdown:
-    - filing_status
+  - filing_status
   reference:
-    - title: Maryland 2025 Resident Tax Forms and Instructions - Standard Deduction
-      href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=21
-    - title: Maryland 2024 State & Local Tax Forms & Instructions - Worksheet 16(a)
-      href: https://www.marylandtaxes.gov/forms/24-forms/Resident-Booklet.pdf#page=20
-    - title: Maryland 2023 State & Local Tax Forms & Instructions
-      href: https://www.marylandtaxes.gov/forms/23_forms/Resident-Booklet.pdf#page=19
-    - title: Maryland 2024 Nonresident Tax Forms & Instructions (15)
-      href: https://www.marylandtaxes.gov/forms/24-forms/Nonresident-Booklet.pdf#page=13
-    - title: "MD Code, Tax - General, § 10-217 (c)(1)"
-      href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
-    - title: "MD Code, Tax - General, § 10-217 (d)(1)-(d)(3)"
-      href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
-    - title: "Maryland new tax year update -exemptions and deductions"
-      href: https://www.marylandtaxes.gov/new-tax-year-update.php#:~:text=Standard%20Deduction%20%2D%20The%20tax%20year,spouse%2C%20and%20taxpayers%20filing%20jointly.
+  - title: Maryland 2025 Resident Tax Forms and Instructions - Standard Deduction
+    href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=21
+  - title: Maryland 2024 State & Local Tax Forms & Instructions - Worksheet 16(a)
+    href: https://www.marylandtaxes.gov/forms/24-forms/Resident-Booklet.pdf#page=20
+  - title: Maryland 2023 State & Local Tax Forms & Instructions
+    href: https://www.marylandtaxes.gov/forms/23_forms/Resident-Booklet.pdf#page=19
+  - title: Maryland 2024 Nonresident Tax Forms & Instructions (15)
+    href: https://www.marylandtaxes.gov/forms/24-forms/Nonresident-Booklet.pdf#page=13
+  - title: "MD Code, Tax - General, § 10-217 (c)(1)"
+    href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
+  - title: "MD Code, Tax - General, § 10-217 (d)(1)-(d)(3)"
+    href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
+  - title: "Maryland new tax year update -exemptions and deductions"
+    href: https://www.marylandtaxes.gov/new-tax-year-update.php#:~:text=Standard%20Deduction%20%2D%20The%20tax%20year,spouse%2C%20and%20taxpayers%20filing%20jointly.
 JOINT:
   values:
     2018-01-01: 4_500
@@ -28,12 +33,6 @@ JOINT:
     2022-01-01: 4_850
     2023-01-01: 5_150
     2024-01-01: 5_450
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2018-01-01: 4_500
@@ -41,12 +40,6 @@ HEAD_OF_HOUSEHOLD:
     2022-01-01: 4_850
     2023-01-01: 5_150
     2024-01-01: 5_450
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2018-01-01: 4_500
@@ -54,12 +47,6 @@ SURVIVING_SPOUSE:
     2022-01-01: 4_850
     2023-01-01: 5_150
     2024-01-01: 5_450
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SINGLE:
   values:
     2018-01-01: 2_250
@@ -67,12 +54,6 @@ SINGLE:
     2022-01-01: 2_400
     2023-01-01: 2_550
     2024-01-01: 2_700
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2018-01-01: 2_250
@@ -80,9 +61,3 @@ SEPARATE:
     2022-01-01: 2_400
     2023-01-01: 2_550
     2024-01-01: 2_700
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/md/tax/income/deductions/standard/min.yaml
+++ b/policyengine_us/parameters/gov/states/md/tax/income/deductions/standard/min.yaml
@@ -1,28 +1,33 @@
 description: Maryland provides a standard deduction of at least this amount.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   label: Maryland minimum standard deduction
   period: year
   unit: currency-USD
   breakdown:
-    - filing_status
+  - filing_status
   reference:
-    - title: Maryland 2025 Resident Tax Forms and Instructions - Standard Deduction
-      href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=21
-    - title: Maryland 2022 State & Local Tax Forms & Instructions
-      href: https://www.marylandtaxes.gov/forms/22_forms/Resident_Booklet.pdf#page=18
-    - title: Maryland 2023 State & Local Tax Forms & Instructions 
-      href: https://www.marylandtaxes.gov/forms/23_forms/Resident-Booklet.pdf#page=19
-    - title: Maryland 2024 State & Local Tax Forms & Instructions - Worksheet 16(a)
-      href: https://www.marylandtaxes.gov/forms/24-forms/Resident-Booklet.pdf#page=20
-    - title: MD Code, Tax - General, § 10-217 (c)(1)
-      href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
-    - title: MD Code, Tax - General, § 10-217 (d)(1)-(d)(3)
-      href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
-    - title: MD Code, Tax - General, § 10-217 (d)(1)-(d)(3)
-      href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
-    - title: Maryland new tax year update -exemptions and deductions
-      href: https://www.marylandtaxes.gov/new-tax-year-update.php#:~:text=Standard%20Deduction%20%2D%20The%20tax%20year,spouse%2C%20and%20taxpayers%20filing%20jointly.
+  - title: Maryland 2025 Resident Tax Forms and Instructions - Standard Deduction
+    href: https://www.marylandcomptroller.gov/content/dam/mdcomp/tax/instructions/2025/resident-booklet.pdf#page=21
+  - title: Maryland 2022 State & Local Tax Forms & Instructions
+    href: https://www.marylandtaxes.gov/forms/22_forms/Resident_Booklet.pdf#page=18
+  - title: Maryland 2023 State & Local Tax Forms & Instructions
+    href: https://www.marylandtaxes.gov/forms/23_forms/Resident-Booklet.pdf#page=19
+  - title: Maryland 2024 State & Local Tax Forms & Instructions - Worksheet 16(a)
+    href: https://www.marylandtaxes.gov/forms/24-forms/Resident-Booklet.pdf#page=20
+  - title: MD Code, Tax - General, § 10-217 (c)(1)
+    href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
+  - title: MD Code, Tax - General, § 10-217 (d)(1)-(d)(3)
+    href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
+  - title: MD Code, Tax - General, § 10-217 (d)(1)-(d)(3)
+    href: https://govt.westlaw.com/mdc/Document/NC8EB19606F6911E8A99BCF2C90B83D38?viewType=FullText&originationContext=documenttoc&transitionType=CategoryPageItem&contextData=(sc.Default)#co_anchor_I552E3B107DF711ECA8F2FF3A9E62BB69
+  - title: Maryland new tax year update -exemptions and deductions
+    href: https://www.marylandtaxes.gov/new-tax-year-update.php#:~:text=Standard%20Deduction%20%2D%20The%20tax%20year,spouse%2C%20and%20taxpayers%20filing%20jointly.
 JOINT:
   values:
     2018-01-01: 3_000
@@ -30,12 +35,6 @@ JOINT:
     2022-01-01: 3_200
     2023-01-01: 3_450
     2024-01-01: 3_650
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2018-01-01: 3_000
@@ -43,12 +42,6 @@ HEAD_OF_HOUSEHOLD:
     2022-01-01: 3_200
     2023-01-01: 3_450
     2024-01-01: 3_650
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2018-01-01: 3_000
@@ -56,12 +49,6 @@ SURVIVING_SPOUSE:
     2022-01-01: 3_200
     2023-01-01: 3_450
     2024-01-01: 3_650
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SINGLE:
   values:
     2018-01-01: 1_500
@@ -69,12 +56,6 @@ SINGLE:
     2022-01-01: 1_600
     2023-01-01: 1_700
     2024-01-01: 1_800
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2018-01-01: 1_500
@@ -82,9 +63,3 @@ SEPARATE:
     2022-01-01: 1_600
     2023-01-01: 1_700
     2024-01-01: 1_800
-  metadata:
-    uprating: 
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/pension_exclusion/phaseout/start.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/agi/subtractions/pension_exclusion/phaseout/start.yaml
@@ -1,67 +1,42 @@
 description: Maine limits the non-military pension income deduction for filers with federal adjusted gross income above this amount, based on filing status, under the Maine state income tax.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   unit: currency-USD
   period: year
   label: Maine pension income deduction phaseout start
   reference:
-    - title: 36 M.R.S. § 5122(2)(M-3) — Phaseout of pension income deduction applicable amount
-      href: https://www.mainelegislature.org/legis/statutes/36/title36sec5122.html
-    - title: 36 M.R.S. § 5403(11) — Income deduction for retirement plan benefits; applicable amount (annual inflation adjustments)
-      href: https://www.mainelegislature.org/legis/statutes/36/title36sec5403.html
-    - title: 2025 Form 1040ME General Instructions, Important Changes for 2025
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf#page=3
-    - title: 2025 Form 1040ME Schedule 1S, Worksheet for Phaseout of Non-Military Pension Income Deduction
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_1s_fillable.pdf#page=2
+  - title: 36 M.R.S. § 5122(2)(M-3) — Phaseout of pension income deduction applicable amount
+    href: https://www.mainelegislature.org/legis/statutes/36/title36sec5122.html
+  - title: 36 M.R.S. § 5403(11) — Income deduction for retirement plan benefits; applicable amount (annual inflation adjustments)
+    href: https://www.mainelegislature.org/legis/statutes/36/title36sec5403.html
+  - title: 2025 Form 1040ME General Instructions, Important Changes for 2025
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf#page=3
+  - title: 2025 Form 1040ME Schedule 1S, Worksheet for Phaseout of Non-Military Pension Income Deduction
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_1s_fillable.pdf#page=2
   breakdown:
-    - filing_status
+  - filing_status
 SINGLE:
   values:
     2014-01-01: .inf
     2025-01-01: 125_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2014-01-01: .inf
     2025-01-01: 125_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2014-01-01: .inf
     2025-01-01: 187_500
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 JOINT:
   values:
     2014-01-01: .inf
     2025-01-01: 250_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2014-01-01: .inf
     2025-01-01: 250_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/base.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/amount/base.yaml
@@ -5,12 +5,6 @@ SINGLE:
     2023-01-01: 140
     2024-01-01: 150
     2025-01-01: 155
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 JOINT:
   values:
     2021-01-01: 180
@@ -18,21 +12,9 @@ JOINT:
     2023-01-01: 200
     2024-01-01: 210
     2025-01-01: 215
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 SEPARATE:
   values:
     2021-01-01: 0
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 180
@@ -40,12 +22,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 200
     2024-01-01: 210
     2025-01-01: 215
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 180
@@ -53,32 +29,30 @@ SURVIVING_SPOUSE:
     2023-01-01: 200
     2024-01-01: 210
     2025-01-01: 215
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
-
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 5
   unit: currency-USD
   reference:
     # Legal specifies inflation unadjusted amounts
-    - title: §5213-A. Sales tax fairness credit (A-1) 
-      href: https://legislature.maine.gov/statutes/36/title36sec5213-A.html
-    - title: §5403. Annual adjustments for inflation 5(A)
-      href: https://legislature.maine.gov/statutes/36/title36sec5403.html
-    - title: 2021 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit 
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/21_1040me_sched_pstfc_dwnldff.pdf#page=4
-    - title: 2022 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit 
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_pstfc_ff.pdf#page=4
-    - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
-    - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4
-    - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
+  - title: §5213-A. Sales tax fairness credit (A-1)
+    href: https://legislature.maine.gov/statutes/36/title36sec5213-A.html
+  - title: §5403. Annual adjustments for inflation 5(A)
+    href: https://legislature.maine.gov/statutes/36/title36sec5403.html
+  - title: 2021 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/21_1040me_sched_pstfc_dwnldff.pdf#page=4
+  - title: 2022 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_pstfc_ff.pdf#page=4
+  - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+  - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_Form%201040ME_Sch%20PTFC_ff.pdf#page=4
+  - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   period: year
   label: Maine sales tax fairness credit base amount
   breakdown:

--- a/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/reduction/start.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/credits/fairness/sales_tax/reduction/start.yaml
@@ -1,27 +1,32 @@
 description: Maine reduces the sales tax fairness credit for filers with income above this amount, based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   unit: currency-USD
   period: year
   label: Maine sales tax fairness credit phase-out start
   reference:
-    - title: §5213-A. Sales tax fairness credit (4)
-      href: https://legislature.maine.gov/statutes/36/title36sec5213-A.html
-    - title: §5403. Annual adjustments for inflation 5(C)
-      href: https://legislature.maine.gov/statutes/36/title36sec5403.html
+  - title: §5213-A. Sales tax fairness credit (4)
+    href: https://legislature.maine.gov/statutes/36/title36sec5213-A.html
+  - title: §5403. Annual adjustments for inflation 5(C)
+    href: https://legislature.maine.gov/statutes/36/title36sec5403.html
   # Reduction parameters only specified in the law
-    - title: 2021 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit 
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/21_1040me_sched_pstfc_dwnldff.pdf#page=4
-    - title: 2022 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit 
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_pstfc_ff.pdf#page=4
-    - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
-    - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
-    - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
+  - title: 2021 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/21_1040me_sched_pstfc_dwnldff.pdf#page=4
+  - title: 2022 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_pstfc_ff.pdf#page=4
+  - title: 2023 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+  - title: 2024 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_pstfc_ff.pdf#page=4
+  - title: 2025 Form 1040ME Property Tax Fairness Credit / Sales Tax Fairness Credit
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_sch_ptfc_fillable.pdf#page=4
   breakdown:
-    - filing_status
+  - filing_status
 SINGLE:
   values:
     2021-01-01: 21_350
@@ -29,21 +34,9 @@ SINGLE:
     2023-01-01: 23_300
     2024-01-01: 24_750
     2025-01-01: 25_450
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2021-01-01: 0
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 32_000
@@ -51,12 +44,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 34_950
     2024-01-01: 37_100
     2025-01-01: 38_200
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 JOINT:
   values:
     2021-01-01: 42_700
@@ -64,12 +51,6 @@ JOINT:
     2023-01-01: 46_600
     2024-01-01: 49_500
     2025-01-01: 50_950
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 42_700
@@ -77,9 +58,3 @@ SURVIVING_SPOUSE:
     2023-01-01: 46_600
     2024-01-01: 49_500
     2025-01-01: 50_950
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/me/tax/income/deductions/phase_out/start.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/deductions/phase_out/start.yaml
@@ -1,39 +1,44 @@
 description: Maine starts phasing out its standard/itemized deduction for filers with Maine AGI above this threshold.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   unit: currency-USD
   period: year
   label: Maine standard/itemized exemption phase-out start
   reference:
-    - title: Maine §5125. Itemized deductions 6 - Phase-out
-      href: https://www.mainelegislature.org/legis/statutes/36/title36sec5125.html
-    - title: §5403. Annual adjustments for inflation 4
-      href: https://legislature.maine.gov/statutes/36/title36sec5403.html
-    - title: Maine form 1040 Schedule 2 (2024)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_1040me_sched_2%20_ff.pdf#page=1
-    - title: 2025 Instructions for Form 1040ME - Worksheet for Standard/Itemized Deductions, Line 2
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf#page=5
+  - title: Maine §5125. Itemized deductions 6 - Phase-out
+    href: https://www.mainelegislature.org/legis/statutes/36/title36sec5125.html
+  - title: §5403. Annual adjustments for inflation 4
+    href: https://legislature.maine.gov/statutes/36/title36sec5403.html
+  - title: Maine form 1040 Schedule 2 (2024)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/24_1040me_sched_2%20_ff.pdf#page=1
+  - title: 2025 Instructions for Form 1040ME - Worksheet for Standard/Itemized Deductions, Line 2
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/25_1040me_gen_instr_w_cover_pg.pdf#page=5
     # 2026 phase-out thresholds from MRS 2026 Estimated Tax Worksheet, Line 6a (Phaseout of Itemized/Standard Deductions Worksheet, rev. Dec. 2025).
-    - title: 2026 Maine Estimated Tax Worksheet, Line 6a - Phaseout of Itemized/Standard Deductions Worksheet
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/26_item_stand_%20ded_phaseout_wksht_0.pdf
-    - title: Maine form 1040 Schedule 2 (2023)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_2_ff_0.pdf#page=1
-    - title: Maine form 1040 Schedule 2 (2022)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_2_ff.pdf#page=1
-    - title: Instructions for Form 1040ME (2021)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/21_1040me_book_gen_instr_revMay2022.pdf#page=4
-    - title: Maine form 1040 Schedule 2 (2020)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/20_1040me_2_dwnldff.pdf#page=1
-    - title: Maine form 1040 Schedule 2 (2019)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/19_1040me_2_dwnldff.pdf#page=1
-    - title: Maine form 1040 Schedule 2 (2018)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/18_1040_2_d.pdf#page=1
-    - title: Maine form 1040 Schedule 2 (2017)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/17_1040me_sch2_d_sept18.pdf#page=1
-    - title: Maine form 1040 Schedule 2 (2016)
-      href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/16_1040%20sched%202_download.pdf#page=1
+  - title: 2026 Maine Estimated Tax Worksheet, Line 6a - Phaseout of Itemized/Standard Deductions Worksheet
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/26_item_stand_%20ded_phaseout_wksht_0.pdf
+  - title: Maine form 1040 Schedule 2 (2023)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/23_1040me_sched_2_ff_0.pdf#page=1
+  - title: Maine form 1040 Schedule 2 (2022)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/22_1040me_sched_2_ff.pdf#page=1
+  - title: Instructions for Form 1040ME (2021)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/21_1040me_book_gen_instr_revMay2022.pdf#page=4
+  - title: Maine form 1040 Schedule 2 (2020)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/20_1040me_2_dwnldff.pdf#page=1
+  - title: Maine form 1040 Schedule 2 (2019)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/19_1040me_2_dwnldff.pdf#page=1
+  - title: Maine form 1040 Schedule 2 (2018)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/18_1040_2_d.pdf#page=1
+  - title: Maine form 1040 Schedule 2 (2017)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/17_1040me_sch2_d_sept18.pdf#page=1
+  - title: Maine form 1040 Schedule 2 (2016)
+    href: https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/16_1040%20sched%202_download.pdf#page=1
   breakdown:
-    - filing_status
+  - filing_status
 SINGLE:
   values:
     2016-01-01: 70_000
@@ -46,12 +51,6 @@ SINGLE:
     2024-01-01: 97_150
     2025-01-01: 100_000
     2026-01-01: 102_250
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2016-01-01: 70_000
@@ -64,12 +63,6 @@ SEPARATE:
     2024-01-01: 97_150
     2025-01-01: 100_000
     2026-01-01: 102_250
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2016-01-01: 105_000
@@ -82,12 +75,6 @@ HEAD_OF_HOUSEHOLD:
     2024-01-01: 145_750
     2025-01-01: 150_000
     2026-01-01: 153_400
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 JOINT:
   values:
     2016-01-01: 140_000
@@ -100,12 +87,6 @@ JOINT:
     2024-01-01: 194_300
     2025-01-01: 200_050
     2026-01-01: 204_550
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2016-01-01: 140_000
@@ -118,9 +99,3 @@ SURVIVING_SPOUSE:
     2024-01-01: 194_300
     2025-01-01: 200_050
     2026-01-01: 204_550
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/me/tax/income/surcharge/threshold.yaml
+++ b/policyengine_us/parameters/gov/states/me/tax/income/surcharge/threshold.yaml
@@ -1,6 +1,11 @@
 description: Maine limits its income tax surcharge to taxable income above this threshold under Maine's individual income tax.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   unit: currency-USD
   period: year
   label: Maine income tax surcharge threshold
@@ -25,49 +30,19 @@ SINGLE:
   values:
     0000-01-01: .inf
     2026-01-01: 1_000_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     0000-01-01: .inf
     2026-01-01: 750_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     0000-01-01: .inf
     2026-01-01: 1_500_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 JOINT:
   values:
     0000-01-01: .inf
     2026-01-01: 1_500_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     0000-01-01: .inf
     2026-01-01: 1_500_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/ri/tax/income/agi/subtractions/social_security/limit/income.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/agi/subtractions/social_security/limit/income.yaml
@@ -2,29 +2,34 @@ description: Rhode Island subtracts taxable social security benefits for filers 
 
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   label: Rhode Island social security subtraction income limit
   period: year
   unit: currency-USD
   breakdown:
-    - filing_status
+  - filing_status
   breakdown_label:
-    - Filing status
+  - Filing status
   reference:
-    - title: Rhode Island 2025 Modification for Taxable social security income worksheet
-      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2026-01/Social%20Security%20Worksheet_b.pdf#page=1
-    - title: 2025 RI-1040 Instructions page 18 (Social Security Worksheet)
-      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=18
+  - title: Rhode Island 2025 Modification for Taxable social security income worksheet
+    href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2026-01/Social%20Security%20Worksheet_b.pdf#page=1
+  - title: 2025 RI-1040 Instructions page 18 (Social Security Worksheet)
+    href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=18
   # The tax form points to this worksheet: Social Security modification on Schedule M, line 1s.
-    - title: Rhode Island 2024 Modification for Taxable social security income worksheet
-      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2024-09/Social%20Security%20Worksheet_bd.pdf#page=1
-    - title: Rhode Island 2023 Modification for Taxable social security income worksheet
-      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2023-12/Social%20Security%20Worksheet_w.pdf#page=1
-    - title: Rhode Island 2022 Modification for Taxable social security income worksheet
-      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2022-12/Social%20Security%20Worksheet_w.pdf#page=1
-    - title: Rhode Island 2021 Modification for Taxable social security income worksheet
-      href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2022-01/social-security-worksheet_b_0.pdf#page=1
-    - title: R.I. Gen. Laws § 44-30-12 (c), (8), (i)&(ii)
-      href: http://webserver.rilin.state.ri.us/Statutes/title44/44-30/44-30-12.HTM 
+  - title: Rhode Island 2024 Modification for Taxable social security income worksheet
+    href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2024-09/Social%20Security%20Worksheet_bd.pdf#page=1
+  - title: Rhode Island 2023 Modification for Taxable social security income worksheet
+    href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2023-12/Social%20Security%20Worksheet_w.pdf#page=1
+  - title: Rhode Island 2022 Modification for Taxable social security income worksheet
+    href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2022-12/Social%20Security%20Worksheet_w.pdf#page=1
+  - title: Rhode Island 2021 Modification for Taxable social security income worksheet
+    href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2022-01/social-security-worksheet_b_0.pdf#page=1
+  - title: R.I. Gen. Laws § 44-30-12 (c), (8), (i)&(ii)
+    href: http://webserver.rilin.state.ri.us/Statutes/title44/44-30/44-30-12.HTM
 
 JOINT:
   values:
@@ -34,12 +39,6 @@ JOINT:
     2023-01-01: 126_250
     2024-01-01: 130_250
     2025-01-01: 133_750
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2016-01-01: 80_000
@@ -48,12 +47,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 101_000
     2024-01-01: 104_200
     2025-01-01: 107_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2016-01-01: 100_000
@@ -62,12 +55,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 126_250
     2024-01-01: 130_250
     2025-01-01: 133_750
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SINGLE:
   values:
     2016-01-01: 80_000
@@ -76,12 +63,6 @@ SINGLE:
     2023-01-01: 101_000
     2024-01-01: 104_200
     2025-01-01: 107_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2016-01-01: 80_000
@@ -90,9 +71,3 @@ SEPARATE:
     2023-01-01: 101_025
     2024-01-01: 104_225
     2025-01-01: 107_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/ri/tax/income/agi/subtractions/taxable_retirement_income/income_limit.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/agi/subtractions/taxable_retirement_income/income_limit.yaml
@@ -2,13 +2,18 @@ description: Rhode Island subtracts taxable retirement income for filers with fe
 
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   label: Rhode Island taxable retirement income subtraction income limit
   period: year
   unit: currency-USD
   breakdown:
-    - filing_status
+  - filing_status
   breakdown_label:
-    - Filing status
+  - Filing status
   reference:
   - title: 2025 RI-1040 Instructions page I-10
     href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=10
@@ -23,7 +28,7 @@ metadata:
   # The law points to the social security modification (c) (8) while the actual amounts differ
   # in the tax forms
   - title: R.I. Gen. Laws § 44-30-12 (c), (8), (i)&(ii)
-    href: http://webserver.rilin.state.ri.us/Statutes/title44/44-30/44-30-12.HTM 
+    href: http://webserver.rilin.state.ri.us/Statutes/title44/44-30/44-30-12.HTM
 
 JOINT:
   values:
@@ -32,12 +37,6 @@ JOINT:
     2023-01-01: 126_250
     2024-01-01: 130_250
     2025-01-01: 133_750
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 87_200
@@ -45,12 +44,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 101_000
     2024-01-01: 104_200
     2025-01-01: 107_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 109_050
@@ -58,12 +51,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 126_250
     2024-01-01: 130_250
     2025-01-01: 133_750
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SINGLE:
   values:
     2021-01-01: 87_200
@@ -71,12 +58,6 @@ SINGLE:
     2023-01-01: 101_000
     2024-01-01: 104_200
     2025-01-01: 107_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2021-01-01: 87_200
@@ -84,9 +65,3 @@ SEPARATE:
     2023-01-01: 101_025
     2024-01-01: 104_225
     2025-01-01: 107_000
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/ri/tax/income/credits/ctc/phase_out/increment.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/credits/ctc/phase_out/increment.yaml
@@ -1,59 +1,34 @@
 description: Rhode Island sets this adjusted gross income increment under the Child Tax Credit program.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 5
   unit: currency-USD
   period: year
   label: Rhode Island Child Tax Credit phase-out increment
   breakdown:
-    - filing_status
+  - filing_status
   breakdown_label:
-    - Filing status
+  - Filing status
   reference:
-    - title: 2026 R.I. H 7127 Substitute A as amended, Article 6, Section 4, § 44-30-104(c)
-      href: https://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7127Aaa.html#:~:text=two%20thousand%20eight%20hundred%20seventy-five%20(%242%2C875)
+  - title: 2026 R.I. H 7127 Substitute A as amended, Article 6, Section 4, § 44-30-104(c)
+    href: https://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7127Aaa.html#:~:text=two%20thousand%20eight%20hundred%20seventy-five%20(%242%2C875)
 
 SINGLE:
   values:
     2027-01-01: 2_875
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 JOINT:
   values:
     2027-01-01: 3_590
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 SEPARATE:
   values:
     2027-01-01: 2_875
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 HEAD_OF_HOUSEHOLD:
   values:
     2027-01-01: 2_875
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 SURVIVING_SPOUSE:
   values:
     2027-01-01: 2_875
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5

--- a/policyengine_us/parameters/gov/states/ri/tax/income/credits/ctc/phase_out/threshold.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/credits/ctc/phase_out/threshold.yaml
@@ -1,59 +1,34 @@
 description: Rhode Island sets this adjusted gross income threshold under the Child Tax Credit program.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 5
   unit: currency-USD
   period: year
   label: Rhode Island Child Tax Credit phase-out threshold
   breakdown:
-    - filing_status
+  - filing_status
   breakdown_label:
-    - Filing status
+  - Filing status
   reference:
-    - title: 2026 R.I. H 7127 Substitute A as amended, Article 6, Section 4, § 44-30-104(c)
-      href: https://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7127Aaa.html#:~:text=exceeds%20eighty-eight%20thousand%20five%20hundred%20dollars
+  - title: 2026 R.I. H 7127 Substitute A as amended, Article 6, Section 4, § 44-30-104(c)
+    href: https://webserver.rilegislature.gov/BillText/BillText26/HouseText26/H7127Aaa.html#:~:text=exceeds%20eighty-eight%20thousand%20five%20hundred%20dollars
 
 SINGLE:
   values:
     2027-01-01: 88_500
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 JOINT:
   values:
     2027-01-01: 110_640
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 SEPARATE:
   values:
     2027-01-01: 88_500
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 HEAD_OF_HOUSEHOLD:
   values:
     2027-01-01: 88_500
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5
 SURVIVING_SPOUSE:
   values:
     2027-01-01: 88_500
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 5

--- a/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ri/tax/income/deductions/standard/amount.yaml
@@ -1,13 +1,18 @@
 description: Rhode Island provides filers a standard deduction of this amount, depending on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   label: Rhode Island standard deduction amount
   period: year
   unit: currency-USD
   breakdown:
-    - filing_status
+  - filing_status
   breakdown_label:
-    - Filing status
+  - Filing status
   reference:
   - title: Rhode Island RI-1040 Instructions 2025
     href: https://tax.ri.gov/sites/g/files/xkgbur541/files/2025-12/2025%201040R%20Instructions%20122025.pdf#page=4
@@ -27,12 +32,6 @@ SINGLE:
     2024-01-01: 10_550
     2025-01-01: 10_900
     2026-01-01: 11_200
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 JOINT:
   values:
     2021-01-01: 18_100
@@ -41,12 +40,6 @@ JOINT:
     2024-01-01: 21_150
     2025-01-01: 21_800
     2026-01-01: 22_400
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 13_550
@@ -55,12 +48,6 @@ HEAD_OF_HOUSEHOLD:
     2024-01-01: 15_850
     2025-01-01: 16_350
     2026-01-01: 16_800
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2021-01-01: 9_050
@@ -69,12 +56,6 @@ SEPARATE:
     2024-01-01: 10_575
     2025-01-01: 10_900
     2026-01-01: 11_200
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 18_100
@@ -83,9 +64,3 @@ SURVIVING_SPOUSE:
     2024-01-01: 21_150
     2025-01-01: 21_800
     2026-01-01: 22_400
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50

--- a/policyengine_us/parameters/gov/states/vt/tax/income/deductions/standard/base.yaml
+++ b/policyengine_us/parameters/gov/states/vt/tax/income/deductions/standard/base.yaml
@@ -1,25 +1,30 @@
 description: Vermont provides this standard deduction based on filing status.
 metadata:
   propagate_metadata_to_children: true
+  uprating:
+    parameter: gov.irs.uprating
+    rounding:
+      type: downwards
+      interval: 50
   label: Vermont standard deduction
   period: year
   unit: currency-USD
   breakdown:
-    - filing_status
+  - filing_status
   reference:
-    - title: 2021 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
-      href: https://tax.vermont.gov/sites/tax/files/documents/Income-Booklet-2021.pdf#page=10
-    - title: 2022 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
-      href: https://tax.vermont.gov/sites/tax/files/documents/Income%20Booklet-2022.pdf#page=10
-    - title: 2023 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
-      href: https://tax.vermont.gov/sites/tax/files/documents/Income-Booklet-2023.pdf#page=10
-    - title: 2024 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
-      href: https://tax.vermont.gov/sites/tax/files/documents/Income%20Booklet-2024.pdf#page=10
-    - title: 2025 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
-      href: https://tax.vermont.gov/sites/tax/files/documents/Income-Booklet-2025.pdf#page=11
+  - title: 2021 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
+    href: https://tax.vermont.gov/sites/tax/files/documents/Income-Booklet-2021.pdf#page=10
+  - title: 2022 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
+    href: https://tax.vermont.gov/sites/tax/files/documents/Income%20Booklet-2022.pdf#page=10
+  - title: 2023 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
+    href: https://tax.vermont.gov/sites/tax/files/documents/Income-Booklet-2023.pdf#page=10
+  - title: 2024 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
+    href: https://tax.vermont.gov/sites/tax/files/documents/Income%20Booklet-2024.pdf#page=10
+  - title: 2025 VERMONT Income Tax Return Form Instructions-Taxable Income Line 4
+    href: https://tax.vermont.gov/sites/tax/files/documents/Income-Booklet-2025.pdf#page=11
       # Legal code specifies amount with inflation adjustments..
-    - title: Legal Code Titl. 32 V.S.A. § 5811(21)(C)(ii) 
-      href: https://legislature.vermont.gov/statutes/section/32/151/05811 
+  - title: Legal Code Titl. 32 V.S.A. § 5811(21)(C)(ii)
+    href: https://legislature.vermont.gov/statutes/section/32/151/05811
 
 JOINT:
   values:
@@ -28,12 +33,6 @@ JOINT:
     2023-01-01: 14_050
     2024-01-01: 14_850
     2025-01-01: 15_300
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 HEAD_OF_HOUSEHOLD:
   values:
     2021-01-01: 9_500
@@ -41,12 +40,6 @@ HEAD_OF_HOUSEHOLD:
     2023-01-01: 10_550
     2024-01-01: 11_100
     2025-01-01: 11_450
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SURVIVING_SPOUSE:
   values:
     2021-01-01: 12_700
@@ -54,12 +47,6 @@ SURVIVING_SPOUSE:
     2023-01-01: 14_050
     2024-01-01: 14_850
     2025-01-01: 15_300
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SINGLE:
   values:
     2021-01-01: 6_350
@@ -67,12 +54,6 @@ SINGLE:
     2023-01-01: 7_000
     2024-01-01: 7_400
     2025-01-01: 7_650
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50
 SEPARATE:
   values:
     2021-01-01: 6_350
@@ -80,9 +61,3 @@ SEPARATE:
     2023-01-01: 7_000
     2024-01-01: 7_400
     2025-01-01: 7_650
-  metadata:
-    uprating:
-      parameter: gov.irs.uprating
-      rounding:
-        type: downwards
-        interval: 50


### PR DESCRIPTION
Fixes #5576.

Breakdown parameters currently repeat the same `uprating` block under every filing-status child. Since these files already set `propagate_metadata_to_children: true` in their top-level metadata, the uprating can be declared once at the top level and propagated to each child, as intended by #5570.

This PR hoists the duplicated per-child uprating blocks into the top-level metadata of the 27 remaining breakdown parameter files where every child uprates identically (1 federal, 21 state, 5 contrib). Behaviour is unchanged: `propagate_parameter_metadata` copies the parent's metadata into every child, and each removed child block was identical to the hoisted one. I verified this by loading the parameter tree before and after with policyengine-core and comparing every child's effective uprating - all identical.

Three files were left untouched because their children uprate differently or only some children uprate:
- gov/states/me/tax/income/deductions/personal_exemption/phaseout/start.yaml
- gov/contrib/states/ri/social_security_exemption/income_limit.yaml
- gov/irs/ald/student_loan_interest/reduction/start.yaml