### PR TITLE
Add Trump dividend contributed reform

### DIFF
--- a/changelog.d/trump-dividend.added.md
+++ b/changelog.d/trump-dividend.added.md
@@ -1,0 +1,1 @@
+Trump dividend contributed reform, providing a payment to citizens at or above a minimum age.

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/amount.yaml
@@ -1,3 +1,5 @@
+# Hypothetical illustrative reform; no official source document exists.
+# Parameters reflect the proposal as specified by the contributor.
 description: The Trump dividend provides this payment amount to each eligible person.
 metadata:
   unit: currency-USD

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/amount.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/amount.yaml
@@ -1,0 +1,7 @@
+description: The Trump dividend provides this payment amount to each eligible person.
+metadata:
+  unit: currency-USD
+  label: Trump dividend amount
+  period: year
+values:
+  0000-01-01: 5_000

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/eligible_immigration_statuses.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/eligible_immigration_statuses.yaml
@@ -1,0 +1,8 @@
+description: The Trump dividend is limited to people with the following immigration statuses.
+values:
+  0000-01-01:
+    - CITIZEN
+metadata:
+  unit: list
+  label: Trump dividend eligible immigration statuses
+  period: year

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/eligible_immigration_statuses.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/eligible_immigration_statuses.yaml
@@ -1,3 +1,5 @@
+# Hypothetical illustrative reform; no official source document exists.
+# Parameters reflect the proposal as specified by the contributor.
 description: The Trump dividend is limited to people with the following immigration statuses.
 values:
   0000-01-01:

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/in_effect.yaml
@@ -1,3 +1,5 @@
+# Hypothetical illustrative reform; no official source document exists.
+# Parameters reflect the proposal as specified by the contributor.
 description: The Trump dividend applies if this is true.
 metadata:
   unit: bool

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/in_effect.yaml
@@ -1,4 +1,4 @@
-description: The Trump dividend applies, if this is true.
+description: The Trump dividend applies if this is true.
 metadata:
   unit: bool
   label: Trump dividend in effect

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/in_effect.yaml
@@ -1,0 +1,7 @@
+description: The Trump dividend applies, if this is true.
+metadata:
+  unit: bool
+  label: Trump dividend in effect
+  period: year
+values:
+  0000-01-01: false

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/min_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/min_age.yaml
@@ -1,3 +1,5 @@
+# Hypothetical illustrative reform; no official source document exists.
+# Parameters reflect the proposal as specified by the contributor.
 description: The Trump dividend is limited to people at or above this age.
 metadata:
   unit: year

--- a/policyengine_us/parameters/gov/contrib/trump/dividend/min_age.yaml
+++ b/policyengine_us/parameters/gov/contrib/trump/dividend/min_age.yaml
@@ -1,0 +1,7 @@
+description: The Trump dividend is limited to people at or above this age.
+metadata:
+  unit: year
+  label: Trump dividend minimum age
+  period: year
+values:
+  0000-01-01: 18

--- a/policyengine_us/parameters/gov/household/household_benefits.yaml
+++ b/policyengine_us/parameters/gov/household/household_benefits.yaml
@@ -26,6 +26,7 @@ values:
     - ak_energy_relief
     # Contributed.
     - basic_income
+    - trump_dividend
     - spm_unit_capped_housing_subsidy
     - household_state_benefits
     - household_health_benefits
@@ -51,6 +52,7 @@ values:
     - household_head_start_benefits
     # Contributed.
     - basic_income
+    - trump_dividend
     - spm_unit_capped_housing_subsidy
     - household_state_benefits
     - commodity_supplemental_food_program

--- a/policyengine_us/tests/policy/baseline/contrib/trump/dividend/trump_dividend.yaml
+++ b/policyengine_us/tests/policy/baseline/contrib/trump/dividend/trump_dividend.yaml
@@ -1,0 +1,56 @@
+- name: The dividend is inactive by default.
+  period: 2027
+  input:
+    age: 40
+  output:
+    trump_dividend: 0
+
+- name: An adult citizen receives the dividend when in effect.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 40
+  output:
+    trump_dividend: 5_000
+
+- name: A 17-year-old citizen does not receive the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 17
+  output:
+    trump_dividend: 0
+
+- name: An 18-year-old citizen receives the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 18
+  output:
+    trump_dividend: 5_000
+
+- name: A non-citizen adult does not receive the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 40
+    immigration_status: LEGAL_PERMANENT_RESIDENT
+  output:
+    trump_dividend: 0
+
+- name: Two adult citizens and a child receive two payments in total.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    people:
+      adult_one:
+        age: 40
+      adult_two:
+        age: 38
+      child:
+        age: 10
+    spm_units:
+      spm_unit:
+        members: [adult_one, adult_two, child]
+  output:
+    trump_dividend: [5_000, 5_000, 0]

--- a/policyengine_us/tests/policy/baseline/contrib/trump/dividend/trump_dividend.yaml
+++ b/policyengine_us/tests/policy/baseline/contrib/trump/dividend/trump_dividend.yaml
@@ -38,6 +38,48 @@
   output:
     trump_dividend: 0
 
+- name: An undocumented adult does not receive the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 40
+    immigration_status: UNDOCUMENTED
+  output:
+    trump_dividend: 0
+
+- name: A refugee adult does not receive the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 40
+    immigration_status: REFUGEE
+  output:
+    trump_dividend: 0
+
+- name: An infant citizen does not receive the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 0
+  output:
+    trump_dividend: 0
+
+- name: An adult citizen dependent receives the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    people:
+      parent:
+        age: 45
+      student:
+        age: 20
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [parent, student]
+  output:
+    trump_dividend: [5_000, 5_000]
+
 - name: Two adult citizens and a child receive two payments in total.
   period: 2027
   input:
@@ -54,3 +96,39 @@
         members: [adult_one, adult_two, child]
   output:
     trump_dividend: [5_000, 5_000, 0]
+
+- name: The dividend flows into SPM unit and household benefits without entering adjusted gross income.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    people:
+      adult_one:
+        age: 40
+        employment_income: 100_000
+      adult_two:
+        age: 38
+    spm_units:
+      spm_unit:
+        members: [adult_one, adult_two]
+  output:
+    trump_dividend: [5_000, 5_000]
+    spm_unit_benefits: 10_000
+    household_benefits: 10_000
+    adjusted_gross_income: 100_000
+
+- name: With the reform off by default, the dividend adds nothing to benefit aggregates.
+  period: 2027
+  input:
+    people:
+      adult_one:
+        age: 40
+        employment_income: 100_000
+      adult_two:
+        age: 38
+    spm_units:
+      spm_unit:
+        members: [adult_one, adult_two]
+  output:
+    trump_dividend: [0, 0]
+    spm_unit_benefits: 0
+    household_benefits: 0

--- a/policyengine_us/tests/policy/baseline/contrib/trump/dividend/trump_dividend.yaml
+++ b/policyengine_us/tests/policy/baseline/contrib/trump/dividend/trump_dividend.yaml
@@ -116,7 +116,7 @@
     household_benefits: 10_000
     adjusted_gross_income: 100_000
 
-- name: With the reform off by default, the dividend adds nothing to benefit aggregates.
+- name: With the reform off by default, the dividend adds nothing to benefit aggregates or adjusted gross income.
   period: 2027
   input:
     people:
@@ -132,3 +132,13 @@
     trump_dividend: [0, 0]
     spm_unit_benefits: 0
     household_benefits: 0
+    adjusted_gross_income: 100_000
+
+- name: An adult with citizen status set explicitly receives the dividend.
+  period: 2027
+  input:
+    gov.contrib.trump.dividend.in_effect: true
+    age: 40
+    immigration_status: CITIZEN
+  output:
+    trump_dividend: 5_000

--- a/policyengine_us/variables/contrib/trump/dividend/trump_dividend.py
+++ b/policyengine_us/variables/contrib/trump/dividend/trump_dividend.py
@@ -6,7 +6,13 @@ class trump_dividend(Variable):
     entity = Person
     label = "Trump dividend"
     unit = USD
-    documentation = "Trump dividend payment for this person."
+    documentation = (
+        "Trump dividend payment for this person. By design the payment "
+        "is non-taxable (excluded from adjusted gross income and MAGI "
+        "bases) and does not enter SNAP or SSI countable income; it "
+        "flows only into the benefit aggregates, matching the "
+        "basic_income default non-taxable treatment."
+    )
     definition_period = YEAR
     defined_for = "trump_dividend_eligible"
 

--- a/policyengine_us/variables/contrib/trump/dividend/trump_dividend.py
+++ b/policyengine_us/variables/contrib/trump/dividend/trump_dividend.py
@@ -1,0 +1,13 @@
+from policyengine_us.model_api import *
+
+
+class trump_dividend(Variable):
+    value_type = float
+    entity = Person
+    label = "Trump dividend"
+    unit = USD
+    documentation = "Trump dividend payment for this person."
+    definition_period = YEAR
+    defined_for = "trump_dividend_eligible"
+
+    adds = ["gov.contrib.trump.dividend.amount"]

--- a/policyengine_us/variables/contrib/trump/dividend/trump_dividend_eligible.py
+++ b/policyengine_us/variables/contrib/trump/dividend/trump_dividend_eligible.py
@@ -1,0 +1,22 @@
+from policyengine_us.model_api import *
+
+
+class trump_dividend_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Trump dividend eligible"
+    documentation = "Eligible for the Trump dividend."
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        p = parameters(period).gov.contrib.trump.dividend
+        if not p.in_effect:
+            return False
+        age = person("age", period)
+        meets_age_requirement = age >= p.min_age
+        immigration_status = person("immigration_status", period)
+        immigration_status_str = immigration_status.decode_to_str()
+        eligible_immigration_status = np.isin(
+            immigration_status_str, p.eligible_immigration_statuses
+        )
+        return meets_age_requirement & eligible_immigration_status

--- a/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
+++ b/policyengine_us/variables/household/income/spm_unit/spm_unit_benefits.py
@@ -75,6 +75,7 @@ class spm_unit_benefits(Variable):
             "ak_energy_relief",
             # Contributed.
             "basic_income",
+            "trump_dividend",
             "ny_drive_clean_rebate",
         ]
         if parameters(period).gov.contrib.ubi_center.flat_tax.deduct_ptc:


### PR DESCRIPTION
## Summary

Adds a contributed reform modeling a "Trump dividend": a $5,000 payment to each citizen aged 18 and older. Inert in baseline — activated by setting `gov.contrib.trump.dividend.in_effect` to true (e.g., for tax year 2027).

## Why a new reform instead of adjusting existing parameters

- **American Worker Rebate Act (Hawley tariff rebate)**: pays per filing unit, and the child amount reuses the same `non_joint` parameter, so a $5,000 setting would also pay every CTC-qualifying child. Includes LPRs and misses adult dependents.
- **Recovery rebate credit (stimulus checks)**: eligibility keys on valid SSN rather than citizenship, and adult dependents (neither head nor spouse) would receive nothing.
- **UBI Center basic income**: supports per-person age-bracketed amounts but has no citizenship gating.

## Design decisions

- **Provenance**: hypothetical illustrative parameters — no official source document exists; the parameter files note this explicitly.
- **Taxability**: the payment is intentionally non-taxable (excluded from AGI and MAGI bases), matching `basic_income`'s default treatment; a `taxable` toggle can be added later if needed.
- **Means-tested interactions**: the payment deliberately does not enter SNAP or SSI countable income, matching the `basic_income` precedent.
- **Microsim note**: `immigration_status` defaults to CITIZEN in the microdata, so population runs treat nearly all adults as eligible, overstating cost by roughly the non-citizen adult share.

## Implementation

- Parameters under `gov/contrib/trump/dividend/`: `amount` ($5,000), `min_age` (18), `eligible_immigration_statuses` ([CITIZEN]), `in_effect` (false by default)
- Person-level `trump_dividend_eligible` and `trump_dividend` variables
- Flows into `spm_unit_benefits` and the `household_benefits` parameter list via the same channel as `basic_income`; non-taxable
- Six YAML tests covering the age boundary (17/18), citizenship gating, mixed households, and baseline inertness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqCGPgxDukji8Bhs57c5rH
