### PR TITLE
Add 2025 Alabama standard deduction tests for surviving spouse

### DIFF
--- a/changelog.d/test-al-standard-deduction-surviving-spouse.fixed.md
+++ b/changelog.d/test-al-standard-deduction-surviving-spouse.fixed.md
@@ -1,0 +1,1 @@
+Add surviving spouse 2025 boundary tests for Alabama standard deduction.

--- a/policyengine_us/tests/policy/baseline/gov/states/al/tax/income/deductions/al_standard_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/al/tax/income/deductions/al_standard_deduction.yaml
@@ -138,3 +138,21 @@
     # 13_000 - 12_750 = 250; 250 // 250 = 1; 4_250 - 88 = 4_162
     al_standard_deduction: 4_162
 
+- name: Surviving spouse filer with AGI $25,999 in 2025 (no reduction)
+  period: 2025
+  input:
+    state_code: AL
+    al_agi: 25_999
+    filing_status: SURVIVING_SPOUSE
+  output:
+    al_standard_deduction: 8_500
+
+- name: Surviving spouse filer with AGI $26,000 in 2025 (first $175 reduction)
+  period: 2025
+  input:
+    state_code: AL
+    al_agi: 26_000
+    filing_status: SURVIVING_SPOUSE
+  output:
+    # 26_000 - 25_500 = 500; 500 // 500 = 1; 8_500 - 175 = 8_325
+    al_standard_deduction: 8_325


### PR DESCRIPTION
### Summary
This is a follow-up to #9424 addressing the post-merge review feedback from @anth-volk:

1. **Finding A2 (Surviving Spouse Tests)**: Added 2025 boundary test cases for `SURVIVING_SPOUSE` at $25,999 (full $8,500 deduction) and $26,000 (first $175 reduction to $8,325) in `al_standard_deduction.yaml`.
2. **Finding A3 (EOF Blank Line)**: Removed the trailing blank line at the end of `al_standard_deduction.yaml` so `git diff --check` passes cleanly.
3. **Finding A1 (Act Citation)**: Noted that HB 163 was enacted as **Act 2022-297** (rather than Act 2022-292).
4. **Changelog**: Added changelog fragment in `changelog.d/`.

---

### Response to Finding C1 (Rounding Alabama AGI)
We reviewed Finding C1 regarding rounding Alabama AGI prior to floor division and agree that **no change should be made to the formula in `al_standard_deduction.py`**:

1. **Scope**: PR #9424 only corrected a parameter regression in `threshold.yaml` introduced in #7192. It did not alter the formula logic in `al_standard_deduction.py`, which has performed floor division on continuous AGI since its initial implementation.
2. **Filing Convention vs. Statutory Mandate**: The Form 40 instruction (*"You may round off cents to whole dollars on your return..."*) is a taxpayer filing convenience standard across IRS Form 1040 and state returns to simplify paper/e-file line entries, rather than a statutory mandate modifying the legal definition of adjusted gross income for benefit/deduction evaluation.
3. **Engine-Wide Consistency & Microsimulation**: Throughout PolicyEngine US, continuous float values are preserved throughout intermediate tax calculations rather than rounded to whole dollars at intermediate steps. Introducing localized rounding (e.g. `np.round(al_agi)`) inside individual deduction variables would create artificial notch/step discontinuities for continuous income distributions in microsimulation and API usage without statutory basis.

For these reasons, the existing unrounded continuous evaluation in `al_standard_deduction.py` is appropriate and retained.