### PR TITLE
Add Colorado Initiative 195 graduated income tax contributed reform

### DIFF
--- a/changelog.d/co-progressive-income-tax.added.md
+++ b/changelog.d/co-progressive-income-tax.added.md
@@ -1,0 +1,1 @@
+Colorado Initiative 195 contributed reform, replacing the flat income tax with a graduated rate schedule.

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
@@ -1,3 +1,6 @@
+# The initiative applies to taxable years commencing on or after
+# January 1, 2027, so this switch is intended to be activated for
+# tax year 2027 or later.
 description: Colorado replaces its flat income tax with the graduated rate schedule proposed by Initiative 195, if this is true.
 metadata:
   unit: bool

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
@@ -1,10 +1,7 @@
-# The initiative applies to taxable years commencing on or after
-# January 1, 2027, so this switch is intended to be activated for
-# tax year 2027 or later.
-description: Colorado replaces its flat income tax with the graduated rate schedule proposed by Initiative 195, if this is true.
+description: Colorado replaces its flat income tax with the graduated rate schedule proposed by Initiative 195 (designated Amendment 87 on the 2026 ballot), if this is true; the initiative applies to taxable years commencing on or after January 1, 2027, so this switch is intended to be activated for tax year 2027 or later.
 metadata:
   unit: bool
-  label: Colorado Initiative 195 graduated income tax in effect
+  label: Colorado Initiative 195 (Amendment 87) graduated income tax in effect
   period: year
   reference:
     - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
@@ -1,0 +1,12 @@
+description: Colorado replaces its flat income tax with the graduated rate schedule proposed by Initiative 195, if this is true.
+metadata:
+  unit: bool
+  label: Colorado Initiative 195 graduated income tax in effect
+  period: year
+  reference:
+    - title: Colorado Proposed Initiative 2025-2026 195, Results
+      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/results/2025-2026/195Results.html
+    - title: The Colorado Sun, Initiative 195 graduated income tax overview
+      href: https://coloradosun.com/2026/09/01/colorado-graduated-income-tax-ballot-measures-2026/
+values:
+  0000-01-01: false

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/in_effect.yaml
@@ -4,8 +4,8 @@ metadata:
   label: Colorado Initiative 195 graduated income tax in effect
   period: year
   reference:
-    - title: Colorado Proposed Initiative 2025-2026 195, Results
-      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/results/2025-2026/195Results.html
+    - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)
+      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf#page=3
     - title: The Colorado Sun, Initiative 195 graduated income tax overview
       href: https://coloradosun.com/2026/09/01/colorado-graduated-income-tax-ballot-measures-2026/
 values:

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
@@ -1,10 +1,15 @@
 # Initiative 195 (C.R.S. 39-22-104 (1.8)) applies these graduated rates to
 # taxable years commencing on or after January 1, 2027. Unmodeled provisions:
-# (1.8)(b) taxes principal-residence gains above the IRC Section 121 exclusion
-# at a flat 4.4% rather than the graduated rates, so the model overstates tax
-# for filers above $500,000 with such gains; Section 4 applies a matching
-# schedule to C corporations and Section 5 directs excess revenue to the
-# Colorado's Future Fund, both outside the household model's scope.
+# (1.8)(b) (195Final.pdf, physical page 5) taxes principal-residence gains
+# above the IRC Section 121 exclusion at a fixed 4.4% rather than the
+# graduated rates, and does not specify how that income stacks against the
+# brackets. Omitting it cuts both ways: the model understates tax for filers
+# at or below $100,000 of taxable income with such gains (whose graduated
+# rates of 3.7%/4.2% fall below 4.4%), matches between $100,000 and
+# $500,000 (where the graduated rate is also 4.4%), and overstates tax
+# above $500,000. Section 4 applies a matching schedule to C corporations
+# and Section 5 directs excess revenue to the Colorado's Future Fund, both
+# outside the household model's scope.
 description: Colorado taxes personal income at these graduated rates under Initiative 195, regardless of filing status.
 
 brackets:
@@ -40,9 +45,7 @@ metadata:
   type: marginal_rate
   label: Colorado Initiative 195 graduated income tax rates
   reference:
-    - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)(a)(I)-(III)
+    - title: Colorado Initiative 2025-2026 #195 final text, Section 3, C.R.S. 39-22-104 (1.8)(a)
       href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf#page=3
-    - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)(a)(III)-(VI)
-      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf#page=4
     - title: The Colorado Sun, Initiative 195 tax calculator
       href: https://coloradosun.com/2026/09/03/colorado-initiative-195-graduated-income-tax-calculator/

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
@@ -1,3 +1,10 @@
+# Initiative 195 (C.R.S. 39-22-104 (1.8)) applies these graduated rates to
+# taxable years commencing on or after January 1, 2027. Unmodeled provisions:
+# (1.8)(b) taxes principal-residence gains above the IRC Section 121 exclusion
+# at a flat 4.4% rather than the graduated rates, so the model overstates tax
+# for filers above $500,000 with such gains; Section 4 applies a matching
+# schedule to C corporations and Section 5 directs excess revenue to the
+# Colorado's Future Fund, both outside the household model's scope.
 description: Colorado taxes personal income at these graduated rates under Initiative 195, regardless of filing status.
 
 brackets:
@@ -33,7 +40,9 @@ metadata:
   type: marginal_rate
   label: Colorado Initiative 195 graduated income tax rates
   reference:
-    - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)(a)
+    - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)(a)(I)-(III)
       href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf#page=3
+    - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)(a)(III)-(VI)
+      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf#page=4
     - title: The Colorado Sun, Initiative 195 tax calculator
       href: https://coloradosun.com/2026/09/03/colorado-initiative-195-graduated-income-tax-calculator/

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
@@ -1,0 +1,39 @@
+description: Colorado taxes personal income at these graduated rates under Initiative 195, regardless of filing status.
+
+brackets:
+  - threshold:
+      0000-01-01: 0
+    rate:
+      0000-01-01: 0.037
+  - threshold:
+      0000-01-01: 25_000
+    rate:
+      0000-01-01: 0.042
+  - threshold:
+      0000-01-01: 100_000
+    rate:
+      0000-01-01: 0.044
+  - threshold:
+      0000-01-01: 500_000
+    rate:
+      0000-01-01: 0.074
+  - threshold:
+      0000-01-01: 750_000
+    rate:
+      0000-01-01: 0.079
+  - threshold:
+      0000-01-01: 1_000_000
+    rate:
+      0000-01-01: 0.084
+
+metadata:
+  threshold_unit: currency-USD
+  rate_unit: /1
+  threshold_period: year
+  type: marginal_rate
+  label: Colorado Initiative 195 graduated income tax rates
+  reference:
+    - title: Colorado Proposed Initiative 2025-2026 195, Results
+      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/results/2025-2026/195Results.html
+    - title: The Colorado Sun, Initiative 195 tax calculator
+      href: https://coloradosun.com/2026/09/03/colorado-initiative-195-graduated-income-tax-calculator/

--- a/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
+++ b/policyengine_us/parameters/gov/contrib/states/co/progressive_income_tax/rate.yaml
@@ -33,7 +33,7 @@ metadata:
   type: marginal_rate
   label: Colorado Initiative 195 graduated income tax rates
   reference:
-    - title: Colorado Proposed Initiative 2025-2026 195, Results
-      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/results/2025-2026/195Results.html
+    - title: Colorado Proposed Initiative 2025-2026 195, Final Text, Section 3, C.R.S. 39-22-104 (1.8)(a)
+      href: https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf#page=3
     - title: The Colorado Sun, Initiative 195 tax calculator
       href: https://coloradosun.com/2026/09/03/colorado-initiative-195-graduated-income-tax-calculator/

--- a/policyengine_us/tests/policy/contrib/states/co/progressive_income_tax/co_progressive_income_tax.yaml
+++ b/policyengine_us/tests/policy/contrib/states/co/progressive_income_tax/co_progressive_income_tax.yaml
@@ -1,0 +1,62 @@
+# Initiative 195 brackets: 3.7% to $25k, 4.2% to $100k, 4.4% to $500k,
+# 7.4% to $750k, 7.9% to $1m, 8.4% above.
+- name: Flat tax applies when the reform is not in effect.
+  period: 2027
+  input:
+    state_code: CO
+    co_taxable_income: 50_000
+  output:
+    # 50,000 * 0.044 = 2,200.
+    co_income_tax_before_non_refundable_credits: 2_200
+
+- name: Income in the first bracket.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 20_000
+  output:
+    # 20,000 * 0.037 = 740.
+    co_income_tax_before_non_refundable_credits: 740
+
+- name: Income in the second bracket.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 50_000
+  output:
+    # 25,000 * 0.037 + 25,000 * 0.042 = 925 + 1,050 = 1,975.
+    co_income_tax_before_non_refundable_credits: 1_975
+
+- name: Income in the fourth bracket.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 600_000
+  output:
+    # 925 + 75,000 * 0.042 + 400,000 * 0.044 + 100,000 * 0.074
+    # = 925 + 3,150 + 17,600 + 7,400 = 29,075.
+    co_income_tax_before_non_refundable_credits: 29_075
+
+- name: Income in the top bracket.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 1_200_000
+  output:
+    # 925 + 3,150 + 17,600 + 250,000 * 0.074 + 250,000 * 0.079
+    # + 200,000 * 0.084 = 925 + 3,150 + 17,600 + 18,500 + 19,750
+    # + 16,800 = 76,725.
+    co_income_tax_before_non_refundable_credits: 76_725
+
+- name: Zero taxable income owes no tax under the reform.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 0
+  output:
+    co_income_tax_before_non_refundable_credits: 0

--- a/policyengine_us/tests/policy/contrib/states/co/progressive_income_tax/co_progressive_income_tax.yaml
+++ b/policyengine_us/tests/policy/contrib/states/co/progressive_income_tax/co_progressive_income_tax.yaml
@@ -1,5 +1,7 @@
 # Initiative 195 brackets: 3.7% to $25k, 4.2% to $100k, 4.4% to $500k,
 # 7.4% to $750k, 7.9% to $1m, 8.4% above.
+# The in_effect switch defaults to false, so this case exercises the
+# baseline flat-tax path deliberately.
 - name: Flat tax applies when the reform is not in effect.
   period: 2027
   input:
@@ -29,6 +31,37 @@
     # 25,000 * 0.037 + 25,000 * 0.042 = 925 + 1,050 = 1,975.
     co_income_tax_before_non_refundable_credits: 1_975
 
+- name: Joint filers face the same brackets as single filers.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    filing_status: JOINT
+    co_taxable_income: 50_000
+  output:
+    # Same as the single-filer second-bracket case: 925 + 1,050 = 1,975.
+    co_income_tax_before_non_refundable_credits: 1_975
+
+- name: Income exactly at the second bracket boundary.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 100_000
+  output:
+    # 25,000 * 0.037 + 75,000 * 0.042 = 925 + 3,150 = 4,075.
+    co_income_tax_before_non_refundable_credits: 4_075
+
+- name: Income in the third bracket.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 300_000
+  output:
+    # 925 + 3,150 + 200,000 * 0.044 = 925 + 3,150 + 8,800 = 12,875.
+    co_income_tax_before_non_refundable_credits: 12_875
+
 - name: Income in the fourth bracket.
   period: 2027
   input:
@@ -39,6 +72,17 @@
     # 925 + 75,000 * 0.042 + 400,000 * 0.044 + 100,000 * 0.074
     # = 925 + 3,150 + 17,600 + 7,400 = 29,075.
     co_income_tax_before_non_refundable_credits: 29_075
+
+- name: Income in the fifth bracket.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 900_000
+  output:
+    # 925 + 3,150 + 17,600 + 250,000 * 0.074 + 150,000 * 0.079
+    # = 925 + 3,150 + 17,600 + 18,500 + 11,850 = 52,025.
+    co_income_tax_before_non_refundable_credits: 52_025
 
 - name: Income in the top bracket.
   period: 2027

--- a/policyengine_us/tests/policy/contrib/states/co/progressive_income_tax/co_progressive_income_tax.yaml
+++ b/policyengine_us/tests/policy/contrib/states/co/progressive_income_tax/co_progressive_income_tax.yaml
@@ -2,7 +2,7 @@
 # 7.4% to $750k, 7.9% to $1m, 8.4% above.
 # The in_effect switch defaults to false, so this case exercises the
 # baseline flat-tax path deliberately.
-- name: Flat tax applies when the reform is not in effect.
+- name: Case 1, flat tax applies when the reform is not in effect.
   period: 2027
   input:
     state_code: CO
@@ -11,7 +11,7 @@
     # 50,000 * 0.044 = 2,200.
     co_income_tax_before_non_refundable_credits: 2_200
 
-- name: Income in the first bracket.
+- name: Case 2, income in the first bracket.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -21,7 +21,7 @@
     # 20,000 * 0.037 = 740.
     co_income_tax_before_non_refundable_credits: 740
 
-- name: Income in the second bracket.
+- name: Case 3, income in the second bracket.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -31,7 +31,7 @@
     # 25,000 * 0.037 + 25,000 * 0.042 = 925 + 1,050 = 1,975.
     co_income_tax_before_non_refundable_credits: 1_975
 
-- name: Joint filers face the same brackets as single filers.
+- name: Case 4, joint filers face the same brackets as single filers.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -42,7 +42,7 @@
     # Same as the single-filer second-bracket case: 925 + 1,050 = 1,975.
     co_income_tax_before_non_refundable_credits: 1_975
 
-- name: Income exactly at the second bracket boundary.
+- name: Case 5, income exactly at the second bracket boundary.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -52,7 +52,7 @@
     # 25,000 * 0.037 + 75,000 * 0.042 = 925 + 3,150 = 4,075.
     co_income_tax_before_non_refundable_credits: 4_075
 
-- name: Income in the third bracket.
+- name: Case 6, income in the third bracket.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -62,7 +62,7 @@
     # 925 + 3,150 + 200,000 * 0.044 = 925 + 3,150 + 8,800 = 12,875.
     co_income_tax_before_non_refundable_credits: 12_875
 
-- name: Income in the fourth bracket.
+- name: Case 7, income in the fourth bracket.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -73,7 +73,7 @@
     # = 925 + 3,150 + 17,600 + 7,400 = 29,075.
     co_income_tax_before_non_refundable_credits: 29_075
 
-- name: Income in the fifth bracket.
+- name: Case 8, income in the fifth bracket.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -84,7 +84,7 @@
     # = 925 + 3,150 + 17,600 + 18,500 + 11,850 = 52,025.
     co_income_tax_before_non_refundable_credits: 52_025
 
-- name: Income in the top bracket.
+- name: Case 9, income in the top bracket.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -96,7 +96,7 @@
     # + 16,800 = 76,725.
     co_income_tax_before_non_refundable_credits: 76_725
 
-- name: Zero taxable income owes no tax under the reform.
+- name: Case 10, zero taxable income owes no tax under the reform.
   period: 2027
   input:
     gov.contrib.states.co.progressive_income_tax.in_effect: true
@@ -104,3 +104,114 @@
     co_taxable_income: 0
   output:
     co_income_tax_before_non_refundable_credits: 0
+
+- name: Case 11, end-to-end single filer with $30,000 of employment income.
+  period: 2027
+  absolute_error_margin: 0.01
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    people:
+      person:
+        age: 40
+        employment_income: 30_000
+    tax_units:
+      tax_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code: CO
+  output:
+    co_taxable_income: 13_450
+    # 13,450 * 0.037 = 497.65 before non-refundable credits.
+    co_income_tax_before_non_refundable_credits: 497.65
+    co_income_tax: 478.65
+
+- name: Case 12, end-to-end single filer with $600,000 of employment income.
+  period: 2027
+  absolute_error_margin: 0.01
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    people:
+      person:
+        age: 40
+        employment_income: 600_000
+    tax_units:
+      tax_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code: CO
+  output:
+    co_taxable_income: 599_000
+    # 925 + 3,150 + 17,600 + 99,000 * 0.074 = 29,001 before
+    # non-refundable credits.
+    co_income_tax_before_non_refundable_credits: 29_001
+    co_income_tax: 28_942
+
+- name: Case 13, end-to-end single filer with $1,200,000 of employment income.
+  period: 2027
+  absolute_error_margin: 0.01
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    people:
+      person:
+        age: 40
+        employment_income: 1_200_000
+    tax_units:
+      tax_unit:
+        members: [person]
+    households:
+      household:
+        members: [person]
+        state_code: CO
+  output:
+    co_taxable_income: 1_199_000
+    # 925 + 3,150 + 17,600 + 18,500 + 19,750 + 199,000 * 0.084
+    # = 76,641 before non-refundable credits.
+    co_income_tax_before_non_refundable_credits: 76_641
+    co_income_tax: 76_582
+
+# Bracket tops are inclusive: MarginalRateTaxScale taxes the boundary
+# dollar at the lower bracket's rate.
+- name: Case 14, income exactly at the first bracket boundary.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 25_000
+  output:
+    # 25,000 * 0.037 = 925.
+    co_income_tax_before_non_refundable_credits: 925
+
+- name: Case 15, income exactly at the third bracket boundary.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 500_000
+  output:
+    # 925 + 3,150 + 400,000 * 0.044 = 925 + 3,150 + 17,600 = 21,675.
+    co_income_tax_before_non_refundable_credits: 21_675
+
+- name: Case 16, income exactly at the fourth bracket boundary.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 750_000
+  output:
+    # 925 + 3,150 + 17,600 + 250,000 * 0.074 = 21,675 + 18,500 = 40,175.
+    co_income_tax_before_non_refundable_credits: 40_175
+
+- name: Case 17, income exactly at the fifth bracket boundary.
+  period: 2027
+  input:
+    gov.contrib.states.co.progressive_income_tax.in_effect: true
+    state_code: CO
+    co_taxable_income: 1_000_000
+  output:
+    # 925 + 3,150 + 17,600 + 18,500 + 250,000 * 0.079
+    # = 40,175 + 19,750 = 59,925.
+    co_income_tax_before_non_refundable_credits: 59_925

--- a/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.py
@@ -11,5 +11,8 @@ class co_income_tax_before_non_refundable_credits(Variable):
 
     def formula(tax_unit, period, parameters):
         income = tax_unit("co_taxable_income", period)
+        p_reform = parameters(period).gov.contrib.states.co.progressive_income_tax
+        if p_reform.in_effect:
+            return p_reform.rate.calc(income)
         rate = parameters(period).gov.states.co.tax.income.rate
         return income * rate

--- a/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.py
+++ b/policyengine_us/variables/gov/states/co/tax/income/co_income_tax_before_non_refundable_credits.py
@@ -12,6 +12,9 @@ class co_income_tax_before_non_refundable_credits(Variable):
     def formula(tax_unit, period, parameters):
         income = tax_unit("co_taxable_income", period)
         p_reform = parameters(period).gov.contrib.states.co.progressive_income_tax
+        # Deliberate in-formula contrib gate — the documented simpler
+        # alternative to a reform factory (first state-level use; federal
+        # precedent: the ubi_center flat-tax gates in income_tax.py).
         if p_reform.in_effect:
             return p_reform.rate.calc(income)
         rate = parameters(period).gov.states.co.tax.income.rate


### PR DESCRIPTION
## Summary

Models Colorado Initiative 195 (the "Income Tax Fairness Act"), which qualified for the November 2026 ballot. When `gov.contrib.states.co.progressive_income_tax.in_effect` is true, the reform replaces Colorado's 4.4% flat income tax with the initiative's six-bracket graduated schedule, first applying to tax year 2027 per the measure's effective date.

Rates and thresholds verified against the [official final text filed with the Colorado Secretary of State](https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf) (Section 3, adding C.R.S. 39-22-104 (1.8)).

## Rate schedule

Applied to Colorado taxable income, uniform across filing statuses (the initiative amends 39-22-104 (2) so existing state additions and subtractions still modify federal taxable income before the graduated rates apply):

| Taxable income | Marginal rate |
|---|---|
| Up to $25,000 | 3.7% |
| $25,000 – $100,000 | 4.2% |
| $100,000 – $500,000 | 4.4% |
| $500,000 – $750,000 | 7.4% |
| $750,000 – $1,000,000 | 7.9% |
| Above $1,000,000 | 8.4% |

## Implementation

- Parameters under `gov/contrib/states/co/progressive_income_tax/`: `in_effect` (false by default) and a `marginal_rate`-type `rate` bracket scale
- `co_income_tax_before_non_refundable_credits` applies the graduated schedule instead of the flat rate when the switch is on; baseline behavior is unchanged (existing baseline CO tests pass)
- 17 YAML tests with hand-computed marginal arithmetic covering the flat-tax default, every bracket position, all four untested exact bracket boundaries, joint filers, zero income, and end-to-end `co_income_tax` cases computed from employment income under the reform

## Known limitations

- C.R.S. 39-22-104 (1.8)(b) taxes home-sale gains above the federal Section 121 exclusion at a fixed 4.4% rather than the graduated schedule, and does not specify how that income stacks against the brackets. The microdata does not isolate principal-residence capital gains, so this carve-out is not modeled; the omission cuts both ways — the model understates tax for filers at or below $100,000 of taxable income with such gains (whose graduated rates of 3.7%/4.2% fall below 4.4%), matches between $100,000 and $500,000 (where the graduated rate is also 4.4%), and overstates tax above $500,000.
- The initiative does not amend the Colorado AMT (C.R.S. 39-22-105), so the 3.47% tentative-minimum-tax rate is unchanged. Because `co_amt` nets against `co_income_tax_before_non_refundable_credits`, the graduated schedule mechanically reduces how often the AMT binds at high incomes; this follows from a literal reading of the measure rather than a modeling choice.
- Section 4 applies the same graduated schedule to C corporations, which is outside the household model's scope.
- TABOR "Colorado's Future Fund" revenue accounting (Section 5) is not modeled.

## References

- [Colorado SOS Proposed Initiative 2025-2026 #195, final text](https://www.sos.state.co.us/pubs/elections/Initiatives/titleBoard/filings/2025-2026/195Final.pdf)
- [The Colorado Sun: graduated income tax ballot measure](https://coloradosun.com/2026/09/01/colorado-graduated-income-tax-ballot-measures-2026/)
- [The Colorado Sun: Initiative 195 tax calculator](https://coloradosun.com/2026/09/03/colorado-initiative-195-graduated-income-tax-calculator/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqCGPgxDukji8Bhs57c5rH
