### PR TITLE
Fix MA CFTC disabled spouse and MFS rules, and surviving spouse filing status treatment

### DIFF
--- a/changelog.d/fix-ma-cftc-and-ss-filing-status.fixed.md
+++ b/changelog.d/fix-ma-cftc-and-ss-filing-status.fixed.md
@@ -1,0 +1,1 @@
+Massachusetts Child and Family Tax Credit now counts disabled spouses from 2023 and excludes separate filers, and surviving spouse filers receive head of household treatment in Massachusetts filing-status parameters.

--- a/changelog.d/fix-ma-cftc-and-ss-filing-status.fixed.md
+++ b/changelog.d/fix-ma-cftc-and-ss-filing-status.fixed.md
@@ -1,1 +1,1 @@
-Massachusetts Child and Family Tax Credit now counts disabled spouses from 2023 and excludes separate filers, and surviving spouse filers receive head of household treatment in Massachusetts filing-status parameters.
+Massachusetts Child and Family Tax Credit now counts disabled spouses from 2023 and excludes separate filers, and a new ma_filing_status variable routes federal surviving spouse filers to head of household treatment across Massachusetts filing-status parameters.

--- a/policyengine_us/parameters/gov/states/ma/tax/income/credits/child_and_family/disabled_spouse_eligible.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/credits/child_and_family/disabled_spouse_eligible.yaml
@@ -1,0 +1,21 @@
+description: Massachusetts counts a disabled spouse as an eligible individual for the child and family tax credit if this is true.
+values:
+  # The predecessor credit for eligible dependents covered only IRC Section 152
+  # dependents; the 2023 child and family tax credit added qualifying
+  # individuals under IRC Section 21, which include a spouse incapable of
+  # self-care.
+  2021-01-01: false
+  2023-01-01: true
+metadata:
+  reference:
+    - title: Massachusetts General Laws Part I Title IX Chapter 62 Section 6 (x) (1) (ii)
+      href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section6
+    - title: IRC Section 21 (b) (1) (C)
+      href: https://www.law.cornell.edu/uscode/text/26/21#b_1_C
+    - title: Credit for Eligible Dependents, Governor's FY25 Budget Tax Expenditure 1.624
+      href: https://budget.digital.mass.gov/govbudget/fy25/tax-expenditure-budget/personal-income-tax/credits-against-tax/1-624/
+    - title: Massachusetts Session Laws Chapter 50 of the Acts of 2023 Section 22
+      href: https://malegislature.gov/Laws/SessionLaws/Acts/2023/Chapter50
+  unit: bool
+  period: year
+  label: Massachusetts child and family tax credit disabled spouse eligible

--- a/policyengine_us/parameters/gov/states/ma/tax/income/credits/child_and_family/disabled_spouse_eligible.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/credits/child_and_family/disabled_spouse_eligible.yaml
@@ -1,4 +1,4 @@
-description: Massachusetts counts a disabled spouse as an eligible individual for the child and family tax credit if this is true.
+description: Massachusetts counts a disabled spouse as an eligible individual if this is true under the Child and Family Tax Credit program.
 values:
   # The predecessor credit for eligible dependents covered only IRC Section 152
   # dependents; the 2023 child and family tax credit added qualifying
@@ -8,13 +8,15 @@ values:
   2023-01-01: true
 metadata:
   reference:
-    - title: Massachusetts General Laws Part I Title IX Chapter 62 Section 6 (x) (1) (ii)
+    - title: Massachusetts General Laws Part I Title IX Chapter 62 Section 6 (x) (ii)
       href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section6
     - title: IRC Section 21 (b) (1) (C)
       href: https://www.law.cornell.edu/uscode/text/26/21#b_1_C
     - title: Credit for Eligible Dependents, Governor's FY25 Budget Tax Expenditure 1.624
       href: https://budget.digital.mass.gov/govbudget/fy25/tax-expenditure-budget/personal-income-tax/credits-against-tax/1-624/
-    - title: Massachusetts Session Laws Chapter 50 of the Acts of 2023 Section 22
+    - title: Massachusetts Session Laws Chapter 50 of the Acts of 2023 Section 21
+      href: https://malegislature.gov/Laws/SessionLaws/Acts/2023/Chapter50
+    - title: Massachusetts Session Laws Chapter 50 of the Acts of 2023 Section 49
       href: https://malegislature.gov/Laws/SessionLaws/Acts/2023/Chapter50
   unit: bool
   period: year

--- a/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/eligibility/max_income.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/eligibility/max_income.yaml
@@ -21,15 +21,6 @@ HEAD_OF_HOUSEHOLD:
   2023-01-01: 86_000
   2024-01-01: 91_000
   2025-01-01: 94_000
-# Massachusetts has no surviving spouse filing status; federal qualifying
-# surviving spouses generally file as head of household in Massachusetts.
-SURVIVING_SPOUSE:
-  2001-01-01: 50_000
-  2021-01-01: 78_000
-  2022-01-01: 80_000
-  2023-01-01: 86_000
-  2024-01-01: 91_000
-  2025-01-01: 94_000
 SEPARATE:
   2001-01-01: 40_000
   2021-01-01: 62_000
@@ -41,7 +32,7 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-    - filing_status
+    - ma_filing_status
   label: Massachusetts Senior Circuit Breaker maximum income
   uprating:
     parameter: gov.irs.uprating

--- a/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/eligibility/max_income.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/eligibility/max_income.yaml
@@ -21,13 +21,15 @@ HEAD_OF_HOUSEHOLD:
   2023-01-01: 86_000
   2024-01-01: 91_000
   2025-01-01: 94_000
+# Massachusetts has no surviving spouse filing status; federal qualifying
+# surviving spouses generally file as head of household in Massachusetts.
 SURVIVING_SPOUSE:
-  2001-01-01: 40_000
-  2021-01-01: 62_000
-  2022-01-01: 64_000
-  2023-01-01: 69_000
-  2024-01-01: 72_000
-  2025-01-01: 75_000
+  2001-01-01: 50_000
+  2021-01-01: 78_000
+  2022-01-01: 80_000
+  2023-01-01: 86_000
+  2024-01-01: 91_000
+  2025-01-01: 94_000
 SEPARATE:
   2001-01-01: 40_000
   2021-01-01: 62_000
@@ -52,6 +54,8 @@ metadata:
       href: https://www.mass.gov/info-details/mass-general-laws-c62-ss-6
     - title: Massachusetts Senior Circuit Breaker Tax Credit | Mass.gov
       href: https://www.mass.gov/info-details/massachusetts-senior-circuit-breaker-tax-credit
+    - title: Filing Status on Massachusetts Personal Income Tax
+      href: https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax
     - title: 2022 Schedule CB
       href: https://www.mass.gov/doc/2022-schedule-cb-circuit-breaker-credit/download
     - title: 2023 Schedule CB

--- a/policyengine_us/parameters/gov/states/ma/tax/income/deductions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/deductions/plan_529_contributions/cap.yaml
@@ -11,11 +11,15 @@ metadata:
     href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section3
   - title: Massachusetts DOR 529 Deduction Information
     href: https://www.mass.gov/info-details/529-plan-deduction
+  - title: Filing Status on Massachusetts Personal Income Tax
+    href: https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax
 
 JOINT:
   2021-01-01: 2_000
+# Massachusetts has no surviving spouse filing status; federal qualifying
+# surviving spouses generally file as head of household in Massachusetts.
 SURVIVING_SPOUSE:
-  2021-01-01: 2_000
+  2021-01-01: 1_000
 SINGLE:
   2021-01-01: 1_000
 HEAD_OF_HOUSEHOLD:

--- a/policyengine_us/parameters/gov/states/ma/tax/income/deductions/plan_529_contributions/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/deductions/plan_529_contributions/cap.yaml
@@ -5,7 +5,7 @@ metadata:
   period: year
   unit: currency-USD
   breakdown:
-  - filing_status
+  - ma_filing_status
   reference:
   - title: Massachusetts General Laws Chapter 62 § 3(B)(a)(14)
     href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section3
@@ -16,10 +16,6 @@ metadata:
 
 JOINT:
   2021-01-01: 2_000
-# Massachusetts has no surviving spouse filing status; federal qualifying
-# surviving spouses generally file as head of household in Massachusetts.
-SURVIVING_SPOUSE:
-  2021-01-01: 1_000
 SINGLE:
   2021-01-01: 1_000
 HEAD_OF_HOUSEHOLD:

--- a/policyengine_us/parameters/gov/states/ma/tax/income/deductions/rent/cap.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/deductions/rent/cap.yaml
@@ -2,9 +2,6 @@ description: Massachusetts caps the rental deduction at this amount, based on th
 SINGLE:
   2011-01-01: 3_000
   2023-01-01: 4_000
-SURVIVING_SPOUSE:
-  2011-01-01: 3_000
-  2023-01-01: 4_000
 JOINT:
   2011-01-01: 3_000
   2023-01-01: 4_000
@@ -53,5 +50,5 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-  - filing_status
+  - ma_filing_status
   label: Massachusetts rental deduction cap.

--- a/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/base.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/base.yaml
@@ -2,11 +2,6 @@ description: AGI limit to be exempt from state income tax. Joint or head-of-hous
 SINGLE:
   2020-01-01: 0
   2021-01-01: 8_000
-# Massachusetts has no surviving spouse filing status; federal qualifying
-# surviving spouses generally file as head of household in Massachusetts.
-SURVIVING_SPOUSE:
-  2020-01-01: 0
-  2021-01-01: 7_600
 SEPARATE:
   2020-01-01: 0
 JOINT:
@@ -27,5 +22,5 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-  - filing_status
+  - ma_filing_status
   label: AGI addition to limit to be exempt from Massachusetts income tax.

--- a/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/base.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/base.yaml
@@ -2,9 +2,11 @@ description: AGI limit to be exempt from state income tax. Joint or head-of-hous
 SINGLE:
   2020-01-01: 0
   2021-01-01: 8_000
+# Massachusetts has no surviving spouse filing status; federal qualifying
+# surviving spouses generally file as head of household in Massachusetts.
 SURVIVING_SPOUSE:
   2020-01-01: 0
-  2021-01-01: 8_000
+  2021-01-01: 7_600
 SEPARATE:
   2020-01-01: 0
 JOINT:
@@ -16,8 +18,10 @@ HEAD_OF_HOUSEHOLD:
 metadata:
   propagate_metadata_to_children: true
   reference:
-    - title: § 5 Exempt income of individuals; exemption of stock bonus, pension or profit-sharing trust 
+    - title: § 5 Exempt income of individuals; exemption of stock bonus, pension or profit-sharing trust
       href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section5
+    - title: Filing Status on Massachusetts Personal Income Tax
+      href: https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax
     # NB: This parameter does not show up directly in tax forms.
     #     It is not inflation adjusted.
   unit: currency-USD

--- a/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/personal_exemption_added.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/personal_exemption_added.yaml
@@ -5,15 +5,19 @@ JOINT:
   2020-01-01: true
 HEAD_OF_HOUSEHOLD:
   2020-01-01: true
+# Massachusetts has no surviving spouse filing status; federal qualifying
+# surviving spouses generally file as head of household in Massachusetts.
 SURVIVING_SPOUSE:
-  2020-01-01: false
+  2020-01-01: true
 SEPARATE:
   2020-01-01: false
 metadata:
   propagate_metadata_to_children: true
   reference:
-    - title: § 5 Exempt income of individuals; exemption of stock bonus, pension or profit-sharing trust 
+    - title: § 5 Exempt income of individuals; exemption of stock bonus, pension or profit-sharing trust
       href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section5
+    - title: Filing Status on Massachusetts Personal Income Tax
+      href: https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax
   unit: currency-USD
   period: year
   breakdown:

--- a/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/personal_exemption_added.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/exempt_status/limit/personal_exemption_added.yaml
@@ -5,10 +5,6 @@ JOINT:
   2020-01-01: true
 HEAD_OF_HOUSEHOLD:
   2020-01-01: true
-# Massachusetts has no surviving spouse filing status; federal qualifying
-# surviving spouses generally file as head of household in Massachusetts.
-SURVIVING_SPOUSE:
-  2020-01-01: true
 SEPARATE:
   2020-01-01: false
 metadata:
@@ -21,5 +17,5 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-  - filing_status
+  - ma_filing_status
   label: Massachusetts income tax exemption limit includes personal exemptions

--- a/policyengine_us/parameters/gov/states/ma/tax/income/exemptions/interest/amount.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/exemptions/interest/amount.yaml
@@ -5,8 +5,6 @@ JOINT:
   2002-01-01: 200
 HEAD_OF_HOUSEHOLD:
   2002-01-01: 100
-SURVIVING_SPOUSE:
-  2002-01-01: 100
 SEPARATE:
   2002-01-01: 100
 metadata:
@@ -14,7 +12,7 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-  - filing_status
+  - ma_filing_status
   label: Massachusetts interest exemption
   reference:
     - title: Mass. General Laws c.62 § 3(B)(a)(6)

--- a/policyengine_us/parameters/gov/states/ma/tax/income/exemptions/personal.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/exemptions/personal.yaml
@@ -8,13 +8,6 @@ SEPARATE:
   # Rises with inflation starting in 2004.
   # Values from 2015 to 2022 are from Tax Foundation.
   2015-01-01: 4_400
-# Massachusetts has no surviving spouse filing status; federal qualifying
-# surviving spouses generally file as head of household in Massachusetts.
-SURVIVING_SPOUSE:
-  2002-01-01: 5_100
-  # Rises with inflation starting in 2004.
-  # Values from 2015 to 2022 are from Tax Foundation.
-  2015-01-01: 6_800
 HEAD_OF_HOUSEHOLD:
   2002-01-01: 5_100
   # Rises with inflation starting in 2004.
@@ -30,7 +23,7 @@ metadata:
   unit: currency-USD
   period: year
   breakdown:
-  - filing_status
+  - ma_filing_status
   label: Massachusetts income tax personal exemption
   reference:
     - title: "Taxable income: adjusted gross income less deductions and exemptions (b)(2)(A)"

--- a/policyengine_us/parameters/gov/states/ma/tax/income/exemptions/personal.yaml
+++ b/policyengine_us/parameters/gov/states/ma/tax/income/exemptions/personal.yaml
@@ -8,11 +8,13 @@ SEPARATE:
   # Rises with inflation starting in 2004.
   # Values from 2015 to 2022 are from Tax Foundation.
   2015-01-01: 4_400
+# Massachusetts has no surviving spouse filing status; federal qualifying
+# surviving spouses generally file as head of household in Massachusetts.
 SURVIVING_SPOUSE:
-  2002-01-01: 3_300
+  2002-01-01: 5_100
   # Rises with inflation starting in 2004.
   # Values from 2015 to 2022 are from Tax Foundation.
-  2015-01-01: 4_400
+  2015-01-01: 6_800
 HEAD_OF_HOUSEHOLD:
   2002-01-01: 5_100
   # Rises with inflation starting in 2004.
@@ -33,6 +35,8 @@ metadata:
   reference:
     - title: "Taxable income: adjusted gross income less deductions and exemptions (b)(2)(A)"
       href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section3
+    - title: Filing Status on Massachusetts Personal Income Tax
+      href: https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax
     - title: State Individual Income Tax Rates and Brackets (Tax Foundation)
       href: https://taxfoundation.org/publications/state-individual-income-tax-rates-and-brackets/
     - title: Form 1 2022 | Massachusetts | Resident Income Tax (line 2)

--- a/policyengine_us/reforms/state_dependent_exemptions/repeal_state_dependent_exemptions.py
+++ b/policyengine_us/reforms/state_dependent_exemptions/repeal_state_dependent_exemptions.py
@@ -359,7 +359,7 @@ def create_repeal_state_dependent_exemptions() -> Reform:
         defined_for = StateCode.MA
 
         def formula(tax_unit, period, parameters):
-            filing_status = tax_unit("filing_status", period)
+            filing_status = tax_unit("ma_filing_status", period)
             tax = parameters(period).gov.states.ma.tax.income
             exempt_status = tax.exempt_status.limit
             personal_exemptions_added = (

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_child_and_family_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_child_and_family_credit.yaml
@@ -134,3 +134,79 @@
         members: [filer, disabled_dependent, elderly_dependent]
   output:
     ma_child_and_family_credit: 880
+
+- name: Disabled spouse qualifies in 2024
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      spouse:
+        is_tax_unit_spouse: true
+        is_tax_unit_dependent: false
+        is_disabled: true
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+    households:
+      household:
+        state_code: MA
+        members: [head, spouse]
+  output:
+    # IRC Section 21(b)(1)(C) qualifying individual: 1 x 440 = 440.
+    ma_child_and_family_credit: 440
+
+- name: Disabled spouse does not qualify in 2022 under the predecessor credit
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      spouse:
+        is_tax_unit_spouse: true
+        is_tax_unit_dependent: false
+        is_disabled: true
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+    households:
+      household:
+        state_code: MA
+        members: [head, spouse]
+  output:
+    # The pre-2023 credit for eligible dependents covered only
+    # IRC Section 152 dependents.
+    ma_child_and_family_credit: 0
+
+- name: Married filing separately cannot claim the credit in 2024
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      child:
+        is_tax_unit_dependent: true
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: SEPARATE
+    households:
+      household:
+        state_code: MA
+        members: [head, child]
+  output:
+    ma_child_and_family_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_child_and_family_credit.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/ma_child_and_family_credit.yaml
@@ -210,3 +210,138 @@
         members: [head, child]
   output:
     ma_child_and_family_credit: 0
+
+- name: Disabled spouse qualifies at the gate flip year 2023
+  period: 2023
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      spouse:
+        is_tax_unit_spouse: true
+        is_tax_unit_dependent: false
+        is_disabled: true
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+    households:
+      household:
+        state_code: MA
+        members: [head, spouse]
+  output:
+    # Disabled-spouse gate turns on 2023-01-01: 1 x 310 (2023 amount) = 310.
+    ma_child_and_family_credit: 310
+
+- name: Disabled spouse does not qualify in the 2021 pre-gate window
+  period: 2021
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      spouse:
+        is_tax_unit_spouse: true
+        is_tax_unit_dependent: false
+        is_disabled: true
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: JOINT
+    households:
+      household:
+        state_code: MA
+        members: [head, spouse]
+  output:
+    # Disabled-spouse gate is off before 2023, so the spouse is not eligible.
+    ma_child_and_family_credit: 0
+
+- name: Disabled spouse in a separate unit cannot claim the credit in 2024
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      spouse:
+        is_tax_unit_spouse: true
+        is_tax_unit_dependent: false
+        is_disabled: true
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head, spouse]
+        filing_status: SEPARATE
+    households:
+      household:
+        state_code: MA
+        members: [head, spouse]
+  output:
+    # Married filing separately overrides an otherwise-eligible disabled spouse.
+    ma_child_and_family_credit: 0
+
+- name: Joint filer with one qualifying child claims the credit in 2024
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      spouse:
+        is_tax_unit_spouse: true
+        is_tax_unit_dependent: false
+        age: 40
+      child:
+        is_tax_unit_dependent: true
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, spouse, child]
+        filing_status: JOINT
+    households:
+      household:
+        state_code: MA
+        members: [head, spouse, child]
+  output:
+    # 1 qualifying child x 440 (2024 amount) = 440.
+    ma_child_and_family_credit: 440
+
+- name: Identical household filing separately zeroes the credit in 2024
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      spouse:
+        is_tax_unit_spouse: true
+        is_tax_unit_dependent: false
+        age: 40
+      child:
+        is_tax_unit_dependent: true
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, spouse, child]
+        filing_status: SEPARATE
+    households:
+      household:
+        state_code: MA
+        members: [head, spouse, child]
+  output:
+    # Same qualifying child as the joint case, but the ~separate gate zeroes the
+    # otherwise-440 base.
+    ma_child_and_family_credit: 0

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/senior_circuit_breaker/ma_senior_circuit_breaker.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/credits/senior_circuit_breaker/ma_senior_circuit_breaker.yaml
@@ -123,3 +123,30 @@
     # over threshold: 8,000 - 7,130 = 870
     # credit: min(870, 2,820) = 870
     ma_senior_circuit_breaker: 870
+
+- name: Surviving spouse filer receives the head of household income limit in 2025.
+  period: 2025
+  absolute_error_margin: 0.1
+  input:
+    people:
+      person1:
+        age: 70
+        real_estate_taxes: 10_000
+        assessed_property_value: 500_000
+    tax_units:
+      tax_unit:
+        ma_scb_total_income: 90_000
+        filing_status: SURVIVING_SPOUSE
+        members: [person1]
+    households:
+      household:
+        members: [person1]
+        state_code: MA
+  output:
+    # Massachusetts has no surviving spouse filing status; the filer receives
+    # the head of household income limit (94,000), not the single limit
+    # (75,000), so 90,000 of income remains eligible.
+    # income threshold: 90,000 * 0.10 = 9,000
+    # over threshold: 10,000 - 9,000 = 1,000
+    # credit: min(1,000, 2,820) = 1,000
+    ma_senior_circuit_breaker: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.yaml
@@ -39,3 +39,15 @@
     investment_in_529_plan: 0
   output:
     ma_529_deduction: 0
+
+- name: Case 5, surviving spouse filer receives the head of household cap.
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    state_code: MA
+    filing_status: SURVIVING_SPOUSE
+    investment_in_529_plan: 5_000
+  output:
+    # Massachusetts has no surviving spouse filing status; the filer receives
+    # the head of household cap of $1,000, not the joint cap of $2,000.
+    ma_529_deduction: 1_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_filing_status.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_filing_status.yaml
@@ -1,0 +1,42 @@
+- name: Single filer maps to Massachusetts single
+  period: 2024
+  input:
+    state_code: MA
+    filing_status: SINGLE
+  output:
+    ma_filing_status: SINGLE
+
+- name: Joint filer maps to Massachusetts joint
+  period: 2024
+  input:
+    state_code: MA
+    filing_status: JOINT
+  output:
+    ma_filing_status: JOINT
+
+- name: Separate filer maps to Massachusetts separate
+  period: 2024
+  input:
+    state_code: MA
+    filing_status: SEPARATE
+  output:
+    ma_filing_status: SEPARATE
+
+- name: Head of household filer maps to Massachusetts head of household
+  period: 2024
+  input:
+    state_code: MA
+    filing_status: HEAD_OF_HOUSEHOLD
+  output:
+    ma_filing_status: HEAD_OF_HOUSEHOLD
+
+- name: Surviving spouse filer is treated as head of household
+  period: 2024
+  input:
+    state_code: MA
+    filing_status: SURVIVING_SPOUSE
+  output:
+    # Massachusetts has no surviving spouse filing status; federal qualifying
+    # surviving spouses file as head of household for two years after the year
+    # the spouse died.
+    ma_filing_status: HEAD_OF_HOUSEHOLD

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_income_tax_exemption_threshold.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/ma_income_tax_exemption_threshold.yaml
@@ -1,0 +1,49 @@
+- name: Surviving spouse filer receives head of household treatment in 2024
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      child:
+        is_tax_unit_dependent: true
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: SURVIVING_SPOUSE
+    households:
+      household:
+        state_code: MA
+        members: [head, child]
+  output:
+    # Massachusetts has no surviving spouse filing status; federal qualifying
+    # surviving spouses generally file as head of household in Massachusetts.
+    # Base 7,600 + personal exemption 6,800 + 1 dependent x 1,000 = 15,400.
+    ma_income_tax_exemption_threshold: 15_400
+
+- name: Head of household filer with one dependent in 2024
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        age: 40
+      child:
+        is_tax_unit_dependent: true
+        age: 5
+    tax_units:
+      tax_unit:
+        members: [head, child]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        state_code: MA
+        members: [head, child]
+  output:
+    # Base 7,600 + personal exemption 6,800 + 1 dependent x 1,000 = 15,400.
+    ma_income_tax_exemption_threshold: 15_400

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.yaml
@@ -1,0 +1,22 @@
+- name: Surviving spouse renter receives the standard rent deduction cap in 2024
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        age: 40
+        rent: 10_000
+    tax_units:
+      tax_unit:
+        filing_status: SURVIVING_SPOUSE
+        members: [head]
+    households:
+      household:
+        state_code: MA
+        members: [head]
+  output:
+    # Massachusetts has no surviving spouse filing status; the filer receives
+    # the head of household rent deduction cap.
+    # Rent deduction: min(10,000 x 0.5, 4,000) = 4,000; no other deductions.
+    ma_part_b_taxable_income_deductions: 4_000

--- a/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_exemption.yaml
+++ b/policyengine_us/tests/policy/baseline/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_exemption.yaml
@@ -1,0 +1,45 @@
+- name: Head of household filer receives the head of household personal exemption
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        is_blind: false
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: HEAD_OF_HOUSEHOLD
+    households:
+      household:
+        state_code: MA
+        members: [head]
+  output:
+    # Head of household personal exemption 6,800; no dependents, aged, blind,
+    # or medical exemptions.
+    ma_part_b_taxable_income_exemption: 6_800
+
+- name: Surviving spouse filer receives head of household personal exemption
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    people:
+      head:
+        is_tax_unit_head: true
+        is_tax_unit_dependent: false
+        is_blind: false
+        age: 40
+    tax_units:
+      tax_unit:
+        members: [head]
+        filing_status: SURVIVING_SPOUSE
+    households:
+      household:
+        state_code: MA
+        members: [head]
+  output:
+    # Federal surviving spouse maps to MA head of household, so the personal
+    # exemption is the head of household 6,800.
+    ma_part_b_taxable_income_exemption: 6_800

--- a/policyengine_us/tests/policy/contrib/state_dependent_exemptions/repeal_state_dependent_exemptions.yaml
+++ b/policyengine_us/tests/policy/contrib/state_dependent_exemptions/repeal_state_dependent_exemptions.yaml
@@ -103,3 +103,51 @@
     # The rate scale: 130% -> 0.1, 133% -> 0
     # Since 132.8% is between 130% and 133%, the rate is 0.1
     ky_family_size_tax_credit_rate: 0.1
+
+- name: Surviving spouse with one dependent in Massachusetts - reform drops dependent add
+  period: 2024
+  reforms: policyengine_us.reforms.state_dependent_exemptions.repeal_state_dependent_exemptions.repeal_state_dependent_exemptions
+  input:
+    gov.contrib.repeal_state_dependent_exemptions.in_effect: true
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SURVIVING_SPOUSE
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MA
+  output:
+    # Federal surviving spouse maps to MA head of household via ma_filing_status.
+    # Reform removes the dependent add: base 7,600 + personal exemption 6,800 = 14,400.
+    ma_income_tax_exemption_threshold: 14_400
+
+- name: Surviving spouse with one dependent in Massachusetts - reform not in effect
+  period: 2024
+  input:
+    gov.contrib.repeal_state_dependent_exemptions.in_effect: false
+    people:
+      person1:
+        age: 40
+        is_tax_unit_head: true
+      person2:
+        age: 5
+        is_tax_unit_dependent: true
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        filing_status: SURVIVING_SPOUSE
+    households:
+      household:
+        members: [person1, person2]
+        state_code: MA
+  output:
+    # Baseline keeps the dependent add: 7,600 + 1 x 1,000 + 6,800 = 15,400.
+    ma_income_tax_exemption_threshold: 15_400

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_child_and_family_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_child_and_family_credit.py
@@ -20,7 +20,16 @@ class ma_child_and_family_credit(Variable):
         child = age < p.child_age_limit
         elderly = age >= p.elderly_age_limit
         disabled = person("is_disabled", period)
-        eligible = dependent & (child | elderly | disabled)
+        eligible_dependent = dependent & (child | elderly | disabled)
+        # A disabled spouse is a qualifying individual under
+        # IRC Section 21(b)(1)(C), incorporated by M.G.L. c. 62
+        # Section 6(x)(1)(ii) since 2023.
+        spouse = person("is_tax_unit_spouse", period)
+        eligible_spouse = p.disabled_spouse_eligible & spouse & disabled
+        eligible = eligible_dependent | eligible_spouse
         count_eligible = tax_unit.sum(eligible)
         capped_eligible = min_(count_eligible, p.dependent_cap)
-        return capped_eligible * p.amount
+        # Married taxpayers filing separately cannot claim the credit.
+        filing_status = tax_unit("filing_status", period)
+        separate = filing_status == filing_status.possible_values.SEPARATE
+        return ~separate * capped_eligible * p.amount

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_child_and_family_credit.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/ma_child_and_family_credit.py
@@ -30,6 +30,6 @@ class ma_child_and_family_credit(Variable):
         count_eligible = tax_unit.sum(eligible)
         capped_eligible = min_(count_eligible, p.dependent_cap)
         # Married taxpayers filing separately cannot claim the credit.
-        filing_status = tax_unit("filing_status", period)
+        filing_status = tax_unit("ma_filing_status", period)
         separate = filing_status == filing_status.possible_values.SEPARATE
         return ~separate * capped_eligible * p.amount

--- a/policyengine_us/variables/gov/states/ma/tax/income/credits/senior_circuit_breaker/ma_senior_circuit_breaker.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/credits/senior_circuit_breaker/ma_senior_circuit_breaker.py
@@ -35,7 +35,7 @@ class ma_senior_circuit_breaker(Variable):
         max_payment = min_(ret_over_threshold, scb.amount.max)
 
         # Means-test conditions based on income (cliff).
-        filing_status = tax_unit("filing_status", period)
+        filing_status = tax_unit("ma_filing_status", period)
         meets_max_income_condition = income <= scb.eligibility.max_income[filing_status]
 
         # Means-tested conditions based on property value (cliff).

--- a/policyengine_us/variables/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/deductions/plan_529_contributions/ma_529_deduction.py
@@ -18,6 +18,6 @@ class ma_529_deduction(Variable):
             period
         ).gov.states.ma.tax.income.deductions.plan_529_contributions
         contributions = tax_unit("investment_in_529_plan", period)
-        filing_status = tax_unit("filing_status", period)
+        filing_status = tax_unit("ma_filing_status", period)
         cap = p.cap[filing_status]
         return min_(contributions, cap)

--- a/policyengine_us/variables/gov/states/ma/tax/income/ma_filing_status.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/ma_filing_status.py
@@ -15,6 +15,11 @@ class ma_filing_status(Variable):
     default_value = MassachusettsFilingStatus.SINGLE
     definition_period = YEAR
     reference = "https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax"
+    documentation = (
+        "Since Massachusetts doesn't have a filing status equivalent to the "
+        "federal qualifying widow(er) with dependent child, you can file as "
+        "head of household for 2 years after the year your spouse died."
+    )
     label = "Massachusetts filing status"
     defined_for = StateCode.MA
 

--- a/policyengine_us/variables/gov/states/ma/tax/income/ma_filing_status.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/ma_filing_status.py
@@ -1,0 +1,38 @@
+from policyengine_us.model_api import *
+
+
+class MassachusettsFilingStatus(Enum):
+    SINGLE = "Single"
+    SEPARATE = "Separate"
+    HEAD_OF_HOUSEHOLD = "Head of household"
+    JOINT = "Joint"
+
+
+class ma_filing_status(Variable):
+    value_type = Enum
+    entity = TaxUnit
+    possible_values = MassachusettsFilingStatus
+    default_value = MassachusettsFilingStatus.SINGLE
+    definition_period = YEAR
+    reference = "https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax"
+    label = "Massachusetts filing status"
+    defined_for = StateCode.MA
+
+    def formula(tax_unit, period, parameters):
+        us_filing_status = tax_unit("filing_status", period)
+        fsvals = us_filing_status.possible_values
+        return select(
+            [
+                us_filing_status == fsvals.JOINT,
+                us_filing_status == fsvals.SINGLE,
+                us_filing_status == fsvals.SEPARATE,
+            ],
+            [
+                MassachusettsFilingStatus.JOINT,
+                MassachusettsFilingStatus.SINGLE,
+                MassachusettsFilingStatus.SEPARATE,
+            ],
+            # Massachusetts has no surviving spouse filing status; federal
+            # qualifying surviving spouses generally file as head of household.
+            default=MassachusettsFilingStatus.HEAD_OF_HOUSEHOLD,
+        )

--- a/policyengine_us/variables/gov/states/ma/tax/income/ma_income_tax_exemption_threshold.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/ma_income_tax_exemption_threshold.py
@@ -16,7 +16,7 @@ class ma_income_tax_exemption_threshold(Variable):
     defined_for = StateCode.MA
 
     def formula(tax_unit, period, parameters):
-        filing_status = tax_unit("filing_status", period)
+        filing_status = tax_unit("ma_filing_status", period)
         dependents = tax_unit("tax_unit_dependents", period)
         tax = parameters(period).gov.states.ma.tax.income
         exempt_status = tax.exempt_status.limit

--- a/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_deductions.py
@@ -33,7 +33,7 @@ class ma_part_b_taxable_income_deductions(Variable):
         )
         fica = tax_unit.sum(fica_head) + tax_unit.sum(fica_spouse)
         # Bank interest deduction.
-        filing_status = tax_unit("filing_status", period)
+        filing_status = tax_unit("ma_filing_status", period)
         if tax.exemptions.interest.in_effect:
             bank_interest = add(tax_unit, period, ["taxable_interest_income"])
             bank_interest_deduction = min_(

--- a/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_exemption.py
+++ b/policyengine_us/variables/gov/states/ma/tax/income/taxable_income/ma_part_b_taxable_income_exemption.py
@@ -16,7 +16,7 @@ class ma_part_b_taxable_income_exemption(Variable):
         # NB: The law only mentions FICA and FRRA, but mass.gov includes SECA.
         # https://www.mass.gov/service-details/learn-about-business-and-professional-income
         person = tax_unit.members
-        filing_status = tax_unit("filing_status", period)
+        filing_status = tax_unit("ma_filing_status", period)
         # (B)(b): Exemptions.
         # (1A) and (2A): Personal exemption based on filing status.
         personal_exemption = tax.exemptions.personal[filing_status]


### PR DESCRIPTION
Fixes #9435
Fixes #9436

## Child and Family Tax Credit (#9435)

- **Disabled spouses now qualify from 2023.** M.G.L. c. 62 § 6(x)(ii) incorporates IRC § 21 qualifying individuals, which include a spouse incapable of self-care (§ 21(b)(1)(C)); Schedule DI / Form 1 Line 46 confirm. The predecessor credit for eligible dependents covered only § 152 dependents (per the [FY25 tax expenditure budget 1.624](https://budget.digital.mass.gov/govbudget/fy25/tax-expenditure-budget/personal-income-tax/credits-against-tax/1-624/)), so eligibility is gated by a new dated parameter `disabled_spouse_eligible` (false 2021, true 2023).
- **Married filing separately can no longer claim the credit**, matching the form instructions for both the predecessor and current credit.

## Surviving spouse → head of household treatment (#9436)

Massachusetts has only four filing statuses; federal qualifying surviving spouses generally file as head of household on the MA return ([Mass.gov](https://www.mass.gov/info-details/filing-status-on-massachusetts-personal-income-tax)).

Rather than duplicating HoH values under `SURVIVING_SPOUSE` keys (which invites value drift), this adds a **`ma_filing_status`** variable following the `az_filing_status` pattern: a four-value state enum that maps federal QSS to `HEAD_OF_HOUSEHOLD`. All MA filing-status breakdown parameters now key on `ma_filing_status` and drop their `SURVIVING_SPOUSE` entries:

- `exemptions/personal.yaml` (SS now receives HoH's $6,800 instead of single's $4,400)
- `exempt_status/limit/base.yaml` and `personal_exemption_added.yaml` — also corrects the no-tax-status threshold and, downstream, the Limited Income Credit
- `deductions/rent/cap.yaml`, `deductions/plan_529_contributions/cap.yaml`, `exemptions/interest/amount.yaml`
- `credits/senior_circuit_breaker/eligibility/max_income.yaml` (SS moves from the single to the HoH schedule)

The six MA tax variables that index these parameters (and the MA branch of the `repeal_state_dependent_exemptions` contrib reform) now use `ma_filing_status`.

## Tests

- CFTC: disabled spouse qualifies in 2024; disabled spouse excluded in 2022 under the predecessor credit; MFS filer with a qualifying child gets $0.
- New `ma_income_tax_exemption_threshold` tests: a `SURVIVING_SPOUSE` filer receives the HoH threshold ($15,400 with one dependent), with an HoH control case.
- Full MA baseline tax tree (78), `repeal_state_dependent_exemptions` contrib tests (5), and MA partner analytics contract tests (27) pass; no partner-pinned expectations changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpDjxfRjk5RYFfQRzTyNqc
