### PR TITLE
Address remaining review findings from #9345

### DIFF
--- a/changelog.d/9345-review-followup.fixed.md
+++ b/changelog.d/9345-review-followup.fixed.md
@@ -1,0 +1,1 @@
+Add anchored SNAP student regulatory citations, correct the SSI working student exclusion eligibility variable type, and add a monthly SSI aggregation test for USDA disability.

--- a/policyengine_us/tests/policy/baseline/gov/usda/is_usda_disabled.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/usda/is_usda_disabled.yaml
@@ -67,3 +67,12 @@
     social_security_disability: 100
   output:
     is_usda_disabled: true
+
+- name: Case 9, monthly SSI receipt in a single month aggregates to a year-level USDA disabled status.
+  period: 2021
+  input:
+    age: 30
+    receives_ssi:
+      2021-01: true
+  output:
+    is_usda_disabled: true

--- a/policyengine_us/variables/gov/ssa/ssi/eligibility/income/is_ssi_blind_or_disabled_working_student_exclusion_eligible.py
+++ b/policyengine_us/variables/gov/ssa/ssi/eligibility/income/is_ssi_blind_or_disabled_working_student_exclusion_eligible.py
@@ -2,10 +2,9 @@ from policyengine_us.model_api import *
 
 
 class is_ssi_blind_or_disabled_working_student_exclusion_eligible(Variable):
-    value_type = float
+    value_type = bool
     entity = Person
     label = "Eligible for SSI blind or disabled working student earned income exclusion"
-    unit = USD
     definition_period = YEAR
     reference = (
         "https://www.law.cornell.edu/cfr/text/20/416.1112#c_3",

--- a/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_ineligible_student.py
+++ b/policyengine_us/variables/gov/usda/snap/eligibility/student/is_snap_ineligible_student.py
@@ -7,7 +7,11 @@ class is_snap_ineligible_student(Variable):
     label = "Is an ineligible student for SNAP"
     definition_period = YEAR
     defined_for = "is_snap_higher_ed_student"
-    reference = "https://www.law.cornell.edu/uscode/text/7/2015#e"
+    reference = (
+        "https://www.law.cornell.edu/uscode/text/7/2015#e",
+        "https://www.law.cornell.edu/cfr/text/7/273.7#b_1_ii",
+        "https://www.law.cornell.edu/cfr/text/7/273.24#c_2_i",
+    )
 
     def formula(person, period, parameters):
         # Base rule: Students enrolled at least half-time in higher education


### PR DESCRIPTION
## Summary

Of the 9 review findings on #9345, 8 were resolved before that PR merged. This follow-up applies the 3 that remained:

1. **Anchored SNAP student regulatory citations** — `is_snap_ineligible_student` now cites `7 CFR 273.7(b)(1)(ii)` and `273.24(c)(2)(i)` with deep-link anchors (`#b_1_ii`, `#c_2_i`) alongside the existing reference. Formula untouched.
2. **SSI working student exclusion eligibility variable** — removed a stray `unit = USD` and corrected `value_type` from float to bool on `is_ssi_blind_or_disabled_working_student_exclusion_eligible` (a boolean eligibility variable used only as `defined_for`).
3. **Month-aggregation test for `is_usda_disabled`** — added a case with a month-keyed `receives_ssi` input evaluated over a year period, verifying monthly SSI aggregation.

## Tests

102/102 passing across the three affected suites:
- `is_usda_disabled.yaml`: 9/9 (incl. new case)
- SSI working student exclusion: 14/14
- `snap/eligibility/student/`: 79/79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqCGPgxDukji8Bhs57c5rH